### PR TITLE
Revert FXIOS-15916 address bar fixes to stabilize build

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -454,9 +454,6 @@ final class LocationView: UIView,
                 let scaledTransformation = CGAffineTransform(scaleX: UX.smallScale, y: UX.smallScale)
                     .translatedBy(x: 0, y: yOffset)
                 self.transform = scaledTransformation
-            }, completion: { [unowned self] _ in
-                urlTextField.isUserInteractionEnabled = false
-                isUserInteractionEnabled = false
             })
     }
 
@@ -467,11 +464,7 @@ final class LocationView: UIView,
             options: [.curveEaseInOut],
             animations: { [unowned self] in
                 transform = .identity
-            }, completion: { [unowned self] _ in
-                urlTextField.isUserInteractionEnabled = true
-                isUserInteractionEnabled = true
-            }
-        )
+            })
     }
 
     private func removeGlassEffectImmediately() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1730,14 +1730,14 @@ class BrowserViewController: UIViewController,
     private func updateSnapKitOverKeyboardContainerConstraints() {
         guard !isSnapKitRemovalEnabled else { return }
 
-        let existingOffset = overKeyboardContainerConstraint?.layoutConstraint?.constant ?? 0
-
         overKeyboardContainer.snp.remakeConstraints { make in
-            // Apply same constraints update we do in native path we 
-            let constraint = make.bottom.equalTo(bottomContainer.snp.top).offset(existingOffset).constraint
-            let reference = ConstraintReference(snapKit: constraint)
-            overKeyboardContainerConstraint = reference
-            (scrollController as? LegacyTabScrollProvider)?.overKeyboardContainerConstraint = reference
+            if let scrollController = scrollController as? LegacyTabScrollProvider {
+                let constraint = make.bottom.equalTo(bottomContainer.snp.top).constraint
+                scrollController.overKeyboardContainerConstraint = ConstraintReference(snapKit: constraint)
+            } else {
+                let constraint = make.bottom.equalTo(bottomContainer.snp.top).constraint
+                overKeyboardContainerConstraint = ConstraintReference(snapKit: constraint)
+            }
 
             if !isBottomSearchBar, zoomPageBar != nil {
                 make.height.greaterThanOrEqualTo(0)
@@ -1752,13 +1752,15 @@ class BrowserViewController: UIViewController,
     private func updateSnapKitBottomContainerConstraints() {
         guard !isSnapKitRemovalEnabled else { return }
 
-        let existingOffset = bottomContainerConstraint?.layoutConstraint?.constant ?? 0
-
         bottomContainer.snp.remakeConstraints { make in
-            let constraint = make.bottom.equalTo(view.snp.bottom).offset(existingOffset).constraint
-            let reference = ConstraintReference(snapKit: constraint)
-            bottomContainerConstraint = reference
-            (scrollController as? LegacyTabScrollProvider)?.bottomContainerConstraint = reference
+            let constraint = make.bottom.equalTo(view.snp.bottom).constraint
+            let constraintReference = ConstraintReference(snapKit: constraint)
+
+            if let scrollController = scrollController as? LegacyTabScrollProvider {
+                scrollController.bottomContainerConstraint = constraintReference
+            } else {
+                bottomContainerConstraint = constraintReference
+            }
             make.leading.trailing.equalTo(view)
         }
     }
@@ -1778,7 +1780,9 @@ class BrowserViewController: UIViewController,
     private func updateSnapkitConstraintsForKeyboard() {
         guard !isSnapKitRemovalEnabled else { return }
 
-        if tabManager.selectedTab?.isFindInPageMode == false {
+        if let tab = tabManager.selectedTab, tab.isFindInPageMode {
+            scrollController.hideToolbars(animated: false)
+        } else {
             adjustBottomSearchBarForKeyboard()
         }
     }
@@ -5008,7 +5012,15 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-
+        if #available(iOS 26.0, *), isBottomSearchBar {
+            store.dispatch(
+                ToolbarAction(
+                    scrollAlpha: 1,
+                    windowUUID: windowUUID,
+                    actionType: ToolbarActionType.scrollAlphaNeedsUpdate
+                )
+            )
+        }
         keyboardState = nil
         if !isSnapKitRemovalEnabled {
             updateViewConstraints()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1484,12 +1484,6 @@ class BrowserViewController: UIViewController,
         coordinator.animate(alongsideTransition: { [self] context in
             legacyScrollController?.updateMinimumZoom()
             topTabsViewController?.scrollToCurrentTab(false, centerCell: false)
-            if !isSnapKitRemovalEnabled {
-                updateViewConstraints()
-            } else {
-                updateConstraintsForKeyboard()
-                updateBottomContentStackViewConstraints()
-            }
             searchController?.view.layoutIfNeeded()
         }, completion: { [weak self] _ in
             legacyScrollController?.traitCollectionDidChange()
@@ -5014,7 +5008,6 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        guard !isEditingBottomAddressBar else { return }
 
         keyboardState = nil
         if !isSnapKitRemovalEnabled {
@@ -5087,13 +5080,6 @@ extension BrowserViewController: KeyboardHelperDelegate {
         }
         guard shouldCancelEditing else { return }
         overlayManager.cancelEditing(shouldCancelLoading: false)
-    }
-
-    private var isEditingBottomAddressBar: Bool {
-        guard searchBarPosition == .bottom else { return false }
-        return store.state
-            .componentState(ToolbarState.self, for: .toolbar, window: windowUUID)?
-            .addressToolbar.isEditing ?? false
     }
 
     private var shouldCancelEditing: Bool {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4984,12 +4984,7 @@ extension BrowserViewController {
 }
 
 extension BrowserViewController: KeyboardHelperDelegate {
-    private var isModalPresentedOverBrowser: Bool {
-        presentedViewController != nil || navigationController?.presentedViewController != nil
-    }
-
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
-        guard !isModalPresentedOverBrowser else { return }
         keyboardState = state
 
         if !isSnapKitRemovalEnabled {
@@ -5019,14 +5014,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        guard !isModalPresentedOverBrowser else { return }
         guard !isEditingBottomAddressBar else { return }
-
-        // Give the toolbar a chance to undo any prior minimization (FXIOS-15910). Called
-        // here — once per keyboard transition — rather than from adjustBottomSearchBarForKeyboard,
-        // which fires on every layout pass and would dispatch stray shouldShowKeyboard updates
-        // mid-edit.
-        _ = addressToolbarContainer.offsetForKeyboardAccessory(hasAccessoryView: false)
 
         keyboardState = nil
         if !isSnapKitRemovalEnabled {
@@ -5050,7 +5038,6 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState) {
-        guard !isModalPresentedOverBrowser else { return }
         let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: windowUUID)
         let isEditing = toolbarState?.addressToolbar.isEditing == true
         if !isEditing {
@@ -5069,7 +5056,6 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillChangeWithState state: KeyboardState) {
-        guard !isModalPresentedOverBrowser else { return }
         keyboardState = state
         if !isSnapKitRemovalEnabled {
             updateViewConstraints()
@@ -5080,7 +5066,6 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
-        guard !isModalPresentedOverBrowser else { return }
         keyboardState = state
         if !isSnapKitRemovalEnabled {
             updateViewConstraints()

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -226,30 +226,6 @@ final class AddressToolbarContainer: UIView,
 
         let accessoryViewOffset = shouldAdjustForAccessory ? UX.keyboardAccessoryViewOffset : 0
 
-        // Keep the gradient frame matched to current bounds on every call where the accessory
-        // is active. Required after rotation so the gradient stays full-width.
-        if shouldAdjustForAccessory {
-            let height = frame.height + UX.accessoryViewGradientOffset
-            accessoryViewGradient.frame = CGRect(width: bounds.width, height: height)
-        }
-
-        // Undo a previous accessory-driven minimization. Gated on shouldShowKeyboard so we
-        // don't undo legitimate scroll-hides, and on !isEditingAddress so we don't dispatch
-        // while the user is mid-edit
-        if !hasAccessoryView,
-           !isEditingAddress,
-           shouldShowKeyboard == true,
-           state?.scrollAlpha == 0 {
-            accessoryViewGradient.opacity = 0
-            store.dispatch(
-                ToolbarAction(
-                    scrollAlpha: 1,
-                    windowUUID: windowUUID,
-                    actionType: ToolbarActionType.scrollAlphaNeedsUpdate
-                )
-            )
-        }
-
         /// We want to check here if the keyboard accessory view state has changed
         /// To avoid spamming redux actions.
         guard hasAccessoryView != shouldShowKeyboard else { return accessoryViewOffset }
@@ -262,6 +238,8 @@ final class AddressToolbarContainer: UIView,
         )
 
         if shouldAdjustForAccessory {
+            let height = frame.height + UX.accessoryViewGradientOffset
+            accessoryViewGradient.frame = CGRect(width: bounds.width, height: height)
             accessoryViewGradient.opacity = 1
             store.dispatch(
                 ToolbarAction(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerKeyboardConstraintTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerKeyboardConstraintTests.swift
@@ -16,7 +16,6 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
 
     func test_keyboardWillShow_withSnapKit_BottomToolbar_viewsHaveRightHeight() {
         let subject = createSubject()
-        selectTabWithFindInPage()
         let state = createKeyboardState()
         let keyboardHelper = createKeyboardHelper()
         XCTAssertEqual(subject.overKeyboardContainer.subviews.count, 1)
@@ -65,7 +64,6 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
 
     func test_keyboardDidShow_withSnapkit_BottomToolbar_viewsHaveRightHeight() {
         let subject = createSubject()
-        selectTabWithFindInPage()
         let state = createKeyboardState()
         let keyboardHelper = createKeyboardHelper()
         XCTAssertEqual(subject.overKeyboardContainer.subviews.count, 1)
@@ -111,7 +109,6 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
 
     func test_keyboardWillHide_withSnapKit_BottomToolbar_viewsHaveRightHeight() {
         let subject = createSubject()
-        selectTabWithFindInPage()
         let keyboardHelper = createKeyboardHelper()
 
         // Show keyboard first
@@ -177,7 +174,6 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
 
     func test_keyboardWillChange_withSnapKit_BottomToolbar_viewsHaveRightHeight() {
         let subject = createSubject()
-        selectTabWithFindInPage()
         let keyboardHelper = createKeyboardHelper()
 
         // Show keyboard first


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15916)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Reverts PRs that touched minimized address bar or constraints related to toolbar views
https://github.com/mozilla-mobile/firefox-ios/pull/33985
https://github.com/mozilla-mobile/firefox-ios/pull/33949
https://github.com/mozilla-mobile/firefox-ios/pull/33913
https://github.com/mozilla-mobile/firefox-ios/pull/33838


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

