### PR TITLE
BugFix [World Cup] FXIOS-15890 transition from milestone1 to milestone2 reenable the settings

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -114,6 +114,11 @@ public struct PrefsKeys {
         public static let BookmarksSection = "BookmarksSectionUserPrefsKey"
         public static let JumpBackInSection = "JumpBackInSectionUserPrefsKey"
         public static let WorldCupSection = "WorldCupSectionUserPrefsKey"
+        /// Tracks whether we've performed the one-time transition from World
+        /// Cup milestone 1 to milestone 2. When the milestone 2 date is first
+        /// reached we force-enable the homepage section once, then respect the
+        /// user preference on subsequent reads.
+        public static let WorldCupMilestone2Transitioned = "WorldCupMilestone2TransitionedUserPrefsKey"
         /// Override for the merino WCS base host
         public static let WorldCupBaseHost = "worldCupBaseHostKey"
         /// Dev-only override for the World Cup `/matches` and `/live` polling

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -689,8 +689,9 @@ final class HomepageViewController: UIViewController,
     }
 
     private func relayoutForCellHeightChange() {
-        guard let collectionView else { return }
-        collectionView.collectionViewLayout.invalidateLayout()
+        DispatchQueue.main.async {
+            self.refreshHomepageDataSourceSnapshot()
+        }
     }
 
     private func configurePrivacyNoticeCell(cell: PrivacyNoticeCell) {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCellFactory.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCellFactory.swift
@@ -27,9 +27,7 @@ struct WorldCupCellFactory {
             return view
         }
 
-        // If the WorldCup has started and the user selected a team, we don't display
-        // anymore the timer view
-        if state.hasWorldCupStarted && state.selectedCountryId != nil {
+        if state.selectedCountryId != nil {
             return matchesViews
         }
         let timerView = WorldCupTimerView(windowUUID: state.windowUUID)

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
@@ -58,11 +58,20 @@ struct WorldCupStore: WorldCupStoreProtocol, FeatureFlaggable {
     }
 
     var isFeatureEnabledAndSectionEnabled: Bool {
-        return isFeatureEnabled && isHomepageSectionEnabled
+        guard isFeatureEnabled else { return false }
+        if isMilestone2 && !hasTransitionedToMilestone2 {
+            setIsHomepageSectionEnabled(true)
+            profile.prefs.setBool(true, forKey: PrefsKeys.HomepageSettings.WorldCupMilestone2Transitioned)
+        }
+        return isHomepageSectionEnabled
     }
 
     private var isHomepageSectionEnabled: Bool {
         return profile.prefs.boolForKey(PrefsKeys.HomepageSettings.WorldCupSection) ?? true
+    }
+
+    private var hasTransitionedToMilestone2: Bool {
+        return profile.prefs.boolForKey(PrefsKeys.HomepageSettings.WorldCupMilestone2Transitioned) ?? false
     }
 
     var selectedTeam: String? {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupCellFactoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupCellFactoryTests.swift
@@ -42,7 +42,7 @@ final class WorldCupCellFactoryTests: XCTestCase {
         XCTAssertTrue(pages.first is WorldCupTimerView)
     }
 
-    func test_makePages_whenMilestone2_withMatches_returnsTimerFollowedByMatchCards() {
+    func test_makePages_whenMilestone2_withMatches_returnsTimerFollowedByMatchCards_whenTeamNotSelected() {
         var state = WorldCupSectionState(windowUUID: .XCTestDefaultUUID)
         state.isMilestone2 = true
         state.matches = [makeMatches(), makeMatches()]
@@ -90,46 +90,16 @@ final class WorldCupCellFactoryTests: XCTestCase {
         XCTAssertTrue(pages.first is WorldCupTimerView)
     }
 
-    func test_makePages_whenWorldCupStarted_withSelectedTeam_returnsOnlyMatchCards() {
+    func test_makePages_whenSelectedTeam_returnsMatchesCard() {
         var state = WorldCupSectionState(windowUUID: .XCTestDefaultUUID)
         state.isMilestone2 = true
-        state.hasWorldCupStarted = true
         state.selectedCountryId = "FRA"
-        state.matches = [makeMatches(), makeMatches()]
+        state.matches = [makeMatches()]
 
         let pages = WorldCupCellFactory.makePages(from: state)
 
-        XCTAssertEqual(pages.count, 2)
+        XCTAssertEqual(pages.count, 1)
         XCTAssertTrue(pages[0] is WorldCupMatchCardView)
-        XCTAssertTrue(pages[1] is WorldCupMatchCardView)
-    }
-
-    func test_makePages_whenWorldCupStarted_withoutSelectedTeam_returnsTimerFollowedByMatchCards() {
-        var state = WorldCupSectionState(windowUUID: .XCTestDefaultUUID)
-        state.isMilestone2 = true
-        state.hasWorldCupStarted = true
-        state.selectedCountryId = nil
-        state.matches = [makeMatches()]
-
-        let pages = WorldCupCellFactory.makePages(from: state)
-
-        XCTAssertEqual(pages.count, 2)
-        XCTAssertTrue(pages[0] is WorldCupTimerView)
-        XCTAssertTrue(pages[1] is WorldCupMatchCardView)
-    }
-
-    func test_makePages_whenWorldCupNotStarted_withSelectedTeam_returnsTimerFollowedByMatchCards() {
-        var state = WorldCupSectionState(windowUUID: .XCTestDefaultUUID)
-        state.isMilestone2 = true
-        state.hasWorldCupStarted = false
-        state.selectedCountryId = "FRA"
-        state.matches = [makeMatches()]
-
-        let pages = WorldCupCellFactory.makePages(from: state)
-
-        XCTAssertEqual(pages.count, 2)
-        XCTAssertTrue(pages[0] is WorldCupTimerView)
-        XCTAssertTrue(pages[1] is WorldCupMatchCardView)
     }
 
     private func makeMatches() -> WorldCupMatches {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupStoreTests.swift
@@ -42,7 +42,7 @@ final class WorldCupStoreTests: XCTestCase {
     // MARK: - isFeatureEnabledAndSectionEnabled
 
     func test_isFeatureEnabledAndSectionEnabled_withFeatureOnAndSectionOn_returnsTrue() {
-        setNimbusFeature(enabled: true)
+        setNimbusFeature(enabled: true, milestone2EnableDate: "2099-01-01T00:00:00Z")
         mockProfile.prefs.setBool(true, forKey: PrefsKeys.HomepageSettings.WorldCupSection)
         let subject = createSubject()
 
@@ -50,7 +50,7 @@ final class WorldCupStoreTests: XCTestCase {
     }
 
     func test_isFeatureEnabledAndSectionEnabled_withFeatureOffAndSectionOn_returnsFalse() {
-        setNimbusFeature(enabled: false)
+        setNimbusFeature(enabled: false, milestone2EnableDate: "2099-01-01T00:00:00Z")
         mockProfile.prefs.setBool(true, forKey: PrefsKeys.HomepageSettings.WorldCupSection)
         let subject = createSubject()
 
@@ -58,7 +58,7 @@ final class WorldCupStoreTests: XCTestCase {
     }
 
     func test_isFeatureEnabledAndSectionEnabled_withFeatureOnAndSectionOff_returnsFalse() {
-        setNimbusFeature(enabled: true)
+        setNimbusFeature(enabled: true, milestone2EnableDate: "2099-01-01T00:00:00Z")
         mockProfile.prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.WorldCupSection)
         let subject = createSubject()
 
@@ -66,10 +66,58 @@ final class WorldCupStoreTests: XCTestCase {
     }
 
     func test_isFeatureEnabledAndSectionEnabled_withoutSectionPref_defaultsToFeatureFlagValue() {
-        setNimbusFeature(enabled: true)
+        setNimbusFeature(enabled: true, milestone2EnableDate: "2099-01-01T00:00:00Z")
         let subject = createSubject()
 
         XCTAssertTrue(subject.isFeatureEnabledAndSectionEnabled)
+    }
+
+    func test_isFeatureEnabledAndSectionEnabled_onMilestone2_whenSectionDisabled_forceEnablesSectionOnce() {
+        setNimbusFeature(enabled: true, milestone2EnableDate: "2026-05-10T19:00:00Z")
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.WorldCupSection)
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date("2026-05-11T00:00:00Z"))
+        )
+
+        XCTAssertTrue(subject.isFeatureEnabledAndSectionEnabled)
+        XCTAssertEqual(
+            mockProfile.prefs.boolForKey(PrefsKeys.HomepageSettings.WorldCupSection),
+            true
+        )
+        XCTAssertEqual(
+            mockProfile.prefs.boolForKey(PrefsKeys.HomepageSettings.WorldCupMilestone2Transitioned),
+            true
+        )
+    }
+
+    func test_isFeatureEnabledAndSectionEnabled_onMilestone2_afterTransition_respectsUserPreference() {
+        setNimbusFeature(enabled: true, milestone2EnableDate: "2026-05-10T19:00:00Z")
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.HomepageSettings.WorldCupMilestone2Transitioned)
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.WorldCupSection)
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date("2026-05-11T00:00:00Z"))
+        )
+
+        XCTAssertFalse(subject.isFeatureEnabledAndSectionEnabled)
+        XCTAssertEqual(
+            mockProfile.prefs.boolForKey(PrefsKeys.HomepageSettings.WorldCupSection),
+            false
+        )
+    }
+
+    func test_isFeatureEnabledAndSectionEnabled_beforeMilestone2_doesNotTransition() {
+        setNimbusFeature(enabled: true, milestone2EnableDate: "2026-05-10T19:00:00Z")
+        mockProfile.prefs.setBool(false, forKey: PrefsKeys.HomepageSettings.WorldCupSection)
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date("2026-05-10T18:59:59Z"))
+        )
+
+        XCTAssertFalse(subject.isFeatureEnabledAndSectionEnabled)
+        XCTAssertNil(mockProfile.prefs.boolForKey(PrefsKeys.HomepageSettings.WorldCupMilestone2Transitioned))
+        XCTAssertEqual(
+            mockProfile.prefs.boolForKey(PrefsKeys.HomepageSettings.WorldCupSection),
+            false
+        )
     }
 
     // MARK: - selectedTeam


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15890)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33969)

## :bulb: Description
Transitioning from milestone1 to mileston2 re enable the WorldCup section.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

