### PR TITLE
Refactor MTE-5225 Remove XCTExpectFailure

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -62,10 +62,6 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
     func testDefaultSites() throws {
         app.launch()
 
-        XCTExpectFailure("The app was not launched", strict: false) {
-            topSites.assertVisible()
-        }
-
         topSites.assertVisible()
         topSites.assertTopSitesCount(5)
         topSites.assertDefaultTopSites()
@@ -201,9 +197,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         app.launch()
 
         // Assert that the Top Sites are visible upon launch
-        XCTExpectFailure("The app was not launched", strict: false) {
-            topSites.assertVisible()
-        }
+        topSites.assertVisible()
 
         // Wait for the toolbar to exist, which includes the settings menu button
         toolbar.assertSettingsButtonExists()
@@ -231,9 +225,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
     // Smoketest
     func testTopSitesOpenInNewPrivateTabDefaultTopSite() {
         app.launch()
-        XCTExpectFailure("The app was not launched", strict: false) {
-            topSites.assertVisible()
-        }
+        topSites.assertVisible()
         toolbar.assertSettingsButtonExists()
         navigator.nowAt(NewTabScreen)
 
@@ -309,9 +301,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2861436
     func testShortcutsToggle() {
         app.launch()
-        XCTExpectFailure("The app was not launched", strict: false) {
-            mozWaitForElementToExist(TopSiteCellgroup, timeout: TIMEOUT_LONG)
-        }
+        mozWaitForElementToExist(TopSiteCellgroup, timeout: TIMEOUT_LONG)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         //  Go to customize homepage
         navigator.nowAt(NewTabScreen)
@@ -357,9 +347,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2861432
     func testHomepageHeader() {
         app.launch()
-        XCTExpectFailure("The app was not launched", strict: false) {
-            topSites.assertVisible()
-        }
+        topSites.assertVisible()
         // "Firefox" text is displayed in the header
         homePage.validateHomePageLogo(isPrivate: false)
         // Validate step 1 in private browsing

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -95,58 +95,54 @@ class HistoryTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307487
     func testClearHistoryFromSettings() throws {
-        XCTExpectFailure("The app was not launched", strict: false) {
-            navigator.nowAt(NewTabScreen)
-            // Browse to have an item in history list
-            navigator.goto(LibraryPanel_History)
-            waitForElementsToExist(
-                [
-                    app.tables.cells[HistoryPanelA11y.recentlyClosedCell],
-                    app.tables.cells.staticTexts[oldHistoryEntries[0]]
-                ]
-            )
-            mozWaitForElementToNotExist(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg])
+        navigator.nowAt(NewTabScreen)
+        // Browse to have an item in history list
+        navigator.goto(LibraryPanel_History)
+        waitForElementsToExist(
+            [
+                app.tables.cells[HistoryPanelA11y.recentlyClosedCell],
+                app.tables.cells.staticTexts[oldHistoryEntries[0]]
+            ]
+        )
+        mozWaitForElementToNotExist(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg])
 
-            // Clear all private data via the settings
-            navigator.goto(HomePanelsScreen)
-            navigator.nowAt(NewTabScreen)
-            navigator.goto(ClearPrivateDataSettings)
-            app.tables.cells["ClearPrivateData"].waitAndTap()
-            app.alerts.buttons["OK"].waitAndTap()
+        // Clear all private data via the settings
+        navigator.goto(HomePanelsScreen)
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(ClearPrivateDataSettings)
+        app.tables.cells["ClearPrivateData"].waitAndTap()
+        app.alerts.buttons["OK"].waitAndTap()
 
-            // Back on History panel view check that there is not any item
-            navigator.goto(LibraryPanel_History)
-            waitForElementsToExist(
-                [
-                    app.tables[HistoryPanelA11y.tableView],
-                    app.tables.cells[HistoryPanelA11y.recentlyClosedCell]
-                ]
-            )
-            mozWaitForElementToNotExist(app.tables.cells.staticTexts[oldHistoryEntries[0]])
-            mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg])
-        }
+        // Back on History panel view check that there is not any item
+        navigator.goto(LibraryPanel_History)
+        waitForElementsToExist(
+            [
+                app.tables[HistoryPanelA11y.tableView],
+                app.tables.cells[HistoryPanelA11y.recentlyClosedCell]
+            ]
+        )
+        mozWaitForElementToNotExist(app.tables.cells.staticTexts[oldHistoryEntries[0]])
+        mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView].staticTexts[emptyRecentlyClosedMesg])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307014
     // Smoketest
     func testClearPrivateData() throws {
-        XCTExpectFailure("The app was not launched", strict: false) {
-            navigator.nowAt(NewTabScreen)
-            toolbarScreen.assertSettingsButtonExists()
-            // Clear private data from settings and confirm
-            navigator.goto(ClearPrivateDataSettings)
-            settingScreen.clearPrivateDataAndConfirm()
+        navigator.nowAt(NewTabScreen)
+        toolbarScreen.assertSettingsButtonExists()
+        // Clear private data from settings and confirm
+        navigator.goto(ClearPrivateDataSettings)
+        settingScreen.clearPrivateDataAndConfirm()
 
-            // Wait for OK pop-up to disappear after confirming
-            settingScreen.assertConfirmationAlertNotPresent()
-            // Try to tap on the disabled Clear Private Data button
-            settingScreen.tryTapClearPrivateDataButton()
+        // Wait for OK pop-up to disappear after confirming
+        settingScreen.assertConfirmationAlertNotPresent()
+        // Try to tap on the disabled Clear Private Data button
+        settingScreen.tryTapClearPrivateDataButton()
 
-            // If the button is disabled, the confirmation pop-up should not exist
-            // Disabling assertion due to https://mozilla-hub.atlassian.net/browse/FXIOS-7494 issue
-            // After this issue is clarified the assertion will be re-enabled or changed.
-            // XCTAssertEqual(app.alerts.buttons["OK"].exists, false)
-        }
+        // If the button is disabled, the confirmation pop-up should not exist
+        // Disabling assertion due to https://mozilla-hub.atlassian.net/browse/FXIOS-7494 issue
+        // After this issue is clarified the assertion will be re-enabled or changed.
+        // XCTAssertEqual(app.alerts.buttons["OK"].exists, false)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307357


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5225)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Remove XCTExpectFailure from all XCUITests. They seem to be unnecessary.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

