### PR TITLE
Refactor FXIOS-15877 [Homepage] Move homepage header text color in diffable state

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Header/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Header/HomepageHeaderCell.swift
@@ -51,6 +51,8 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable, F
     }
 
     private lazy var logoTextImage: UIImageView = .build { imageView in
+        imageView.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoText)
+            .withRenderingMode(.alwaysTemplate)
         imageView.contentMode = .scaleAspectFit
     }
 
@@ -161,8 +163,6 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable, F
 
     // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
-        logoTextImage.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoText)
-            .withRenderingMode(.alwaysTemplate)
         logoTextImage.tintColor = logoTextColor ?? theme.colors.textPrimary
 
         quickAnswersButton.configuration?.baseBackgroundColor = theme.colors.layer4

--- a/firefox-ios/Client/Frontend/Home/Homepage/Header/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Header/HomepageHeaderCell.swift
@@ -25,6 +25,7 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable, F
 
     private var onQuickAnswersTapped: (() -> Void)?
     private var headerState: HeaderState?
+    private var logoTextColor: UIColor?
     private var hasConfiguredView = false
     private var headerConstraints = [NSLayoutConstraint]()
     private var logoConstraints = [NSLayoutConstraint]()
@@ -149,31 +150,20 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable, F
         NSLayoutConstraint.activate(logoConstraints)
     }
 
-    func configure(headerState: HeaderState, onQuickAnswersTapped: (() -> Void)? = nil) {
+    func configure(headerState: HeaderState,
+                   logoTextColor: UIColor? = nil,
+                   onQuickAnswersTapped: (() -> Void)? = nil) {
         self.headerState = headerState
+        self.logoTextColor = logoTextColor
         self.onQuickAnswersTapped = onQuickAnswersTapped
         setupView(headerState: headerState)
     }
 
     // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
-        // TODO: FXIOS-10851 This can be moved to the new homescreen wallpaper fetching redux
-        let wallpaperManager = WallpaperManager()
-        let browserViewType = store.state.componentState(
-            BrowserViewControllerState.self,
-            for: .browserViewController,
-            window: currentWindowUUID
-        )?.browserViewType
-
-        if let logoTextColor = wallpaperManager.currentWallpaper.logoTextColor, browserViewType != .privateHomepage {
-            logoTextImage.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoText)
-                .withRenderingMode(.alwaysTemplate)
-            logoTextImage.tintColor = logoTextColor
-        } else {
-            logoTextImage.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoText)
-                .withRenderingMode(.alwaysTemplate)
-            logoTextImage.tintColor = theme.colors.textPrimary
-        }
+        logoTextImage.image = UIImage(imageLiteralResourceName: ImageIdentifiers.homeHeaderLogoText)
+            .withRenderingMode(.alwaysTemplate)
+        logoTextImage.tintColor = logoTextColor ?? theme.colors.textPrimary
 
         quickAnswersButton.configuration?.baseBackgroundColor = theme.colors.layer4
         quickAnswersButton.configuration?.baseForegroundColor = theme.colors.actionPrimary

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -43,7 +43,7 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
     }
 
     enum HomeItem: Hashable, Sendable {
-        case header(HeaderState)
+        case header(HeaderState, TextColor?)
         case privacyNotice
         case messageCard(MessageCardConfiguration)
         case topSite(TopSiteConfiguration, TextColor?)
@@ -111,21 +111,17 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
         state: HomepageState,
         selectedNewsfeedCategoryID: String? = nil,
         jumpBackInDisplayConfig: JumpBackInSectionLayoutConfiguration,
-        reconfigureHeader: Bool = false,
         animatingDifferences: Bool = true,
         completion: (() -> Void)? = nil
     ) {
         var snapshot = NSDiffableDataSourceSnapshot<HomeSection, HomeItem>()
 
         let textColor = state.wallpaperState.wallpaperConfiguration.textColor
-        let headerItem = HomeItem.header(state.headerState)
+        let headerItem = HomeItem.header(state.headerState,
+                                         state.wallpaperState.wallpaperConfiguration.logoTextColor)
 
         snapshot.appendSections([.header])
         snapshot.appendItems([headerItem], toSection: .header)
-
-        if reconfigureHeader {
-            snapshot.reconfigureItems([headerItem])
-        }
 
         if state.shouldShowPrivacyNotice {
             snapshot.appendSections([.privacyNotice])

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -431,11 +431,9 @@ final class HomepageViewController: UIViewController,
         // this is a quick workaround to avoid blocking the main thread by calling apply snapshot many times.
         if homepageState != state {
             let animatingDifferences = state.availableContentHeight == homepageState.availableContentHeight
-            let shouldReconfigureHeader = shouldReconfigureHomepageHeader(for: state)
             self.homepageState = state
 
             refreshHomepageDataSourceSnapshot(
-                reconfigureHeader: shouldReconfigureHeader,
                 animatingDifferences: animatingDifferences
             ) { [weak self] in
                 self?.collectionView?.layoutIfNeeded()
@@ -618,9 +616,9 @@ final class HomepageViewController: UIViewController,
         at indexPath: IndexPath
     ) -> UICollectionViewCell {
         switch item {
-        case .header(let state):
+        case .header(let state, let logoTextColor):
             return configuredCell(cellType: HomepageHeaderCell.self, at: indexPath) { cell in
-                cell.configure(headerState: state) { [weak self] in
+                cell.configure(headerState: state, logoTextColor: logoTextColor) { [weak self] in
                     self?.dispatchNavigationBrowserAction(
                         with: NavigationDestination(.quickAnswers),
                         actionType: NavigationBrowserActionType.tapOnQuickAnswersButton
@@ -1152,23 +1150,16 @@ final class HomepageViewController: UIViewController,
         }
     }
 
-    private func refreshHomepageDataSourceSnapshot(reconfigureHeader: Bool = false,
-                                                   animatingDifferences: Bool = true,
+    private func refreshHomepageDataSourceSnapshot(animatingDifferences: Bool = true,
                                                    completion: (() -> Void)? = nil) {
         dataSource?.updateSnapshot(
             state: homepageState,
             selectedNewsfeedCategoryID: currentHomepageTabState.selectedNewsfeedCategoryID,
             jumpBackInDisplayConfig: getJumpBackInDisplayConfig(),
-            reconfigureHeader: reconfigureHeader,
             animatingDifferences: animatingDifferences
         ) {
             completion?()
         }
-    }
-
-    private func shouldReconfigureHomepageHeader(for state: HomepageState) -> Bool {
-        return state.wallpaperState.wallpaperConfiguration.logoTextColor !=
-            homepageState.wallpaperState.wallpaperConfiguration.logoTextColor
     }
 
     /// Applies the active `HomepageTabState`'s relevant properties to the category picker without rebuilding the section.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
@@ -106,6 +106,10 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         )
 
         let snapshot = dataSource.snapshot()
+        XCTAssertEqual(
+            snapshot.itemIdentifiers(inSection: .header).first,
+            HomepageItem.header(updatedState.headerState, .blue)
+        )
         XCTAssertEqual(snapshot.numberOfItems(inSection: .pocket(.systemCyan)), 20)
         let expectedSections: [HomepageSection] = [
             .header,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15877)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33956)

## :bulb: Description
- Move homepage header logo text color into the diffable header item so snapshot updates drive reconfiguration without controller-side wallpaper diffing

### 📝 Technical Notes
- `HomepageViewController` had custom wallpaper diffing to force header reconfiguration, while `HomepageHeaderCell` still queried wallpaper/global state directly
- To fix this, we make the homepage header logo text color part of the diffable header item and pass it into the cell, so normal snapshot updates drive the header refresh
- The header now renders from the same state that identifies it in the snapshot, and is now consistent with how the other text on the homepage is rendered
- There are no user-facing changes

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

