### PR TITLE
Bugfix FXIOS-15625 [ETP] Refresh certificate screen theme on system appearance changes

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesCell.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesCell.swift
@@ -28,6 +28,14 @@ final class CertificatesCell: UITableViewCell, ReusableCell, ThemeApplicable {
         stack.spacing = UX.allSectionItemsSpacing
     }
 
+    private enum ItemLabelRole {
+        case title
+        case value
+        case underlinedValue
+    }
+
+    private var itemLabels: [(label: UILabel, role: ItemLabelRole)] = []
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
@@ -56,6 +64,7 @@ final class CertificatesCell: UITableViewCell, ReusableCell, ThemeApplicable {
         super.prepareForReuse()
         allSectionItemsStackView.removeAllArrangedViews()
         sectionLabel.text = nil
+        itemLabels.removeAll()
     }
 
     required init?(coder: NSCoder) {
@@ -63,7 +72,6 @@ final class CertificatesCell: UITableViewCell, ReusableCell, ThemeApplicable {
     }
 
     func configure(theme: Theme, sectionTitle: String, items: CertificateItems, isIssuerName: Bool = false) {
-        applyTheme(theme: theme)
         sectionLabel.text = sectionTitle
         for (key, value) in items {
             let isUnderlined = isIssuerName && key == .Menu.EnhancedTrackingProtection.certificateCommonName
@@ -79,6 +87,7 @@ final class CertificatesCell: UITableViewCell, ReusableCell, ThemeApplicable {
             ))
             allSectionItemsStackView.addArrangedSubview(stackView)
         }
+        applyTheme(theme: theme)
     }
 
     // MARK: Accessibility
@@ -91,6 +100,16 @@ final class CertificatesCell: UITableViewCell, ReusableCell, ThemeApplicable {
     func applyTheme(theme: Theme) {
         backgroundColor = theme.colors.layer5
         sectionLabel.textColor = theme.colors.textPrimary
+        for (label, role) in itemLabels {
+            switch role {
+            case .title:
+                label.textColor = theme.colors.textSecondary
+            case .value:
+                label.textColor = theme.colors.textPrimary
+            case .underlinedValue:
+                label.textColor = theme.colors.textAccent
+            }
+        }
     }
 
     private func getItemLabel(theme: Theme, with title: String, isTitle: Bool, isUnderlined: Bool) -> UILabel {
@@ -100,6 +119,7 @@ final class CertificatesCell: UITableViewCell, ReusableCell, ThemeApplicable {
         itemLabel.numberOfLines = 0
         itemLabel.lineBreakMode = .byWordWrapping
         itemLabel.accessibilityIdentifier = AccessibilityIdentifiers.EnhancedTrackingProtection.DetailsScreen.itemLabel
+        let role: ItemLabelRole
         if isUnderlined, !isTitle {
             let attributedString = NSAttributedString(
                 string: title,
@@ -109,10 +129,13 @@ final class CertificatesCell: UITableViewCell, ReusableCell, ThemeApplicable {
             )
             itemLabel.textColor = theme.colors.textAccent
             itemLabel.attributedText = attributedString
+            role = .underlinedValue
         } else {
             itemLabel.textColor = isTitle ? theme.colors.textSecondary : theme.colors.textPrimary
             itemLabel.text = title
+            role = isTitle ? .title : .value
         }
+        itemLabels.append((itemLabel, role))
         return itemLabel
     }
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesHeaderItem.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesHeaderItem.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Common
 
-final class CertificatesHeaderItem: UIView {
+final class CertificatesHeaderItem: UIView, ThemeApplicable {
     struct UX {
         static let headerItemIndicatorHeight = 4.0
         static let headerItemsSpacing = 10.0
@@ -13,6 +13,7 @@ final class CertificatesHeaderItem: UIView {
 
     private var itemSelectedCallback: (() -> Void)?
     private var theme: Theme?
+    private var isSelected = false
 
     private let stackView: UIStackView = .build { stack in
         stack.axis = .vertical
@@ -52,13 +53,17 @@ final class CertificatesHeaderItem: UIView {
     }
 
     func configure(theme: Theme, title: String?, isSelected: Bool, itemSelectedCallback: @escaping () -> Void) {
-        self.theme = theme
+        self.isSelected = isSelected
         button.setTitle(title, for: .normal)
         button.addTarget(self, action: #selector(certificateButtonTapped(_:)), for: .touchUpInside)
+        self.itemSelectedCallback = itemSelectedCallback
+        applyTheme(theme: theme)
+    }
+
+    func applyTheme(theme: Theme) {
+        self.theme = theme
         indicator.backgroundColor = isSelected ? theme.colors.textAccent : .clear
         button.setTitleColor(isSelected ? theme.colors.textAccent : theme.colors.textPrimary, for: .normal)
-        indicator.backgroundColor = isSelected ? theme.colors.textAccent : .clear
-        self.itemSelectedCallback = itemSelectedCallback
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesHeaderView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesHelpers/CertificatesHeaderView.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Common
 
-class CertificatesHeaderView: UITableViewHeaderFooterView, ReusableCell {
+class CertificatesHeaderView: UITableViewHeaderFooterView, ReusableCell, ThemeApplicable {
     private struct UX {
         static let headerStackViewSpacing = 16.0
         static let separatorHeight = 1.0
@@ -63,10 +63,17 @@ class CertificatesHeaderView: UITableViewHeaderFooterView, ReusableCell {
             headerStackView.addArrangedSubview(item)
         }
 
+        applyTheme(theme: theme)
+    }
+
+    func applyTheme(theme: Theme) {
         contentView.backgroundColor = theme.colors.layer5
         headerStackView.backgroundColor = theme.colors.layer5
         separatorBottomView.backgroundColor = theme.colors.borderPrimary
         separatorTopView.backgroundColor = theme.colors.borderPrimary
+        for case let item as CertificatesHeaderItem in headerStackView.arrangedSubviews {
+            item.applyTheme(theme: theme)
+        }
     }
 
     // MARK: Accessibility

--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
@@ -325,6 +325,12 @@ extension CertificatesViewController {
 
         certificatesTableView.backgroundColor = theme.colors.layer3
         certificatesTableView.separatorColor = theme.colors.borderPrimary
-        certificatesTableView.reloadData()
+
+        for case let cell as CertificatesCell in certificatesTableView.visibleCells {
+            cell.applyTheme(theme: theme)
+        }
+        for section in 0..<certificatesTableView.numberOfSections {
+            (certificatesTableView.headerView(forSection: section) as? CertificatesHeaderView)?.applyTheme(theme: theme)
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
@@ -317,9 +317,14 @@ class CertificatesViewController: UIViewController,
 extension CertificatesViewController {
     func applyTheme() {
         let theme = currentTheme()
+        overrideUserInterfaceStyle = theme.type.getInterfaceStyle()
         view.backgroundColor = theme.colors.layer3
         titleLabel.textColor = theme.colors.textPrimary
         titleLabel.backgroundColor = theme.colors.layer5
         headerView.applyTheme(theme: theme)
+
+        certificatesTableView.backgroundColor = theme.colors.layer3
+        certificatesTableView.separatorColor = theme.colors.borderPrimary
+        certificatesTableView.reloadData()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15625)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33481)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Refreshes the certificate screen theme when system appearance changes. The certificate table now updates its background, separator color, and reloads its  rows so certificate details use the current theme.

## :movie_camera: Demos

https://github.com/user-attachments/assets/67e09aed-a5d5-4b38-948e-170991318d70


| Before | After |
| - | - |
| <img width="190" alt="Screenshot 2026-05-27 at 1 18 14 AM" src="https://github.com/user-attachments/assets/badf2539-24d5-4749-82a0-235c9bb45311" /> | <img width="190" alt="Screenshot 2026-05-27 at 1 18 37 AM" src="https://github.com/user-attachments/assets/d3b2be0b-06d2-4280-876f-6384c310c898" /> |


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

