### PR TITLE
Bugfix FXIOS-15902 [Crash] Attempt at crash with DiskImageStore

### DIFF
--- a/firefox-ios/Storage/DiskImageStore.swift
+++ b/firefox-ios/Storage/DiskImageStore.swift
@@ -5,10 +5,10 @@
 import UIKit
 import Common
 
-enum DiskImageStoreErrorCase: Error {
-    case notFound(description: String)
-    case invalidImageData(description: String)
-    case cannotWrite(description: String)
+enum DiskImageStoreErrorCase: Error, Equatable {
+    case notFound
+    case invalidImageData
+    case cannotWrite
 }
 
 public protocol DiskImageStore: Sendable {
@@ -68,7 +68,7 @@ public actor DefaultDiskImageStore: DiskImageStore {
 
     public func getImageForKey(_ key: String) async throws -> UIImage {
         if !keys.contains(key) {
-            throw DiskImageStoreErrorCase.notFound(description: "Image key not found")
+            throw DiskImageStoreErrorCase.notFound
         }
 
         let imagePath = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
@@ -76,7 +76,7 @@ public actor DefaultDiskImageStore: DiskImageStore {
         if let image = UIImage(data: data, scale: 1.0) {
             return image
         } else {
-            throw DiskImageStoreErrorCase.invalidImageData(description: "Invalid image data")
+            throw DiskImageStoreErrorCase.invalidImageData
         }
     }
 
@@ -84,7 +84,7 @@ public actor DefaultDiskImageStore: DiskImageStore {
         let imageURL = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
 
         guard let data = scaleImageFrom3xTo1x(image).jpegData(compressionQuality: quality) else {
-            throw DiskImageStoreErrorCase.cannotWrite(description: "Could not write image to file")
+            throw DiskImageStoreErrorCase.cannotWrite
         }
 
         try data.write(to: imageURL, options: .noFileProtection)
@@ -94,19 +94,22 @@ public actor DefaultDiskImageStore: DiskImageStore {
     private func scaleImageFrom3xTo1x(_ image: UIImage) -> UIImage {
         let targetScale: CGFloat = 1.0
 
-        if image.scale > targetScale {
-            let newSize = CGSize(
-                width: image.size.width * (targetScale / image.scale),
-                height: image.size.height * (targetScale / image.scale)
-            )
-
-            return UIGraphicsImageRenderer(size: newSize)
-                .image { context in
-                    image.draw(in: CGRect(origin: .zero, size: newSize))
-                }
+        // FXIOS-15902 - Guard against invalid images that would crash UIGraphicsImageRenderer
+        guard image.scale > targetScale,
+              image.size.width > 0,
+              image.size.height > 0,
+              image.cgImage != nil else {
+            return image
         }
 
-        return image
+        let newSize = CGSize(
+            width: image.size.width * (targetScale / image.scale),
+            height: image.size.height * (targetScale / image.scale)
+        )
+
+        return UIGraphicsImageRenderer(size: newSize).image { _ in
+            image.draw(in: CGRect(origin: .zero, size: newSize))
+        }
     }
 
     public func clearAllScreenshotsExcluding(_ keys: Set<String>) async throws {

--- a/firefox-ios/Storage/DiskImageStore.swift
+++ b/firefox-ios/Storage/DiskImageStore.swift
@@ -5,10 +5,10 @@
 import UIKit
 import Common
 
-enum DiskImageStoreErrorCase: Error, Equatable {
-    case notFound
-    case invalidImageData
-    case cannotWrite
+public enum DiskImageStoreErrorCase: Error, Equatable {
+    case notFound(description: String)
+    case invalidImageData(description: String)
+    case cannotWrite(description: String)
 }
 
 public protocol DiskImageStore: Sendable {
@@ -68,7 +68,7 @@ public actor DefaultDiskImageStore: DiskImageStore {
 
     public func getImageForKey(_ key: String) async throws -> UIImage {
         if !keys.contains(key) {
-            throw DiskImageStoreErrorCase.notFound
+            throw DiskImageStoreErrorCase.notFound(description: "Image key not found")
         }
 
         let imagePath = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
@@ -76,7 +76,7 @@ public actor DefaultDiskImageStore: DiskImageStore {
         if let image = UIImage(data: data, scale: 1.0) {
             return image
         } else {
-            throw DiskImageStoreErrorCase.invalidImageData
+            throw DiskImageStoreErrorCase.invalidImageData(description: "Invalid image data")
         }
     }
 
@@ -84,7 +84,7 @@ public actor DefaultDiskImageStore: DiskImageStore {
         let imageURL = URL(fileURLWithPath: filesDir).appendingPathComponent(key)
 
         guard let data = scaleImageFrom3xTo1x(image).jpegData(compressionQuality: quality) else {
-            throw DiskImageStoreErrorCase.cannotWrite
+            throw DiskImageStoreErrorCase.cannotWrite(description: "Could not write image to file")
         }
 
         try data.write(to: imageURL, options: .noFileProtection)

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/DiskImageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/DiskImageStoreTests.swift
@@ -55,6 +55,19 @@ class DiskImageStoreTests: XCTestCase {
         }
     }
 
+    func testSaveImageForKey_withZeroSizeImage_doesNotCrash() async throws {
+        let testKey = "zeroSizeImageKey"
+        let zeroSizeImage = UIImage()
+
+        do {
+            try await store.saveImageForKey(testKey, image: zeroSizeImage)
+            XCTFail("Expected saveImageForKey to throw for a zero-size image")
+        } catch let error as DiskImageStoreErrorCase {
+            // Expected: scaling is skipped and jpegData() returns nil, surfacing as cannotWrite.
+            XCTAssertEqual(DiskImageStoreErrorCase.cannotWrite, error)
+        }
+    }
+
     // MARK: - Helper methods
 
     func clearStore() async {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/DiskImageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/DiskImageStoreTests.swift
@@ -64,7 +64,7 @@ class DiskImageStoreTests: XCTestCase {
             XCTFail("Expected saveImageForKey to throw for a zero-size image")
         } catch let error as DiskImageStoreErrorCase {
             // Expected: scaling is skipped and jpegData() returns nil, surfacing as cannotWrite.
-            XCTAssertEqual(DiskImageStoreErrorCase.cannotWrite, error)
+            XCTAssertEqual(DiskImageStoreErrorCase.cannotWrite(description: "Could not write image to file"), error)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15902)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33990)

## :bulb: Description
Crash happens on:
```
        return UIGraphicsImageRenderer(size: newSize).image { _ in
            image.draw(in: CGRect(origin: .zero, size: newSize))
        }
```

Current assumption is that there are some images that doesn't fit the requirements for this API to work. This PR just adds some validation checks to hopeful help with that. 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

