### PR TITLE
Refactor FXIOS-15970 [NativeErrorPage] Add explicit ErrorPageType to replace indirect UI state checks

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -156,7 +156,8 @@ class NativeErrorPageHelper {
                     foxImageName: ImageIdentifiers.NativeErrorPage.noInternetConnection,
                     url: nil,
                     advancedSection: nil,
-                    showGoBackButton: false
+                    showGoBackButton: false,
+                    type: .internetConnection
                 )
             case NSURLErrorServerCertificateUntrusted,
                  NSURLErrorServerCertificateHasBadDate,
@@ -170,7 +171,8 @@ class NativeErrorPageHelper {
                     foxImageName: ImageIdentifiers.NativeErrorPage.securityError,
                     url: url,
                     advancedSection: nil,
-                    showGoBackButton: false
+                    showGoBackButton: false,
+                    type: .generic
                 )
             }
         } else {
@@ -180,7 +182,8 @@ class NativeErrorPageHelper {
                 foxImageName: ImageIdentifiers.NativeErrorPage.noInternetConnection,
                 url: nil,
                 advancedSection: nil,
-                showGoBackButton: false
+                showGoBackButton: false,
+                type: .internetConnection
             )
         }
         return model
@@ -244,7 +247,8 @@ class NativeErrorPageHelper {
                 foxImageName: ImageIdentifiers.NativeErrorPage.securityError,
                 url: url,
                 advancedSection: nil,
-                showGoBackButton: false
+                showGoBackButton: false,
+                type: .generic
             )
         }
 
@@ -278,7 +282,8 @@ class NativeErrorPageHelper {
                 foxImageName: ImageIdentifiers.NativeErrorPage.securityError,
                 url: url,
                 advancedSection: advancedSection,
-                showGoBackButton: true
+                showGoBackButton: true,
+                type: .badCertDomain
             )
         } else {
             return ErrorPageModel(
@@ -287,7 +292,8 @@ class NativeErrorPageHelper {
                 foxImageName: ImageIdentifiers.NativeErrorPage.securityError,
                 url: url,
                 advancedSection: nil,
-                showGoBackButton: false
+                showGoBackButton: false,
+                type: .generic
             )
         }
     }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
@@ -4,6 +4,19 @@
 
 import Foundation
 
+enum ErrorPageType: Equatable {
+    case internetConnection
+    case badCertDomain
+    case generic
+
+    var isRegularUI: Bool {
+        switch self {
+        case .internetConnection, .generic: return true
+        case .badCertDomain: return false
+        }
+    }
+}
+
 struct ErrorPageModel: Equatable {
     let errorTitle: String
     let errorDescription: String
@@ -11,6 +24,7 @@ struct ErrorPageModel: Equatable {
     let url: URL?
     let advancedSection: AdvancedSectionConfig?
     let showGoBackButton: Bool
+    let type: ErrorPageType
 
     struct AdvancedSectionConfig: Equatable {
         let buttonText: String

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
@@ -24,6 +24,9 @@ struct ErrorPageModel: Equatable {
     let url: URL?
     let advancedSection: AdvancedSectionConfig?
     let showGoBackButton: Bool
+    // TODO - FXIOS-16001 - Refactoring the error page model 
+    // so that the error page type determines the model structure 
+    // rather than storing type within the error page model itself.
     let type: ErrorPageType
 
     struct AdvancedSectionConfig: Equatable {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
@@ -12,7 +12,7 @@ struct NativeErrorPageState: ScreenState {
     var foxImage: String
     var url: URL?
     var advancedSection: ErrorPageModel.AdvancedSectionConfig?
-    var showGoBackButton: Bool
+    var type: ErrorPageType
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let nativeErrorPageState = appState.componentState(
@@ -31,7 +31,7 @@ struct NativeErrorPageState: ScreenState {
             foxImage: nativeErrorPageState.foxImage,
             url: nativeErrorPageState.url,
             advancedSection: nativeErrorPageState.advancedSection,
-            showGoBackButton: nativeErrorPageState.showGoBackButton
+            type: nativeErrorPageState.type
         )
     }
 
@@ -42,7 +42,7 @@ struct NativeErrorPageState: ScreenState {
         foxImage: String = "",
         url: URL? = nil,
         advancedSection: ErrorPageModel.AdvancedSectionConfig? = nil,
-        showGoBackButton: Bool = false
+        type: ErrorPageType = .generic
     ) {
         self.windowUUID = windowUUID
         self.title = title
@@ -50,7 +50,7 @@ struct NativeErrorPageState: ScreenState {
         self.foxImage = foxImage
         self.url = url
         self.advancedSection = advancedSection
-        self.showGoBackButton = showGoBackButton
+        self.type = type
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -70,7 +70,7 @@ struct NativeErrorPageState: ScreenState {
                 foxImage: model.foxImageName,
                 url: model.url,
                 advancedSection: model.advancedSection,
-                showGoBackButton: model.showGoBackButton
+                type: model.type
             )
         default:
             return defaultState(from: state)
@@ -85,7 +85,7 @@ struct NativeErrorPageState: ScreenState {
             foxImage: state.foxImage,
             url: state.url,
             advancedSection: state.advancedSection,
-            showGoBackButton: state.showGoBackButton
+            type: state.type
         )
     }
 }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -182,11 +182,10 @@ final class NativeErrorPageViewController: UIViewController,
         nativeErrorPageState = state
         guard !state.title.isEmpty else { return }
 
-        let isBadCert = state.advancedSection != nil && state.showGoBackButton
-        if isBadCert {
-            showBadCertUI()
-        } else {
+        if state.type.isRegularUI {
             showRegularUI()
+        } else {
+            showBadCertUI()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
@@ -161,6 +161,8 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.noInternetConnection)
         XCTAssertNil(model.url)
+        XCTAssertEqual(model.type, .internetConnection)
+        XCTAssertTrue(model.type.isRegularUI)
     }
 
     func testParseErrorDetails_noFailingURL_returnsNoInternetModel() {
@@ -172,6 +174,7 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.noInternetConnection)
         XCTAssertNil(model.url)
+        XCTAssertEqual(model.type, .internetConnection)
     }
 
     func testParseErrorDetails_certError_withURL_returnsSecurityModel() {
@@ -186,6 +189,8 @@ final class NativeErrorPageHelperTests: XCTestCase {
         let model = helper.parseErrorDetails()
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
+        XCTAssertEqual(model.type, .generic)
+        XCTAssertTrue(model.type.isRegularUI)
     }
 
     func testParseErrorDetails_certErrorBadCertDomain_returnsAdvancedSection() {
@@ -208,6 +213,8 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertNotNil(model.advancedSection)
         XCTAssertTrue(model.showGoBackButton)
+        XCTAssertEqual(model.type, .badCertDomain)
+        XCTAssertFalse(model.type.isRegularUI)
     }
 
     func testParseErrorDetails_genericError_withURL_returnsGenericModel() {
@@ -221,6 +228,8 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
         XCTAssertNil(model.advancedSection)
+        XCTAssertEqual(model.type, .generic)
+        XCTAssertTrue(model.type.isRegularUI)
     }
 
     // MARK: - getCertDetails
@@ -257,5 +266,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
         XCTAssertNil(model.advancedSection)
+        XCTAssertEqual(model.type, .generic)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageStateTests.swift
@@ -16,7 +16,7 @@ final class NativeErrorPageStateTests: XCTestCase {
         XCTAssertEqual(initialState.foxImage, "")
         XCTAssertNil(initialState.url)
         XCTAssertNil(initialState.advancedSection)
-        XCTAssertFalse(initialState.showGoBackButton)
+        XCTAssertEqual(initialState.type, .generic)
     }
 
     @MainActor
@@ -32,7 +32,8 @@ final class NativeErrorPageStateTests: XCTestCase {
                 string: "url.com"
             ),
             advancedSection: nil,
-            showGoBackButton: false
+            showGoBackButton: false,
+            type: .internetConnection
         )
 
         let action = getAction(model: mockModel, for: .initialize)
@@ -43,7 +44,8 @@ final class NativeErrorPageStateTests: XCTestCase {
         XCTAssertEqual(newState.foxImage, mockModel.foxImageName)
         XCTAssertEqual(newState.url, mockModel.url)
         XCTAssertNil(newState.advancedSection)
-        XCTAssertFalse(newState.showGoBackButton)
+        XCTAssertEqual(newState.type, .internetConnection)
+        XCTAssertTrue(newState.type.isRegularUI)
     }
 
     @MainActor
@@ -68,7 +70,8 @@ If you’re on a corporate network, your support team might have more info.
             foxImageName: "securityError",
             url: URL(string: "https://example.com"),
             advancedSection: advancedSection,
-            showGoBackButton: true
+            showGoBackButton: true,
+            type: .badCertDomain
         )
 
         let action = getAction(model: mockModel, for: .initialize)
@@ -78,7 +81,8 @@ If you’re on a corporate network, your support team might have more info.
         XCTAssertEqual(newState.description, mockModel.errorDescription)
         XCTAssertEqual(newState.foxImage, mockModel.foxImageName)
         XCTAssertEqual(newState.url, mockModel.url)
-        XCTAssertTrue(newState.showGoBackButton)
+        XCTAssertEqual(newState.type, .badCertDomain)
+        XCTAssertFalse(newState.type.isRegularUI)
         XCTAssertNotNil(newState.advancedSection)
         XCTAssertEqual(newState.advancedSection?.buttonText, advancedSection.buttonText)
         XCTAssertEqual(newState.advancedSection?.infoText, advancedSection.infoText)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15970)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34096)

## :bulb: Description
`NativeErrorPageViewController` was referring the error type from unrelated UI properties (`advancedSection != nil && showGoBackButton`), and any future error type with the same properties would incorrectly trigger the bad cert UI.

Added an explicit `ErrorPageType` enum (`internetConnection`, `badCertDomain`, `generic`) with an `isRegularUI` computed property. The type is now set at the source in `NativeErrorPageHelper` when parsing the error, carried through `ErrorPageModel` into `NativeErrorPageState`, and used in the view controller via `state.type.isRegularUI`. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
