### PR TITLE
Update CloseButton to 44pt and add iOS 26 glass styling

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -350,9 +350,7 @@ public class BottomSheetViewController: UIViewController,
     // MARK: - BottomSheetDismissProtocol
 
     public func getBottomSheetHeaderHeight() -> CGFloat {
-        // this is a little work around to have `BottomSheetChild` being able to adjust for dynamic font size change
-        // since modifying the constraints is going to break the UI of other bottom sheet child.
-        return closeButton.dynamicSize.height
+        return closeButton.buttonSize.height
     }
 
     public func dismissSheetViewController(completion: (() -> Void)? = nil) {

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
@@ -54,6 +54,13 @@ public class CloseButton: UIButton,
         updateButtonSizeForDynamicFont()
     }
 
+    public func applyTheme(tintColor: UIColor) {
+        self.tintColor = tintColor
+        if #available(iOS 26.0, *) {
+            configuration?.baseForegroundColor = tintColor
+        }
+    }
+
     public func configure(viewModel: CloseButtonViewModel,
                           notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.notificationCenter = notificationCenter

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
@@ -5,25 +5,15 @@
 import Common
 import UIKit
 
-public class CloseButton: UIButton,
-                          Notifiable {
-    public var notificationCenter: any NotificationProtocol = NotificationCenter.default
-
+public class CloseButton: UIButton, ThemeApplicable {
     private var viewModel: CloseButtonViewModel?
-    private var heightConstraint: NSLayoutConstraint?
-    private var widthConstraint: NSLayoutConstraint?
-    /// Returns the updated size of the button scaled with the current dynamic font size
-    var dynamicSize: CGSize {
-        updateButtonSizeForDynamicFont()
-        return CGSize(width: widthConstraint?.constant ?? UX.closeButtonSize.width,
-                      height: heightConstraint?.constant ?? UX.closeButtonSize.height)
-    }
+
+    var buttonSize: CGSize { UX.closeButtonSize }
 
     private struct UX {
         static let closeButtonSize = CGSize(width: 44, height: 44)
-        static let maxCloseButtonSize = CGSize(width: 44, height: 44)
         static let legacyCrossCircleImage = StandardImageIdentifiers.ExtraLarge.crossCircleFill
-        static let glassCrossImage = StandardImageIdentifiers.Medium.cross
+        static let glassCrossImage = StandardImageIdentifiers.Large.cross
     }
 
     override init(frame: CGRect) {
@@ -47,53 +37,25 @@ public class CloseButton: UIButton,
 
     private func setupConstraints() {
         translatesAutoresizingMaskIntoConstraints = false
-        heightConstraint = heightAnchor.constraint(equalToConstant: UX.closeButtonSize.height)
-        heightConstraint?.isActive = true
-        widthConstraint = widthAnchor.constraint(equalToConstant: UX.closeButtonSize.width)
-        widthConstraint?.isActive = true
-        updateButtonSizeForDynamicFont()
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: UX.closeButtonSize.height),
+            widthAnchor.constraint(equalToConstant: UX.closeButtonSize.width)
+        ])
     }
 
-    public func applyTheme(tintColor: UIColor) {
-        self.tintColor = tintColor
-        if #available(iOS 26.0, *) {
-            configuration?.baseForegroundColor = tintColor
-        }
-    }
-
-    public func configure(viewModel: CloseButtonViewModel,
-                          notificationCenter: NotificationProtocol = NotificationCenter.default) {
-        self.notificationCenter = notificationCenter
-        startObservingNotifications(
-            withNotificationCenter: notificationCenter,
-            forObserver: self,
-            observing: [UIContentSizeCategory.didChangeNotification]
-        )
-
+    public func configure(viewModel: CloseButtonViewModel) {
         self.viewModel = viewModel
         accessibilityIdentifier = viewModel.a11yIdentifier
         accessibilityLabel = viewModel.a11yLabel
     }
 
-    private func updateButtonSizeForDynamicFont() {
-        let scaledWidth = UIFontMetrics.default.scaledValue(for: UX.closeButtonSize.width)
-        let scaledHeight = UIFontMetrics.default.scaledValue(for: UX.closeButtonSize.height)
-        let dynamicWidth = min(max(scaledWidth, UX.closeButtonSize.width), UX.maxCloseButtonSize.width)
-        let dynamicHeight = min(max(scaledHeight, UX.closeButtonSize.height), UX.maxCloseButtonSize.height)
-        heightConstraint?.constant = dynamicHeight
-        widthConstraint?.constant = dynamicWidth
-    }
+    // MARK: - ThemeApplicable
 
-    // MARK: - Notifiable
-
-    public func handleNotifications(_ notification: Notification) {
-        switch notification.name {
-        case UIContentSizeCategory.didChangeNotification:
-            ensureMainThread {
-                self.updateButtonSizeForDynamicFont()
-            }
-        default:
-            break
+    public func applyTheme(theme: Theme) {
+        let tintColor = theme.colors.iconSecondary
+        self.tintColor = tintColor
+        if #available(iOS 26.0, *) {
+            configuration?.baseForegroundColor = tintColor
         }
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
@@ -32,7 +32,6 @@ public class CloseButton: UIButton,
         adjustsImageSizeForAccessibilityContentSizeCategory = true
         setupConstraints()
 
-        #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
             var glassConfiguration = UIButton.Configuration.glass()
             glassConfiguration.image = UIImage(named: UX.glassCrossImage)?.withRenderingMode(.alwaysTemplate)
@@ -40,9 +39,6 @@ public class CloseButton: UIButton,
         } else {
             setImage(UIImage(named: UX.legacyCrossCircleImage), for: .normal)
         }
-        #else
-        setImage(UIImage(named: UX.legacyCrossCircleImage), for: .normal)
-        #endif
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
@@ -20,22 +20,28 @@ public class CloseButton: UIButton,
     }
 
     private struct UX {
-        static let closeButtonSize = CGSize(width: 30, height: 30)
+        static let closeButtonSize = CGSize(width: 44, height: 44)
         static let maxCloseButtonSize = CGSize(width: 44, height: 44)
-        static let crossCircleImage = StandardImageIdentifiers.ExtraLarge.crossCircleFill
+        static let legacyCrossCircleImage = StandardImageIdentifiers.ExtraLarge.crossCircleFill
+        static let glassCrossImage = StandardImageIdentifiers.Medium.cross
     }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        setImage(UIImage(named: UX.crossCircleImage), for: .normal)
         adjustsImageSizeForAccessibilityContentSizeCategory = true
         setupConstraints()
 
         #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
-            configuration = .glass()
+            var glassConfiguration = UIButton.Configuration.glass()
+            glassConfiguration.image = UIImage(named: UX.glassCrossImage)?.withRenderingMode(.alwaysTemplate)
+            configuration = glassConfiguration
+        } else {
+            setImage(UIImage(named: UX.legacyCrossCircleImage), for: .normal)
         }
+        #else
+        setImage(UIImage(named: UX.legacyCrossCircleImage), for: .normal)
         #endif
     }
 

--- a/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
@@ -18,7 +18,7 @@ public final class HeaderView: UIView, ThemeApplicable {
         static let horizontalMargin: CGFloat = 16
         static let headerLabelDistance: CGFloat = 2
         static let separatorHeight: CGFloat = 1
-        static let closeButtonSize: CGFloat = 30
+        static let closeButtonSize: CGFloat = 44
         static let warningIconSize: CGFloat = 24
     }
 
@@ -264,13 +264,23 @@ public final class HeaderView: UIView, ThemeApplicable {
     }
 
     public func applyTheme(theme: Theme) {
-        let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
-            .withTintColor(theme.colors.iconSecondary)
         subtitleLabel.textColor = theme.colors.textSecondary
         titleLabel.textColor = theme.colors.textPrimary
         self.tintColor = theme.colors.layer2
+        closeButton.tintColor = theme.colors.iconSecondary
+        #if canImport(FoundationModels)
+        if #unavailable(iOS 26.0) {
+            let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
+                .withTintColor(theme.colors.iconSecondary)
+            closeButton.setImage(buttonImage, for: .normal)
+            closeButton.backgroundColor = theme.colors.layer2
+        }
+        #else
+        let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
+            .withTintColor(theme.colors.iconSecondary)
         closeButton.setImage(buttonImage, for: .normal)
         closeButton.backgroundColor = theme.colors.layer2
+        #endif
         horizontalLine.backgroundColor = theme.colors.borderPrimary
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
@@ -267,7 +267,7 @@ public final class HeaderView: UIView, ThemeApplicable {
         subtitleLabel.textColor = theme.colors.textSecondary
         titleLabel.textColor = theme.colors.textPrimary
         self.tintColor = theme.colors.layer2
-        closeButton.tintColor = theme.colors.iconSecondary
+        closeButton.applyTheme(tintColor: theme.colors.iconSecondary)
         if #unavailable(iOS 26.0) {
             let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
                 .withTintColor(theme.colors.iconSecondary)

--- a/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
@@ -268,19 +268,12 @@ public final class HeaderView: UIView, ThemeApplicable {
         titleLabel.textColor = theme.colors.textPrimary
         self.tintColor = theme.colors.layer2
         closeButton.tintColor = theme.colors.iconSecondary
-        #if canImport(FoundationModels)
         if #unavailable(iOS 26.0) {
             let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
                 .withTintColor(theme.colors.iconSecondary)
             closeButton.setImage(buttonImage, for: .normal)
             closeButton.backgroundColor = theme.colors.layer2
         }
-        #else
-        let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
-            .withTintColor(theme.colors.iconSecondary)
-        closeButton.setImage(buttonImage, for: .normal)
-        closeButton.backgroundColor = theme.colors.layer2
-        #endif
         horizontalLine.backgroundColor = theme.colors.borderPrimary
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
@@ -267,7 +267,7 @@ public final class HeaderView: UIView, ThemeApplicable {
         subtitleLabel.textColor = theme.colors.textSecondary
         titleLabel.textColor = theme.colors.textPrimary
         self.tintColor = theme.colors.layer2
-        closeButton.applyTheme(tintColor: theme.colors.iconSecondary)
+        closeButton.applyTheme(theme: theme)
         if #unavailable(iOS 26.0) {
             let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
                 .withTintColor(theme.colors.iconSecondary)

--- a/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
@@ -142,7 +142,7 @@ public final class NavigationHeaderView: UIView {
 
     // MARK: ThemeApplicable
     public func applyTheme(theme: Theme) {
-        closeButton.tintColor = theme.colors.iconSecondary
+        closeButton.applyTheme(tintColor: theme.colors.iconSecondary)
         if #unavailable(iOS 26.0) {
             let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
                 .withTintColor(theme.colors.iconSecondary)

--- a/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
@@ -142,7 +142,7 @@ public final class NavigationHeaderView: UIView {
 
     // MARK: ThemeApplicable
     public func applyTheme(theme: Theme) {
-        closeButton.applyTheme(tintColor: theme.colors.iconSecondary)
+        closeButton.applyTheme(theme: theme)
         if #unavailable(iOS 26.0) {
             let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
                 .withTintColor(theme.colors.iconSecondary)

--- a/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
@@ -143,19 +143,12 @@ public final class NavigationHeaderView: UIView {
     // MARK: ThemeApplicable
     public func applyTheme(theme: Theme) {
         closeButton.tintColor = theme.colors.iconSecondary
-        #if canImport(FoundationModels)
         if #unavailable(iOS 26.0) {
             let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
                 .withTintColor(theme.colors.iconSecondary)
             closeButton.setImage(buttonImage, for: .normal)
             closeButton.backgroundColor = theme.colors.layer2
         }
-        #else
-        let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
-            .withTintColor(theme.colors.iconSecondary)
-        closeButton.setImage(buttonImage, for: .normal)
-        closeButton.backgroundColor = theme.colors.layer2
-        #endif
         backButton.tintColor = theme.colors.iconAccent
         backButton.setTitleColor(theme.colors.textAccent, for: .normal)
         horizontalLine.backgroundColor = theme.colors.borderPrimary

--- a/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
@@ -7,7 +7,7 @@ import Common
 
 public final class NavigationHeaderView: UIView {
     private struct UX {
-        static let closeButtonSize: CGFloat = 30
+        static let closeButtonSize: CGFloat = 44
         static let imageMargins: CGFloat = 10
         static let baseDistance: CGFloat = 21
         static let horizontalMargin: CGFloat = 16
@@ -142,10 +142,20 @@ public final class NavigationHeaderView: UIView {
 
     // MARK: ThemeApplicable
     public func applyTheme(theme: Theme) {
+        closeButton.tintColor = theme.colors.iconSecondary
+        #if canImport(FoundationModels)
+        if #unavailable(iOS 26.0) {
+            let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
+                .withTintColor(theme.colors.iconSecondary)
+            closeButton.setImage(buttonImage, for: .normal)
+            closeButton.backgroundColor = theme.colors.layer2
+        }
+        #else
         let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
             .withTintColor(theme.colors.iconSecondary)
         closeButton.setImage(buttonImage, for: .normal)
         closeButton.backgroundColor = theme.colors.layer2
+        #endif
         backButton.tintColor = theme.colors.iconAccent
         backButton.setTitleColor(theme.colors.textAccent, for: .normal)
         horizontalLine.backgroundColor = theme.colors.borderPrimary

--- a/BrowserKit/Sources/MenuKit/HeaderBanner.swift
+++ b/BrowserKit/Sources/MenuKit/HeaderBanner.swift
@@ -150,7 +150,7 @@ public final class HeaderBanner: UIView, ThemeApplicable {
         headerLabelsContainer.backgroundColor = .clear
         titleLabel.textColor = theme.colors.textPrimary
         subtitleLabel.textColor = theme.colors.textSecondary
-        closeButton.tintColor = theme.colors.iconSecondary
+        closeButton.applyTheme(tintColor: theme.colors.iconSecondary)
         if #unavailable(iOS 26.0) {
             closeButton.backgroundColor = .clear
         }

--- a/BrowserKit/Sources/MenuKit/HeaderBanner.swift
+++ b/BrowserKit/Sources/MenuKit/HeaderBanner.swift
@@ -13,7 +13,7 @@ public final class HeaderBanner: UIView, ThemeApplicable {
         static let horizontalMargin: CGFloat = 16
         static let verticalMargin: CGFloat = 2
         static let cornerRadius: CGFloat = 16
-        static let closeButtonSize: CGFloat = 20
+        static let closeButtonSize: CGFloat = 44
         static let closeButtonHorizontalMargin: CGFloat = 12
         static let closeButtonVerticalMargin: CGFloat = 8
         static let foxImageHeight: CGFloat = 53
@@ -64,7 +64,13 @@ public final class HeaderBanner: UIView, ThemeApplicable {
 
     private lazy var closeButton: CloseButton = .build { button in
         button.addTarget(self, action: #selector(self.closeButtonTapped), for: .touchUpInside)
+        #if canImport(FoundationModels)
+        if #unavailable(iOS 26.0) {
+            button.setImage(UIImage(named: UX.crossLarge)?.withRenderingMode(.alwaysTemplate), for: .normal)
+        }
+        #else
         button.setImage(UIImage(named: UX.crossLarge)?.withRenderingMode(.alwaysTemplate), for: .normal)
+        #endif
     }
 
     init() {
@@ -149,6 +155,12 @@ public final class HeaderBanner: UIView, ThemeApplicable {
         titleLabel.textColor = theme.colors.textPrimary
         subtitleLabel.textColor = theme.colors.textSecondary
         closeButton.tintColor = theme.colors.iconSecondary
+        #if canImport(FoundationModels)
+        if #unavailable(iOS 26.0) {
+            closeButton.backgroundColor = .clear
+        }
+        #else
         closeButton.backgroundColor = .clear
+        #endif
     }
 }

--- a/BrowserKit/Sources/MenuKit/HeaderBanner.swift
+++ b/BrowserKit/Sources/MenuKit/HeaderBanner.swift
@@ -64,13 +64,9 @@ public final class HeaderBanner: UIView, ThemeApplicable {
 
     private lazy var closeButton: CloseButton = .build { button in
         button.addTarget(self, action: #selector(self.closeButtonTapped), for: .touchUpInside)
-        #if canImport(FoundationModels)
         if #unavailable(iOS 26.0) {
             button.setImage(UIImage(named: UX.crossLarge)?.withRenderingMode(.alwaysTemplate), for: .normal)
         }
-        #else
-        button.setImage(UIImage(named: UX.crossLarge)?.withRenderingMode(.alwaysTemplate), for: .normal)
-        #endif
     }
 
     init() {
@@ -155,12 +151,8 @@ public final class HeaderBanner: UIView, ThemeApplicable {
         titleLabel.textColor = theme.colors.textPrimary
         subtitleLabel.textColor = theme.colors.textSecondary
         closeButton.tintColor = theme.colors.iconSecondary
-        #if canImport(FoundationModels)
         if #unavailable(iOS 26.0) {
             closeButton.backgroundColor = .clear
         }
-        #else
-        closeButton.backgroundColor = .clear
-        #endif
     }
 }

--- a/BrowserKit/Sources/MenuKit/HeaderBanner.swift
+++ b/BrowserKit/Sources/MenuKit/HeaderBanner.swift
@@ -150,7 +150,7 @@ public final class HeaderBanner: UIView, ThemeApplicable {
         headerLabelsContainer.backgroundColor = .clear
         titleLabel.textColor = theme.colors.textPrimary
         subtitleLabel.textColor = theme.colors.textSecondary
-        closeButton.applyTheme(tintColor: theme.colors.iconSecondary)
+        closeButton.applyTheme(theme: theme)
         if #unavailable(iOS 26.0) {
             closeButton.backgroundColor = .clear
         }

--- a/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
@@ -207,7 +207,7 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
     public func applyTheme(theme: Theme) {
         titleLabel.textColor = theme.colors.textPrimary
         subtitleLabel.textColor = theme.colors.textSecondary
-        closeButton.applyTheme(tintColor: theme.colors.iconSecondary)
+        closeButton.applyTheme(theme: theme)
         if #unavailable(iOS 26.0) {
             closeButton.backgroundColor = theme.colors.actionCloseButton.withAlphaComponent(mainMenuHelper.backgroundAlpha())
         }

--- a/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
@@ -53,15 +53,10 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
 
     private lazy var closeButton: CloseButton = .build { button in
         button.addTarget(self, action: #selector(self.closeButtonTapped), for: .touchUpInside)
-        #if canImport(FoundationModels)
         if #unavailable(iOS 26.0) {
             let imageName = StandardImageIdentifiers.Medium.cross
             button.setImage(UIImage(named: imageName)?.withRenderingMode(.alwaysTemplate) ?? UIImage(), for: .normal)
         }
-        #else
-        let imageName = StandardImageIdentifiers.Medium.cross
-        button.setImage(UIImage(named: imageName)?.withRenderingMode(.alwaysTemplate) ?? UIImage(), for: .normal)
-        #endif
     }
 
     private lazy var siteProtectionsContent: UIStackView = .build { [weak self] stack in
@@ -213,13 +208,9 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         titleLabel.textColor = theme.colors.textPrimary
         subtitleLabel.textColor = theme.colors.textSecondary
         closeButton.tintColor = theme.colors.iconSecondary
-        #if canImport(FoundationModels)
         if #unavailable(iOS 26.0) {
             closeButton.backgroundColor = theme.colors.actionCloseButton.withAlphaComponent(mainMenuHelper.backgroundAlpha())
         }
-        #else
-        closeButton.backgroundColor = theme.colors.actionCloseButton.withAlphaComponent(mainMenuHelper.backgroundAlpha())
-        #endif
         siteProtectionsLabel.textColor = theme.colors.textSecondary
         siteProtectionsContent.layer.borderColor = theme.colors.actionSecondaryHover.cgColor
         if #available(iOS 26.0, *) {

--- a/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
@@ -9,7 +9,7 @@ import ComponentLibrary
 
 public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
     private struct UX {
-        static let closeButtonSize: CGFloat = 30
+        static let closeButtonSize: CGFloat = 44
         static let contentLabelsSpacing: CGFloat = 1
         static let horizontalContentMargin: CGFloat = 16
         static let favIconSize: CGFloat = 40
@@ -53,8 +53,15 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
 
     private lazy var closeButton: CloseButton = .build { button in
         button.addTarget(self, action: #selector(self.closeButtonTapped), for: .touchUpInside)
+        #if canImport(FoundationModels)
+        if #unavailable(iOS 26.0) {
+            let imageName = StandardImageIdentifiers.Medium.cross
+            button.setImage(UIImage(named: imageName)?.withRenderingMode(.alwaysTemplate) ?? UIImage(), for: .normal)
+        }
+        #else
         let imageName = StandardImageIdentifiers.Medium.cross
         button.setImage(UIImage(named: imageName)?.withRenderingMode(.alwaysTemplate) ?? UIImage(), for: .normal)
+        #endif
     }
 
     private lazy var siteProtectionsContent: UIStackView = .build { [weak self] stack in
@@ -206,7 +213,13 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         titleLabel.textColor = theme.colors.textPrimary
         subtitleLabel.textColor = theme.colors.textSecondary
         closeButton.tintColor = theme.colors.iconSecondary
+        #if canImport(FoundationModels)
+        if #unavailable(iOS 26.0) {
+            closeButton.backgroundColor = theme.colors.actionCloseButton.withAlphaComponent(mainMenuHelper.backgroundAlpha())
+        }
+        #else
         closeButton.backgroundColor = theme.colors.actionCloseButton.withAlphaComponent(mainMenuHelper.backgroundAlpha())
+        #endif
         siteProtectionsLabel.textColor = theme.colors.textSecondary
         siteProtectionsContent.layer.borderColor = theme.colors.actionSecondaryHover.cgColor
         if #available(iOS 26.0, *) {

--- a/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
@@ -207,7 +207,7 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
     public func applyTheme(theme: Theme) {
         titleLabel.textColor = theme.colors.textPrimary
         subtitleLabel.textColor = theme.colors.textSecondary
-        closeButton.tintColor = theme.colors.iconSecondary
+        closeButton.applyTheme(tintColor: theme.colors.iconSecondary)
         if #unavailable(iOS 26.0) {
             closeButton.backgroundColor = theme.colors.actionCloseButton.withAlphaComponent(mainMenuHelper.backgroundAlpha())
         }

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -329,7 +329,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
             return zoomOutButton?.state == .highlighted ? colors.iconDisabled : baseColor
         })
         zoomOutButton.configuration?.imageColorTransformer = zoomOutButtonImageColorTransformer
-        closeButton.tintColor = colors.iconSecondary
+        closeButton.applyTheme(tintColor: colors.iconSecondary)
         if #unavailable(iOS 26.0) {
             let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
                 .withTintColor(theme.colors.iconSecondary)

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -329,7 +329,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
             return zoomOutButton?.state == .highlighted ? colors.iconDisabled : baseColor
         })
         zoomOutButton.configuration?.imageColorTransformer = zoomOutButtonImageColorTransformer
-        closeButton.applyTheme(tintColor: colors.iconSecondary)
+        closeButton.applyTheme(theme: theme)
         if #unavailable(iOS 26.0) {
             let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
                 .withTintColor(theme.colors.iconSecondary)

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -31,7 +31,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         static let stepperShadowOffset = CGSize(width: 0, height: 3)
         static let separatorWidth: CGFloat = 1
         static let separatorHeightMultiplier = 0.4
-        static let closButtonSize: CGFloat = 30
+        static let closButtonSize: CGFloat = 44
         static let closButtonLargeSize: CGFloat = 48
         static let shadowHeightOffset = 6
     }
@@ -329,11 +329,20 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
             return zoomOutButton?.state == .highlighted ? colors.iconDisabled : baseColor
         })
         zoomOutButton.configuration?.imageColorTransformer = zoomOutButtonImageColorTransformer
-        // Close button
+        closeButton.tintColor = colors.iconSecondary
+        #if canImport(FoundationModels)
+        if #unavailable(iOS 26.0) {
+            let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
+                .withTintColor(theme.colors.iconSecondary)
+            closeButton.setImage(buttonImage, for: .normal)
+            closeButton.backgroundColor = colors.layer4
+        }
+        #else
         let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
             .withTintColor(theme.colors.iconSecondary)
         closeButton.setImage(buttonImage, for: .normal)
         closeButton.backgroundColor = colors.layer4
+        #endif
 
         layer.shadowColor = colors.shadowDefault.cgColor
     }

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -330,19 +330,12 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         })
         zoomOutButton.configuration?.imageColorTransformer = zoomOutButtonImageColorTransformer
         closeButton.tintColor = colors.iconSecondary
-        #if canImport(FoundationModels)
         if #unavailable(iOS 26.0) {
             let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
                 .withTintColor(theme.colors.iconSecondary)
             closeButton.setImage(buttonImage, for: .normal)
             closeButton.backgroundColor = colors.layer4
         }
-        #else
-        let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
-            .withTintColor(theme.colors.iconSecondary)
-        closeButton.setImage(buttonImage, for: .normal)
-        closeButton.backgroundColor = colors.layer4
-        #endif
 
         layer.shadowColor = colors.shadowDefault.cgColor
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -209,7 +209,7 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     func applyTheme(theme: Theme) {
         backgroundColor = theme.colors.layer1
         titleLabel.textColor = theme.colors.textPrimary
-        closeButton.applyTheme(tintColor: theme.colors.textSecondary)
+        closeButton.applyTheme(theme: theme)
         topBorderView.backgroundColor = theme.colors.borderPrimary
         surveyButton.applyTheme(theme: theme)
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -209,7 +209,7 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     func applyTheme(theme: Theme) {
         backgroundColor = theme.colors.layer1
         titleLabel.textColor = theme.colors.textPrimary
-        closeButton.tintColor = theme.colors.textSecondary
+        closeButton.applyTheme(tintColor: theme.colors.textSecondary)
         topBorderView.backgroundColor = theme.colors.borderPrimary
         surveyButton.applyTheme(theme: theme)
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -301,7 +301,7 @@ final class MicrosurveyViewController: UIViewController,
         view.backgroundColor = theme.colors.layer3
 
         headerLabel.textColor = theme.colors.textPrimary
-        closeButton.applyTheme(tintColor: theme.colors.textSecondary)
+        closeButton.applyTheme(theme: theme)
         tableView.backgroundColor = theme.colors.layer2
         tableView.layer.borderColor = theme.colors.borderPrimary.cgColor
         tableView.separatorColor = theme.colors.borderPrimary

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -301,7 +301,7 @@ final class MicrosurveyViewController: UIViewController,
         view.backgroundColor = theme.colors.layer3
 
         headerLabel.textColor = theme.colors.textPrimary
-        closeButton.tintColor = theme.colors.textSecondary
+        closeButton.applyTheme(tintColor: theme.colors.textSecondary)
         tableView.backgroundColor = theme.colors.layer2
         tableView.layer.borderColor = theme.colors.borderPrimary.cgColor
         tableView.separatorColor = theme.colors.borderPrimary

--- a/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
+++ b/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
@@ -164,6 +164,6 @@ final class AutoTranslatePromptView: UIView, AlphaDimmable, ThemeApplicable, Not
         topBorderView.backgroundColor = theme.colors.borderPrimary
         messageLabel.textColor = theme.colors.textPrimary
         enableButton.setTitleColor(theme.colors.textAccent, for: .normal)
-        closeButton.applyTheme(tintColor: theme.colors.textSecondary)
+        closeButton.applyTheme(theme: theme)
     }
 }

--- a/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
+++ b/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptView.swift
@@ -164,6 +164,6 @@ final class AutoTranslatePromptView: UIView, AlphaDimmable, ThemeApplicable, Not
         topBorderView.backgroundColor = theme.colors.borderPrimary
         messageLabel.textColor = theme.colors.textPrimary
         enableButton.setTitleColor(theme.colors.textAccent, for: .normal)
-        closeButton.tintColor = theme.colors.textSecondary
+        closeButton.applyTheme(tintColor: theme.colors.textSecondary)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15779)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33752)

## :bulb: Description
Updates the shared close button sizing from 30x30pt to 44x44pt and applies iOS 26 glass styling where supported.

Also updates close button call sites with manual sizing or styling so pre-iOS 26 keeps the existing visual treatment while iOS 26 avoids overriding the glass appearance.

## :movie_camera: Screenshots
**Before**
<img width="200" alt="image" src="https://github.com/user-attachments/assets/5ff048f3-2df1-4a11-9ff2-3a40f7debdd5" />

**After**
<img width="200" alt="image" src="https://github.com/user-attachments/assets/2f02d69a-0f6b-4a88-aa85-d5c378f9add0" />



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code