### PR TITLE
Bugfix FXIOS-15587 Prevent Reader Mode style changes from leaking into the original page

### DIFF
--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -106,11 +106,7 @@ class ReaderMode: TabContentScript {
     @MainActor
     lazy var style = ReaderModeStyle.defaultStyle(for: tab?.windowUUID) {
         didSet {
-            // Make sure to only inject if URL matches reader mode pattern
-            guard tab?.url?.absoluteString.range(
-                of: #"^http://localhost:\d+/reader-mode/page"#,
-                options: .regularExpression
-            ) != nil else {
+            guard tab?.url?.absoluteString.hasPrefix(ReaderModeSchemeHandler.currentBaseURL) == true else {
                 return
             }
             if state == ReaderModeState.active {

--- a/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
+++ b/firefox-ios/Client/Frontend/Reader/ReaderMode.swift
@@ -106,6 +106,13 @@ class ReaderMode: TabContentScript {
     @MainActor
     lazy var style = ReaderModeStyle.defaultStyle(for: tab?.windowUUID) {
         didSet {
+            // Make sure to only inject if URL matches reader mode pattern
+            guard tab?.url?.absoluteString.range(
+                of: #"^http://localhost:\d+/reader-mode/page"#,
+                options: .regularExpression
+            ) != nil else {
+                return
+            }
             if state == ReaderModeState.active {
                 tab?.webView?.evaluateJavascriptInDefaultContentWorld(
                     "\(ReaderModeInfo.namespace.rawValue).setStyle(\(style.encode()))"

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderModeStyles.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderModeStyles.js
@@ -1,5 +1,4 @@
 import { enable as enableDarkReader, setFetchMethod } from "darkreader";
-import { readerModeURL } from "./ReaderMode.js";
 
 // Needed in order for dark reader to handle CORS properly
 // This tells dark reader to use the global window.fetch.
@@ -50,10 +49,6 @@ const applyFontConfig = (style) => {
 };
 
 export const setStyle = (style) => {
-  // Make sure we only apply style changes on reader mode pages because the script is injected in all pages.
-  if (!document.location.href.match(readerModeURL)) {
-    return;
-  }
   // Remove all theme classes
   THEME_CLASSES.forEach((theme) => {
     document.body.classList.toggle(theme, theme === style?.theme);

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderModeStyles.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/ReaderModeStyles.js
@@ -1,4 +1,5 @@
 import { enable as enableDarkReader, setFetchMethod } from "darkreader";
+import { readerModeURL } from "./ReaderMode.js";
 
 // Needed in order for dark reader to handle CORS properly
 // This tells dark reader to use the global window.fetch.
@@ -49,6 +50,10 @@ const applyFontConfig = (style) => {
 };
 
 export const setStyle = (style) => {
+  // Make sure we only apply style changes on reader mode pages because the script is injected in all pages.
+  if (!document.location.href.match(readerModeURL)) {
+    return;
+  }
   // Remove all theme classes
   THEME_CLASSES.forEach((theme) => {
     document.body.classList.toggle(theme, theme === style?.theme);


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15587)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33391)

## :bulb: Description
Dark Reader styles were bleeding onto the original page after exiting Reader Mode. This happened because the bundled JS is injected into every page in the same WKWebView, so Dark Reader's state persisted when navigating back. Attempting to call Dark Reader's disable() before navigation didn't seem to help, possibly due to timing issues with the async JS execution. The fix adds a URL check in setStyle() so Dark Reader only activates on Reader Mode pages. readerModeURL is also exported from ReaderMode.js as a single source of truth, so if the Reader Mode URL scheme ever changes, the guard stays in sync automatically.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

