### PR TITLE
Fix FxA account mock not having the exhausted switch

### DIFF
--- a/MozillaRustComponents/Package.swift
+++ b/MozillaRustComponents/Package.swift
@@ -1,13 +1,13 @@
 // swift-tools-version: 5.10
 import PackageDescription
 
-let checksum = "41aa4a8e5a9daefdc3db3ea409fcdf513b126ab0c97b1729ad235e572a0bf624"
-let version = "153.0.20260523050223"
-let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260523050223/artifacts/public/build/MozillaRustComponents.xcframework.zip"
+let checksum = "560b2c42463fabde6e77e6aa17ab60515eabd9a6acb5c088c64d3029f6fb7ad7"
+let version = "153.0.20260525050231"
+let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260525050231/artifacts/public/build/MozillaRustComponents.xcframework.zip"
 
 // Focus xcframework
-let focusChecksum = "9784b3aa80322849a9096e33ce3cb2ccc54b5934e4e68e42bef8639ca067a56c"
-let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260523050223/artifacts/public/build/FocusRustComponents.xcframework.zip"
+let focusChecksum = "83e0e188029368d5f2bc549740082b0b1c4a5e0f7050e9e18753d08253a9ca10"
+let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260525050231/artifacts/public/build/FocusRustComponents.xcframework.zip"
 
 let package = Package(
     name: "MozillaRustComponentsSwift",

--- a/MozillaRustComponents/Package.swift
+++ b/MozillaRustComponents/Package.swift
@@ -1,13 +1,13 @@
 // swift-tools-version: 5.10
 import PackageDescription
 
-let checksum = "b037a0cf45951f78702a34d8dcbddd5d076a9444625b83d166aff4f9190d7842"
-let version = "153.0.20260521050302"
-let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260521050302/artifacts/public/build/MozillaRustComponents.xcframework.zip"
+let checksum = "41aa4a8e5a9daefdc3db3ea409fcdf513b126ab0c97b1729ad235e572a0bf624"
+let version = "153.0.20260523050223"
+let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260523050223/artifacts/public/build/MozillaRustComponents.xcframework.zip"
 
 // Focus xcframework
-let focusChecksum = "0bf36cc3024b654604b786f2f657e9546596a2d1b351c06b09e2e9a572f7e239"
-let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260521050302/artifacts/public/build/FocusRustComponents.xcframework.zip"
+let focusChecksum = "9784b3aa80322849a9096e33ce3cb2ccc54b5934e4e68e42bef8639ca067a56c"
+let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260523050223/artifacts/public/build/FocusRustComponents.xcframework.zip"
 
 let package = Package(
     name: "MozillaRustComponentsSwift",

--- a/MozillaRustComponents/Package.swift
+++ b/MozillaRustComponents/Package.swift
@@ -1,13 +1,13 @@
 // swift-tools-version: 5.10
 import PackageDescription
 
-let checksum = "560b2c42463fabde6e77e6aa17ab60515eabd9a6acb5c088c64d3029f6fb7ad7"
-let version = "153.0.20260525050231"
-let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260525050231/artifacts/public/build/MozillaRustComponents.xcframework.zip"
+let checksum = "72591522d933e6eb01d24d4590915cf585d5d94a3cc2f50cbaebd4dbbbf66c97"
+let version = "153.0.20260528050256"
+let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260528050256/artifacts/public/build/MozillaRustComponents.xcframework.zip"
 
 // Focus xcframework
-let focusChecksum = "83e0e188029368d5f2bc549740082b0b1c4a5e0f7050e9e18753d08253a9ca10"
-let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260525050231/artifacts/public/build/FocusRustComponents.xcframework.zip"
+let focusChecksum = "7e0c68c3715e985f9bde6ac7dae3854e6978885b76ea0b17ed927426470c06fc"
+let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.153.20260528050256/artifacts/public/build/FocusRustComponents.xcframework.zip"
 
 let package = Package(
     name: "MozillaRustComponentsSwift",

--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 25, hour: 5, minute: 34, second: 6))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 28, hour: 5, minute: 29, second: 38))
     }
 
     enum NimbusEvents {

--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 23, hour: 5, minute: 24, second: 46))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 25, hour: 5, minute: 34, second: 6))
     }
 
     enum NimbusEvents {

--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 21, hour: 5, minute: 30, second: 29))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 23, hour: 5, minute: 24, second: 46))
     }
 
     enum NimbusEvents {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 21, hour: 5, minute: 30, second: 27))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 23, hour: 5, minute: 24, second: 44))
     }
 
     enum AdsClient {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 25, hour: 5, minute: 34, second: 4))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 28, hour: 5, minute: 29, second: 35))
     }
 
     enum AdsClient {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 23, hour: 5, minute: 24, second: 44))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 5, day: 25, hour: 5, minute: 34, second: 4))
     }
 
     enum AdsClient {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/fxa_client.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/fxa_client.swift
@@ -3839,6 +3839,8 @@ public enum FxaEvent: Equatable, Hashable {
     )
     case cancelOAuthFlow
     case checkAuthorizationStatus
+    case webChannelPasswordChange(jsonPayload: String
+    )
     case disconnect
     case callGetProfile
 
@@ -3878,9 +3880,12 @@ public struct FfiConverterTypeFxaEvent: FfiConverterRustBuffer {
         
         case 6: return .checkAuthorizationStatus
         
-        case 7: return .disconnect
+        case 7: return .webChannelPasswordChange(jsonPayload: try FfiConverterString.read(from: &buf)
+        )
         
-        case 8: return .callGetProfile
+        case 8: return .disconnect
+        
+        case 9: return .callGetProfile
         
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -3924,12 +3929,17 @@ public struct FfiConverterTypeFxaEvent: FfiConverterRustBuffer {
             writeInt(&buf, Int32(6))
         
         
-        case .disconnect:
+        case let .webChannelPasswordChange(jsonPayload):
             writeInt(&buf, Int32(7))
+            FfiConverterString.write(jsonPayload, into: &buf)
+            
+        
+        case .disconnect:
+            writeInt(&buf, Int32(8))
         
         
         case .callGetProfile:
-            writeInt(&buf, Int32(8))
+            writeInt(&buf, Int32(9))
         
         }
     }

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/logins.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/logins.swift
@@ -996,8 +996,6 @@ public protocol LoginStoreProtocol: AnyObject, Sendable {
     
     func getByBaseDomain(baseDomain: String) throws  -> [Login]
     
-    func getCheckpoint() throws  -> String?
-    
     func hasLoginsByBaseDomain(baseDomain: String) throws  -> Bool
     
     func isEmpty() throws  -> Bool
@@ -1048,8 +1046,6 @@ public protocol LoginStoreProtocol: AnyObject, Sendable {
      * database.
      */
     func runMaintenance(options: RunMaintenanceOptions?) throws 
-    
-    func setCheckpoint(checkpoint: String) throws 
     
     func shutdown() 
     
@@ -1283,14 +1279,6 @@ open func getByBaseDomain(baseDomain: String)throws  -> [Login]  {
 })
 }
     
-open func getCheckpoint()throws  -> String?  {
-    return try  FfiConverterOptionString.lift(try rustCallWithError(FfiConverterTypeLoginsApiError_lift) {
-    uniffi_logins_fn_method_loginstore_get_checkpoint(
-            self.uniffiCloneHandle(),$0
-    )
-})
-}
-    
 open func hasLoginsByBaseDomain(baseDomain: String)throws  -> Bool  {
     return try  FfiConverterBool.lift(try rustCallWithError(FfiConverterTypeLoginsApiError_lift) {
     uniffi_logins_fn_method_loginstore_has_logins_by_base_domain(
@@ -1404,14 +1392,6 @@ open func runMaintenance(options: RunMaintenanceOptions? = nil)throws   {try rus
     uniffi_logins_fn_method_loginstore_run_maintenance(
             self.uniffiCloneHandle(),
         FfiConverterOptionTypeRunMaintenanceOptions.lower(options),$0
-    )
-}
-}
-    
-open func setCheckpoint(checkpoint: String)throws   {try rustCallWithError(FfiConverterTypeLoginsApiError_lift) {
-    uniffi_logins_fn_method_loginstore_set_checkpoint(
-            self.uniffiCloneHandle(),
-        FfiConverterString.lower(checkpoint),$0
     )
 }
 }
@@ -2911,9 +2891,6 @@ private let initializationResult: InitializationResult = {
     if (uniffi_logins_checksum_method_loginstore_get_by_base_domain() != 30272) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_logins_checksum_method_loginstore_get_checkpoint() != 9423) {
-        return InitializationResult.apiChecksumMismatch
-    }
     if (uniffi_logins_checksum_method_loginstore_has_logins_by_base_domain() != 40417) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -2945,9 +2922,6 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_logins_checksum_method_loginstore_run_maintenance() != 53717) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_logins_checksum_method_loginstore_set_checkpoint() != 45296) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_logins_checksum_method_loginstore_shutdown() != 50825) {

--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/FxAccountMocks.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/FxAccountMocks.swift
@@ -59,7 +59,7 @@ class MockFxAccount: PersistedFirefoxAccount {
             return info.active ? .connected : .authIssues
         case .disconnect:
             return .disconnected
-        case .callGetProfile:
+        case .callGetProfile, .webChannelPasswordChange:
             return .connected
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
The latest pull from AS failed https://github.com/mozilla-mobile/firefox-ios/pull/33993. It failed from this PR https://github.com/mozilla/application-services/pull/7379 which allows the FxA state machine to natively handle the web channel password changes rather than the consuming having to do it. Ideally we'd get iOS on this eventually but for now we'll make sure the CI is green for pulling a-s.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

