### PR TITLE
Bugfix FXIOS-15833 [Quick Answers] clear key between environments

### DIFF
--- a/BrowserKit/Sources/LLMKit/LiteLLMCreator.swift
+++ b/BrowserKit/Sources/LLMKit/LiteLLMCreator.swift
@@ -9,37 +9,28 @@ import MLPAKit
 public protocol LiteLLMCreating {
     func createAppAttestLiteLLM(
         using prefs: Prefs,
-        serviceType: MLPAServiceType,
-        bundleIdentifier: String
+        serviceType: MLPAServiceType
     ) -> LiteLLMClientProtocol?
-}
-
-public extension LiteLLMCreating {
-    func createAppAttestLiteLLM(
-        using prefs: Prefs,
-        serviceType: MLPAServiceType,
-        bundleIdentifier: String = AppInfo.bundleIdentifier
-    ) -> LiteLLMClientProtocol? {
-        createAppAttestLiteLLM(using: prefs, serviceType: serviceType, bundleIdentifier: bundleIdentifier)
-    }
 }
 
 public struct LiteLLMCreator: LiteLLMCreating {
     private let keyStore: AppAttestKeyIDStore
     private let appAttestService: AppAttestServiceProtocol
+    private let bundleIdentifier: String
 
     public init(
         keyStore: AppAttestKeyIDStore = KeychainAppAttestKeyIDStore(),
-        appAttestService: AppAttestServiceProtocol = DCAppAttestService.shared
+        appAttestService: AppAttestServiceProtocol = DCAppAttestService.shared,
+        bundleIdentifier: String = AppInfo.bundleIdentifier
     ) {
         self.keyStore = keyStore
         self.appAttestService = appAttestService
+        self.bundleIdentifier = bundleIdentifier
     }
 
     public func createAppAttestLiteLLM(
         using prefs: Prefs,
-        serviceType: MLPAServiceType,
-        bundleIdentifier: String
+        serviceType: MLPAServiceType
     ) -> LiteLLMClientProtocol? {
         let mlpaEnvironmentKey = prefs.stringForKey(PrefsKeys.MLPASettings.mlpaEndpointEnvironment) ?? ""
         let mlpaEnvironment = MLPAEnvironment(rawValue: mlpaEnvironmentKey) ?? .prod

--- a/BrowserKit/Sources/LLMKit/LiteLLMCreator.swift
+++ b/BrowserKit/Sources/LLMKit/LiteLLMCreator.swift
@@ -1,24 +1,80 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Common
+import DeviceCheck
 import Shared
 import MLPAKit
 
 public protocol LiteLLMCreating {
-    func createAppAttestLiteLLM(using prefs: Prefs, serviceType: MLPAServiceType) -> LiteLLMClientProtocol?
+    func createAppAttestLiteLLM(
+        using prefs: Prefs,
+        serviceType: MLPAServiceType,
+        bundleIdentifier: String
+    ) -> LiteLLMClientProtocol?
+}
+
+public extension LiteLLMCreating {
+    func createAppAttestLiteLLM(
+        using prefs: Prefs,
+        serviceType: MLPAServiceType,
+        bundleIdentifier: String = AppInfo.bundleIdentifier
+    ) -> LiteLLMClientProtocol? {
+        createAppAttestLiteLLM(using: prefs, serviceType: serviceType, bundleIdentifier: bundleIdentifier)
+    }
 }
 
 public struct LiteLLMCreator: LiteLLMCreating {
-    public init() { }
+    private let keyStore: AppAttestKeyIDStore
+    private let appAttestService: AppAttestServiceProtocol
 
-    public func createAppAttestLiteLLM(using prefs: Prefs, serviceType: MLPAServiceType) -> LiteLLMClientProtocol? {
+    public init(
+        keyStore: AppAttestKeyIDStore = KeychainAppAttestKeyIDStore(),
+        appAttestService: AppAttestServiceProtocol = DCAppAttestService.shared
+    ) {
+        self.keyStore = keyStore
+        self.appAttestService = appAttestService
+    }
+
+    public func createAppAttestLiteLLM(
+        using prefs: Prefs,
+        serviceType: MLPAServiceType,
+        bundleIdentifier: String
+    ) -> LiteLLMClientProtocol? {
         let mlpaEnvironmentKey = prefs.stringForKey(PrefsKeys.MLPASettings.mlpaEndpointEnvironment) ?? ""
         let mlpaEnvironment = MLPAEnvironment(rawValue: mlpaEnvironmentKey) ?? .prod
+
+        // Reset attestation key if environment has changed
+        resetKeyIfEnvironmentChanged(prefs: prefs, currentEnvironment: mlpaEnvironment)
+
         guard let endPoint = MLPAConstants.completionsEndpoint(with: mlpaEnvironment),
-              let client = try? AppAttestClient(remoteServer: MLPAAppAttestServer(with: mlpaEnvironment)) else {
+              let client = try? AppAttestClient(
+                appAttestService: appAttestService,
+                remoteServer: MLPAAppAttestServer(with: mlpaEnvironment, bundleIdentifier: bundleIdentifier),
+                keyStore: keyStore
+              ) else {
             return nil
         }
-        let authenticator = AppAttestRequestAuth(appAttestClient: client, serviceType: serviceType)
+        let authenticator = AppAttestRequestAuth(
+            appAttestClient: client,
+            bundleIdentifier: bundleIdentifier,
+            serviceType: serviceType
+        )
         return LiteLLMClient(authenticator: authenticator, baseURL: endPoint)
+    }
+
+    /// Resets the App Attest key if the MLPA environment has changed since last use.
+    ///
+    /// This ensures that when switching between environments (prod/staging/dev),
+    /// the app will re-attest with the correct server.
+    private func resetKeyIfEnvironmentChanged(prefs: Prefs, currentEnvironment: MLPAEnvironment) {
+        let lastUsedEnvironment = prefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment)
+        let currentEnvironmentValue = currentEnvironment.rawValue
+
+        if let lastUsedEnvironment, lastUsedEnvironment != currentEnvironmentValue {
+            try? keyStore.clearKeyID()
+        }
+
+        prefs.setString(currentEnvironmentValue, forKey: PrefsKeys.MLPASettings.lastUsedEnvironment)
     }
 }

--- a/BrowserKit/Sources/MLPAKit/AppAttestClient.swift
+++ b/BrowserKit/Sources/MLPAKit/AppAttestClient.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import CryptoKit
-import DeviceCheck
+import Foundation
 
 /// Manages the App Attest attestation and assertion flows.
 ///
@@ -22,7 +22,7 @@ public struct AppAttestClient: Sendable {
     private let remoteServer: AppAttestRemoteServerProtocol
     private let keyStore: AppAttestKeyIDStore
 
-    public init(appAttestService: AppAttestServiceProtocol = DCAppAttestService.shared,
+    public init(appAttestService: AppAttestServiceProtocol,
                 remoteServer: AppAttestRemoteServerProtocol,
                 keyStore: AppAttestKeyIDStore = KeychainAppAttestKeyIDStore()) throws {
         guard appAttestService.isSupported else {

--- a/BrowserKit/Sources/MLPAKit/AppAttestRequestAuth.swift
+++ b/BrowserKit/Sources/MLPAKit/AppAttestRequestAuth.swift
@@ -18,7 +18,7 @@ public struct AppAttestRequestAuth: RequestAuthProtocol {
 
     public init(
         appAttestClient: AppAttestClient,
-        bundleIdentifier: String = AppInfo.bundleIdentifier,
+        bundleIdentifier: String,
         serviceType: MLPAServiceType
     ) {
         self.appAttestClient = appAttestClient

--- a/BrowserKit/Sources/MLPAKit/MLPAAppAttestServer.swift
+++ b/BrowserKit/Sources/MLPAKit/MLPAAppAttestServer.swift
@@ -18,7 +18,7 @@ public struct MLPAAppAttestServer: AppAttestRemoteServerProtocol {
     public init(
         with type: MLPAEnvironment = .prod,
         urlSession: URLSessionProtocol = URLSession.shared,
-        bundleIdentifier: String = AppInfo.bundleIdentifier
+        bundleIdentifier: String
     ) {
         self.environmentType = type
         self.urlSession = urlSession

--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -154,6 +154,7 @@ public struct PrefsKeys {
 
     public struct MLPASettings {
         public static let mlpaEndpointEnvironment = "mlpaEndpointEnvironment"
+        public static let lastUsedEnvironment = "mlpaLastUsedEnvironment"
     }
 
     public struct UserFeatureFlagPrefs {

--- a/BrowserKit/Tests/LLMKitTests/LiteLLMCreatorTests.swift
+++ b/BrowserKit/Tests/LLMKitTests/LiteLLMCreatorTests.swift
@@ -33,8 +33,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with prod environment")
@@ -51,8 +50,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with dev environment")
@@ -69,8 +67,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with stage environment")
@@ -85,8 +82,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with default prod environment")
@@ -103,8 +99,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with default prod environment")
@@ -121,8 +116,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .s2s,
-            bundleIdentifier: "bundleId"
+            serviceType: .s2s
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with s2s service type")
@@ -138,8 +132,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
 
         XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when environment changes")
@@ -158,8 +151,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
 
         XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when environment changes from prod to stage")
@@ -179,8 +171,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
 
         XCTAssertEqual(
@@ -203,8 +194,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
 
         XCTAssertEqual(
@@ -229,18 +219,15 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
 
         XCTAssertEqual(
@@ -257,16 +244,14 @@ final class LiteLLMCreatorTests: XCTestCase {
         mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
         try mockKeyStore.saveKeyID(existingKeyID)
 
         mockPrefs.setString(MLPAEnvironment.dev.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
         XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when switching from prod to dev")
         try mockKeyStore.saveKeyID(existingKeyID)
@@ -274,13 +259,18 @@ final class LiteLLMCreatorTests: XCTestCase {
         mockPrefs.setString(MLPAEnvironment.stage.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers,
-            bundleIdentifier: "bundleId"
+            serviceType: .quickAnswers
         )
         XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when switching from dev to stage")
     }
 
     private func createSubject() -> LiteLLMCreator {
-        return LiteLLMCreator(keyStore: mockKeyStore, appAttestService: MockAppAttestService(isSupported: true))
+        return LiteLLMCreator(
+            keyStore: mockKeyStore,
+            appAttestService: MockAppAttestService(
+                isSupported: true
+            ),
+            bundleIdentifier: "testBundleId"
+        )
     }
 }

--- a/BrowserKit/Tests/LLMKitTests/LiteLLMCreatorTests.swift
+++ b/BrowserKit/Tests/LLMKitTests/LiteLLMCreatorTests.swift
@@ -1,0 +1,286 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import TestKit
+import MLPAKit
+import Shared
+
+@testable import LLMKit
+
+final class LiteLLMCreatorTests: XCTestCase {
+    private var mockKeyStore: MockAppAttestKeyIDStore!
+    private var mockPrefs: MockProfilePrefs!
+
+    override func setUp() {
+        super.setUp()
+        mockKeyStore = MockAppAttestKeyIDStore()
+        mockPrefs = MockProfilePrefs()
+    }
+
+    override func tearDown() {
+        mockKeyStore = nil
+        mockPrefs = nil
+        super.tearDown()
+    }
+
+    // MARK: - Successful Creation Tests
+
+    func testCreateAppAttestLiteLLM_withProdEnvironment_returnsClient() {
+        mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+
+        let subject = createSubject()
+        let result = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertNotNil(result, "Should create LiteLLM client with prod environment, instead got \(result)")
+        XCTAssertEqual(
+            mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
+            MLPAEnvironment.prod.rawValue,
+            "Should store the last used environment"
+        )
+    }
+
+    func testCreateAppAttestLiteLLM_withDevEnvironment_returnsClient() {
+        mockPrefs.setString(MLPAEnvironment.dev.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+
+        let subject = createSubject()
+        let result = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertNotNil(result, "Should create LiteLLM client with dev environment, instead got \(result)")
+        XCTAssertEqual(
+            mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
+            MLPAEnvironment.dev.rawValue,
+            "Should store the last used environment"
+        )
+    }
+
+    func testCreateAppAttestLiteLLM_withStageEnvironment_returnsClient() {
+        mockPrefs.setString(MLPAEnvironment.stage.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+
+        let subject = createSubject()
+        let result = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertNotNil(result, "Should create LiteLLM client with stage environment, instead got \(result)")
+        XCTAssertEqual(
+            mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
+            MLPAEnvironment.stage.rawValue,
+            "Should store the last used environment"
+        )
+    }
+
+    func testCreateAppAttestLiteLLM_withNoEnvironmentSet_defaultsToProdAndReturnsClient() {
+        let subject = createSubject()
+        let result = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertNotNil(result, "Should create LiteLLM client with default prod environment, instead got \(result)")
+        XCTAssertEqual(
+            mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
+            MLPAEnvironment.prod.rawValue,
+            "Should default to prod environment and store it"
+        )
+    }
+
+    func testCreateAppAttestLiteLLM_withInvalidEnvironment_defaultsToProdAndReturnsClient() {
+        mockPrefs.setString("invalid-environment", forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+
+        let subject = createSubject()
+        let result = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertNotNil(result, "Should create LiteLLM client with default prod environment, instead got \(result)")
+        XCTAssertEqual(
+            mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
+            MLPAEnvironment.prod.rawValue,
+            "Should default to prod environment when invalid value is provided"
+        )
+    }
+
+    func testCreateAppAttestLiteLLM_withS2SServiceType_returnsClient() {
+        mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+
+        let subject = createSubject()
+        let result = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .s2s,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertNotNil(result, "Should create LiteLLM client with s2s service type, instead got \(result)")
+    }
+
+    // MARK: - Environment Change Tests
+
+    func testCreateAppAttestLiteLLM_whenEnvironmentChanges_clearsKey() throws {
+        mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+        mockPrefs.setString(MLPAEnvironment.dev.rawValue, forKey: PrefsKeys.MLPASettings.lastUsedEnvironment)
+        try mockKeyStore.saveKeyID("existing-key-id")
+
+        let subject = createSubject()
+        _ = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when environment changes")
+        XCTAssertEqual(
+            mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
+            MLPAEnvironment.prod.rawValue,
+            "Should update last used environment"
+        )
+    }
+
+    func testCreateAppAttestLiteLLM_whenEnvironmentChangesProdToStage_clearsKey() throws {
+        mockPrefs.setString(MLPAEnvironment.stage.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+        mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.lastUsedEnvironment)
+        try mockKeyStore.saveKeyID("existing-key-id")
+
+        let subject = createSubject()
+        _ = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when environment changes from prod to stage")
+        XCTAssertEqual(
+            mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
+            MLPAEnvironment.stage.rawValue,
+            "Should update last used environment"
+        )
+    }
+
+    func testCreateAppAttestLiteLLM_whenEnvironmentSameAsPrevious_doesNotClearKey() throws {
+        mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+        mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.lastUsedEnvironment)
+        let existingKeyID = "existing-key-id"
+        try mockKeyStore.saveKeyID(existingKeyID)
+
+        let subject = createSubject()
+        _ = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertEqual(
+            mockKeyStore.loadKeyID(),
+            existingKeyID,
+            "Should not clear key when environment remains the same"
+        )
+        XCTAssertEqual(
+            mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
+            MLPAEnvironment.prod.rawValue,
+            "Should keep last used environment"
+        )
+    }
+
+    func testCreateAppAttestLiteLLM_whenNoLastUsedEnvironment_doesNotClearKey() throws {
+        mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+        let existingKeyID = "existing-key-id"
+        try mockKeyStore.saveKeyID(existingKeyID)
+
+        let subject = createSubject()
+        _ = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertEqual(
+            mockKeyStore.loadKeyID(),
+            existingKeyID,
+            "Should not clear key when no last used environment exists"
+        )
+        XCTAssertEqual(
+            mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
+            MLPAEnvironment.prod.rawValue,
+            "Should set last used environment"
+        )
+    }
+
+    // MARK: - Edge Cases
+
+    func testCreateAppAttestLiteLLM_multipleCallsSameEnvironment_doesNotClearKeyMultipleTimes() throws {
+        mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+        let existingKeyID = "existing-key-id"
+        try mockKeyStore.saveKeyID(existingKeyID)
+
+        let subject = createSubject()
+        _ = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+        _ = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+        _ = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+
+        XCTAssertEqual(
+            mockKeyStore.loadKeyID(),
+            existingKeyID,
+            "Should not clear key on multiple calls with same environment"
+        )
+    }
+
+    func testCreateAppAttestLiteLLM_multipleCallsDifferentEnvironments_clearsKeyEachTime() throws {
+        let existingKeyID = "existing-key-id"
+        let subject = createSubject()
+
+        mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+        _ = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+        try mockKeyStore.saveKeyID(existingKeyID)
+
+        mockPrefs.setString(MLPAEnvironment.dev.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+        _ = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+        XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when switching from prod to dev")
+        try mockKeyStore.saveKeyID(existingKeyID)
+
+        mockPrefs.setString(MLPAEnvironment.stage.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
+        _ = subject.createAppAttestLiteLLM(
+            using: mockPrefs,
+            serviceType: .quickAnswers,
+            bundleIdentifier: "bundleId"
+        )
+        XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when switching from dev to stage")
+    }
+
+    private func createSubject() -> LiteLLMCreator {
+        return LiteLLMCreator(keyStore: mockKeyStore, appAttestService: MockAppAttestService(isSupported: true))
+    }
+}

--- a/BrowserKit/Tests/LLMKitTests/LiteLLMCreatorTests.swift
+++ b/BrowserKit/Tests/LLMKitTests/LiteLLMCreatorTests.swift
@@ -37,7 +37,7 @@ final class LiteLLMCreatorTests: XCTestCase {
             bundleIdentifier: "bundleId"
         )
 
-        XCTAssertNotNil(result, "Should create LiteLLM client with prod environment, instead got \(result)")
+        XCTAssertNotNil(result, "Should create LiteLLM client with prod environment")
         XCTAssertEqual(
             mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
             MLPAEnvironment.prod.rawValue,
@@ -55,7 +55,7 @@ final class LiteLLMCreatorTests: XCTestCase {
             bundleIdentifier: "bundleId"
         )
 
-        XCTAssertNotNil(result, "Should create LiteLLM client with dev environment, instead got \(result)")
+        XCTAssertNotNil(result, "Should create LiteLLM client with dev environment")
         XCTAssertEqual(
             mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
             MLPAEnvironment.dev.rawValue,
@@ -73,7 +73,7 @@ final class LiteLLMCreatorTests: XCTestCase {
             bundleIdentifier: "bundleId"
         )
 
-        XCTAssertNotNil(result, "Should create LiteLLM client with stage environment, instead got \(result)")
+        XCTAssertNotNil(result, "Should create LiteLLM client with stage environment")
         XCTAssertEqual(
             mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
             MLPAEnvironment.stage.rawValue,
@@ -89,7 +89,7 @@ final class LiteLLMCreatorTests: XCTestCase {
             bundleIdentifier: "bundleId"
         )
 
-        XCTAssertNotNil(result, "Should create LiteLLM client with default prod environment, instead got \(result)")
+        XCTAssertNotNil(result, "Should create LiteLLM client with default prod environment")
         XCTAssertEqual(
             mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
             MLPAEnvironment.prod.rawValue,
@@ -107,7 +107,7 @@ final class LiteLLMCreatorTests: XCTestCase {
             bundleIdentifier: "bundleId"
         )
 
-        XCTAssertNotNil(result, "Should create LiteLLM client with default prod environment, instead got \(result)")
+        XCTAssertNotNil(result, "Should create LiteLLM client with default prod environment")
         XCTAssertEqual(
             mockPrefs.stringForKey(PrefsKeys.MLPASettings.lastUsedEnvironment),
             MLPAEnvironment.prod.rawValue,
@@ -125,7 +125,7 @@ final class LiteLLMCreatorTests: XCTestCase {
             bundleIdentifier: "bundleId"
         )
 
-        XCTAssertNotNil(result, "Should create LiteLLM client with s2s service type, instead got \(result)")
+        XCTAssertNotNil(result, "Should create LiteLLM client with s2s service type")
     }
 
     // MARK: - Environment Change Tests

--- a/BrowserKit/Tests/LLMKitTests/Mocks/MockAppAttestKeyIDStore.swift
+++ b/BrowserKit/Tests/LLMKitTests/Mocks/MockAppAttestKeyIDStore.swift
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MLPAKit
+import Foundation
+
+// TODO: FXIOS-15199 Want to consolidate our mocks
+
+/// Concrete implementation of `AppAttestKeyIDStore` that keeps the `keyID` in memory.
+/// This is only used for testing since the keychain implementation is not easily testable
+/// and might fail sometimes on non-signed builds on CI.
+final class MockAppAttestKeyIDStore: AppAttestKeyIDStore, @unchecked Sendable {
+    private var value: String?
+
+    init(initial: String? = nil) {
+        self.value = initial
+    }
+
+    func loadKeyID() -> String? {
+        return value
+    }
+
+    func saveKeyID(_ keyID: String) throws {
+        value = keyID
+    }
+
+    func clearKeyID() throws {
+        value = nil
+    }
+}
+
+final class MockAppAttestService: AppAttestServiceProtocol, @unchecked Sendable {
+    let isSupported: Bool
+    var keyToReturn = "mock-key-id"
+    var attestationToReturn = Data()
+    var assertionToReturn = Data()
+
+    init(isSupported: Bool) {
+        self.isSupported = isSupported
+    }
+
+    func generateKey() async throws -> String {
+        return keyToReturn
+    }
+
+    func attestKey(_ keyId: String, clientDataHash: Data) async throws -> Data {
+        return attestationToReturn
+    }
+    func generateAssertion(_ keyId: String, clientDataHash: Data) async throws -> Data {
+        return assertionToReturn
+    }
+}

--- a/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockLLMClientCreator.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockLLMClientCreator.swift
@@ -12,7 +12,10 @@ final class MockLLMClientCreator: LiteLLMCreating {
     var shouldReturnNil = false
     var createAppAttestLiteLLMCallCount = 0
 
-    func createAppAttestLiteLLM(using prefs: Prefs, serviceType: MLPAServiceType) -> LiteLLMClientProtocol? {
+    func createAppAttestLiteLLM(
+        using prefs: Prefs,
+        serviceType: MLPAServiceType
+    ) -> LiteLLMClientProtocol? {
         createAppAttestLiteLLMCallCount += 1
         return shouldReturnNil ? nil : clientToReturn
     }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeMLPAEndpointSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeMLPAEndpointSetting.swift
@@ -22,6 +22,8 @@ final class ChangeMLPAEndpointSetting: HiddenSetting {
         let currentEnvRaw = prefs.stringForKey(prefsKey) ?? MLPAEnvironment.prod.rawValue
         let message = """
         Current: \(currentEnvRaw.capitalized)
+
+        Note: App Attest key should automatically clear when switching environments.
         """
         let alert = UIAlertController(title: "MLPA Endpoint",
                                       message: message,
@@ -39,6 +41,7 @@ final class ChangeMLPAEndpointSetting: HiddenSetting {
             guard let self else { return }
             self.prefs.setString(MLPAEnvironment.dev.rawValue, forKey: self.prefsKey)
         }))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
         settings.present(alert, animated: true)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15833)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33868)

## :bulb: Description
**Context**
For Quick Answers, we added a debug setting to toggle between different MLPA endpoints. Before we were only using Prod endpoint for S2S, but for quick answers Prod is not ready so we were using Dev. 

However,  the dev environment stopped working and was mentioned from AI team that we should be using stage instead. It seems that switching to stage does not show the expected responses. This is because we were not resetting the key between endpoint changes. This PR adds code to support switching between MLPA endpoints and automatically clear the app attest key. Staging works if the user sets the endpoint to stage before we create the key, but we were having issues with authentication when switching from prod to stage.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

