### PR TITLE
Bugfix FXIOS-15914 [Translations] Fix icon appearing after re-enabling translations

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -1118,6 +1118,11 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
         let toolbarAction = action as? ToolbarAction
         let actionTranslationConfiguration = TranslationConfiguration(from: action)
+        // For TranslationsAction the action's config is the sole authority — nil means "clear the icon".
+        // For ToolbarAction we fall back to state so the icon persists across unrelated toolbar updates.
+        let resolvedTranslationConfiguration: TranslationConfiguration? = action is TranslationsAction
+            ? actionTranslationConfiguration
+            : actionTranslationConfiguration ?? addressBarState.translationConfiguration
         let isShowingNavigationToolbar = toolbarAction?.isShowingNavigationToolbar
             ?? toolbarState.isShowingNavigationToolbar
         let isURLDidChangeAction = action.actionType as? ToolbarActionType == .urlDidChange
@@ -1139,8 +1144,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
             actions.append(shareAction)
 
             if let translationAction = configureTranslationIcon(
-                actionTranslationConfiguration: actionTranslationConfiguration,
-                addressBarState: addressBarState,
+                translationConfiguration: resolvedTranslationConfiguration,
                 isLoading: isLoading,
                 hasAlternativeLocationColor: hasAlternativeLocationColor
             ) {
@@ -1152,8 +1156,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
             actions.append(shareAction)
 
             if let translationAction = configureTranslationIcon(
-                actionTranslationConfiguration: actionTranslationConfiguration,
-                addressBarState: addressBarState,
+                translationConfiguration: resolvedTranslationConfiguration,
                 isLoading: isLoading,
                 hasAlternativeLocationColor: hasAlternativeLocationColor
             ) {
@@ -1167,26 +1170,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
     // Checks whether we should show the translation icon based on the translation configuration
     // state and setups up the configuration for the translation icon on the toolbar (for iPad and iPhone)
     private static func configureTranslationIcon(
-        actionTranslationConfiguration: TranslationConfiguration?,
-        addressBarState: AddressBarState,
+        translationConfiguration: TranslationConfiguration?,
         isLoading: Bool?,
         hasAlternativeLocationColor: Bool
     ) -> ToolbarActionConfiguration? {
-        // Check if action has an updated configuration, otherwise default to state.
-        // We need to do this check because of existing architecture
-        // in which the state is updated after
-        // we configure the button, so we need to check action too.
-        // When the action explicitly provides a config, use it as the authority (e.g. settings toggle).
-        // Only fall back to state when the action carries no config.
-        let shouldShowTranslationIcon: Bool
-        if let actionConfig = actionTranslationConfiguration {
-            shouldShowTranslationIcon = actionConfig.isTranslationFeatureEnabled
-        } else {
-            shouldShowTranslationIcon = addressBarState.translationConfiguration?.isTranslationFeatureEnabled ?? false
-        }
-        guard shouldShowTranslationIcon else { return nil }
-        let iconState = actionTranslationConfiguration?.state ?? addressBarState.translationConfiguration?.state
-        guard let iconState else { return nil }
+        guard let config = translationConfiguration, config.isTranslationFeatureEnabled else { return nil }
+        guard let iconState = config.state else { return nil }
         return translateAction(
             enabled: isLoading == false,
             state: iconState,

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsViewController.swift
@@ -42,8 +42,7 @@ final class TranslationSettingsViewController: SettingsTableViewController {
                     isTranslationsEnabled: isEnabled,
                     translationConfiguration: TranslationConfiguration(
                         prefs: self.prefs,
-                        isUserSettingEnabled: isEnabled,
-                        state: .inactive
+                        isUserSettingEnabled: isEnabled
                     ),
                     windowUUID: self.windowUUID,
                     actionType: TranslationsActionType.didTranslationSettingsChange


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15914)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34018)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
When toggling translations back on in settings, the translate icon incorrectly appeared on pages not eligible for translation (e.g. English Wikipedia with an English device language).

Two changes:
- Settings toggle no longer sends state: .inactive in the action config — icon visibility is determined solely by the middleware eligibility check.
- AddressBarState reducer treats TranslationsAction configs as authoritative: nil means clear the icon, rather than falling back to stale state from the previous action.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


