### PR TITLE
Add [World Cup] FXIOS-15933 telemetry for swipe of the pager card.

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1565,6 +1565,7 @@
 		C22753402A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */; };
 		C2296FCC2A601C190046ECA6 /* IntensityVisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */; };
 		C22C00C32FC44A2100951BF6 /* WorldCupWinnerBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22C00C22FC44A2100951BF6 /* WorldCupWinnerBackgroundView.swift */; };
+		C22C0D772FC832BC00951BF6 /* WorldCupPagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22C0D762FC832BC00951BF6 /* WorldCupPagerView.swift */; };
 		C234BFC02EBB8321004BF5A8 /* SettingsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C234BFBF2EBB82E1004BF5A8 /* SettingsNavigationController.swift */; };
 		C234BFC22EBB8356004BF5A8 /* ModalSettingsNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C234BFC12EBB8352004BF5A8 /* ModalSettingsNavigationController.swift */; };
 		C23889DF2A4EFCE500429673 /* ShareSheetCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23889DE2A4EFCE500429673 /* ShareSheetCoordinator.swift */; };
@@ -10413,6 +10414,7 @@
 		C227533F2A3C9E1300B9C0D1 /* WebsiteDataManagementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebsiteDataManagementViewModel.swift; sourceTree = "<group>"; };
 		C2296FCB2A601C190046ECA6 /* IntensityVisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntensityVisualEffectView.swift; sourceTree = "<group>"; };
 		C22C00C22FC44A2100951BF6 /* WorldCupWinnerBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupWinnerBackgroundView.swift; sourceTree = "<group>"; };
+		C22C0D762FC832BC00951BF6 /* WorldCupPagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupPagerView.swift; sourceTree = "<group>"; };
 		C234BFBF2EBB82E1004BF5A8 /* SettingsNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationController.swift; sourceTree = "<group>"; };
 		C234BFC12EBB8352004BF5A8 /* ModalSettingsNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalSettingsNavigationController.swift; sourceTree = "<group>"; };
 		C23889DE2A4EFCE500429673 /* ShareSheetCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheetCoordinator.swift; sourceTree = "<group>"; };
@@ -15296,6 +15298,7 @@
 				C27AB7062F9B85A50085439A /* WorldCupCountry.swift */,
 				C27AB7072F9B85A50085439A /* WorldCupCountryPickerView.swift */,
 				C22C00C22FC44A2100951BF6 /* WorldCupWinnerBackgroundView.swift */,
+				C22C0D762FC832BC00951BF6 /* WorldCupPagerView.swift */,
 			);
 			path = WorldCup;
 			sourceTree = "<group>";
@@ -19839,6 +19842,7 @@
 				81020C942BB5B026007B8481 /* OnboardingMultipleChoiceButtonViewModel.swift in Sources */,
 				8A5A24C12FA3F85B00D11F8A /* OffloadBackgroundWebViewsSetting.swift in Sources */,
 				E12BD0AE28AC38480029AAF0 /* UIImage+Extension.swift in Sources */,
+				C22C0D772FC832BC00951BF6 /* WorldCupPagerView.swift in Sources */,
 				0A7693692C81F2A300103A6D /* TrackingProtectionConnectionDetailsView.swift in Sources */,
 				F886218C270CD3B8007F4562 /* DevicePasscodeRequiredViewController.swift in Sources */,
 				BA4BB99A2D7F374C006BD137 /* AppearanceSettingsView.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -29,7 +29,7 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
         case jumpBackIn(TextColor?, JumpBackInSectionLayoutConfiguration)
         case bookmarks(TextColor?)
         case pocket(TextColor?)
-        case worldcup(TextColor?)
+        case worldcup
         case spacer
 
         var canHandleLongPress: Bool {
@@ -144,10 +144,10 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
         }
 
         if state.worldcupState.shouldShowSection {
-            snapshot.appendSections([.worldcup(textColor)])
+            snapshot.appendSections([.worldcup])
             snapshot.appendItems(
                 [.worldcupCard],
-                toSection: .worldcup(textColor)
+                toSection: .worldcup
             )
             snapshot.reconfigureItems([.worldcupCard])
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -664,10 +664,17 @@ final class HomepageViewController: UIViewController,
             return configureMerinoCell(story, at: indexPath)
         case .worldcupCard:
             return configuredCell(cellType: WorldCupCell.self, at: indexPath) { cell in
-                cell.configure(with: homepageState.worldcupState, theme: currentTheme) { [weak self] height in
-                    self?.sectionProvider.setWorldCupCellHeight(height)
-                    self?.relayoutForCellHeightChange()
-                }
+                cell.configure(
+                    with: homepageState.worldcupState,
+                    theme: currentTheme,
+                    onHeightChange: { [weak self] height in
+                        self?.sectionProvider.setWorldCupCellHeight(height)
+                        self?.relayoutForCellHeightChange()
+                    },
+                    isCardImpression: { [weak self] in
+                        return self?.alreadyTrackedSections.contains(.worldcup) ?? false
+                    }
+                )
             }
         case .spacer:
             return configuredCell(cellType: HomepageSpacerCell.self, at: indexPath) { _ in }

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -672,7 +672,7 @@ final class HomepageViewController: UIViewController,
                         self?.relayoutForCellHeightChange()
                     },
                     isCardImpression: { [weak self] in
-                        return self?.alreadyTrackedSections.contains(.worldcup) ?? false
+                        return !(self?.alreadyTrackedSections.contains(.worldcup) ?? true)
                     }
                 )
             }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -251,8 +251,6 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
         onHeightChange: @escaping (CGFloat) -> Void,
         isCardImpression: @escaping () -> Bool
     ) {
-        // apply the blur suddenly to avoid any lags when showing the cell on the background blur
-        adjustBlur(theme: theme)
         self.onHeightChange = onHeightChange
         self.isCardImpression = isCardImpression
         if currentState != state {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -385,7 +385,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
             }
         )
     }
-    
+
     private func recordSwipeTelemetry(forPage page: Int) {
         guard let container = pagesStack.arrangedSubviews[safe: page] as? PageContainer,
               let viewName = container.content.telemetryValue else { return }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -227,7 +227,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        goToPage(pageControl.currentPage)
+        goToPage(pageControl.currentPage, recordTelemetry: false)
     }
 
     override func layoutSubviews() {
@@ -342,7 +342,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
         return true
     }
 
-    private func goToPage(_ page: Int) {
+    private func goToPage(_ page: Int, recordTelemetry: Bool = true) {
         pageControl.currentPage = page
         updatePageAccessibility()
         let (isShowingWinnerView, applyWinnerChanges) = getWinnerStatusForCurrentPage()
@@ -350,7 +350,9 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
         let (scrollViewHeight, contentViewHeight) = getContentsHeight(for: page, isShowingWinnerView: isShowingWinnerView)
         applyWinnerChanges()
         scrollViewHeightConstraint?.constant = scrollViewHeight
-        recordSwipeTelemetry(forPage: page)
+        if recordTelemetry {
+            recordSwipeTelemetry(forPage: page)
+        }
         UIView.animate(
             withDuration: UX.contentConstraintsChangeAnimationDuration,
             delay: UX.animationDelay,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -18,7 +18,7 @@ private final class PageContainer: UIView, ThemeApplicable {
         static let hiddenAlpha: CGFloat = 0.0
     }
 
-    let content: UIView
+    let content: WorldCupPagerView
     private let loadingImageView: UIImageView = .build { image in
         image.image = UIImage(named: UX.loadingImage)
         image.isAccessibilityElement = false
@@ -26,7 +26,7 @@ private final class PageContainer: UIView, ThemeApplicable {
         image.isHidden = true
     }
 
-    init(content: UIView) {
+    init(content: WorldCupPagerView) {
         self.content = content
         super.init(frame: .zero)
         setupLayout()
@@ -145,8 +145,13 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
     private var rootContainerBottomConstraint: NSLayoutConstraint?
     private var currentState: WorldCupSectionState?
     private var onHeightChange: ((CGFloat) -> Void)?
+    /// Called the first time a card is shown after the cell is configured.
+    /// The closure should record the section-level impression as a side effect
+    /// and return `true` only the first time it's called per homepage session.
+    private var isCardImpression: (() -> Bool)?
     private var lastScrollViewWidth: CGFloat = 0
     private var theme: Theme?
+    private let telemetry = WorldCupTelemetry()
 
     override init(frame: CGRect) {
         super.init(frame: .zero)
@@ -243,9 +248,13 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
     func configure(
         with state: WorldCupSectionState,
         theme: Theme,
-        onHeightChange: @escaping (CGFloat) -> Void
+        onHeightChange: @escaping (CGFloat) -> Void,
+        isCardImpression: @escaping () -> Bool
     ) {
+        // apply the blur suddenly to avoid any lags when showing the cell on the background blur
+        adjustBlur(theme: theme)
         self.onHeightChange = onHeightChange
+        self.isCardImpression = isCardImpression
         if currentState != state {
             currentState = state
             rebuildPages(for: state)
@@ -341,6 +350,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
         let (scrollViewHeight, contentViewHeight) = getContentsHeight(for: page, isShowingWinnerView: isShowingWinnerView)
         applyWinnerChanges()
         scrollViewHeightConstraint?.constant = scrollViewHeight
+        recordSwipeTelemetry(forPage: page)
         UIView.animate(
             withDuration: UX.contentConstraintsChangeAnimationDuration,
             delay: UX.animationDelay,
@@ -372,6 +382,13 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
                 )
             }
         )
+    }
+    
+    private func recordSwipeTelemetry(forPage page: Int) {
+        guard let container = pagesStack.arrangedSubviews[safe: page] as? PageContainer,
+              let viewName = container.content.telemetryValue else { return }
+        let isImpression = isCardImpression?() ?? false
+        telemetry.cardSwiped(view: viewName, isImpression: isImpression)
     }
 
     private func getContentsHeight(

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCellFactory.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCellFactory.swift
@@ -8,7 +8,7 @@ import UIKit
 @MainActor
 struct WorldCupCellFactory {
     /// Builds the subpages array from the given state
-    static func makePages(from state: WorldCupSectionState) -> [UIView] {
+    static func makePages(from state: WorldCupSectionState) -> [WorldCupPagerView] {
         guard state.isMilestone2 else {
             let timerView = WorldCupTimerView(windowUUID: state.windowUUID)
             timerView.configure(state: state)

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupErrorView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupErrorView.swift
@@ -6,7 +6,7 @@ import Common
 import Shared
 import UIKit
 
-final class WorldCupErrorView: UIView, ThemeApplicable {
+final class WorldCupErrorView: UIView, ThemeApplicable, WorldCupPagerView {
     private struct UX {
         static let horizontalPadding: CGFloat = 16
         static let titleLabelLeadingPadding: CGFloat = 12.0
@@ -25,6 +25,9 @@ final class WorldCupErrorView: UIView, ThemeApplicable {
 
     private let windowUUID: WindowUUID
     private let telemetry = WorldCupTelemetry()
+    var telemetryValue: String? {
+        return "error"
+    }
 
     // MARK: - UI
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
@@ -6,7 +6,7 @@ import Common
 import Shared
 import UIKit
 
-final class WorldCupMatchCardView: UIView, ThemeApplicable {
+final class WorldCupMatchCardView: UIView, ThemeApplicable, WorldCupPagerView {
     private struct UX {
         static let sectionSpacing: CGFloat = 16
         static let headerSpacing: CGFloat = 6
@@ -193,6 +193,12 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable {
     func getWinnerThirdPlaceOrFinal() -> (teamKey: String, winnerLabel: String)? {
         guard let model else { return nil }
         return model.winnerThirdPlaceOrFinal
+    }
+
+    /// Untranslated phase identifier for this card, surfaced through the
+    /// enclosing cell when emitting swipe telemetry.
+    var telemetryValue: String? {
+        return model?.telemetryPhaseValue
     }
 
     private func rebuildFeaturedMatches(matches: [WorldCupMatch]) {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatches.swift
@@ -7,6 +7,10 @@ import Shared
 
 struct WorldCupMatches: Equatable, Hashable {
     let phaseTitle: String
+    /// English, untranslated identifier for the card's phase, used as a stable
+    /// telemetry value (e.g. "Group A", "Round of 16", "Final"). Mirrors
+    /// `phaseTitle` but bypasses the localized string table.
+    let telemetryPhaseValue: String
     let dateLabel: String?
     let isLive: Bool
     let featuredMatch: [WorldCupMatch]
@@ -24,11 +28,13 @@ struct WorldCupMatches: Equatable, Hashable {
     }
 
     init(phaseTitle: String,
+         telemetryPhaseValue: String,
          dateLabel: String? = nil,
          isLive: Bool,
          featuredMatch: [WorldCupMatch],
          upcomingMatches: [WorldCupMatch]) {
         self.phaseTitle = phaseTitle
+        self.telemetryPhaseValue = telemetryPhaseValue
         self.dateLabel = dateLabel
         self.isLive = isLive
         self.featuredMatch = featuredMatch
@@ -92,6 +98,7 @@ struct WorldCupMatches: Equatable, Hashable {
 
         let allIDs = allMatches.map(\.globalEventId)
         self.phaseTitle = Self.phaseTitle(from: featured.first)
+        self.telemetryPhaseValue = Self.telemetryPhaseValue(from: featured.first)
         self.dateLabel = nil
         self.isLive = allIDs.contains(where: { liveIDs.contains($0) })
         self.featuredMatch = featured.map { WorldCupMatch($0, localeProvider: localeProvider) }
@@ -168,6 +175,7 @@ struct WorldCupMatches: Equatable, Hashable {
             let nonLive = group.matches.filter { !liveIDs.contains($0.globalEventId) }
             return WorldCupMatches(
                 phaseTitle: label(for: group.stage),
+                telemetryPhaseValue: group.stage?.rawValue ?? WorldCupMatchesResponse.Match.Stage.groupStage.rawValue,
                 dateLabel: dayLabel(for: group.day, locale: localeProvider.current),
                 isLive: !liveMatches.isEmpty,
                 featuredMatch: liveMatches.map { WorldCupMatch($0, localeProvider: localeProvider, timeOnly: true) },
@@ -200,6 +208,11 @@ struct WorldCupMatches: Equatable, Hashable {
                 ?? String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel
         }
         return label(for: match.stage)
+    }
+
+    static func telemetryPhaseValue(from match: WorldCupMatchesResponse.Match?) -> String {
+        guard let match else { return WorldCupMatchesResponse.Match.Stage.groupStage.rawValue }
+        return match.stage?.rawValue ?? WorldCupMatchesResponse.Match.Stage.groupStage.rawValue
     }
 
     private static func label(for stage: WorldCupMatchesResponse.Match.Stage?) -> String {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchesResponse.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchesResponse.swift
@@ -127,7 +127,10 @@ struct WorldCupMatchesResponse: Decodable, Equatable, Sendable {
             return nil
         }
 
-        /// Closed set of tournament stages emitted by merino's `stage` field..
+        /// Closed set of tournament stages emitted by merino's `stage` field.
+        /// `rawValue` round-trips the original server string — including the
+        /// `.unknown` case — which makes it suitable both for decoding and as
+        /// a stable, untranslated telemetry identifier.
         enum Stage: Decodable, Hashable, Sendable {
             case groupStage
             case roundOf32
@@ -137,6 +140,19 @@ struct WorldCupMatchesResponse: Decodable, Equatable, Sendable {
             case thirdPlace
             case final
             case unknown(String)
+
+            var rawValue: String {
+                switch self {
+                case .groupStage: return "Group Stage"
+                case .roundOf32: return "Round of 32"
+                case .roundOf16: return "Round of 16"
+                case .quarterFinals: return "Quarter-finals"
+                case .semiFinals: return "Semi-finals"
+                case .thirdPlace: return "3rd Place"
+                case .final: return "Final"
+                case .unknown(let raw): return raw
+                }
+            }
 
             init(from decoder: Decoder) throws {
                 let raw = try decoder.singleValueContainer().decode(String.self)

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupPagerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupPagerView.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+/// A subview of the `WorldCupCell` pager view.
+protocol WorldCupPagerView: UIView {
+    /// The raw representation for the subviews of the `WorldCupCell` used for telemetry identification.
+    var telemetryValue: String? { get }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTelemetry.swift
@@ -44,4 +44,9 @@ struct WorldCupTelemetry {
     func countrySelectorDisplayed() {
         gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.countrySelectorDisplayed)
     }
+
+    func cardSwiped(view: String, isImpression: Bool) {
+        let extra = GleanMetrics.WorldCupWidget.CardSwipedExtra(isImpression: isImpression, view: view)
+        gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.cardSwiped, extras: extra)
+    }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTimerView.swift
@@ -7,7 +7,7 @@ import ComponentLibrary
 import Shared
 import UIKit
 
-final class WorldCupTimerView: UIView, ThemeApplicable {
+final class WorldCupTimerView: UIView, ThemeApplicable, WorldCupPagerView {
     private struct UX {
         static let horizontalPadding: CGFloat = 16.0
         static let leftContentStackSpacing: CGFloat = 16.0
@@ -30,6 +30,10 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
     private let profile: Profile
     private var countdownModel: WorldCupCountdownModel?
     private let telemetry = WorldCupTelemetry()
+    private var hasWorldCupStarted = false
+    var telemetryValue: String? {
+        return hasWorldCupStarted ? "follow_your_team" : "countdown"
+    }
 
     private var heroVisibleConstraints: [NSLayoutConstraint] = []
     private var heroHiddenConstraints: [NSLayoutConstraint] = []
@@ -272,6 +276,7 @@ final class WorldCupTimerView: UIView, ThemeApplicable {
     }
 
     private func applyStartedState(_ hasStarted: Bool) {
+        hasWorldCupStarted = hasStarted
         timerContainer.isHidden = hasStarted
         subtitleLabel.isHidden = !hasStarted
         if hasStarted {

--- a/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
+++ b/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
@@ -122,6 +122,7 @@ world_cup_widget:
           cards this is the untranslated phase value (e.g. "Group Stage",
           "Round of 16", "Final"); for the timer view it is "countdown"
           before the tournament starts and "follow_your_team" after.
+          For the error view just return "error".
         type: string
       is_impression:
         description: |

--- a/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
+++ b/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
@@ -111,3 +111,28 @@ world_cup_widget:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-12-01"
+  card_swiped:
+    type: event
+    description: |
+      Records when the user swipes between cards in the WorldCup widget.
+    extra_keys:
+      view:
+        description: |
+          String identifier of the view the user has scrolled to. For match
+          cards this is the untranslated phase value (e.g. "Group A",
+          "Round of 16", "Final"); for the timer view it is "countdown"
+          before the tournament starts and "follow_your_team" after.
+        type: string
+      is_impression:
+        description: |
+          True for the first card recorded after the WorldCup section is
+          built in the current homepage session — i.e. the section's initial
+          impression. False for every subsequent swipe within that session.
+        type: boolean
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-12-01"

--- a/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
+++ b/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
@@ -119,7 +119,7 @@ world_cup_widget:
       view:
         description: |
           String identifier of the view the user has scrolled to. For match
-          cards this is the untranslated phase value (e.g. "Group A",
+          cards this is the untranslated phase value (e.g. "Group Stage",
           "Round of 16", "Final"); for the timer view it is "countdown"
           before the tournament starts and "follow_your_team" after.
         type: string
@@ -130,9 +130,9 @@ world_cup_widget:
           impression. False for every subsequent swipe within that session.
         type: boolean
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15933
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34046
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-12-01"

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
@@ -65,9 +65,9 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
 
         let snapshot = dataSource.snapshot()
         XCTAssertEqual(snapshot.numberOfSections, 3)
-        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .worldcup(nil), .spacer])
+        XCTAssertEqual(snapshot.sectionIdentifiers, [.header, .worldcup, .spacer])
         XCTAssertEqual(snapshot.numberOfItems(inSection: .header), 1)
-        XCTAssertEqual(snapshot.numberOfItems(inSection: .worldcup(nil)), 1)
+        XCTAssertEqual(snapshot.numberOfItems(inSection: .worldcup), 1)
         XCTAssertEqual(snapshot.numberOfItems(inSection: .spacer), 1)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupCellFactoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupCellFactoryTests.swift
@@ -105,6 +105,7 @@ final class WorldCupCellFactoryTests: XCTestCase {
     private func makeMatches() -> WorldCupMatches {
         return WorldCupMatches(
             phaseTitle: "Group Stage",
+            telemetryPhaseValue: "Group Stage",
             isLive: false,
             featuredMatch: [],
             upcomingMatches: []

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
@@ -775,13 +775,6 @@ struct WorldCupMatchesTests {
     // MARK: - telemetryPhaseValue
 
     @Test
-    func test_telemetryPhaseValue_groupStage_usesRawGroupString() {
-        let match = makeMatch(id: 0, home: "ENG", away: "USA", group: "Group C", stage: .groupStage)
-
-        #expect(WorldCupMatches.telemetryPhaseValue(from: match) == "Group C")
-    }
-
-    @Test
     func test_telemetryPhaseValue_groupStage_fallsBackToGroupStage_whenGroupMissing() {
         let match = makeMatch(id: 0, home: "ENG", away: "USA", group: nil, stage: .groupStage)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
@@ -772,12 +772,61 @@ struct WorldCupMatchesTests {
                 == String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel)
     }
 
+    // MARK: - telemetryPhaseValue
+
+    @Test
+    func test_telemetryPhaseValue_groupStage_usesRawGroupString() {
+        let match = makeMatch(id: 0, home: "ENG", away: "USA", group: "Group C", stage: .groupStage)
+
+        #expect(WorldCupMatches.telemetryPhaseValue(from: match) == "Group C")
+    }
+
+    @Test
+    func test_telemetryPhaseValue_groupStage_fallsBackToGroupStage_whenGroupMissing() {
+        let match = makeMatch(id: 0, home: "ENG", away: "USA", group: nil, stage: .groupStage)
+
+        #expect(WorldCupMatches.telemetryPhaseValue(from: match) == "Group Stage")
+    }
+
+    @Test
+    func test_telemetryPhaseValue_knockoutStages_mapToUntranslatedLabels() {
+        let mappings: [(WorldCupMatchesResponse.Match.Stage, String)] = [
+            (.roundOf32, "Round of 32"),
+            (.roundOf16, "Round of 16"),
+            (.quarterFinals, "Quarter-finals"),
+            (.semiFinals, "Semi-finals"),
+            (.thirdPlace, "3rd Place"),
+            (.final, "Final")
+        ]
+        for (stage, expected) in mappings {
+            let match = makeMatch(id: 0, home: "BRA", away: "ARG", group: nil, stage: stage)
+            #expect(WorldCupMatches.telemetryPhaseValue(from: match) == expected)
+        }
+    }
+
+    @Test
+    func test_telemetryPhaseValue_unknownStage_returnsRawString() {
+        let match = makeMatch(id: 0,
+                              home: "BRA",
+                              away: "ARG",
+                              group: nil,
+                              stage: .unknown("Galactic Quarterfinals"))
+
+        #expect(WorldCupMatches.telemetryPhaseValue(from: match) == "Galactic Quarterfinals")
+    }
+
+    @Test
+    func test_telemetryPhaseValue_nilMatch_fallsBackToGroupStage() {
+        #expect(WorldCupMatches.telemetryPhaseValue(from: nil) == "Group Stage")
+    }
+
     // MARK: - winnerThirdPlaceOrFinal
 
     @Test
     func test_winnerThirdPlaceOrFinal_returnsNil_forNonFinalPhase() {
         let model = WorldCupMatches(
             phaseTitle: String.WorldCup.HomepageWidget.RoundPhase.QuarterFinalsLabel,
+            telemetryPhaseValue: "",
             isLive: false,
             featuredMatch: [makeViewMatch(home: "BRA", away: "ARG", winnerKey: "BRA")],
             upcomingMatches: []
@@ -790,6 +839,7 @@ struct WorldCupMatchesTests {
     func test_winnerThirdPlaceOrFinal_returnsWinWorldCupLabel_forFinalPhase() {
         let model = WorldCupMatches(
             phaseTitle: String.WorldCup.HomepageWidget.RoundPhase.FinalLabel,
+            telemetryPhaseValue: "",
             isLive: false,
             featuredMatch: [makeViewMatch(home: "BRA", away: "ARG", winnerKey: "BRA")],
             upcomingMatches: []
@@ -804,6 +854,7 @@ struct WorldCupMatchesTests {
     func test_winnerThirdPlaceOrFinal_returnsThirdPlaceLabel_forBronzeFinalPhase() {
         let model = WorldCupMatches(
             phaseTitle: String.WorldCup.HomepageWidget.RoundPhase.BronzeFinalLabel,
+            telemetryPhaseValue: "",
             isLive: false,
             featuredMatch: [makeViewMatch(home: "FRA", away: "GER", winnerKey: "FRA")],
             upcomingMatches: []
@@ -819,6 +870,7 @@ struct WorldCupMatchesTests {
         // Final hasn't been played yet — neither match has a winnerKey.
         let model = WorldCupMatches(
             phaseTitle: String.WorldCup.HomepageWidget.RoundPhase.FinalLabel,
+            telemetryPhaseValue: "",
             isLive: false,
             featuredMatch: [makeViewMatch(home: "BRA", away: "ARG", winnerKey: nil)],
             upcomingMatches: []
@@ -831,6 +883,7 @@ struct WorldCupMatchesTests {
     func test_winnerThirdPlaceOrFinal_pullsWinnerFromFeaturedMatchFirst() {
         let model = WorldCupMatches(
             phaseTitle: String.WorldCup.HomepageWidget.RoundPhase.FinalLabel,
+            telemetryPhaseValue: "",
             isLive: false,
             featuredMatch: [makeViewMatch(home: "BRA", away: "ARG", winnerKey: "BRA")],
             upcomingMatches: [makeViewMatch(home: "FRA", away: "GER", winnerKey: "FRA")]
@@ -843,6 +896,7 @@ struct WorldCupMatchesTests {
     func test_winnerThirdPlaceOrFinal_fallsBackToUpcomingMatch_whenFeaturedHasNoWinner() {
         let model = WorldCupMatches(
             phaseTitle: String.WorldCup.HomepageWidget.RoundPhase.FinalLabel,
+            telemetryPhaseValue: "",
             isLive: false,
             featuredMatch: [makeViewMatch(home: "BRA", away: "ARG", winnerKey: nil)],
             upcomingMatches: [makeViewMatch(home: "FRA", away: "GER", winnerKey: "GER")]
@@ -855,6 +909,7 @@ struct WorldCupMatchesTests {
     func test_winnerThirdPlaceOrFinal_returnsNil_forGroupStagePhase() {
         let model = WorldCupMatches(
             phaseTitle: String.WorldCup.HomepageWidget.GroupPhase.GroupStageLabel,
+            telemetryPhaseValue: "",
             isLive: false,
             featuredMatch: [makeViewMatch(home: "BRA", away: "ARG", winnerKey: "BRA")],
             upcomingMatches: []

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupTelemetryTests.swift
@@ -130,6 +130,28 @@ final class WorldCupTelemetryTests: XCTestCase {
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 
+    func test_cardSwiped_recordsEventWithViewAndImpressionExtras() throws {
+        let event = GleanMetrics.WorldCupWidget.cardSwiped
+        typealias EventExtrasType = GleanMetrics.WorldCupWidget.CardSwipedExtra
+
+        let subject = createSubject()
+        let expectedView = "Round of 16"
+        let expectedIsImpression = true
+        let expectedMetricType = type(of: event)
+
+        subject.cardSwiped(view: expectedView, isImpression: expectedIsImpression)
+
+        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.view, expectedView)
+        XCTAssertEqual(savedExtras.isImpression, expectedIsImpression)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
     func test_countrySelectorDisplayed_recordsEvent() throws {
         let subject = createSubject()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15933)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34047)

## :bulb: Description
Add telemetry when the user swipes a card in the `WorldCupCell`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

