### PR TITLE
Revert "[no-ticket] Run performance tests on iOS 26 and 18 simulators on Bitrise"

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1580,10 +1580,6 @@ workflows:
             envman add --key BITRISE_BETA_VERSION --value "$version"
 
   Bitrise_Performance_Test:
-    envs:
-    - DEVICE_NAME: "iPhone 16"
-    - IOS_VERSION: "18.6"
-    - DEVICE_KEY: "iphone16-18-6"
     steps:
     - cache-pull@2:
         is_always_run: true
@@ -1591,7 +1587,7 @@ workflows:
         inputs:
         - project_path: firefox-ios/Client.xcodeproj
         - scheme: Fennec
-        - destination: platform=iOS Simulator,name=$DEVICE_NAME,OS=$IOS_VERSION
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
         - test_plan: PerformanceTestPlan
     - script@1:
         is_always_run: true
@@ -1614,7 +1610,7 @@ workflows:
             echo "DerivedData/Client/Log/Tests"
             ls /Users/vagrant/Library/Developer/Xcode/DerivedData
             CLIENT_PATH=$(ls /Users/vagrant/Library/Developer/Xcode/DerivedData | grep 'Client-')
-            mv /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec.xcresult /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec-${DEVICE_KEY}.xcresult
+            mv /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec.xcresult /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test/Test-Fennec-test.xcresult
 
             ls /Users/vagrant/Library/Developer/Xcode/DerivedData/$CLIENT_PATH/Logs/Test
 
@@ -1626,7 +1622,7 @@ workflows:
             cat test.json
             python3 perfTestTransform.py
             mkdir -p "$BITRISE_DEPLOY_DIR"
-            mv perfherder-data.json "$BITRISE_DEPLOY_DIR/perfherder-data-${DEVICE_KEY}.json"
+            mv perfherder-data.json $BITRISE_DEPLOY_DIR
     - deploy-to-bitrise-io@2: {}
     before_run:
     - 1_git_clone_and_post_clone

--- a/taskcluster/kinds/bitrise-performance/kind.yml
+++ b/taskcluster/kinds/bitrise-performance/kind.yml
@@ -10,36 +10,16 @@ transforms:
 
 
 tasks:
-    iphone16-ios186:
-        description: Run Performance Tests on iPhone 16 / iOS 18.6 in Bitrise
+    tests:
+        description: Run Performance Tests on iOS Simulator in Bitrise
         run-on-tasks-for: []
         treeherder:
             symbol: bitrise-perf
             kind: test
-            platform: ios-simulator-iphone16-18-6/opt
+            platform: ios-simulator-iphone14-16-4/opt
             tier: 1
         worker-type: bitrise
         bitrise:
             artifact_prefix: public
             workflows:
-                - Bitrise_Performance_Test:
-                    - DEVICE_NAME: "iPhone 16"
-                    - IOS_VERSION: "18.6"
-                    - DEVICE_KEY: "iphone16-18-6"
-
-    iphone17-ios265:
-        description: Run Performance Tests on iPhone 17 / iOS 26.5 in Bitrise
-        run-on-tasks-for: []
-        treeherder:
-            symbol: bitrise-perf
-            kind: test
-            platform: ios-simulator-iphone17-26-5/opt
-            tier: 1
-        worker-type: bitrise
-        bitrise:
-            artifact_prefix: public
-            workflows:
-                - Bitrise_Performance_Test:
-                    - DEVICE_NAME: "iPhone 17"
-                    - IOS_VERSION: "26.5"
-                    - DEVICE_KEY: "iphone17-26-5"
+                - Bitrise_Performance_Test

--- a/test-fixtures/perfTestTransform.py
+++ b/test-fixtures/perfTestTransform.py
@@ -1,7 +1,4 @@
 import json
-import os
-
-device_key = os.environ.get("DEVICE_KEY")
 
 PERFHERDER_DATA = {"framework": {"name":"mozperftest"},
                    "application": {"name": "fennec"},
@@ -13,8 +10,6 @@ with open('test.json') as json_file:
     for p in data:
         suite = {}
         suite["name"] = p["testName"]
-        if device_key:
-            suite["extraOptions"] = [device_key]
         suite["subtests"] = []
         for key, value in p.items():
             if key != "testName":


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-ios#33953

The rolling builds on Bitrise cancels the runs for all but one device.
<img width="1087" height="480" alt="Screenshot 2026-06-01 at 10 22 44" src="https://github.com/user-attachments/assets/a1ddcb4b-af30-44b5-919f-984d71236993" />
