### PR TITLE
Update FXIOS-15926 [SKAN] Update fine values to map to conversion funnel

### DIFF
--- a/firefox-ios/Client/Application/ConversionTracking/ConversionEventTracker.swift
+++ b/firefox-ios/Client/Application/ConversionTracking/ConversionEventTracker.swift
@@ -90,14 +90,14 @@ enum ConversionEvent {
             return .init(fine: 10, coarse: .low, lockWindow: false)
         case .appOpenDay2Plus:
             return .init(fine: 15, coarse: .medium, lockWindow: false)
+        case .activeLastThreeWeek1:
+            return .init(fine: 20, coarse: .medium, lockWindow: false)
+        case .thirdActivityFirstWeek:
+            return .init(fine: 22, coarse: .medium, lockWindow: false)
         case .uriLoadDay2Plus:
             return .init(fine: 25, coarse: .medium, lockWindow: false)
         case .firstAdClick:
             return .init(fine: 35, coarse: .medium, lockWindow: false)
-        case .thirdActivityFirstWeek:
-            return .init(fine: 15, coarse: .medium, lockWindow: false)
-        case .activeLastThreeWeek1:
-            return .init(fine: 20, coarse: .medium, lockWindow: false)
         case .activeTwoOfFourAndThreeWeek1:
             return .init(fine: 30, coarse: .medium, lockWindow: false)
         case .activated:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/ConversionTracking/ConversionEventTrackerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/ConversionTracking/ConversionEventTrackerTests.swift
@@ -89,7 +89,7 @@ final class ConversionEventTrackerTests: XCTestCase {
         subject.record(.thirdActivityFirstWeek)
 
         XCTAssertEqual(mockUpdater.receivedConversionValues.count, 1)
-        XCTAssertEqual(mockUpdater.receivedConversionValues.first?.fine, 15)
+        XCTAssertEqual(mockUpdater.receivedConversionValues.first?.fine, 22)
         XCTAssertEqual(mockUpdater.receivedConversionValues.first?.coarse, .medium)
         XCTAssertEqual(mockUpdater.receivedConversionValues.first?.lockWindow, false)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15926)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Update conversion fine value for `thirdActivityFirstWeek` to fit within the funnel of events, even though it will only ever be the sent in the second and third postbacks.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

