### PR TITLE
Bugfix FXIOS-15648 ⁃ Tapping on tabs is weirdly unresponsive

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTitleSupplementaryView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTitleSupplementaryView.swift
@@ -36,6 +36,8 @@ final class TabTitleSupplementaryView: UICollectionReusableView, ThemeApplicable
     override init(frame: CGRect) {
         super.init(frame: frame)
 
+        self.isUserInteractionEnabled = false
+
         addSubview(footerView)
         footerView.addArrangedSubview(faviconContainer)
         footerView.addArrangedSubview(titleText)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTitleSupplementaryView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTitleSupplementaryView.swift
@@ -35,8 +35,7 @@ final class TabTitleSupplementaryView: UICollectionReusableView, ThemeApplicable
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-
-        self.isUserInteractionEnabled = false
+        isUserInteractionEnabled = false
 
         addSubview(footerView)
         footerView.addArrangedSubview(faviconContainer)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15648)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33520)

## :bulb: Description
Setting to false isUserInteractionEnabled, for TabTitleSupplementaryView

## :movie_camera: Demos

https://github.com/user-attachments/assets/57bf46ad-1ab0-4087-9c41-da4f65466227




| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

