### PR TITLE
Add FXIOS-15905 [webcompat] Add *.mozilla.org to the list of desktop UA exclusions

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -128,6 +128,8 @@ struct CustomUserAgentConstant {
     static let customDesktopUAForDomain = [
         // FXIOS-10251: Do not appear as desktop/Safari for firefox.com/pair
         "firefox.com": defaultMobileUA,
+        // FXIOS-15905: Do not identify as (desktop) Safari on addons.m.o, bugzilla.m.o, support.m.o for correct info
+        "mozilla.org": defaultMobileUA,
         // TODO: FXIOS-15483 [webcompat] Docusign forms broken using desktop UA
         "docusign.com": defaultMobileUA,
         "docusign.net": defaultMobileUA


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket FXIOS-15905
GitHub issue #33996

## :bulb: Description

Do not identify as (desktop) Safari on addons.m.o, bugzilla.m.o, support.m.o for correct info

<!--- 
## :movie_camera: Demos

| Before | After |
| - | - |

<details>
<summary>Demo</summary>
</details>
-->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code