### PR TITLE
Add FXIOS-15849 [Add Shortcut Tile] Custom webpage shortcut alert

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -267,6 +267,11 @@ struct AccessibilityIdentifiers {
 
         struct TopSites {
             static let itemCell = "TopSitesCell"
+
+            struct AddShortcutAlert {
+                static let view = "TopSites.AddShortcutAlert"
+                static let urlTextField = "TopSites.AddShortcutAlert.URLTextField"
+            }
         }
 
         struct SearchBar {

--- a/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
@@ -91,4 +91,43 @@ extension UIAlertController {
 
         return deleteAlert
     }
+
+    class func addShortcutAlert() -> UIAlertController {
+        let alert = UIAlertController(
+            title: .FirefoxHomepage.Shortcuts.AddShortcut.AlertTitle,
+            message: .FirefoxHomepage.Shortcuts.AddShortcut.AlertDescription,
+            preferredStyle: .alert
+        )
+        alert.view.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.TopSites.AddShortcutAlert.view
+
+        let cancelAction = UIAlertAction(
+            title: .FirefoxHomepage.Shortcuts.AddShortcut.CancelButtonTitle,
+            style: .cancel
+        )
+        let saveAction = UIAlertAction(
+            title: .FirefoxHomepage.Shortcuts.AddShortcut.SaveButtonTitle,
+            style: .default
+        )
+        saveAction.isEnabled = false
+
+        alert.addTextField { textField in
+            textField.placeholder = .FirefoxHomepage.Shortcuts.AddShortcut.URLTextFieldPlaceholder
+            textField.keyboardType = .URL
+            textField.autocapitalizationType = .none
+            textField.autocorrectionType = .no
+            textField.returnKeyType = .done
+            textField.clearButtonMode = .whileEditing
+            textField.accessibilityIdentifier =
+                AccessibilityIdentifiers.FirefoxHomepage.TopSites.AddShortcutAlert.urlTextField
+            textField.addAction(UIAction { [weak textField, weak saveAction] _ in
+                let text = textField?.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                saveAction?.isEnabled = !text.isEmpty
+            }, for: .editingChanged)
+        }
+
+        alert.addAction(cancelAction)
+        alert.addAction(saveAction)
+
+        return alert
+    }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -1261,6 +1261,8 @@ final class HomepageViewController: UIViewController,
             return
         }
         switch item {
+        case .addShortcutTile:
+            presentAddShortcutAlert()
         case .topSite(let config, _):
             dispatchDidSelectCardItemAction(with: item)
             let destination = NavigationDestination(
@@ -1311,6 +1313,11 @@ final class HomepageViewController: UIViewController,
         default:
             return
         }
+    }
+
+    private func presentAddShortcutAlert() {
+        let alert = UIAlertController.addShortcutAlert()
+        present(alert, animated: true)
     }
 
     /// Sends telemetry data associated with tapping on a card item. The jump back in synced card item

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -361,6 +361,11 @@ class ShortcutsLibraryViewController: UIViewController,
             return
         }
 
+        if case .addShortcutTile = item {
+            presentAddShortcutAlert()
+            return
+        }
+
         guard case let .shortcut(config) = item else { return }
         let destination = NavigationDestination(
             .link,
@@ -384,6 +389,11 @@ class ShortcutsLibraryViewController: UIViewController,
                 actionType: ShortcutsLibraryActionType.tapOnShortcutCell
             )
         )
+    }
+
+    private func presentAddShortcutAlert() {
+        let alert = UIAlertController.addShortcutAlert()
+        present(alert, animated: true)
     }
 
     // MARK: - DismissalNotifiable


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15849)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33901)

## :bulb: Description
- Add the Add Shortcut alert

## :movie_camera: Demos
https://github.com/user-attachments/assets/95e83798-82be-4420-b670-2e351ef01057

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

