### PR TITLE
Bugfix FXIOS-15891 [Translation Phase 2] Translation incorrectly offered on same-language pages

### DIFF
--- a/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
+++ b/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
@@ -16,14 +16,31 @@ final class LanguageDetector: LanguageDetectorProvider {
     private let languageSampleScript =
         "return await window.__firefox__.Translations.getLanguageSampleWhenReady()"
 
+    private let htmlLangScript = "return document.documentElement.lang || null"
+
+    /// NLLanguageRecognizer hypotheses below this threshold are treated as unreliable.
+    static let minimumConfidence: Double = 0.5
+
     func detectLanguage(from source: LanguageSampleSource) async throws -> String? {
+        if let htmlLang = try await extractHTMLLangAttribute(from: source) {
+            return htmlLang
+        }
         let sample = try await extractSample(from: source)
         guard let textSample = sample else { return nil }
         return getDominantLanguage(of: textSample)
     }
 
+    /// Reads the `lang` attribute from the page's `<html>` element.
+    private func extractHTMLLangAttribute(from source: LanguageSampleSource) async throws -> String? {
+        guard let rawLang = try await source.getLanguageSample(scriptEvalExpression: htmlLangScript),
+              !rawLang.isEmpty else {
+            return nil
+        }
+        return Self.normalizeLanguageCode(rawLang)
+    }
+
     /// Extracts a text sample from the page via the JS bridge.
-    /// Returns `nil` if the bridge isn’t ready or no sample is available.
+    /// Returns `nil` if the bridge isn't ready or no sample is available.
     private func extractSample(from source: LanguageSampleSource) async throws -> String? {
         let sample = try await source.getLanguageSample(scriptEvalExpression: languageSampleScript)
         guard let sample = sample, !sample.isEmpty else { return nil }
@@ -34,6 +51,28 @@ final class LanguageDetector: LanguageDetectorProvider {
     private func getDominantLanguage(of text: String) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        return NLLanguageRecognizer.dominantLanguage(for: trimmed)?.rawValue
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(trimmed)
+        guard let dominant = recognizer.dominantLanguage else { return nil }
+        let confidence = recognizer.languageHypotheses(withMaximum: 1)[dominant] ?? 0
+        guard confidence >= Self.minimumConfidence else { return nil }
+        return dominant.rawValue
+    }
+
+    /// Normalizes a raw HTML `lang` value to the format used by the translation models.
+    /// Preserves script subtags (e.g. `"zh-Hans-CN"` → `"zh-Hans"`) but drops region-only
+    /// suffixes (e.g. `"en-US"` → `"en"`).
+    static func normalizeLanguageCode(_ code: String) -> String? {
+        let components = code.split(separator: "-")
+        guard let language = components.first, !language.isEmpty else { return nil }
+        let languageCode = String(language).lowercased()
+        // BCP-47 script subtags are exactly 4 characters, starting with uppercase (e.g. "Hans", "Hant").
+        if components.count >= 2 {
+            let second = String(components[1])
+            if second.count == 4, second.first?.isUppercase == true {
+                return "\(languageCode)-\(second)"
+            }
+        }
+        return languageCode
     }
 }

--- a/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
+++ b/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
@@ -19,7 +19,7 @@ final class LanguageDetector: LanguageDetectorProvider {
     private let htmlLangScript = "return document.documentElement.lang || null"
 
     /// NLLanguageRecognizer hypotheses below this threshold are treated as unreliable.
-    static let minimumConfidence: Double = 0.5
+    static let minimumConfidence = 0.5
 
     func detectLanguage(from source: LanguageSampleSource) async throws -> String? {
         if let htmlLang = try await extractHTMLLangAttribute(from: source) {

--- a/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
+++ b/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
@@ -18,13 +18,44 @@ final class LanguageDetector: LanguageDetectorProvider {
 
     private let htmlLangScript = "return document.documentElement.lang || null"
 
+    /// Minimum confidence from `NLLanguageRecognizer` for a text-sample identification to be trusted.
+    /// The recognizer's own confidence reliably separates clean text (scores ~0.9+, even on short or
+    /// non-Latin samples) from code, markup, and mixed-language content (well below), so it is a better
+    /// gate than an input-length threshold and is calibrated against the recognizer we actually ship.
+    private let confidenceThreshold: Double
+
+    init(confidenceThreshold: Double = 0.85) {
+        self.confidenceThreshold = confidenceThreshold
+    }
+
+    /// Detects the page language from two signals. A confident text-sample identification is the
+    /// strongest signal and overrides the `<html lang>` attribute, which authors frequently
+    /// mislabel (e.g. `lang="en"` on non-English content). When the text identification isn't
+    /// confident, it falls back to the HTML tag. Returns `nil` when neither yields a result.
     func detectLanguage(from source: LanguageSampleSource) async throws -> String? {
-        if let htmlLang = try await extractHTMLLangAttribute(from: source) {
-            return htmlLang
-        }
+        let htmlTagLanguage = try await extractHTMLLangAttribute(from: source)
+        let confidentLanguage = try await confidentlyIdentifiedLanguage(from: source)
+        return confidentLanguage ?? htmlTagLanguage
+    }
+
+    /// Identifies the page language from an extracted text sample, but only when `NLLanguageRecognizer`
+    /// reports a confidence at or above ``confidenceThreshold``. A low-confidence result (typical of
+    /// code, markup, or mixed-language samples) is discarded rather than used to override the HTML tag
+    /// or stand on its own. Returns `nil` for empty or unrecognized samples.
+    private func confidentlyIdentifiedLanguage(from source: LanguageSampleSource) async throws -> String? {
         let sample = try await extractSample(from: source)
-        guard let textSample = sample else { return nil }
-        return getDominantLanguage(of: textSample)
+        guard let sample else { return nil }
+        let trimmed = sample.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(trimmed)
+        guard let dominant = recognizer.dominantLanguage,
+              let confidence = recognizer.languageHypotheses(withMaximum: 1)[dominant],
+              confidence >= confidenceThreshold else {
+            return nil
+        }
+        return dominant.rawValue
     }
 
     /// Reads the `lang` attribute from the page's `<html>` element.
@@ -42,13 +73,6 @@ final class LanguageDetector: LanguageDetectorProvider {
         let sample = try await source.getLanguageSample(scriptEvalExpression: languageSampleScript)
         guard let sample = sample, !sample.isEmpty else { return nil }
         return sample
-    }
-
-    /// Detects the dominant language of a given text and returns its BCP-47 code (e.g. `"en"`, `"fr"`).
-    private func getDominantLanguage(of text: String) -> String? {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        return NLLanguageRecognizer.dominantLanguage(for: trimmed)?.rawValue
     }
 
     /// Normalizes a raw HTML `lang` value to the format used by the translation models.

--- a/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
+++ b/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
@@ -39,7 +39,7 @@ final class LanguageDetector: LanguageDetectorProvider {
     }
 
     /// Identifies the page language from an extracted text sample, but only when `NLLanguageRecognizer`
-    /// reports a confidence at or above ``confidenceThreshold``. A low-confidence result (typical of
+    /// reports a confidence at or above `confidenceThreshold`. A low-confidence result (typical of
     /// code, markup, or mixed-language samples) is discarded rather than used to override the HTML tag
     /// or stand on its own. Returns `nil` for empty or unrecognized samples.
     private func confidentlyIdentifiedLanguage(from source: LanguageSampleSource) async throws -> String? {

--- a/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
+++ b/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
@@ -18,9 +18,6 @@ final class LanguageDetector: LanguageDetectorProvider {
 
     private let htmlLangScript = "return document.documentElement.lang || null"
 
-    /// NLLanguageRecognizer hypotheses below this threshold are treated as unreliable.
-    static let minimumConfidence = 0.5
-
     func detectLanguage(from source: LanguageSampleSource) async throws -> String? {
         if let htmlLang = try await extractHTMLLangAttribute(from: source) {
             return htmlLang
@@ -51,12 +48,7 @@ final class LanguageDetector: LanguageDetectorProvider {
     private func getDominantLanguage(of text: String) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        let recognizer = NLLanguageRecognizer()
-        recognizer.processString(trimmed)
-        guard let dominant = recognizer.dominantLanguage else { return nil }
-        let confidence = recognizer.languageHypotheses(withMaximum: 1)[dominant] ?? 0
-        guard confidence >= Self.minimumConfidence else { return nil }
-        return dominant.rawValue
+        return NLLanguageRecognizer.dominantLanguage(for: trimmed)?.rawValue
     }
 
     /// Normalizes a raw HTML `lang` value to the format used by the translation models.

--- a/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
+++ b/firefox-ios/Client/Frontend/Translations/LanguageDetector/LanguageDetector.swift
@@ -11,6 +11,27 @@ protocol LanguageDetectorProvider: Sendable {
     func detectLanguage(from source: LanguageSampleSource) async throws -> String?
 }
 
+/// Identifies the dominant natural language of a text sample and how confident that identification is.
+/// Wrapping the detection backend lets callers (and tests) substitute a deterministic implementation.
+protocol LanguageRecognizing: Sendable {
+    /// Returns the dominant language's BCP-47 code and a confidence in the range `0...1`,
+    /// or `nil` if no dominant language could be determined.
+    func dominantLanguage(in text: String) -> (languageCode: String, confidence: Double)?
+}
+
+/// Default `LanguageRecognizing` backed by Apple's `NLLanguageRecognizer`.
+struct NaturalLanguageRecognizer: LanguageRecognizing {
+    func dominantLanguage(in text: String) -> (languageCode: String, confidence: Double)? {
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(text)
+        guard let dominant = recognizer.dominantLanguage,
+              let confidence = recognizer.languageHypotheses(withMaximum: 1)[dominant] else {
+            return nil
+        }
+        return (dominant.rawValue, confidence)
+    }
+}
+
 final class LanguageDetector: LanguageDetectorProvider {
     /// JS function that is called to get a page sample back. The function is implemented in `Summarizer.js`.
     private let languageSampleScript =
@@ -18,14 +39,16 @@ final class LanguageDetector: LanguageDetectorProvider {
 
     private let htmlLangScript = "return document.documentElement.lang || null"
 
-    /// Minimum confidence from `NLLanguageRecognizer` for a text-sample identification to be trusted.
-    /// The recognizer's own confidence reliably separates clean text (scores ~0.9+, even on short or
-    /// non-Latin samples) from code, markup, and mixed-language content (well below), so it is a better
-    /// gate than an input-length threshold and is calibrated against the recognizer we actually ship.
-    private let confidenceThreshold: Double
+    /// Minimum confidence for a text-sample identification to be trusted. The recognizer's own
+    /// confidence reliably separates clean text (scores ~0.9+, even on short or non-Latin samples)
+    /// from code, markup, and mixed-language content (well below), so it is a better gate than an
+    /// input-length threshold and is calibrated against the recognizer we actually ship.
+    private static let confidenceThreshold = 0.85
 
-    init(confidenceThreshold: Double = 0.85) {
-        self.confidenceThreshold = confidenceThreshold
+    private let recognizer: LanguageRecognizing
+
+    init(recognizer: LanguageRecognizing = NaturalLanguageRecognizer()) {
+        self.recognizer = recognizer
     }
 
     /// Detects the page language from two signals. A confident text-sample identification is the
@@ -38,7 +61,7 @@ final class LanguageDetector: LanguageDetectorProvider {
         return confidentLanguage ?? htmlTagLanguage
     }
 
-    /// Identifies the page language from an extracted text sample, but only when `NLLanguageRecognizer`
+    /// Identifies the page language from an extracted text sample, but only when the recognizer
     /// reports a confidence at or above `confidenceThreshold`. A low-confidence result (typical of
     /// code, markup, or mixed-language samples) is discarded rather than used to override the HTML tag
     /// or stand on its own. Returns `nil` for empty or unrecognized samples.
@@ -48,14 +71,11 @@ final class LanguageDetector: LanguageDetectorProvider {
         let trimmed = sample.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
-        let recognizer = NLLanguageRecognizer()
-        recognizer.processString(trimmed)
-        guard let dominant = recognizer.dominantLanguage,
-              let confidence = recognizer.languageHypotheses(withMaximum: 1)[dominant],
-              confidence >= confidenceThreshold else {
+        guard let identified = recognizer.dominantLanguage(in: trimmed),
+              identified.confidence >= Self.confidenceThreshold else {
             return nil
         }
-        return dominant.rawValue
+        return identified.languageCode
     }
 
     /// Reads the `lang` attribute from the page's `<html>` element.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
@@ -9,6 +9,48 @@ import XCTest
 final class LanguageDetectorTests: XCTestCase {
     var mockLanguageSampleSource = MockLanguageSampleSource()
 
+    // MARK: - HTML lang attribute
+
+    func test_detectLanguage_prefersHTMLLangOverTextAnalysis() async throws {
+        mockLanguageSampleSource.htmlLangResult = "de"
+        mockLanguageSampleSource.mockResult = "Hello world, this is clearly an English sentence."
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "de")
+    }
+
+    func test_detectLanguage_normalizesHTMLLangWithRegion() async throws {
+        mockLanguageSampleSource.htmlLangResult = "en-US"
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "en")
+    }
+
+    func test_detectLanguage_preservesScriptSubtag() async throws {
+        mockLanguageSampleSource.htmlLangResult = "zh-Hans-CN"
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "zh-Hans")
+    }
+
+    func test_detectLanguage_fallsBackToTextWhenHTMLLangMissing() async throws {
+        mockLanguageSampleSource.htmlLangResult = nil
+        mockLanguageSampleSource.mockResult = "Bonjour le monde"
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "fr")
+    }
+
+    func test_detectLanguage_ignoresEmptyHTMLLang() async throws {
+        mockLanguageSampleSource.htmlLangResult = ""
+        mockLanguageSampleSource.mockResult = "Bonjour le monde"
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "fr")
+    }
+
+    // MARK: - NLLanguageRecognizer text analysis
+
     func test_detectLanguage_withFrench_returnsProperLanguageCode() async throws {
         mockLanguageSampleSource.mockResult = "Bonjour le monde"
         let subject = createSubject()
@@ -81,6 +123,30 @@ final class LanguageDetectorTests: XCTestCase {
         let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "en")
     }
+
+    // MARK: - normalizeLanguageCode
+
+    func test_normalizeLanguageCode_simpleCode() {
+        XCTAssertEqual(LanguageDetector.normalizeLanguageCode("en"), "en")
+    }
+
+    func test_normalizeLanguageCode_regionCode() {
+        XCTAssertEqual(LanguageDetector.normalizeLanguageCode("en-US"), "en")
+    }
+
+    func test_normalizeLanguageCode_scriptCode() {
+        XCTAssertEqual(LanguageDetector.normalizeLanguageCode("zh-Hans"), "zh-Hans")
+    }
+
+    func test_normalizeLanguageCode_scriptAndRegion() {
+        XCTAssertEqual(LanguageDetector.normalizeLanguageCode("zh-Hans-CN"), "zh-Hans")
+    }
+
+    func test_normalizeLanguageCode_invalidCode() {
+        XCTAssertNil(LanguageDetector.normalizeLanguageCode(""))
+    }
+
+    // MARK: - Helpers
 
     private func createSubject() -> LanguageDetector {
         LanguageDetector()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
@@ -8,139 +8,135 @@ import XCTest
 @MainActor
 final class LanguageDetectorTests: XCTestCase {
     var mockLanguageSampleSource = MockLanguageSampleSource()
+    var mockRecognizer = MockLanguageRecognizer()
 
     // MARK: - Signal reconciliation
 
     func test_detectLanguage_whenTextIsConfident_overridesHTMLTag() async throws {
         mockLanguageSampleSource.htmlLangResult = "de"
-        mockLanguageSampleSource.mockResult = "Hello world, this is clearly an English sentence."
-        let subject = createSubject(confidenceThreshold: 0.5)
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        mockLanguageSampleSource.mockResult = "sample text"
+        mockRecognizer.result = (languageCode: "en", confidence: 0.95)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "en")
     }
 
     func test_detectLanguage_whenTextIsConfidentAndHTMLLangMissing_returnsText() async throws {
         mockLanguageSampleSource.htmlLangResult = nil
-        mockLanguageSampleSource.mockResult = "Bonjour le monde, ceci est clairement une phrase française."
-        let subject = createSubject(confidenceThreshold: 0.5)
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        mockLanguageSampleSource.mockResult = "sample text"
+        mockRecognizer.result = (languageCode: "fr", confidence: 0.92)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "fr")
     }
 
     func test_detectLanguage_whenTextIsNotConfident_fallsBackToHTMLTag() async throws {
         mockLanguageSampleSource.htmlLangResult = "es"
-        mockLanguageSampleSource.mockResult = "Hello world"
-        let subject = createSubject(confidenceThreshold: 0.99)
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        mockLanguageSampleSource.mockResult = "sample text"
+        mockRecognizer.result = (languageCode: "en", confidence: 0.40)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "es")
     }
 
     func test_detectLanguage_whenTextIsNotConfidentAndHTMLLangMissing_returnsNil() async throws {
         mockLanguageSampleSource.htmlLangResult = nil
-        mockLanguageSampleSource.mockResult = "Hello world"
-        let subject = createSubject(confidenceThreshold: 0.99)
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        mockLanguageSampleSource.mockResult = "sample text"
+        mockRecognizer.result = (languageCode: "en", confidence: 0.40)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
         XCTAssertNil(result)
+    }
+
+    func test_detectLanguage_whenRecognizerReturnsNil_fallsBackToHTMLTag() async throws {
+        mockLanguageSampleSource.htmlLangResult = "es"
+        mockLanguageSampleSource.mockResult = "sample text"
+        mockRecognizer.result = nil
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "es")
     }
 
     func test_detectLanguage_whenOnlyHTMLLangAvailable_returnsHTMLLang() async throws {
         mockLanguageSampleSource.htmlLangResult = "es"
         mockLanguageSampleSource.mockResult = nil
-        let subject = createSubject(confidenceThreshold: 0.5)
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "es")
+    }
+
+    // MARK: - Confidence threshold
+
+    func test_detectLanguage_acceptsConfidenceAtThreshold() async throws {
+        mockLanguageSampleSource.mockResult = "sample text"
+        mockRecognizer.result = (languageCode: "en", confidence: 0.85)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "en")
+    }
+
+    func test_detectLanguage_rejectsConfidenceBelowThreshold() async throws {
+        mockLanguageSampleSource.mockResult = "sample text"
+        mockRecognizer.result = (languageCode: "en", confidence: 0.84)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertNil(result)
     }
 
     // MARK: - HTML lang attribute
 
     func test_detectLanguage_normalizesUppercaseHTMLLang() async throws {
         mockLanguageSampleSource.htmlLangResult = "EN-US"
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "en")
     }
 
     func test_detectLanguage_ignoresEmptyHTMLLang() async throws {
         mockLanguageSampleSource.htmlLangResult = ""
-        mockLanguageSampleSource.mockResult = "Bonjour le monde"
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        mockLanguageSampleSource.mockResult = "sample text"
+        mockRecognizer.result = (languageCode: "fr", confidence: 0.95)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "fr")
     }
 
-    // MARK: - NLLanguageRecognizer text analysis
-
-    func test_detectLanguage_withFrench_returnsProperLanguageCode() async throws {
-        mockLanguageSampleSource.mockResult = "Bonjour le monde"
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
-        XCTAssertEqual(result, "fr")
-    }
-
-    func test_detectLanguage_withEnglish_returnsProperLanguageCode() async throws {
-        mockLanguageSampleSource.mockResult = "Hello world"
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
-        XCTAssertEqual(result, "en")
-    }
-
-    func test_detectLanguage_withSpanish_returnsProperLanguageCode() async throws {
-        mockLanguageSampleSource.mockResult = "Hola mundo"
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
-        XCTAssertEqual(result, "es")
-    }
-
-    func test_detectLanguage_withJapanese_returnsProperLanguageCode() async throws {
-        mockLanguageSampleSource.mockResult = "こんにちは世界"
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
-        XCTAssertEqual(result, "ja")
-    }
-
-    func test_detectLanguage_withKorean_returnsProperLanguageCode() async throws {
-        mockLanguageSampleSource.mockResult = "안녕하세요 세계"
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
-        XCTAssertEqual(result, "ko")
-    }
+    // MARK: - Sample handling
 
     func test_detectLanguage_withEmptyString_returnsNil() async throws {
         mockLanguageSampleSource.mockResult = ""
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
         XCTAssertNil(result)
     }
 
     func test_detectLanguage_withWhitespaces_returnsNil() async throws {
         mockLanguageSampleSource.mockResult = " \n\t "
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        mockRecognizer.result = (languageCode: "en", confidence: 0.99)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
         XCTAssertNil(result)
     }
 
     func test_detectLanguage_returnsNilForNonString() async throws {
         mockLanguageSampleSource.mockResult = 42
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        let result = try await createSubject().detectLanguage(from: mockLanguageSampleSource)
         XCTAssertNil(result)
     }
 
     func test_detectLanguage_propagatesError() async {
         enum FakeError: Error, Equatable { case foo }
         mockLanguageSampleSource.mockError = FakeError.foo
-        let subject = createSubject()
 
         await assertAsyncThrowsEqual(FakeError.foo) {
-            _ = try await subject.detectLanguage(from: mockLanguageSampleSource)
+            _ = try await self.createSubject().detectLanguage(from: self.mockLanguageSampleSource)
         }
     }
 
-    func test_detectLanguage_prefersDominantLanguage() async throws {
-        let subject = createSubject()
-        mockLanguageSampleSource.mockResult = "Hello! This is an English sentence. A common word in French is Bonjour."
+    // MARK: - NaturalLanguageRecognizer integration
+
+    func test_detectLanguage_withRealRecognizer_identifiesConfidentText() async throws {
+        mockLanguageSampleSource.htmlLangResult = nil
+        mockLanguageSampleSource.mockResult = "Hello world, this is clearly an English sentence."
+        let subject = createSubject(recognizer: NaturalLanguageRecognizer())
         let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "en")
+    }
+
+    func test_detectLanguage_withRealRecognizer_rejectsUnidentifiableText() async throws {
+        mockLanguageSampleSource.htmlLangResult = nil
+        mockLanguageSampleSource.mockResult = ":: == >>> ### @@@ {} [] () <> //"
+        let subject = createSubject(recognizer: NaturalLanguageRecognizer())
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertNil(result)
     }
 
     // MARK: - normalizeLanguageCode
@@ -167,7 +163,17 @@ final class LanguageDetectorTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func createSubject(confidenceThreshold: Double = 0) -> LanguageDetector {
-        LanguageDetector(confidenceThreshold: confidenceThreshold)
+    private func createSubject(recognizer: LanguageRecognizing? = nil) -> LanguageDetector {
+        LanguageDetector(recognizer: recognizer ?? mockRecognizer)
+    }
+}
+
+/// Test double for `LanguageRecognizing` that returns a preconfigured result regardless of input,
+/// so reconciliation and threshold logic can be exercised with deterministic confidence values.
+final class MockLanguageRecognizer: LanguageRecognizing, @unchecked Sendable {
+    var result: (languageCode: String, confidence: Double)?
+
+    func dominantLanguage(in text: String) -> (languageCode: String, confidence: Double)? {
+        result
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
@@ -33,6 +33,13 @@ final class LanguageDetectorTests: XCTestCase {
         XCTAssertEqual(result, "zh-Hans")
     }
 
+    func test_detectLanguage_normalizesUppercaseHTMLLang() async throws {
+        mockLanguageSampleSource.htmlLangResult = "EN-US"
+        let subject = createSubject()
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "en")
+    }
+
     func test_detectLanguage_fallsBackToTextWhenHTMLLangMissing() async throws {
         mockLanguageSampleSource.htmlLangResult = nil
         mockLanguageSampleSource.mockResult = "Bonjour le monde"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/LanguageDetectorTests.swift
@@ -9,43 +9,55 @@ import XCTest
 final class LanguageDetectorTests: XCTestCase {
     var mockLanguageSampleSource = MockLanguageSampleSource()
 
-    // MARK: - HTML lang attribute
+    // MARK: - Signal reconciliation
 
-    func test_detectLanguage_prefersHTMLLangOverTextAnalysis() async throws {
+    func test_detectLanguage_whenTextIsConfident_overridesHTMLTag() async throws {
         mockLanguageSampleSource.htmlLangResult = "de"
         mockLanguageSampleSource.mockResult = "Hello world, this is clearly an English sentence."
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
-        XCTAssertEqual(result, "de")
-    }
-
-    func test_detectLanguage_normalizesHTMLLangWithRegion() async throws {
-        mockLanguageSampleSource.htmlLangResult = "en-US"
-        let subject = createSubject()
+        let subject = createSubject(confidenceThreshold: 0.5)
         let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "en")
     }
 
-    func test_detectLanguage_preservesScriptSubtag() async throws {
-        mockLanguageSampleSource.htmlLangResult = "zh-Hans-CN"
-        let subject = createSubject()
+    func test_detectLanguage_whenTextIsConfidentAndHTMLLangMissing_returnsText() async throws {
+        mockLanguageSampleSource.htmlLangResult = nil
+        mockLanguageSampleSource.mockResult = "Bonjour le monde, ceci est clairement une phrase française."
+        let subject = createSubject(confidenceThreshold: 0.5)
         let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
-        XCTAssertEqual(result, "zh-Hans")
+        XCTAssertEqual(result, "fr")
     }
+
+    func test_detectLanguage_whenTextIsNotConfident_fallsBackToHTMLTag() async throws {
+        mockLanguageSampleSource.htmlLangResult = "es"
+        mockLanguageSampleSource.mockResult = "Hello world"
+        let subject = createSubject(confidenceThreshold: 0.99)
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "es")
+    }
+
+    func test_detectLanguage_whenTextIsNotConfidentAndHTMLLangMissing_returnsNil() async throws {
+        mockLanguageSampleSource.htmlLangResult = nil
+        mockLanguageSampleSource.mockResult = "Hello world"
+        let subject = createSubject(confidenceThreshold: 0.99)
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertNil(result)
+    }
+
+    func test_detectLanguage_whenOnlyHTMLLangAvailable_returnsHTMLLang() async throws {
+        mockLanguageSampleSource.htmlLangResult = "es"
+        mockLanguageSampleSource.mockResult = nil
+        let subject = createSubject(confidenceThreshold: 0.5)
+        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
+        XCTAssertEqual(result, "es")
+    }
+
+    // MARK: - HTML lang attribute
 
     func test_detectLanguage_normalizesUppercaseHTMLLang() async throws {
         mockLanguageSampleSource.htmlLangResult = "EN-US"
         let subject = createSubject()
         let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
         XCTAssertEqual(result, "en")
-    }
-
-    func test_detectLanguage_fallsBackToTextWhenHTMLLangMissing() async throws {
-        mockLanguageSampleSource.htmlLangResult = nil
-        mockLanguageSampleSource.mockResult = "Bonjour le monde"
-        let subject = createSubject()
-        let result = try await subject.detectLanguage(from: mockLanguageSampleSource)
-        XCTAssertEqual(result, "fr")
     }
 
     func test_detectLanguage_ignoresEmptyHTMLLang() async throws {
@@ -155,7 +167,7 @@ final class LanguageDetectorTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func createSubject() -> LanguageDetector {
-        LanguageDetector()
+    private func createSubject(confidenceThreshold: Double = 0) -> LanguageDetector {
+        LanguageDetector(confidenceThreshold: confidenceThreshold)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockLanguageSampleSource.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockLanguageSampleSource.swift
@@ -8,11 +8,15 @@ import Foundation
 /// Test helper that simulates JS evaluation for language sample extraction.
 final class MockLanguageSampleSource: LanguageSampleSource, @unchecked Sendable {
     var mockResult: Any?
+    var htmlLangResult: String?
     var mockError: Error?
 
     @MainActor
     func getLanguageSample(scriptEvalExpression: String) async throws -> String? {
         if let error = mockError { throw error }
+        if scriptEvalExpression.contains("documentElement.lang") {
+            return htmlLangResult
+        }
         return mockResult as? String
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15891)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33971)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
`LanguageDetector` relied solely on Apple's `NLLanguageRecognizer` run over a text sample. Statistical detectors misidentify on ambiguous samples (code, markup, mixed-language), and a wrong guess makes the translate icon appear on pages already in the user's language, which then errors with "Couldn't translate page" on tap.

This reconciles two signals instead of trusting a raw detection:
- Extract both the `<html lang>` attribute and a text sample.
- Trust the text identification only when `NLLanguageRecognizer`'s own confidence is at or above `0.85`.
- Otherwise fall back to `<html lang>`; if neither is trustworthy, don't offer.

A confident text read overrides a mislabeled tag (e.g. a page tagged `en` that isn't English), and low-confidence results (typical of code, markup, or mixed-language samples) are dropped rather than acted on. The failure mode shifts toward "no offer" rather than a wrong offer.

Thanks @nordzilla for the Desktop context. Desktop uses an input-length threshold because CLD2's own confidence was unreliable on short text. Testing `NLLanguageRecognizer` showed the opposite for us: its confidence is strong on short clean text (~0.9+, even one-word CJK) and low on code/markup/mixed content, so we gate on the recognizer's confidence directly rather than borrowing a length threshold calibrated for a different model.

**Caveats / follow-ups:** `0.85` was chosen from a labelled local test set, not real traffic, so it's provisional until we have iOS telemetry to tune it. The one case confidence can't catch is genuinely mixed-language pages. Follow-ups: log the detected language at offer time so we can measure misidentification, and add Desktop's user-locale tiebreaker.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
