### PR TITLE
Bugfix FXIOS-15925 [WC] Fix grouping of tbd matches in knockout stages

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
@@ -137,8 +137,13 @@ struct WorldCupMatches: Equatable, Hashable {
         return (cards, max(cards.count - 1, 0))
     }
 
-    /// No-team / eliminated-team multi-card view: group-stage matches go to per-day cards
-    /// (M2 behavior); knockout matches collapse into one card per round.
+    /// No-team / eliminated-team multi-card view: one card per
+    /// (calendar day, stage) pair. `phaseTitle` is the card's stage,
+    /// `dateLabel` is the day. Splitting on stage as well as day means
+    /// the group-to-knockout transition day (last group games in the
+    /// morning UTC, first R32 fixtures in the afternoon) produces two
+    /// separate cards instead of mis-labeling R32 fixtures as group
+    /// stage on a single mixed card.
     static func flattened(
         response: WorldCupMatchesResponse,
         liveIDs: Set<Int> = [],
@@ -147,74 +152,18 @@ struct WorldCupMatches: Equatable, Hashable {
         localeProvider: LocaleProvider = SystemLocaleProvider()
     ) -> (cards: [WorldCupMatches], defaultIndex: Int) {
         let allMatches = (response.previous ?? []) + (response.current ?? []) + (response.next ?? [])
-        let (groupMatches, knockoutByStage) = partition(allMatches)
-
-        // Group stage: per-day cards. Title comes from the day's dominant
-        // stage so unknown/nil-stage entries (the fallback bucket) read as
-        // "Upcoming" rather than mis-labeling them "Group Stage".
-        let groupCards = groupedByDay(groupMatches, calendar: calendar).map { group -> WorldCupMatches in
-            let stageCounts = Dictionary(grouping: group.matches.compactMap(\.stage), by: { $0 })
-                .mapValues(\.count)
-            let dominantStage = stageCounts.max(by: { $0.value < $1.value })?.key
-            return buildCard(matches: group.matches,
-                             phaseTitle: label(for: dominantStage),
-                             dateLabel: dayLabel(for: group.day, locale: localeProvider.current),
-                             liveIDs: liveIDs,
-                             localeProvider: localeProvider)
+        let cards = groupedByDayAndStage(allMatches, calendar: calendar).map { group -> WorldCupMatches in
+            let liveMatches = group.matches.filter { liveIDs.contains($0.globalEventId) }
+            let nonLive = group.matches.filter { !liveIDs.contains($0.globalEventId) }
+            return WorldCupMatches(
+                phaseTitle: label(for: group.stage),
+                dateLabel: dayLabel(for: group.day, locale: localeProvider.current),
+                isLive: !liveMatches.isEmpty,
+                featuredMatch: liveMatches.map { WorldCupMatch($0, localeProvider: localeProvider, timeOnly: true) },
+                upcomingMatches: nonLive.map { WorldCupMatch($0, localeProvider: localeProvider, timeOnly: true) }
+            )
         }
-
-        // Knockouts: per-stage cards in tournament order. Stages with no
-        // matches in the response are skipped.
-        let stageOrder: [WorldCupMatchesResponse.Match.Stage] = [
-            .roundOf32, .roundOf16, .quarterFinals, .semiFinals, .thirdPlace, .final
-        ]
-        let knockoutCards = stageOrder.compactMap { stage -> WorldCupMatches? in
-            guard let matches = knockoutByStage[stage], !matches.isEmpty else { return nil }
-            return buildCard(matches: matches,
-                             phaseTitle: label(for: stage),
-                             dateLabel: nil,
-                             liveIDs: liveIDs,
-                             localeProvider: localeProvider)
-        }
-
-        return (groupCards + knockoutCards, 0)
-    }
-
-    /// Splits matches into group-stage entries and knockout entries
-    /// keyed by stage.
-    private static func partition(
-        _ matches: [WorldCupMatchesResponse.Match]
-    ) -> (group: [WorldCupMatchesResponse.Match],
-          knockoutByStage: [WorldCupMatchesResponse.Match.Stage: [WorldCupMatchesResponse.Match]]) {
-        var group: [WorldCupMatchesResponse.Match] = []
-        var knockout: [WorldCupMatchesResponse.Match.Stage: [WorldCupMatchesResponse.Match]] = [:]
-        for match in matches {
-            switch match.stage {
-            case .roundOf32, .roundOf16, .quarterFinals, .semiFinals, .thirdPlace, .final:
-                knockout[match.stage!, default: []].append(match)
-            case .groupStage, .unknown, .none:
-                group.append(match)
-            }
-        }
-        return (group, knockout)
-    }
-
-    private static func buildCard(
-        matches: [WorldCupMatchesResponse.Match],
-        phaseTitle: String,
-        dateLabel: String?,
-        liveIDs: Set<Int>,
-        localeProvider: LocaleProvider
-    ) -> WorldCupMatches {
-        let liveMatches = matches.filter { liveIDs.contains($0.globalEventId) }
-        let nonLive = matches.filter { !liveIDs.contains($0.globalEventId) }
-        return WorldCupMatches(
-            phaseTitle: phaseTitle,
-            dateLabel: dateLabel,
-            isLive: !liveMatches.isEmpty,
-            featuredMatch: liveMatches.map { WorldCupMatch($0, localeProvider: localeProvider, timeOnly: true) },
-            upcomingMatches: nonLive.map { WorldCupMatch($0, localeProvider: localeProvider, timeOnly: true) }
-        )
+        return (cards, 0)
     }
 
     private static func dayLabel(for day: Date, locale: Locale) -> String {
@@ -290,5 +239,35 @@ struct WorldCupMatches: Equatable, Hashable {
             byDay[day, default: []].append(match)
         }
         return order.sorted().map { ($0, byDay[$0]!) }
+    }
+
+    /// Returned groups are ordered by day, then by
+    /// the earliest kickoff within the day (so on a group→knockout
+    /// transition day, the morning group games come first and the
+    /// afternoon knockout fixtures come second)
+    private static func groupedByDayAndStage(
+        _ matches: [WorldCupMatchesResponse.Match],
+        calendar: Calendar
+    ) -> [(day: Date, stage: WorldCupMatchesResponse.Match.Stage?, matches: [WorldCupMatchesResponse.Match])] {
+        struct Key: Hashable {
+            let day: Date
+            let stage: WorldCupMatchesResponse.Match.Stage?
+        }
+        var byKey: [Key: [(date: Date, match: WorldCupMatchesResponse.Match)]] = [:]
+        var order: [Key] = []
+        for match in matches {
+            guard let parsed = WorldCupMatch.parseDate(match.date) else { continue }
+            let key = Key(day: calendar.startOfDay(for: parsed), stage: match.stage)
+            if byKey[key] == nil { order.append(key) }
+            byKey[key, default: []].append((parsed, match))
+        }
+        return order
+            .sorted { lhs, rhs in
+                if lhs.day != rhs.day { return lhs.day < rhs.day }
+                let lhsFirst = byKey[lhs]?.map(\.date).min() ?? .distantPast
+                let rhsFirst = byKey[rhs]?.map(\.date).min() ?? .distantPast
+                return lhsFirst < rhsFirst
+            }
+            .map { ($0.day, $0.stage, byKey[$0]!.map(\.match)) }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
@@ -241,14 +241,20 @@ struct WorldCupMatches: Equatable, Hashable {
         return order.sorted().map { ($0, byDay[$0]!) }
     }
 
-    /// Returned groups are ordered by day, then by
-    /// the earliest kickoff within the day (so on a group→knockout
-    /// transition day, the morning group games come first and the
-    /// afternoon knockout fixtures come second)
+    /// Returned groups are ordered by day, then by the earliest kickoff
+    /// within the day (so on a group→knockout transition day, the morning
+    /// group games come first and the afternoon knockout fixtures come
+    /// second).
+    private struct DayStageGroup {
+        let day: Date
+        let stage: WorldCupMatchesResponse.Match.Stage?
+        let matches: [WorldCupMatchesResponse.Match]
+    }
+
     private static func groupedByDayAndStage(
         _ matches: [WorldCupMatchesResponse.Match],
         calendar: Calendar
-    ) -> [(day: Date, stage: WorldCupMatchesResponse.Match.Stage?, matches: [WorldCupMatchesResponse.Match])] {
+    ) -> [DayStageGroup] {
         struct Key: Hashable {
             let day: Date
             let stage: WorldCupMatchesResponse.Match.Stage?
@@ -268,6 +274,6 @@ struct WorldCupMatches: Equatable, Hashable {
                 let rhsFirst = byKey[rhs]?.map(\.date).min() ?? .distantPast
                 return lhsFirst < rhsFirst
             }
-            .map { ($0.day, $0.stage, byKey[$0]!.map(\.match)) }
+            .map { DayStageGroup(day: $0.day, stage: $0.stage, matches: byKey[$0]!.map(\.match)) }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
@@ -516,11 +516,10 @@ struct WorldCupMatchesTests {
     }
 
     @Test
-    func test_flattened_knockoutStage_collapsesAllMatchesIntoOneCard_acrossDays() {
-        // QF runs across two days in the real bracket. The flattened view
-        // should collapse all 4 QF matches onto a single "Quarter-Finals"
-        // card instead of splitting by day, so the user doesn't see "2 of
-        // 4 quarter-finals" on each of two cards.
+    func test_flattened_knockoutStage_splitsAcrossDaysWithStageInTitle() {
+        // QF runs across two days in the real bracket. Each day gets its own
+        // card titled with the stage; the date is carried in `dateLabel`
+        // (the UI renders them together, e.g. "QUARTER-FINALS · Jul 10").
         let response = WorldCupMatchesResponse(
             previous: nil,
             current: nil,
@@ -538,27 +537,73 @@ struct WorldCupMatchesTests {
             calendar: utcCalendar()
         )
 
-        #expect(result.cards.count == 1)
-        #expect(result.cards[0].phaseTitle == String.WorldCup.HomepageWidget.RoundPhase.QuarterFinalsLabel)
-        // All four matches live on the one card. Date label is nil
-        // because the matches span two days.
-        #expect(result.cards[0].upcomingMatches.count == 4)
-        #expect(result.cards[0].dateLabel == nil)
+        #expect(result.cards.count == 2)
+        #expect(result.cards.map(\.phaseTitle) == [
+            String.WorldCup.HomepageWidget.RoundPhase.QuarterFinalsLabel,
+            String.WorldCup.HomepageWidget.RoundPhase.QuarterFinalsLabel
+        ])
+        // Each day's QF card carries that day's date in `dateLabel`.
+        #expect(result.cards[0].dateLabel != nil)
+        #expect(result.cards[1].dateLabel != nil)
+        #expect(result.cards[0].dateLabel != result.cards[1].dateLabel)
+        #expect(result.cards[0].upcomingMatches.count == 2)
+        #expect(result.cards[1].upcomingMatches.count == 2)
     }
 
     @Test
-    func test_flattened_separatesKnockoutStagesIntoOneCardEach() {
-        // Multi-stage scenario: R16 + QF + SF + Final all in the response.
-        // Each stage becomes its own card, ordered by tournament progression.
+    func test_flattened_transitionDay_splitsGroupAndKnockoutIntoSeparateCards() {
+        // Real-bracket scenario: Jun 28 holds the last group games in the
+        // morning UTC (COL-PRT 01:30, CDR-UZB 01:30, ALG-AUT 04:00,
+        // JOR-ARG 04:00) and the first R32 fixtures in the afternoon
+        // (CZE-TBD 15:00, CAN-TBD 18:00, MAR-TBD 21:00). A single
+        // "Group Stage · Jun 28" card containing the R32 fixtures (because
+        // group is the dominant count) is wrong — those R32 entries must
+        // surface under their own "Round of 32 · Jun 28" card.
+        let response = WorldCupMatchesResponse(
+            previous: nil,
+            current: nil,
+            next: [
+                makeMatch(id: 1, home: "COL", away: "PRT", date: "2026-06-28T01:30:00+00:00", stage: .groupStage),
+                makeMatch(id: 2, home: "CDR", away: "UZB", date: "2026-06-28T01:30:00+00:00", stage: .groupStage),
+                makeMatch(id: 3, home: "ALG", away: "AUT", date: "2026-06-28T04:00:00+00:00", stage: .groupStage),
+                makeMatch(id: 4, home: "JOR", away: "ARG", date: "2026-06-28T04:00:00+00:00", stage: .groupStage),
+                makeMatch(id: 5, home: "CZE", away: nil, date: "2026-06-28T15:00:00+00:00", stage: .roundOf32),
+                makeMatch(id: 6, home: "CAN", away: nil, date: "2026-06-28T18:00:00+00:00", stage: .roundOf32),
+                makeMatch(id: 7, home: "MAR", away: nil, date: "2026-06-28T21:00:00+00:00", stage: .roundOf32)
+            ]
+        )
+
+        let result = WorldCupMatches.flattened(
+            response: response,
+            now: parse("2026-06-28T00:00:00+00:00"),
+            calendar: utcCalendar()
+        )
+
+        // Two cards for Jun 28: one Group Stage (4 matches), one
+        // Round of 32 (3 matches), in that order (morning before afternoon).
+        #expect(result.cards.count == 2)
+        #expect(result.cards[0].phaseTitle == String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel)
+        #expect(result.cards[0].upcomingMatches.count == 4)
+        #expect(result.cards[1].phaseTitle == String.WorldCup.HomepageWidget.RoundPhase.Round32Label)
+        #expect(result.cards[1].upcomingMatches.count == 3)
+        // Both cards carry the Jun 28 dateLabel.
+        #expect(result.cards[0].dateLabel != nil)
+        #expect(result.cards[0].dateLabel == result.cards[1].dateLabel)
+    }
+
+    @Test
+    func test_flattened_perDayTitle_reflectsThatDaysStage() {
+        // Multi-stage scenario: each day's card is titled by that day's
+        // dominant stage. With one match per day, the dominant stage is
+        // simply that match's stage.
         let response = WorldCupMatchesResponse(
             previous: nil,
             current: nil,
             next: [
                 makeMatch(id: 1, home: "ARG", away: "BRA", date: "2026-07-04T18:00:00+00:00", stage: .roundOf16),
-                makeMatch(id: 2, home: "ENG", away: "USA", date: "2026-07-05T18:00:00+00:00", stage: .roundOf16),
-                makeMatch(id: 3, home: "FRA", away: "GER", date: "2026-07-09T18:00:00+00:00", stage: .quarterFinals),
-                makeMatch(id: 4, home: "ESP", away: "ITA", date: "2026-07-14T18:00:00+00:00", stage: .semiFinals),
-                makeMatch(id: 5, home: "NLD", away: "JPN", date: "2026-07-19T18:00:00+00:00", stage: .final)
+                makeMatch(id: 2, home: "FRA", away: "GER", date: "2026-07-09T18:00:00+00:00", stage: .quarterFinals),
+                makeMatch(id: 3, home: "ESP", away: "ITA", date: "2026-07-14T18:00:00+00:00", stage: .semiFinals),
+                makeMatch(id: 4, home: "NLD", away: "JPN", date: "2026-07-19T18:00:00+00:00", stage: .final)
             ]
         )
 
@@ -575,7 +620,8 @@ struct WorldCupMatchesTests {
             String.WorldCup.HomepageWidget.RoundPhase.SemiFinalsLabel,
             String.WorldCup.HomepageWidget.RoundPhase.FinalLabel
         ])
-        #expect(result.cards[0].upcomingMatches.count == 2)
+        // Every card carries the day's date label.
+        #expect(result.cards.allSatisfy { $0.dateLabel != nil })
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15925)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Knockout stages should also be grouped by date.
- Update tests.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

https://github.com/user-attachments/assets/ef16e8e8-91a6-42fc-a73a-6f121b842bc0


https://github.com/user-attachments/assets/9363db3a-4417-4a34-a2ab-5a23d62e1478


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

