### PR TITLE
Remove FXIOS-15956 [New Error Pages] Removal of unused NetworkErrorType enum from NativeErrorPageHelper

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageAction.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageAction.swift
@@ -9,12 +9,10 @@ struct NativeErrorPageAction: Action {
     let windowUUID: WindowUUID
     let actionType: ActionType
     let networkError: NSError?
-    let errorType: NativeErrorPageHelper.NetworkErrorType?
     let nativePageErrorModel: ErrorPageModel?
 
     init(
         networkError: NSError? = nil,
-        errorType: NativeErrorPageHelper.NetworkErrorType? = nil,
         nativePageErrorModel: ErrorPageModel? = nil,
         windowUUID: WindowUUID,
         actionType: any ActionType
@@ -22,7 +20,6 @@ struct NativeErrorPageAction: Action {
         self.windowUUID = windowUUID
         self.actionType = actionType
         self.networkError = networkError
-        self.errorType = errorType
         self.nativePageErrorModel = nativePageErrorModel
     }
 }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -46,11 +46,6 @@ class NativeErrorPageHelper {
         let cert: SecCertificate
     }
 
-    enum NetworkErrorType {
-        case noInternetConnection
-        case badCertDomain
-    }
-
     var error: NSError
 
     var errorDescriptionItem: String {


### PR DESCRIPTION
### 📜 Tickets
JIRA: FXIOS-15956
GitHub: #34074

### 💡 Description
Removes the `NetworkErrorType` enum from `NativeErrorPageHelper` which was left unreferenced after the error type refactor.

Note: This PR is a part of Outreachy

### 🧩 Implementation
firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

