### PR TITLE
Refactor Set Bottom bar for UI Automated tests

### DIFF
--- a/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
+++ b/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
@@ -71,7 +71,7 @@ final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Send
            let position = SearchBarPosition(rawValue: raw) {
             return position
         }
-        return .top
+        return .bottom
     }
 
     var startAtHomeSetting: StartAtHome {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1133,7 +1133,8 @@ class BrowserViewController: UIViewController,
         let windowUUID = notification.windowUUID
         let zoomSetting = notification.userInfo?["zoom"] as? DomainZoomLevel
         // swiftlint:disable:next closure_body_length
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
+            guard let self else { return }
             switch notificationName {
             case UIApplication.willTerminateNotification:
                 applicationWillTerminate()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
After the bottom / top toolbar experiments ended we thought we would have the default value for the toolbar running on the automated tests. However, that was not the case, without the value changed in this PR the tool bar is shown on top for Fennec and Firefox Beta. It is shown at the bottom on Firefox though. 

We don't really understand why the value is different on Firefox and how can we control this somehow so that can rely on the default or expected value is taken when the UI Automated tests are run.


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

