### PR TITLE
Refactor FXIOS-15699 Fix World Cup setting order in Homepage settings

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -150,23 +150,6 @@ class HomePageSettingViewController: SettingsTableViewController,
             }
             sectionItems.append(jumpBackInSetting)
 
-            let bookmarksSetting = BoolSetting(
-                prefs: profile.prefs,
-                theme: themeManager.getCurrentTheme(for: windowUUID),
-                prefKey: PrefsKeys.HomepageSettings.BookmarksSection,
-                defaultValue: userPreferences.getPreferenceFor(.homepageBookmarksSectionDefault),
-                titleText: .Settings.Homepage.CustomizeFirefoxHome.Bookmarks
-            ) { value in
-                store.dispatch(
-                    BookmarksAction(
-                        isEnabled: value,
-                        windowUUID: self.windowUUID,
-                        actionType: BookmarksActionType.toggleShowSectionSetting
-                    )
-                )
-            }
-            sectionItems.append(bookmarksSetting)
-
             if worldCupStore.isFeatureEnabled {
                 let windowUUID = self.windowUUID
                 let worldCupSetting = BoolSetting(
@@ -185,6 +168,23 @@ class HomePageSettingViewController: SettingsTableViewController,
                 }
                 sectionItems.append(worldCupSetting)
             }
+
+            let bookmarksSetting = BoolSetting(
+                prefs: profile.prefs,
+                theme: themeManager.getCurrentTheme(for: windowUUID),
+                prefKey: PrefsKeys.HomepageSettings.BookmarksSection,
+                defaultValue: userPreferences.getPreferenceFor(.homepageBookmarksSectionDefault),
+                titleText: .Settings.Homepage.CustomizeFirefoxHome.Bookmarks
+            ) { value in
+                store.dispatch(
+                    BookmarksAction(
+                        isEnabled: value,
+                        windowUUID: self.windowUUID,
+                        actionType: BookmarksActionType.toggleShowSectionSetting
+                    )
+                )
+            }
+            sectionItems.append(bookmarksSetting)
         }
 
         // TODO: FXIOS-12980: Replace "Stories" title with "Top Stories" string once it is translated in v143


### PR DESCRIPTION
  World Cup setting order in Homepage settings

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15699)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33605)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Fixed World Cup setting order in Homepage settings, now The World Cup setting is positioned between Jump Back In and Bookmarks.

## ScreenShot
<img width="200" alt="image" src="https://github.com/user-attachments/assets/0acfd2a2-badd-4003-baa6-b32192d16a30" />

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

