### PR TITLE
Refactor FXIOS-15899 [NativeErrorPage] Align cert error detection with ErrorPageHelper

### DIFF
--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -21,9 +21,8 @@ private let StreamErrorCodeKey = "_kCFStreamErrorCodeKey"
 struct CertErrorsMapping {
     // Error codes copied from Gecko. The ints corresponding to these codes were determined
     // by inspecting the NSError in each of these cases.
-    // TODO: This impacts the NativeErrorPageHelper too, once ErrorPageHelper is fully replaced,
-    // we should move this code over there
-    // in NativeErrorPageHelper.swift once ErrorPageHelper is fully replaced.
+    // TODO: FXIOS-15970 This impacts the NativeErrorPageHelper too, once ErrorPageHelper is fully replaced,
+    // we should move this code over there.
     enum GeckoCode: Int {
         case unknownIssuer = -9813
         case expiredCertificate = -9814

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -18,10 +18,11 @@ private let ErrorPageCertErrorParam = "certerror"
 private let PeerCertificateChainKey = "NSErrorPeerCertificateChainKey"
 private let StreamErrorCodeKey = "_kCFStreamErrorCodeKey"
 
-private struct LegacyCertErrors {
+struct CertErrorsMapping {
     // Error codes copied from Gecko. The ints corresponding to these codes were determined
     // by inspecting the NSError in each of these cases.
-    // TODO: This legacy constant should eventually be removed in favor of CertErrorCodes
+    // TODO: This impacts the NativeErrorPageHelper too, once ErrorPageHelper is fully replaced,
+    // we should move this code over there
     // in NativeErrorPageHelper.swift once ErrorPageHelper is fully replaced.
     enum GeckoCode: Int {
         case unknownIssuer = -9813
@@ -55,12 +56,12 @@ private struct LegacyCertErrors {
     ]
 }
 
-private let legacyCertErrors = LegacyCertErrors()
+private let legacyCertErrors = CertErrorsMapping()
 
 private func certErrorFromNetworkErrorCode(_ networkErrorCode: Int) -> String {
     guard let geckoCode = legacyCertErrors.errorMapping[networkErrorCode] else {
         assertionFailure("Missing legacy cert mapping for NSURLErrorDomain code: \(networkErrorCode)")
-        return LegacyCertErrors.GeckoCode.unknownIssuer.description
+        return CertErrorsMapping.GeckoCode.unknownIssuer.description
     }
     return geckoCode.description
 }
@@ -359,7 +360,7 @@ class ErrorPageHelper {
 
             let underlyingError = error.userInfo[NSUnderlyingErrorKey] as? NSError
             let certErrorCode = underlyingError?.userInfo[StreamErrorCodeKey] as? Int
-            let certError = LegacyCertErrors.GeckoCode(rawValue: certErrorCode ?? Int.min)?.description
+            let certError = CertErrorsMapping.GeckoCode(rawValue: certErrorCode ?? Int.min)?.description
                 ?? certErrorFromNetworkErrorCode(error.code)
             queryItems.append(URLQueryItem(name: ErrorPageCertErrorParam, value: certError))
         }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -19,38 +19,7 @@ class NativeErrorPageHelper {
         static let domainDescriptionMarker = "domain"
         static let hostnameDescriptionMarker = "hostname"
     }
-
-    // Error codes copied from Gecko. The ints corresponding to these codes were determined
-    // by inspecting the NSError in each of these cases.
-    enum GeckoCode: Int {
-        case unknownIssuer = -9813
-        case expiredCertificate = -9814
-        case badCertDomain = -9843
-
-        var description: String {
-            switch self {
-            case .unknownIssuer: return "SEC_ERROR_UNKNOWN_ISSUER"
-            case .expiredCertificate: return "SEC_ERROR_EXPIRED_CERTIFICATE"
-            case .badCertDomain: return "SSL_ERROR_BAD_CERT_DOMAIN"
-            }
-        }
-    }
-
-    // Cert errors may be reported inconsistently across iOS versions.
-    private static let certErrors = [
-        NSURLErrorServerCertificateUntrusted,
-        NSURLErrorServerCertificateHasBadDate,
-        NSURLErrorServerCertificateHasUnknownRoot,
-        NSURLErrorServerCertificateNotYetValid
-    ]
-
-    private static let errorMapping: [Int: GeckoCode] = [
-        NSURLErrorServerCertificateUntrusted: .unknownIssuer,
-        NSURLErrorServerCertificateHasUnknownRoot: .unknownIssuer,
-        NSURLErrorServerCertificateHasBadDate: .expiredCertificate,
-        NSURLErrorServerCertificateNotYetValid: .expiredCertificate
-    ]
-
+    private static let certErrorsMapping = CertErrorsMapping()
     /// Holds the parsed certificate details extracted from an NSError.
     struct CertDetails {
         let failingURL: URL
@@ -73,7 +42,7 @@ class NativeErrorPageHelper {
 
     /// Returns whether the given NSURLError code represents a certificate error.
     private static func isCertificateErrorCode(_ code: Int) -> Bool {
-        return certErrors.contains(code)
+        return certErrorsMapping.certErrors.contains(code)
     }
 
     /// Extracts the CFStream certificate error code embedded in the underlying NSError, if present.
@@ -90,7 +59,7 @@ class NativeErrorPageHelper {
     /// failures return false so they fall back to the legacy HTML error page
     private static func isBadCertDomainError(_ error: NSError) -> Bool {
         guard isCertificateErrorCode(error.code) else { return false }
-        return certStreamErrorCode(from: error) == GeckoCode.badCertDomain.rawValue
+        return certStreamErrorCode(from: error) == NativeGeckoCode.badCertDomain.rawValue
     }
 
     /// Centralized predicate for whether we should show the native UI for a wrong-host certificate error.
@@ -130,7 +99,7 @@ class NativeErrorPageHelper {
         let certError = components.queryItems?.first(where: {
             $0.name == Constants.certErrorQueryParam
         })?.value
-        return certError == GeckoCode.badCertDomain.description
+        return certError == NativeGeckoCode.badCertDomain.description
     }
 
     /// Logs diagnostic details for a certificate error to aid debugging.
@@ -218,7 +187,7 @@ class NativeErrorPageHelper {
     }
 
     // MARK: - Private
-
+    typealias NativeGeckoCode = CertErrorsMapping.GeckoCode
     /// Builds certificate-specific query items (cert error name and encoded certificate)
     /// from the given NSError for inclusion in an error page URL.
     private static func buildCertificateQueryItems(for error: NSError) -> [URLQueryItem] {
@@ -226,9 +195,9 @@ class NativeErrorPageHelper {
 
         let certErrorDescription: String?
         if let cfStreamCode = certStreamErrorCode(from: error) {
-            certErrorDescription = GeckoCode(rawValue: cfStreamCode)?.description
+            certErrorDescription = NativeGeckoCode(rawValue: cfStreamCode)?.description
         } else {
-            certErrorDescription = errorMapping[error.code]?.description
+            certErrorDescription = certErrorsMapping.errorMapping[error.code]?.description
         }
         if let desc = certErrorDescription {
             queryItems.append(URLQueryItem(name: Constants.certErrorQueryParam, value: desc))
@@ -265,7 +234,7 @@ class NativeErrorPageHelper {
 
         // TODO: FXIOS-14569 — Investigate using SecTrustEvaluateWithError to evaluate TLS trust
         // errors instead of private APIs.
-        if certStreamErrorCode(from: error) == GeckoCode.badCertDomain.rawValue {
+        if certStreamErrorCode(from: error) == NativeGeckoCode.badCertDomain.rawValue {
             let appName = AppName.shortName.description
             let securityInfo = String.NativeErrorPage.BadCertDomain.AdvancedSecurityInfo
             let certificateInfo = String(
@@ -283,7 +252,7 @@ class NativeErrorPageHelper {
                 buttonText: String.NativeErrorPage.BadCertDomain.AdvancedButton,
                 infoText: advancedInfo,
                 warningText: warningText,
-                certificateErrorCode: GeckoCode.badCertDomain.description,
+                certificateErrorCode: NativeGeckoCode.badCertDomain.description,
                 showProceedButton: true
             )
 

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -7,22 +7,6 @@ import Shared
 import Common
 import Security
 
-// Error codes copied from Gecko. The ints corresponding to these codes were determined
-// by inspecting the NSError in each of these cases.
-// This replaces the legacy CertErrorCodes in ErrorPageHelper.swift.
-let CertErrorCodes: [Int: String] = [
-    -9813: "SEC_ERROR_UNKNOWN_ISSUER",
-    -9814: "SEC_ERROR_EXPIRED_CERTIFICATE",
-    -9843: "SSL_ERROR_BAD_CERT_DOMAIN",
-]
-
-let CertErrors: [Int] = [
-    NSURLErrorServerCertificateUntrusted,
-    NSURLErrorServerCertificateHasBadDate,
-    NSURLErrorServerCertificateHasUnknownRoot,
-    NSURLErrorServerCertificateNotYetValid
-]
-
 class NativeErrorPageHelper {
     private enum Constants {
         static let certErrorQueryParam = "certerror"
@@ -30,13 +14,42 @@ class NativeErrorPageHelper {
         static let codeQueryParam = "code"
         static let cfStreamErrorCodeKey = "_kCFStreamErrorCodeKey"
         static let peerCertificateChainKey = "NSErrorPeerCertificateChainKey"
-        static let defaultBadCertDomainError = "SSL_ERROR_BAD_CERT_DOMAIN"
-        static let sslErrorBadCertDomainCode = -9843
         static let wrongHostMarker = "wrong.host"
         static let badSSLHostMarker = "badssl"
         static let domainDescriptionMarker = "domain"
         static let hostnameDescriptionMarker = "hostname"
     }
+
+    // Error codes copied from Gecko. The ints corresponding to these codes were determined
+    // by inspecting the NSError in each of these cases.
+    enum GeckoCode: Int {
+        case unknownIssuer = -9813
+        case expiredCertificate = -9814
+        case badCertDomain = -9843
+
+        var description: String {
+            switch self {
+            case .unknownIssuer: return "SEC_ERROR_UNKNOWN_ISSUER"
+            case .expiredCertificate: return "SEC_ERROR_EXPIRED_CERTIFICATE"
+            case .badCertDomain: return "SSL_ERROR_BAD_CERT_DOMAIN"
+            }
+        }
+    }
+
+    // Cert errors may be reported inconsistently across iOS versions.
+    private static let certErrors = [
+        NSURLErrorServerCertificateUntrusted,
+        NSURLErrorServerCertificateHasBadDate,
+        NSURLErrorServerCertificateHasUnknownRoot,
+        NSURLErrorServerCertificateNotYetValid
+    ]
+
+    private static let errorMapping: [Int: GeckoCode] = [
+        NSURLErrorServerCertificateUntrusted: .unknownIssuer,
+        NSURLErrorServerCertificateHasUnknownRoot: .unknownIssuer,
+        NSURLErrorServerCertificateHasBadDate: .expiredCertificate,
+        NSURLErrorServerCertificateNotYetValid: .expiredCertificate
+    ]
 
     /// Holds the parsed certificate details extracted from an NSError.
     struct CertDetails {
@@ -60,7 +73,7 @@ class NativeErrorPageHelper {
 
     /// Returns whether the given NSURLError code represents a certificate error.
     private static func isCertificateErrorCode(_ code: Int) -> Bool {
-        return CertErrors.contains(code)
+        return certErrors.contains(code)
     }
 
     /// Extracts the CFStream certificate error code embedded in the underlying NSError, if present.
@@ -77,7 +90,7 @@ class NativeErrorPageHelper {
     /// failures return false so they fall back to the legacy HTML error page
     private static func isBadCertDomainError(_ error: NSError) -> Bool {
         guard isCertificateErrorCode(error.code) else { return false }
-        return certStreamErrorCode(from: error) == Constants.sslErrorBadCertDomainCode
+        return certStreamErrorCode(from: error) == GeckoCode.badCertDomain.rawValue
     }
 
     /// Centralized predicate for whether we should show the native UI for a wrong-host certificate error.
@@ -117,7 +130,7 @@ class NativeErrorPageHelper {
         let certError = components.queryItems?.first(where: {
             $0.name == Constants.certErrorQueryParam
         })?.value
-        return certError == Constants.defaultBadCertDomainError
+        return certError == GeckoCode.badCertDomain.description
     }
 
     /// Logs diagnostic details for a certificate error to aid debugging.
@@ -211,12 +224,14 @@ class NativeErrorPageHelper {
     private static func buildCertificateQueryItems(for error: NSError) -> [URLQueryItem] {
         var queryItems = [URLQueryItem]()
 
-        if let certErrorCode = certStreamErrorCode(from: error),
-           let certErrorString = CertErrorCodes[certErrorCode] {
-            queryItems.append(URLQueryItem(
-                name: Constants.certErrorQueryParam,
-                value: certErrorString
-            ))
+        let certErrorDescription: String?
+        if let cfStreamCode = certStreamErrorCode(from: error) {
+            certErrorDescription = GeckoCode(rawValue: cfStreamCode)?.description
+        } else {
+            certErrorDescription = errorMapping[error.code]?.description
+        }
+        if let desc = certErrorDescription {
+            queryItems.append(URLQueryItem(name: Constants.certErrorQueryParam, value: desc))
         }
 
         if let certChain = error.userInfo[Constants.peerCertificateChainKey] as? [SecCertificate],
@@ -250,7 +265,7 @@ class NativeErrorPageHelper {
 
         // TODO: FXIOS-14569 — Investigate using SecTrustEvaluateWithError to evaluate TLS trust
         // errors instead of private APIs.
-        if certStreamErrorCode(from: error) == Constants.sslErrorBadCertDomainCode {
+        if certStreamErrorCode(from: error) == GeckoCode.badCertDomain.rawValue {
             let appName = AppName.shortName.description
             let securityInfo = String.NativeErrorPage.BadCertDomain.AdvancedSecurityInfo
             let certificateInfo = String(
@@ -268,7 +283,7 @@ class NativeErrorPageHelper {
                 buttonText: String.NativeErrorPage.BadCertDomain.AdvancedButton,
                 infoText: advancedInfo,
                 warningText: warningText,
-                certificateErrorCode: CertErrorCodes[Constants.sslErrorBadCertDomainCode]!,
+                certificateErrorCode: GeckoCode.badCertDomain.description,
                 showProceedButton: true
             )
 

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -20,6 +20,7 @@ class NativeErrorPageHelper {
         static let hostnameDescriptionMarker = "hostname"
     }
     private static let certErrorsMapping = CertErrorsMapping()
+    typealias NativeGeckoCode = CertErrorsMapping.GeckoCode
     /// Holds the parsed certificate details extracted from an NSError.
     struct CertDetails {
         let failingURL: URL
@@ -187,7 +188,6 @@ class NativeErrorPageHelper {
     }
 
     // MARK: - Private
-    typealias NativeGeckoCode = CertErrorsMapping.GeckoCode
     /// Builds certificate-specific query items (cert error name and encoded certificate)
     /// from the given NSError for inclusion in an error page URL.
     private static func buildCertificateQueryItems(for error: NSError) -> [URLQueryItem] {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -199,8 +199,8 @@ class NativeErrorPageHelper {
         } else {
             certErrorDescription = certErrorsMapping.errorMapping[error.code]?.description
         }
-        if let desc = certErrorDescription {
-            queryItems.append(URLQueryItem(name: Constants.certErrorQueryParam, value: desc))
+        if let certErrorDescription {
+            queryItems.append(URLQueryItem(name: Constants.certErrorQueryParam, value: certErrorDescription))
         }
 
         if let certChain = error.userInfo[Constants.peerCertificateChainKey] as? [SecCertificate],

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
@@ -134,7 +134,7 @@ final class NativeErrorPageHelperTests: XCTestCase {
         XCTAssertTrue(items.contains(where: { $0.name == "code" }))
     }
 
-    func testBuildErrorPageQueryItems_certErrorWithoutCFStreamCode_doesNotIncludeCertErrorItem() {
+    func testBuildErrorPageQueryItems_certErrorWithoutCFStreamCode_fallsBackToErrorMapping() {
         let url = URL(string: "https://example.com")!
         let error = NSError(
             domain: NSURLErrorDomain,
@@ -144,7 +144,7 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         let items = NativeErrorPageHelper.buildErrorPageQueryItems(for: error, url: url)
 
-        XCTAssertFalse(items.contains(where: { $0.name == "certerror" }))
+        XCTAssertTrue(items.contains(where: { $0.name == "certerror" && $0.value == "SEC_ERROR_UNKNOWN_ISSUER" }))
     }
 
     // MARK: - parseErrorDetails


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15899)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33986)

## :bulb: Description
Aligns `NativeErrorPageHelper` cert error detection with the approach
already used in the legacy `ErrorPageHelper`.

**What changed:**
- Replaced the file-level `CertErrorCodes: [Int: String]` and `CertErrors: [Int]`
  with a typed `GeckoCode` enum nested inside `NativeErrorPageHelper`, matching
  `LegacyCertErrors.GeckoCode` in `ErrorPageHelper`
- Added `errorMapping: [Int: GeckoCode]` 
- Updated `buildCertificateQueryItems` to try the CFStream code first via
  `GeckoCode(rawValue:)`, then fall back to `errorMapping`, mirroring
  `ErrorPageHelper`'s `LegacyCertErrors.GeckoCode(rawValue: certErrorCode ?? Int.min)?.description ?? certErrorFromNetworkErrorCode(error.code)` pattern
- Replaced numbers/strings (`-9843`, `"SSL_ERROR_BAD_CERT_DOMAIN"`) throughout
  with `GeckoCode.badCertDomain.rawValue` / `.description`
- Updated the corresponding test to assert the fallback behavior rather than
  asserting no cert error item when CFStream code is absent


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
