### PR TITLE
Feature FXIOS-11866 [Quick Actions] add App Icon shortcut to home screen long press menu

### DIFF
--- a/firefox-ios/Client/Application/QuickActions.swift
+++ b/firefox-ios/Client/Application/QuickActions.swift
@@ -10,6 +10,7 @@ enum ShortcutType: String {
     case newTab = "NewTab"
     case newPrivateTab = "NewPrivateTab"
     case openLastBookmark = "OpenLastBookmark"
+    case appIcon = "AppIcon"
 
     var type: String {
         return Bundle.main.bundleIdentifier! + ".\(self.rawValue)"

--- a/firefox-ios/Client/Coordinators/Router/DeeplinkInput.swift
+++ b/firefox-ios/Client/Coordinators/Router/DeeplinkInput.swift
@@ -72,5 +72,6 @@ enum DeeplinkInput {
         case newTab = "NewTab"
         case newPrivateTab = "NewPrivateTab"
         case openLastBookmark = "OpenLastBookmark"
+        case appIcon = "AppIcon"
     }
 }

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -233,6 +233,8 @@ final class RouteBuilder: @unchecked Sendable {
             } else {
                 return nil
             }
+        case .appIcon:
+            return .settings(section: .appIcon)
         }
     }
 

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -79,6 +79,7 @@ final class SettingsCoordinator: BaseCoordinator,
         // We might already know the sub-settings page we want to show, but in some case we don't and
         // the flow decision needs to be figured out by the view controller
         if let viewController = getSettingsViewController(settingsSection: settingsSection) {
+            if isAlreadyOnTop(viewController) { return }
             // If Settings is already showing a subpage, reset to root before opening the routed destination.
             if shouldResetNavigationStack,
                let root = router.rootViewController,
@@ -94,6 +95,11 @@ final class SettingsCoordinator: BaseCoordinator,
             assert(settingsViewController != nil)
             settingsViewController?.handle(route: settingsSection)
         }
+    }
+
+    private func isAlreadyOnTop(_ vc: UIViewController) -> Bool {
+        guard let top = router.navigationController.topViewController else { return false }
+        return type(of: top) == type(of: vc)
     }
 
     override func canHandle(route: Route) -> Bool {

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -79,6 +79,8 @@ final class SettingsCoordinator: BaseCoordinator,
         // We might already know the sub-settings page we want to show, but in some case we don't and
         // the flow decision needs to be figured out by the view controller
         if let viewController = getSettingsViewController(settingsSection: settingsSection) {
+            // FIXME: FXIOS-15967 We should pop to the root of the settings screen before pushing new screens from deeplinks,
+            // which might push a view controller to the wrong sub-settings nav hierarchy.
             if isAlreadyOnTop(viewController) { return }
             // If Settings is already showing a subpage, reset to root before opening the routed destination.
             if shouldResetNavigationStack,

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -184,6 +184,14 @@
 	<array>
 		<dict>
 			<key>UIApplicationShortcutItemIconFile</key>
+			<string>logoFirefoxLarge</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>App Icon</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER).AppIcon</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemIconFile</key>
 			<string>plusLarge</string>
 			<key>UIApplicationShortcutItemTitle</key>
 			<string>New Tab</string>

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
@@ -59,6 +59,23 @@ final class RouteBuilderTests: XCTestCase {
         }
     }
 
+    func test_makeRoute_AppIconShortcut_ReturnsAppIconSettingsRoute() {
+        let routeBuilder = createSubject(mainQueue: MockDispatchQueue())
+        let bundleId = Bundle.main.bundleIdentifier ?? ""
+        let shortcut = UIApplicationShortcutItem(
+            type: "\(bundleId).AppIcon",
+            localizedTitle: "App Icon"
+        )
+
+        let route = routeBuilder.makeRoute(shortcutItem: shortcut, tabSetting: .topSites)
+
+        guard case let .settings(section) = route else {
+            XCTFail("Expected .settings route, got \(String(describing: route))")
+            return
+        }
+        XCTAssertEqual(section, .appIcon)
+    }
+
     func test_makeRoute_ResetsShouldOpenNewTabAfterDelay() {
         let routeBuilder = createSubject(mainQueue: MockDispatchQueue())
         routeBuilder.shouldOpenNewTab = true

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -220,6 +220,15 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(navigationController.viewControllers.last is UIHostingController<AppIconSelectionView>)
     }
 
+    func testAppIconSettingsRoute_calledTwice_pushesOnlyOnce() throws {
+        let subject = createSubject()
+
+        subject.start(with: .appIcon)
+        subject.start(with: .appIcon)
+
+        XCTAssertEqual(mockRouter.pushCalled, 1)
+    }
+
     func testGeneralSettingsRoute_whenStackIsDeep_popsToRoot() throws {
         let subject = createSubject()
         let root = try XCTUnwrap(mockRouter.rootViewController)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -644,6 +644,25 @@ class NavigationTest: FeatureFlaggedTestSuite {
         browserScreen.assertWebViewLinkTextExists(text: "Legal")
     }
 
+    func testLongTapFirefoxIconAppIcon() throws {
+        guard #available(iOS 18, *) else {
+            throw XCTSkip("Test requires iOS 18+ due to app icon springboard behavior after app.terminate()")
+        }
+        let springBoardScreen = SpringboardScreen(springboard: springboard)
+        waitForTabsButton()
+        springBoardScreen.pressHomeButton()
+        if isFennec {
+            springBoardScreen.assertFennecIconExists()
+            springBoardScreen.longPressFennecIcon(at: 0, duration: 1.5)
+        } else {
+            springBoardScreen.assertFirefoxIconExists()
+            springBoardScreen.longPressFirefoxIcon(at: 0, duration: 1.5)
+        }
+        springBoardScreen.assertAppIconButtonExists()
+        springBoardScreen.tapAppIconButton()
+        mozWaitForElementToExist(app.navigationBars["App Icon"])
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/edit/3408300
     func testLongTapFirefoxIconOpenLastBookmark() throws {
         guard #available(iOS 18, *) else {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SpringboardScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SpringboardScreen.swift
@@ -116,10 +116,10 @@ final class SpringboardScreen {
     }
 
     func assertAllContextMenuOptionsExist(timeout: TimeInterval = TIMEOUT) {
+        BaseTestCase().mozWaitForElementToExist(appIconButton, timeout: timeout)
         BaseTestCase().mozWaitForElementToExist(newTabButton, timeout: timeout)
         BaseTestCase().mozWaitForElementToExist(newPrivateButton, timeout: timeout)
         BaseTestCase().mozWaitForElementToExist(openLastBookmarkButton, timeout: timeout)
-        BaseTestCase().mozWaitForElementToExist(appIconButton, timeout: timeout)
     }
 
     func fennecIconsCount() -> Int {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SpringboardScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SpringboardScreen.swift
@@ -44,6 +44,10 @@ final class SpringboardScreen {
         sel.OPEN_LAST_BOOKMARK_BUTTON.element(in: springboard)
     }
 
+    private var appIconButton: XCUIElement {
+        sel.APP_ICON_BUTTON.element(in: springboard)
+    }
+
     // MARK: - System Actions
 
     func pressHomeButton() {
@@ -83,6 +87,10 @@ final class SpringboardScreen {
         openLastBookmarkButton.waitAndTap()
     }
 
+    func tapAppIconButton() {
+        appIconButton.waitAndTap()
+    }
+
     // MARK: - Assertions
 
     func assertFennecIconExists(at index: Int = 0, timeout: TimeInterval = TIMEOUT) {
@@ -103,10 +111,15 @@ final class SpringboardScreen {
         BaseTestCase().mozWaitForElementToExist(openLastBookmarkButton, timeout: timeout)
     }
 
+    func assertAppIconButtonExists(timeout: TimeInterval = TIMEOUT) {
+        BaseTestCase().mozWaitForElementToExist(appIconButton, timeout: timeout)
+    }
+
     func assertAllContextMenuOptionsExist(timeout: TimeInterval = TIMEOUT) {
         BaseTestCase().mozWaitForElementToExist(newTabButton, timeout: timeout)
         BaseTestCase().mozWaitForElementToExist(newPrivateButton, timeout: timeout)
         BaseTestCase().mozWaitForElementToExist(openLastBookmarkButton, timeout: timeout)
+        BaseTestCase().mozWaitForElementToExist(appIconButton, timeout: timeout)
     }
 
     func fennecIconsCount() -> Int {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SpringboardSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SpringboardSelectors.swift
@@ -10,6 +10,7 @@ protocol SpringboardSelectorsSet {
     var NEW_TAB_BUTTON: Selector { get }
     var NEW_PRIVATE_TAB_BUTTON: Selector { get }
     var OPEN_LAST_BOOKMARK_BUTTON: Selector { get }
+    var APP_ICON_BUTTON: Selector { get }
     var all: [Selector] { get }
 }
 
@@ -20,6 +21,7 @@ struct SpringboardSelectors: SpringboardSelectorsSet {
         static let newTabButton = "New Tab"
         static let newPrivateTabButton = "New Private Tab"
         static let openLastBookmarkButton = "org.mozilla.ios.Fennec.OpenLastBookmark"
+        static let appIconButton = "App Icon"
     }
 
     let FENNEC_ICONS = Selector(
@@ -58,13 +60,20 @@ struct SpringboardSelectors: SpringboardSelectorsSet {
         groups: ["springboard", "context-menu"]
     )
 
+    let APP_ICON_BUTTON = Selector.buttonId(
+        IDs.appIconButton,
+        description: "App Icon button in springboard context menu",
+        groups: ["springboard", "context-menu"]
+    )
+
     var all: [Selector] {
         [
             FENNEC_ICONS,
             FIREFOX_ICON,
             NEW_TAB_BUTTON,
             NEW_PRIVATE_TAB_BUTTON,
-            OPEN_LAST_BOOKMARK_BUTTON
+            OPEN_LAST_BOOKMARK_BUTTON,
+            APP_ICON_BUTTON
         ]
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SpringboardSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SpringboardSelectors.swift
@@ -70,10 +70,10 @@ struct SpringboardSelectors: SpringboardSelectorsSet {
         [
             FENNEC_ICONS,
             FIREFOX_ICON,
+            APP_ICON_BUTTON,
             NEW_TAB_BUTTON,
             NEW_PRIVATE_TAB_BUTTON,
-            OPEN_LAST_BOOKMARK_BUTTON,
-            APP_ICON_BUTTON
+            OPEN_LAST_BOOKMARK_BUTTON
         ]
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11866)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25853)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Adds a new "App Icon" home screen quick action. Long pressing the Firefox app icon now exposes a shortcut that deep links directly into the App Icon Selection settings screen.

  - New `ShortcutType.appIcon` and matching `DeeplinkInput.Shortcut.appIcon`.
  - `RouteBuilder` maps the shortcut to `.settings(section: .appIcon)`, which `SettingsCoordinator` already has.
  - `Info.plist` registers the static `UIApplicationShortcutItem` with `logoFirefoxLarge ` icon.
  - added tests

Additionally I found stacking bug
  - Fixed a stacking bug where re-entering the app via the shortcut (after sending to recents) pushed a duplicate App Icon screen onto the existing settings stack. `SettingsCoordinator.start(with:)` now guards via `isAlreadyOnTop(_:)` and skips the push if the same VC type is already on top. it doesn't break any existing settings behaviour
I've attached a demo video for it


## :movie_camera: Demo

<img width="265" height="337" alt="Screenshot 2026-05-27 at 6 26 32 AM" src="https://github.com/user-attachments/assets/c1b47286-f3cc-4a53-b992-5a695312ebaf" />


https://github.com/user-attachments/assets/c937d793-1cdd-4b95-ab0b-71b12f7b40ce



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If needed, I updated documentation and added comments to complex code
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n

