### PR TITLE
BugFix [World Cup] kit gif resizing incorrectly

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
@@ -15,7 +15,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
         static let timerHorizontalPadding: CGFloat = 64
         static let timerSegmentSpacing: CGFloat = 8.0
         static let actionButtonSize = CGSize(width: 24, height: 24)
-        static let heroImageWidth: CGFloat = 160
+        static let heroImageWidth: CGFloat = 80.0
         static let heroImageHeight: CGFloat = 140.0
         static let heroImageTrailingPadding: CGFloat = 12.0
         static let heroGifName = "kitHeroGif"
@@ -165,7 +165,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
                 equalTo: actionButton.leadingAnchor,
                 constant: -UX.heroImageTrailingPadding
             ),
-            heroImageView.widthAnchor.constraint(lessThanOrEqualToConstant: UX.heroImageWidth),
+            heroImageView.widthAnchor.constraint(equalToConstant: UX.heroImageWidth),
             heroImageView.heightAnchor.constraint(lessThanOrEqualToConstant: UX.heroImageHeight),
             heroImageView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
             heroImageView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15719)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33633)

## :bulb: Description
BugFix kit gif resizing incorrectly

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

