### PR TITLE
BugFix [World Cup] FXIOS-15951 when team is eliminated it doesn't default to following all experience

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupFeed.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupFeed.swift
@@ -102,10 +102,12 @@ final class WorldCupFeed {
         }
     }
 
-    /// One-shot `/teams` fetch. Elimination only flips after a knockout
-    /// result, so we don't need to poll: `start()` is invoked again on
-    /// foreground/retry, which refreshes the roster.
+    /// `/teams` fetch. Elimination only flips after a knockout result, so
+    /// we don't poll on a timer: `start()` re-fetches on foreground/retry,
+    /// and `handleLiveResult` re-fetches when a knockout involving the
+    /// selected team leaves the live set.
     private func startTeams() {
+        teamsTask?.cancel()
         teamsTask = Task { @MainActor [weak self] in
             guard let self else { return }
             let result = await self.apiClient.loadTeams(team: nil)
@@ -143,15 +145,46 @@ final class WorldCupFeed {
         // result tile can show alongside live ones. Filter on
         // `statusType == "live"` so the badge only sticks for genuinely
         // in-progress matches.
+        let allMatches = response?.matches ?? []
         let newLiveIDs = Set(
-            response?.matches?
+            allMatches
                 .filter { $0.statusType == "live" }
-                .map(\.globalEventId) ?? []
+                .map(\.globalEventId)
+        )
+        refetchTeamsIfSelectedTeamKnockoutEnded(
+            endedIDs: cachedLiveIDs.subtracting(newLiveIDs),
+            matches: allMatches
         )
         guard newLiveIDs != cachedLiveIDs else { return }
         cachedLiveIDs = newLiveIDs
         guard let last = lastMatchesResponse else { return }
         emit(buildSnapshot(from: last))
+    }
+
+    /// When a knockout fixture involving the selected team transitions out
+    /// of the live set, refetch `/teams` so the roster's `eliminated` flag
+    /// for that team reflects the just-finished result.
+    private func refetchTeamsIfSelectedTeamKnockoutEnded(
+        endedIDs: Set<Int>,
+        matches: [WorldCupMatchesResponse.Match]
+    ) {
+        guard !endedIDs.isEmpty, let team = selectedTeamProvider() else { return }
+        let involvesSelectedKnockout = matches.contains { match in
+            endedIDs.contains(match.globalEventId)
+            && Self.isKnockout(match.stage)
+            && (match.homeTeam?.key == team || match.awayTeam?.key == team)
+        }
+        guard involvesSelectedKnockout else { return }
+        startTeams()
+    }
+
+    private static func isKnockout(_ stage: WorldCupMatchesResponse.Match.Stage?) -> Bool {
+        switch stage {
+        case .roundOf32, .roundOf16, .quarterFinals, .semiFinals, .thirdPlace, .final:
+            return true
+        case .groupStage, .unknown, .none:
+            return false
+        }
     }
 
     private func handleTeamsResult(_ result: Result<WorldCupTeamsResponse?, WorldCupLoadError>) {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
@@ -79,7 +79,6 @@ struct WorldCupStore: WorldCupStoreProtocol, FeatureFlaggable {
     }
 
     var isMilestone2: Bool {
-        return true
         guard let enableDate = milestone2EnableDate else { return false }
         return dateProvider.now() >= enableDate
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
@@ -79,6 +79,7 @@ struct WorldCupStore: WorldCupStoreProtocol, FeatureFlaggable {
     }
 
     var isMilestone2: Bool {
+        return true
         guard let enableDate = milestone2EnableDate else { return false }
         return dateProvider.now() >= enableDate
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15951)

## :bulb: Description
Bug fix when team is eliminated that it doesn't default to following all experience.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

