### PR TITLE
Bugfix FXIOS-15917 User can't type in the address bar (address bar appears frozen)

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -439,6 +439,9 @@ final class LocationView: UIView,
 
     // MARK: - LocationView Scaling
     private func shrinkLocationView(barPosition: AddressToolbarPosition) {
+        urlTextField.isUserInteractionEnabled = false
+        isUserInteractionEnabled = false
+
         let isiPad = UIDevice.current.userInterfaceIdiom == .pad
         let bottomAddressBarYoffset = if #available(iOS 26.0, *) {
             UX.bottomAddressBarYoffset
@@ -454,22 +457,18 @@ final class LocationView: UIView,
                 let scaledTransformation = CGAffineTransform(scaleX: UX.smallScale, y: UX.smallScale)
                     .translatedBy(x: 0, y: yOffset)
                 self.transform = scaledTransformation
-            }, completion: { [unowned self] _ in
-                urlTextField.isUserInteractionEnabled = false
-                isUserInteractionEnabled = false
             })
     }
 
     private func restoreLocationViewSize() {
+        urlTextField.isUserInteractionEnabled = true
+        isUserInteractionEnabled = true
         UIView.animate(
             withDuration: UX.identityResetAnimationDuration,
             delay: 0,
             options: [.curveEaseInOut],
             animations: { [unowned self] in
                 transform = .identity
-            }, completion: { [unowned self] _ in
-                urlTextField.isUserInteractionEnabled = true
-                isUserInteractionEnabled = true
             })
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15917)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Fix animation race condition by moving `urlTextField.isUserInteractionEnabled `and `isUserInteractionEnabled` configuration outside of animation block. We now know why the user interacion is being toggle see [regresion bug](https://mozilla-hub.atlassian.net/browse/FXIOS-15924) based on logs the animation were getting into a race condition where the completion to restore userInteraction was getting called before the shrinkLocationView leaving the textfield with the interaction disabled. 

This is an attempt to fix the terrible bug without the big refactoring that we are planning and to have a fix in the next release

```
  YRD - LocationView: shrinkLocationView
  YRD - LocationView: shrinkLocationView animation started
  YRD - LocationView: restoreLocationViewSize
  YRD - LocationView: restore animation started
  YRD - LocationView: restore completion enabling user interaction
  YRD - LocationView: Shrinked completion disabling user interaction
  
  ```
  
I also tested and with this fix [FXIOS-15924](https://mozilla-hub.atlassian.net/browse/FXIOS-15924) is not reproducible so no regression

## :movie_camera: Demos


https://github.com/user-attachments/assets/9c371b74-639c-4cea-9161-fa1f9ef2d259


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code



[FXIOS-15924]: https://mozilla-hub.atlassian.net/browse/FXIOS-15924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ