### PR TITLE
Bugfix FXIOS-15823 [Add Shortcut Tile] Updated strings for "Add Shortcut" feature

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -1478,14 +1478,14 @@ extension String {
                     value: "Add Shortcut",
                     comment: "The title for the tile on the Firefox homepage shortcuts section that lets users add a new website shortcut.")
                 public static let AlertTitle = MZLocalizedString(
-                    key: "FirefoxHomepage.Shortcuts.AddShortcut.AlertTitle.v153",
+                    key: "FirefoxHomepage.Shortcuts.AddShortcut.AlertTitle.v153.v2",
                     tableName: "FirefoxHomepage",
-                    value: "Enter a Website URL",
+                    value: "Add Shortcut",
                     comment: "The title for the alert where users enter a website URL to add a new shortcut to the Firefox homepage shortcuts section.")
                 public static let AlertDescription = MZLocalizedString(
-                    key: "FirefoxHomepage.Shortcuts.AddShortcut.AlertDescription.v153",
+                    key: "FirefoxHomepage.Shortcuts.AddShortcut.AlertDescription.v153.v2",
                     tableName: "FirefoxHomepage",
-                    value: "Enter the URL and name for the website.",
+                    value: "Enter the URL for the website.",
                     comment: "The description for the alert where users enter a website URL to add a new shortcut to the Firefox homepage shortcuts section.")
                 public static let URLTextFieldPlaceholder = MZLocalizedString(
                     key: "FirefoxHomepage.Shortcuts.AddShortcut.URLTextFieldPlaceholder.v153",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15823)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33843)

## :bulb: Description
- Update a couple of "Add Shortcut" tile feature strings

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [] If needed, I updated documentation and added comments to complex code

