### PR TITLE
Bugfix FXIOS-15917 Fix "frozen" address bar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -454,9 +454,11 @@ final class LocationView: UIView,
                 let scaledTransformation = CGAffineTransform(scaleX: UX.smallScale, y: UX.smallScale)
                     .translatedBy(x: 0, y: yOffset)
                 self.transform = scaledTransformation
-            }, completion: { [unowned self] _ in
-                urlTextField.isUserInteractionEnabled = false
-                isUserInteractionEnabled = false
+            }, completion: { [unowned self] didFinish in
+                if didFinish {
+                    urlTextField.isUserInteractionEnabled = false
+                    isUserInteractionEnabled = false
+                }
             })
     }
 
@@ -467,9 +469,11 @@ final class LocationView: UIView,
             options: [.curveEaseInOut],
             animations: { [unowned self] in
                 transform = .identity
-            }, completion: { [unowned self] _ in
-                urlTextField.isUserInteractionEnabled = true
-                isUserInteractionEnabled = true
+            }, completion: { [unowned self] didFinish in
+                if didFinish {
+                    urlTextField.isUserInteractionEnabled = true
+                    isUserInteractionEnabled = true
+                }
             }
         )
     }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -454,11 +454,6 @@ final class LocationView: UIView,
                 let scaledTransformation = CGAffineTransform(scaleX: UX.smallScale, y: UX.smallScale)
                     .translatedBy(x: 0, y: yOffset)
                 self.transform = scaledTransformation
-            }, completion: { [unowned self] didFinish in
-                if didFinish {
-                    urlTextField.isUserInteractionEnabled = false
-                    isUserInteractionEnabled = false
-                }
             })
     }
 
@@ -469,13 +464,7 @@ final class LocationView: UIView,
             options: [.curveEaseInOut],
             animations: { [unowned self] in
                 transform = .identity
-            }, completion: { [unowned self] didFinish in
-                if didFinish {
-                    urlTextField.isUserInteractionEnabled = true
-                    isUserInteractionEnabled = true
-                }
-            }
-        )
+            })
     }
 
     private func removeGlassEffectImmediately() {


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15917)
Github ticket never synced?

## :bulb: Description

In some cases (slow animations, visiting certain websites), the address bar became completely unresponsive. See the Jira ticket for more context and a demo video.

It seems that something with animations getting cut off was causing `isUserInteractionEnabled` to be be disabled and never reenabled.

This `isUserInteractionEnabled` change was added in https://github.com/mozilla-mobile/firefox-ios/pull/32251

We're not able to conclude why this fix was done, but the original issue that led to that PR is no longer reproducible even without this code, so this change seems unnecessary and risky. Removing this code seems to prevent the freezing interface.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

