### PR TITLE
Add RMST-382 Remote-Settings v2 support and toggling

### DIFF
--- a/BrowserKit/Sources/Shared/RemoteSettingsEnvironment.swift
+++ b/BrowserKit/Sources/Shared/RemoteSettingsEnvironment.swift
@@ -5,6 +5,9 @@
 /// NOTE: It would much cleaner to use RemoteSettingsServer if it had a public initializer.
 /// TODO(FXIOS-13189): Add public initializer from rawValue to RemoteSettingsServer.
 public enum RemoteSettingsEnvironment: String {
+    case prodV2
+    case stageV2
+    case devV2
     case prod
     case stage
     case dev

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -56,7 +56,7 @@ final class ASSearchEngineSelector: ASSearchEngineSelectorProtocol {
             let remoteSettingsEnvironmentKey =
                 profile.prefs.stringForKey(PrefsKeys.RemoteSettings.remoteSettingsEnvironment) ?? ""
             let remoteSettingsEnv = RemoteSettingsEnvironment(rawValue: remoteSettingsEnvironmentKey) ?? .prod
-            let isProd = remoteSettingsEnv == .prod
+            let isProd = remoteSettingsEnv == .prod || remoteSettingsEnv == .prodV2
             if !isProd {
                 _ = try? profile.remoteSettingsService.sync()
             }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeRSServerSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeRSServerSetting.swift
@@ -30,6 +30,24 @@ class ChangeRSServerSetting: HiddenSetting {
                                       message: message,
                                       preferredStyle: .alert)
 
+        alert.addAction(UIAlertAction(title: "Production V2", style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            self.prefs.setString(RemoteSettingsEnvironment.prodV2.rawValue, forKey: self.prefsKey)
+        }))
+        alert.addAction(UIAlertAction(title: "Staging V2", style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            self.prefs.setString(RemoteSettingsEnvironment.stageV2.rawValue, forKey: self.prefsKey)
+        }))
+        alert.addAction(UIAlertAction(title: "Staging V2 + SEC Reset", style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            self.prefs.setString(RemoteSettingsEnvironment.stageV2.rawValue, forKey: self.prefsKey)
+            let searchManager: SearchEnginesManager = AppContainer.shared.resolve()
+            searchManager.resetPrefs()
+        }))
+        alert.addAction(UIAlertAction(title: "Dev V2", style: .default, handler: { [weak self] _ in
+            guard let self else { return }
+            self.prefs.setString(RemoteSettingsEnvironment.devV2.rawValue, forKey: self.prefsKey)
+        }))
         alert.addAction(UIAlertAction(title: "Production", style: .default, handler: { [weak self] _ in
             guard let self else { return }
             self.prefs.removeObjectForKey(self.prefsKey)

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeRSServerSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeRSServerSetting.swift
@@ -23,8 +23,6 @@ class ChangeRSServerSetting: HiddenSetting {
         Current: \(currentEnvRaw.capitalized)
 
         Changes take effect on the next app launch.
-
-        To switch to Staging and reset ordering prefs for Consolidated Search, choose the SEC Reset option.
         """
         let alert = UIAlertController(title: "Remote Settings Server",
                                       message: message,
@@ -38,12 +36,6 @@ class ChangeRSServerSetting: HiddenSetting {
             guard let self else { return }
             self.prefs.setString(RemoteSettingsEnvironment.stageV2.rawValue, forKey: self.prefsKey)
         }))
-        alert.addAction(UIAlertAction(title: "Staging V2 + SEC Reset", style: .default, handler: { [weak self] _ in
-            guard let self else { return }
-            self.prefs.setString(RemoteSettingsEnvironment.stageV2.rawValue, forKey: self.prefsKey)
-            let searchManager: SearchEnginesManager = AppContainer.shared.resolve()
-            searchManager.resetPrefs()
-        }))
         alert.addAction(UIAlertAction(title: "Dev V2", style: .default, handler: { [weak self] _ in
             guard let self else { return }
             self.prefs.setString(RemoteSettingsEnvironment.devV2.rawValue, forKey: self.prefsKey)
@@ -55,12 +47,6 @@ class ChangeRSServerSetting: HiddenSetting {
         alert.addAction(UIAlertAction(title: "Staging", style: .default, handler: { [weak self] _ in
             guard let self else { return }
             self.prefs.setString(RemoteSettingsEnvironment.stage.rawValue, forKey: self.prefsKey)
-        }))
-        alert.addAction(UIAlertAction(title: "Staging + SEC Reset", style: .default, handler: { [weak self] _ in
-            guard let self else { return }
-            self.prefs.setString(RemoteSettingsEnvironment.stage.rawValue, forKey: self.prefsKey)
-            let searchManager: SearchEnginesManager = AppContainer.shared.resolve()
-            searchManager.resetPrefs()
         }))
         alert.addAction(UIAlertAction(title: "Dev", style: .default, handler: { [weak self] _ in
             guard let self else { return }

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -822,6 +822,9 @@ extension RemoteSettingsEnvironment {
         case .prod: return .prod
         case .stage: return .stage
         case .dev: return .dev
+        case .prodV2: return .prodV2
+        case .stageV2: return .stageV2
+        case .devV2: return .devV2
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[RMST-382](https://mozilla-hub.atlassian.net/browse/RMST-382)


## :bulb: Description
This allows devs to switch to V2 remote-settings endpoints for specific testing on dev builds via the hidden settings menu.
We would like to begin rollout of V2 to end users around mid-June.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code



[RMST-382]: https://mozilla-hub.atlassian.net/browse/RMST-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ