### PR TITLE
Remove #if canImport(FoundationModels) checks from codebase

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
+++ b/BrowserKit/Sources/ComponentLibrary/BottomSheet/BottomSheetViewController.swift
@@ -184,11 +184,7 @@ public class BottomSheetViewController: UIViewController,
 
         let effectView = UIVisualEffectView()
 
-        #if canImport(FoundationModels)
         effectView.effect = createGlassEffect()
-        #else
-        effectView.effect = UIBlurEffect(style: .systemUltraThinMaterial)
-        #endif
 
         effectView.layer.cornerRadius = viewModel.cornerRadius
         effectView.clipsToBounds = true
@@ -209,23 +205,17 @@ public class BottomSheetViewController: UIViewController,
 
     @available(iOS 26.0, *)
     private func createGlassEffect() -> UIVisualEffect {
-        #if canImport(FoundationModels)
         let glassEffect = UIGlassEffect()
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         glassEffect.tintColor = theme.colors.layer2.withAlphaComponent(UX.glassAlpha)
         glassEffect.isInteractive = true
         return glassEffect
-        #else
-        return UIBlurEffect(style: .systemUltraThinMaterial)
-        #endif
     }
 
     @available(iOS 26.0, *)
     private func updateGlassEffectTint() {
-        #if canImport(FoundationModels)
         guard let effectView = glassEffectView else { return }
         effectView.effect = createGlassEffect()
-        #endif
     }
 
     private func setupView() {

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
@@ -32,11 +32,9 @@ public class CloseButton: UIButton,
         adjustsImageSizeForAccessibilityContentSizeCategory = true
         setupConstraints()
 
-        #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
             configuration = .glass()
         }
-        #endif
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/FoundationModelsSummarizer.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/FoundationModelsSummarizer.swift
@@ -2,10 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// We need these compile time checks so the app can be built with pre‑iOS 26 SDKs.
-/// Once our BR workflow switches to 26, we can remove them,
-/// as the runtime @available checks will be enough.
-#if canImport(FoundationModels)
 import FoundationModels
 import Foundation
 
@@ -103,5 +99,3 @@ final class FoundationModelsSummarizer: SummarizerProtocol {
         }
     }
 }
-
-#endif

--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelResponseProtocol.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelResponseProtocol.swift
@@ -2,10 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// We need these compile time checks so the app can be built with pre‑iOS 26 SDKs.
-/// Once our BR workflow switches to 26, we can remove them,
-/// as the runtime @available checks will be enough.
-#if canImport(FoundationModels)
 import FoundationModels
 import Foundation
 
@@ -21,5 +17,3 @@ protocol LanguageModelResponseProtocol {
 @available(iOS 26, *)
 extension LanguageModelSession.Response: LanguageModelResponseProtocol
     where Content == String {}
-
-#endif

--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelResponseStreamProtocol.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelResponseStreamProtocol.swift
@@ -2,10 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// We need these compile time checks so the app can be built with pre‑iOS 26 SDKs.
-/// Once our BR workflow switches to 26, we can remove them,
-/// as the runtime @available checks will be enough.
-#if canImport(FoundationModels)
 import FoundationModels
 import Foundation
 
@@ -35,5 +31,3 @@ extension AsyncThrowingStream: LanguageModelResponseStreamProtocol
 
 @available(iOS 26, *)
 extension LanguageModelSession.ResponseStream<String>.Snapshot: LanguageModelResponseSnapshotProtocol {}
-
-#endif

--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelSessionAdapter.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelSessionAdapter.swift
@@ -2,10 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// We need these compile time checks so the app can be built with pre‑iOS 26 SDKs.
-/// Once our BR workflow switches to 26, we can remove them,
-/// as the runtime @available checks will be enough.
-#if canImport(FoundationModels)
 import FoundationModels
 import Foundation
 
@@ -42,5 +38,3 @@ final class LanguageModelSessionAdapter: LanguageModelSessionProtocol {
         return realSession.streamResponse(to: prompt, options: options)
     }
 }
-
-#endif

--- a/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelSessionProtocol.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/AppleIntelligence/LanguageModelSessionProtocol.swift
@@ -2,10 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/// We need these compile time checks so the app can be built with pre‑iOS 26 SDKs.
-/// Once our BR workflow switches to 26, we can remove them,
-/// as the runtime @available checks will be enough.
-#if canImport(FoundationModels)
 import FoundationModels
 import Foundation
 
@@ -37,5 +33,3 @@ extension LanguageModelSessionProtocol {
         streamResponse(to: prompt, options: .init())
     }
 }
-
-#endif

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerConfig.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerConfig.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import LLMKit
+import FoundationModels
 
 /// A configuration container for a summarizer.
 public struct SummarizerConfig: LLMConfig, Equatable, Sendable {
@@ -31,9 +32,6 @@ public struct SummarizerConfig: LLMConfig, Equatable, Sendable {
     }
 }
 
-#if canImport(FoundationModels)
-import FoundationModels
-
 @available(iOS 26, *)
 extension SummarizerConfig {
     func toGenerationOptions() -> GenerationOptions {
@@ -44,4 +42,3 @@ extension SummarizerConfig {
         )
     }
 }
-#endif

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerError.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerError.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import FoundationModels
 
 /// Error types for summarization flows, mapping underlying model errors to user‑friendly cases.
 /// The UI layer will rely on userMessage to display appropriate messages.
@@ -81,12 +82,6 @@ public enum SummarizerError: Error, LocalizedError {
     }
 }
 
-/// We need these compile time checks so the app can be built with pre‑iOS 26 SDKs.
-/// Once our BR workflow switches to 26, we can remove them,
-/// as the runtime @available checks will be enough.
-#if canImport(FoundationModels)
-import FoundationModels
-
 extension SummarizerError {
     /// Initialize from `LanguageModelSession.GenerationError`.
     @available(iOS 26, *)
@@ -107,5 +102,3 @@ extension SummarizerError {
         }
     }
 }
-
-#endif

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerServiceFactory.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerServiceFactory.swift
@@ -36,7 +36,6 @@ public struct DefaultSummarizerServiceFactory: SummarizerServiceFactory {
         let maxWords = maxWords(isAppleSummarizerEnabled: isAppleSummarizerEnabled,
                                 isHostedSummarizerEnabled: isHostedSummarizerEnabled)
         let config = config ?? SummarizerConfig.defaultConfig
-        #if canImport(FoundationModels)
         if isAppleSummarizerEnabled, #available(iOS 26, *) {
             let appleSummarizer = FoundationModelsSummarizer(
                 usesPermissiveGuardrails: usesPermissiveGuardrails,
@@ -64,22 +63,6 @@ public struct DefaultSummarizerServiceFactory: SummarizerServiceFactory {
                 maxWords: maxWords
             )
         }
-        #else
-        guard isHostedSummarizerEnabled,
-              let llmClient = makeLiteLLMClient(
-                config: config,
-                prefs: prefs,
-                isAppAttestAuthEnabled: isAppAttestAuthEnabled
-              ) else {
-            return nil
-        }
-        let llmSummarizer = LiteLLMSummarizer(client: llmClient, config: config)
-        return DefaultSummarizerService(
-            summarizer: llmSummarizer,
-            lifecycleDelegate: lifecycleDelegate,
-            maxWords: maxWords
-        )
-        #endif
     }
 
     public func maxWords(isAppleSummarizerEnabled: Bool, isHostedSummarizerEnabled: Bool) -> Int {

--- a/BrowserKit/Sources/SummarizeKit/UI/InfoView.swift
+++ b/BrowserKit/Sources/SummarizeKit/UI/InfoView.swift
@@ -36,18 +36,12 @@ class InfoView: UIView,
         $0.textAlignment = .center
     }
     private let actionButton: UIButton = .build {
-        // This checks for Xcode 26 sdk availability thus we can compile on older Xcode version too
-        #if canImport(FoundationModels)
         if #available(iOS 26, *) {
             $0.configuration = .prominentClearGlass()
         } else {
             $0.configuration = .filled()
             $0.configuration?.cornerStyle = .capsule
         }
-        #else
-            $0.configuration = .filled()
-            $0.configuration?.cornerStyle = .capsule
-        #endif
         $0.configuration?.contentInsets = UX.actionButtonInsets
     }
     private var viewModel: InfoViewModel?

--- a/BrowserKit/Tests/SummarizeKitTests/FoundationModelsSummarizerTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/FoundationModelsSummarizerTests.swift
@@ -6,8 +6,9 @@
 import XCTest
 import Common
 import TestKit
+import FoundationModels
+import Foundation
 
-/// These compile-time checks ensure the app can still be built with pre–iOS 26 SDKs.
 /// The `@available` attribute only guards *runtime execution*; it doesn’t prevent XCTest
 /// from compiling or discovering the test class. As a result, tests would still be run
 /// (and crash) on lower iOS versions.
@@ -17,9 +18,6 @@ import TestKit
 /// The `@available(iOS 26, *)` annotation is now applied only to individual test
 /// methods where needed, so the compiler can validate iOS 26-only APIs without
 /// blocking the entire class on older SDKs.
-#if canImport(FoundationModels)
-import FoundationModels
-import Foundation
 
 final class FoundationModelsSummarizerTests: XCTestCase {
     override func setUpWithError() throws {
@@ -157,4 +155,3 @@ final class FoundationModelsSummarizerTests: XCTestCase {
         )
     }
 }
-#endif

--- a/BrowserKit/Tests/SummarizeKitTests/Mocks/MockLanguageModelSession.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/Mocks/MockLanguageModelSession.swift
@@ -4,10 +4,6 @@
 
 @testable import SummarizeKit
 
-/// We need these compile time checks so the app can be built with pre‑iOS 26 SDKs.
-/// Once our BR workflow switches to 26, we can remove them,
-/// as the runtime @available checks will be enough.
-#if canImport(FoundationModels)
 import FoundationModels
 import Foundation
 
@@ -54,5 +50,3 @@ final class MockLanguageModelSession: LanguageModelSessionProtocol, @unchecked S
         }
     }
 }
-
-#endif

--- a/BrowserKit/Tests/SummarizeKitTests/SummarizeServiceFactoryTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/SummarizeServiceFactoryTests.swift
@@ -37,7 +37,6 @@ final class SummarizeServiceFactoryTests: XCTestCase {
         super.tearDown()
     }
 
-    #if canImport(FoundationModels)
     func test_make_whenAppleIntelligenceAvailable() throws {
         guard #available(iOS 26, *) else {
             throw XCTSkip("Skipping iOS 26-only test on earlier OS versions")
@@ -55,7 +54,6 @@ final class SummarizeServiceFactoryTests: XCTestCase {
 
         XCTAssertNotNil(service.summarizerLifecycle)
     }
-    #endif
 
     func test_make_whenHostedSummarizerTrue_returnsNilForLLMConfigNotAvailable() throws {
         let subject = createSubject()

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
-        "version" : "509.1.1"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -36,9 +36,7 @@ final class AppLaunchUtil: FeatureFlaggable, Sendable {
         DefaultBrowserUtility().processUserDefaultState(isFirstRun: introScreenManager.shouldShowIntroScreen)
         DefaultBrowserUtility().migrateDefaultBrowserStatusIfNeeded(isFirstRun: introScreenManager.shouldShowIntroScreen)
         if #available(iOS 26, *) {
-            #if canImport(FoundationModels)
-                AppleIntelligenceUtil().processAvailabilityState()
-            #endif
+            AppleIntelligenceUtil().processAvailabilityState()
         }
 
         // Need to get "settings.sendCrashReports" this way so that Sentry can be initialized before getting the Profile.
@@ -146,9 +144,7 @@ final class AppLaunchUtil: FeatureFlaggable, Sendable {
         AppEventQueue.signal(event: .preLaunchDependenciesComplete)
 
         if #available(iOS 26, *) {
-            #if canImport(FoundationModels)
-                AppleIntelligenceUtil().processAvailabilityState()
-            #endif
+            AppleIntelligenceUtil().processAvailabilityState()
         }
     }
 

--- a/firefox-ios/Client/Application/AppleIntelligenceUtil.swift
+++ b/firefox-ios/Client/Application/AppleIntelligenceUtil.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-#if canImport(FoundationModels)
 import Common
 import Foundation
 import FoundationModels
@@ -59,4 +58,3 @@ struct AppleIntelligenceUtil {
         }
     }
 }
-#endif

--- a/firefox-ios/Client/Experiments/Experiments.swift
+++ b/firefox-ios/Client/Experiments/Experiments.swift
@@ -230,20 +230,12 @@ enum Experiments {
 
     private static func isAppleIntelligenceAvailable() -> Bool {
         guard #available(iOS 26, *) else { return false }
-        #if canImport(FoundationModels)
-            return AppleIntelligenceUtil().isAppleIntelligenceAvailable
-        #else
-            return false
-        #endif
+        return AppleIntelligenceUtil().isAppleIntelligenceAvailable
     }
 
     private static func cannotUseAppleIntelligence() -> Bool {
         guard #available(iOS 26, *) else { return true }
-        #if canImport(FoundationModels)
-            return AppleIntelligenceUtil().cannotUseAppleIntelligence
-        #else
-            return true
-        #endif
+        return AppleIntelligenceUtil().cannotUseAppleIntelligence
     }
 
     private static func buildNimbus(dbPath: String,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -406,13 +406,9 @@ class CreditCardBottomSheetViewController: UIViewController,
 
         let effectView = UIVisualEffectView()
 
-        #if canImport(FoundationModels)
         let glassEffect = UIGlassEffect()
         glassEffect.isInteractive = true
         effectView.effect = glassEffect
-        #else
-        effectView.effect = UIBlurEffect(style: .systemUltraThinMaterial)
-        #endif
 
         effectView.layer.cornerRadius = UX.yesButtonCornerRadius
         effectView.clipsToBounds = true

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -217,15 +217,11 @@ class BrowserViewController: UIViewController,
     }
 
     private lazy var effect: some UIVisualEffect = {
-#if canImport(FoundationModels)
         if #available(iOS 26, *), !DeviceInfo.isRunningLiquidGlassEarlyBeta {
             return UIGlassEffect(style: .regular)
         } else {
             return UIBlurEffect(style: .systemUltraThinMaterial)
         }
-#else
-        return UIBlurEffect(style: .systemUltraThinMaterial)
-#endif
     }()
 
     // MARK: Blur views for translucent toolbars
@@ -886,9 +882,7 @@ class BrowserViewController: UIViewController,
 
     private func processAppleIntelligenceState() {
         if #available(iOS 26, *) {
-#if canImport(FoundationModels)
             AppleIntelligenceUtil().processAvailabilityState()
-#endif
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -224,13 +224,9 @@ class MainMenuViewController: UIViewController,
         let shouldShowBlur = !mainMenuHelper.isReduceTransparencyEnabled
 
         if shouldShowBlur {
-#if canImport(FoundationModels)
             if #unavailable(iOS 26.0) {
                 view.addBlurEffectWithClearBackgroundAndClipping(using: .regular)
             }
-#else
-            view.addBlurEffectWithClearBackgroundAndClipping(using: .regular)
-#endif
         } else {
             view.removeVisualEffectView()
         }
@@ -291,13 +287,9 @@ class MainMenuViewController: UIViewController,
     }
 
     private func setupView() {
-        #if canImport(FoundationModels)
         if #unavailable(iOS 26.0) {
             view.addBlurEffectWithClearBackgroundAndClipping(using: .regular)
         }
-        #else
-            view.addBlurEffectWithClearBackgroundAndClipping(using: .regular)
-        #endif
         view.addSubview(menuContent)
 
         NSLayoutConstraint.activate([

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -56,15 +56,11 @@ class TabTraySelectorView: UIView, ThemeApplicable {
     }
 
     lazy var visualEffectView: UIVisualEffectView = .build { view in
-#if canImport(FoundationModels)
         if #available(iOS 26, *), !DeviceInfo.isRunningLiquidGlassEarlyBeta {
             view.effect = UIGlassEffect(style: .regular)
         } else {
             view.effect = UIBlurEffect(style: .systemUltraThinMaterial)
         }
-#else
-        view.effect = UIBlurEffect(style: .systemUltraThinMaterial)
-#endif
     }
 
     init(selectedIndex: Int,

--- a/firefox-ios/Client/Frontend/Browser/Toasts/Toast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/Toast.swift
@@ -148,13 +148,9 @@ class Toast: UIView, ThemeApplicable, Notifiable {
 
         let effectView = UIVisualEffectView()
 
-        #if canImport(FoundationModels)
         let glassEffect = UIGlassEffect()
         glassEffect.tintColor = theme.colors.actionPrimary
         effectView.effect = glassEffect
-        #else
-        effectView.effect = UIBlurEffect(style: .systemUltraThinMaterial)
-        #endif
 
         effectView.layer.cornerRadius = UX.toastCornerRadius
         effectView.clipsToBounds = true

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -64,12 +64,10 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
     }
 
     private lazy var effectView: UIVisualEffectView = .build {
-#if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
             $0.effect = UIGlassEffect()
             $0.layer.cornerRadius = UX.stepperCornerGlassRadius
         }
-#endif
     }
 
     private lazy var zoomOutButton: UIButton = .build { button in

--- a/firefox-ios/Client/Frontend/Components/SaveLoginAlert.swift
+++ b/firefox-ios/Client/Frontend/Components/SaveLoginAlert.swift
@@ -59,20 +59,16 @@ class SaveLoginAlert: UIView, ThemeApplicable {
     }
 
     private lazy var notNowButton: SecondaryRoundedButton = .build { button in
-        #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
             button.configuration = .glass()
         }
-        #endif
         button.addTarget(self, action: #selector(self.notNowButtonPressed), for: .touchUpInside)
     }
 
     private lazy var saveButton: PrimaryRoundedButton = .build { button in
-        #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
             button.configuration = .glass()
         }
-        #endif
         button.addTarget(self, action: #selector(self.saveButtonPressed), for: .touchUpInside)
     }
 
@@ -195,13 +191,9 @@ class SaveLoginAlert: UIView, ThemeApplicable {
 
         let effectView = UIVisualEffectView()
 
-        #if canImport(FoundationModels)
         let glassEffect = UIGlassEffect()
         glassEffect.isInteractive = true
         effectView.effect = glassEffect
-        #else
-        effectView.effect = UIBlurEffect(style: .systemUltraThinMaterial)
-        #endif
 
         effectView.layer.cornerRadius = UX.cornerRadius
         effectView.clipsToBounds = true

--- a/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPreferencesViewController.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Views/PrivacyPreferencesViewController.swift
@@ -308,13 +308,9 @@ final class PrivacyPreferencesViewController: UIViewController,
 
         let effectView = UIVisualEffectView()
 
-        #if canImport(FoundationModels)
         let glassEffect = UIGlassEffect()
         glassEffect.isInteractive = true
         effectView.effect = glassEffect
-        #else
-        effectView.effect = UIBlurEffect(style: .systemUltraThinMaterial)
-        #endif
 
         effectView.clipsToBounds = true
         effectView.translatesAutoresizingMaskIntoConstraints = false

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerNimbusUtils.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerNimbusUtils.swift
@@ -88,16 +88,12 @@ struct DefaultSummarizerNimbusUtils: FeatureFlaggable, SummarizerNimbusUtils {
     }
 
     func isAppleSummarizerEnabled() -> Bool {
-        #if canImport(FoundationModels)
-            // if the language expansion is enabled don't check the en locale cause we support multiple locales
-            if isLanguageExpansionEnabled {
-                return appleIntelligenceUtil.isAppleIntelligenceAvailable
-            }
-            let isEngLang = localeProvider.current.languageCode == "en"
-            return isEngLang && appleIntelligenceUtil.isAppleIntelligenceAvailable
-        #else
-            return false
-        #endif
+        // if the language expansion is enabled don't check the en locale cause we support multiple locales
+        if isLanguageExpansionEnabled {
+            return appleIntelligenceUtil.isAppleIntelligenceAvailable
+        }
+        let isEngLang = localeProvider.current.languageCode == "en"
+        return isEngLang && appleIntelligenceUtil.isAppleIntelligenceAvailable
     }
 
     func isHostedSummarizerEnabled() -> Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppleIntelligenceUtilTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AppleIntelligenceUtilTests.swift
@@ -1,7 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-#if canImport(FoundationModels)
 import Shared
 import XCTest
 
@@ -63,4 +62,3 @@ final class MockLanguageModel: LanguageModelProtocol {
         self.isAvailable = isAvailable
     }
 }
-#endif


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](mozilla-hub.atlassian.net/browse/FXIOS-15960)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
 removes all #if canImport(FoundationModels) checks across the codebase, keeping the positive (FoundationModels / iOS 26) path and dropping the pre-iOS 26 fallback branches and now-stale explanatory comments. Bitrise is now on iOS26 so we don't need these anymore. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

