### PR TITLE
Bugfix FXIOS-15907 [Translations] Distinguish Chinese Simplified and Traditional in language picker

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3004,8 +3004,8 @@ class BrowserViewController: UIViewController,
         }
 
         data.languages.forEach { code in
-            let native = (Locale(identifier: code).localizedString(forLanguageCode: code) ?? code).localizedCapitalized
-            let localized = (Locale.current.localizedString(forLanguageCode: code) ?? code).localizedCapitalized
+            let native = (Locale(identifier: code).localizedString(forIdentifier: code) ?? code).localizedCapitalized
+            let localized = (Locale.current.localizedString(forIdentifier: code) ?? code).localizedCapitalized
             let title = native == localized ? native : "\(native) (\(localized))"
             alert.addAction(UIAlertAction(title: title, style: .default) { [weak self] _ in
                 guard let self else { return }
@@ -3062,7 +3062,7 @@ class BrowserViewController: UIViewController,
         for alert: UIAlertController,
         languageCode: String
     ) {
-        let langName = Locale.current.localizedString(forLanguageCode: languageCode) ?? languageCode
+        let langName = Locale.current.localizedString(forIdentifier: languageCode) ?? languageCode
         alert.title = String(format: .Translations.LanguagePicker.PageTranslatedTitle, langName)
         let showOriginalAction = UIAlertAction(
             title: .Translations.LanguagePicker.ShowOriginal,

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -421,7 +421,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         let isActive = translationConfig.state == .active
         let infoTitle: String
         if isActive, let langCode = translationConfig.translatedToLanguage {
-            infoTitle = localeProvider.current.localizedString(forLanguageCode: langCode) ?? langCode
+            infoTitle = localeProvider.current.localizedString(forIdentifier: langCode) ?? langCode
         } else {
             infoTitle = .MainMenu.ToolsSection.Translation.Off
         }

--- a/firefox-ios/Client/Frontend/Browser/TranslationToastHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TranslationToastHandler.swift
@@ -44,8 +44,8 @@ class TranslationToastHandler: TabEventHandler {
 
     func promptTranslation(_ tab: Tab, from pageLanguage: String, to myLanguage: String) {
         let locale = Locale.current
-        let localizedMyLanguage = locale.localizedString(forLanguageCode: myLanguage) ?? myLanguage
-        let localizedPageLanguage = locale.localizedString(forLanguageCode: pageLanguage) ?? pageLanguage
+        let localizedMyLanguage = locale.localizedString(forIdentifier: myLanguage) ?? myLanguage
+        let localizedPageLanguage = locale.localizedString(forIdentifier: pageLanguage) ?? pageLanguage
 
         let service = setting.useTranslationService
         let promptMessage = String(

--- a/firefox-ios/Client/Utils/LocaleProvider.swift
+++ b/firefox-ios/Client/Utils/LocaleProvider.swift
@@ -20,12 +20,12 @@ extension LocaleProvider {
 
     /// Returns the language name localized in the current locale (e.g. "French" for "fr" when current locale is "en").
     func localizedLanguageName(for code: String) -> String {
-        return current.localizedString(forLanguageCode: code)?.localizedCapitalized ?? code
+        return current.localizedString(forIdentifier: code)?.localizedCapitalized ?? code
     }
 
     /// Returns the language name in its own language (e.g. "Français" for "fr").
     func nativeLanguageName(for code: String) -> String {
-        return Locale(identifier: code).localizedString(forLanguageCode: code)?.localizedCapitalized ?? code
+        return Locale(identifier: code).localizedString(forIdentifier: code)?.localizedCapitalized ?? code
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
@@ -206,7 +206,7 @@ final class MainMenuConfigurationUtilityTests: XCTestCase {
         let allItems = sections.flatMap { $0.options }
         let title = String.MainMenu.ToolsSection.Translation.TranslatedPageTitle
         let translateItem = allItems.first { $0.title == title }
-        let expectedHint = locale.localizedString(forLanguageCode: "fr")
+        let expectedHint = locale.localizedString(forIdentifier: "fr")
 
         XCTAssertEqual(translateItem?.a11yHint, expectedHint)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15907)

## :bulb: Description
The language picker, the translation prompt, and the tools menu all showed "Chinese" for both Simplified and Traditional. This happened because `Locale.localizedString(forLanguageCode:)` strips the script subtag and only resolves the base language code `zh`, so `zh-Hans` and `zh-Hant` both resolved to the same display name.

## :movie_camera: Demos
| Before | After |
| - | - |
| <img width="630" height="1368" alt="IMG_0390" src="https://github.com/user-attachments/assets/c369d8a1-e122-466f-8061-443ecbe00fd5" /> | <img width="660" height="1434" alt="Screenshot 2026-06-02 at 10 03 29" src="https://github.com/user-attachments/assets/9c9702b7-54b7-413c-b306-f259551d3f53" /> |


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the data stewardship requirements and will request a data review
- [x] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
