### PR TITLE
[MTE-5326] - fix for jump back in failures on iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
@@ -125,12 +125,6 @@ final class TabTrayScreen {
         tabCell.waitAndTap()
     }
 
-    func switchToPrivateBrowsing() {
-        let privateModeButton = sel.tabSelectorButton(at: 0).element(in: app)
-        BaseTestCase().mozWaitForElementToExist(privateModeButton)
-        privateModeButton.waitAndTap()
-    }
-
     func assertTabButtonEnabled(at index: Int) {
         let tabButton = sel.tabSelectorButton(at: index).element(in: app)
         BaseTestCase().mozWaitForElementToExist(tabButton)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5326

## :bulb: Description
Removed the extra switchToPrivateBrowsing() from TabTrayScreen that caused the jump back in tests to fail on iPad.
There is a new switchToPrivateBrowsing function added with the conversion to TAE task that handles iPad also.
The tests were calling the old function, so removing it will allow the test to go through the right function.