### PR TITLE
Bugfix FXIOS-14384 Resolve conflicting keyboard shortcut between in app settings and system settings

### DIFF
--- a/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
+++ b/firefox-ios/Client/Helpers/MenuBuilderHelper.swift
@@ -32,7 +32,7 @@ class MenuBuilderHelper {
                     title: .AppSettingsTitle,
                     action: #selector(BrowserViewController.openSettingsKeyCommand),
                     input: ",",
-                    modifierFlags: .command,
+                    modifierFlags: [.command, .alternate],
                     discoverabilityTitle: .AppSettingsTitle
                 )
             ]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14384)
No directly linked github issue

## :bulb: Description
The shortcut ⌘ + , was registered twice, causing a conflict. One registration was used by the app to open in app settings, while the other was reserved by iOS to open system settings. This was resolved by changing the in app settings shortcut to ⌘ + ⌥ + ,, eliminating the conflict. It is also worth noting that, prior to this change, ⌘ + , already opened iOS settings because the system handled the shortcut before the app could receive it. As a result, user facing behavior for ⌘ + , remains unchanged.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

