### PR TITLE
Refactor FXIOS-15901 [Technical Debt] [Redux] Migrate Redux HomepageState and substates to `@Copyable` macro

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -75,7 +75,7 @@ workflows:
 
             xcrun simctl list
             xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
-            xcodebuild "-project" "/Users/vagrant/git/firefox-ios/Client.xcodeproj" "-scheme" "Fennec" -configuration "Fennec_Testing" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 17,OS=26.5" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" | xcpretty | tee xcodebuild_fennec.log
+            xcodebuild "-project" "/Users/vagrant/git/firefox-ios/Client.xcodeproj" "-scheme" "Fennec" -configuration "Fennec_Testing" "CODE_SIGNING_ALLOWED=NO" -sdk "iphonesimulator" "-destination" "platform=iOS Simulator,name=iPhone 17,OS=26.5" "COMPILER_INDEX_STORE_ENABLE=NO" "build-for-testing" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -derivedDataPath "/Users/vagrant/git/DerivedData" -skipMacroValidation | xcpretty | tee xcodebuild_fennec.log
 
             ls /Users/vagrant/git/DerivedData/Build/Products
             ls /Users/vagrant/git/DerivedData
@@ -161,7 +161,7 @@ workflows:
         - scheme: Fennec
         - configuration: Fennec_Testing
         - project_path: /Users/vagrant/git/firefox-ios/Client.xcodeproj
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates -skipMacroValidation DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
     - script@1:
         title: Detect number of warnings
@@ -355,7 +355,7 @@ workflows:
         - scheme: Firefox
         - configuration: Firefox
         - project_path: /Users/vagrant/git/firefox-ios/Client.xcodeproj
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID EXCLUDED_SOURCE_FILE_NAMES=""'
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates -skipMacroValidation DEVELOPMENT_TEAM=$APPLE_TEAM_ID EXCLUDED_SOURCE_FILE_NAMES=""'
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
     - script@1:
         title: Find Smoketest xctestrun file
@@ -451,7 +451,7 @@ workflows:
         - scheme: FirefoxBeta
         - configuration: FirefoxBeta
         - project_path: /Users/vagrant/git/firefox-ios/Client.xcodeproj
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID EXCLUDED_SOURCE_FILE_NAMES=""'
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates -skipMacroValidation DEVELOPMENT_TEAM=$APPLE_TEAM_ID EXCLUDED_SOURCE_FILE_NAMES=""'
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
     - script@1:
         title: Find Smoketest xctestrun file
@@ -950,7 +950,7 @@ workflows:
     - xcode-build-for-simulator@3:
         run_if: '{{getenv "NEW_XCODE_VERSION" | eq "New_Version_Found" | or (getenv "RUN_ALL_STEPS" | eq "Run_All_Steps")}}'
         inputs:
-        - xcodebuild_options: CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+        - xcodebuild_options: -skipMacroValidation CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
         - scheme: Fennec
         - simulator_device: iPhone 17
     - xcode-test@6:
@@ -1768,6 +1768,7 @@ workflows:
                 -sdk "$SDK$IOS_VERSION" \
                 -destination "$DESTINATION" \
                 -derivedDataPath "${DERIVED_DATA_DIR}" \
+                -skipMacroValidation
                 ENABLE_DEBUG_DYLIB=NO
 
             echo "-- verify build artifacts --"

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2253,6 +2253,7 @@
 		EDC3C2562CCAC9CB005A047F /* SearchEnginesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3C2552CCAC9CB005A047F /* SearchEnginesManager.swift */; };
 		EDC3D34F2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDC3D34E2CB5E70500C62DE3 /* SearchEngineTestAssets.xcassets */; };
 		EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3D3542CB70A3F00C62DE3 /* OpenSearchEngineTests.swift */; };
+		EDD09DC12FCF6AB20038C8FA /* ModifiedCopy in Frameworks */ = {isa = PBXBuildFile; productRef = EDD09DC02FCF6AB20038C8FA /* ModifiedCopy */; };
 		EDD21F2E2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD21F2D2CAEFB8F00AF7D1F /* SearchEngineSelectionViewController.swift */; };
 		EDD2A7F82CDACE7C00ED464C /* UnifiedSearchKit in Frameworks */ = {isa = PBXBuildFile; productRef = EDD2A7F72CDACE7C00ED464C /* UnifiedSearchKit */; };
 		EDD2A7FA2CDBD1D100ED464C /* SearchEngineElement+initFromSearchEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD2A7F92CDBD1D000ED464C /* SearchEngineElement+initFromSearchEngine.swift */; };
@@ -12001,6 +12002,7 @@
 				0B6D1C882E15456F00919F1E /* SummarizeKit in Frameworks */,
 				7B8A47F61D01D3B400C07734 /* PassKit.framework in Frameworks */,
 				5A8FD0EC293A7D5E00333AA7 /* SnapKit in Frameworks */,
+				EDD09DC12FCF6AB20038C8FA /* ModifiedCopy in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -17839,6 +17841,7 @@
 				AA459F862F630F3500D05D04 /* QuickAnswersKit */,
 				AA93AB042F6B06BE002E5E88 /* MLPAKit */,
 				AA93B7142F6D95D6002E5E88 /* LLMKit */,
+				EDD09DC02FCF6AB20038C8FA /* ModifiedCopy */,
 			);
 			productName = Client;
 			productReference = F84B21BE1A090F8100AAB793 /* Client.app */;
@@ -18178,6 +18181,7 @@
 				8AB30EC62B6C038600BD9A9B /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				AB2AC6612BCFD0A200022AAB /* XCRemoteSwiftPackageReference "swift-certificates" */,
 				5A984D322C8A31A0007938C9 /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				EDD09DBF2FCF6AB20038C8FA /* XCRemoteSwiftPackageReference "ModifiedCopyMacro" */,
 			);
 			productRefGroup = F84B21BF1A090F8100AAB793 /* Products */;
 			projectDirPath = "";
@@ -32879,6 +32883,8 @@
 				kind = exactVersion;
 				version = 9.10.0;
 			};
+			traits = (
+			);
 		};
 		5A984D322C8A31A0007938C9 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -32902,6 +32908,14 @@
 			requirement = {
 				kind = exactVersion;
 				version = 1.2.0;
+			};
+		};
+		EDD09DBF2FCF6AB20038C8FA /* XCRemoteSwiftPackageReference "ModifiedCopyMacro" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/WilhelmOks/ModifiedCopyMacro.git";
+			requirement = {
+				kind = exactVersion;
+				version = 2.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -33220,6 +33234,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5A37861729A2C337006B3A34 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = "Sentry-Dynamic";
+		};
+		EDD09DC02FCF6AB20038C8FA /* ModifiedCopy */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EDD09DBF2FCF6AB20038C8FA /* XCRemoteSwiftPackageReference "ModifiedCopyMacro" */;
+			productName = ModifiedCopy;
 		};
 		EDD2A7F72CDACE7C00ED464C /* UnifiedSearchKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2260,6 +2260,8 @@
 		EDD3348E2D109458004516D0 /* ShareTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD3348D2D109458004516D0 /* ShareTelemetryTests.swift */; };
 		EDD334902D109A5B004516D0 /* ShareTelemetryActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD3348F2D109A5B004516D0 /* ShareTelemetryActivityItemProviderTests.swift */; };
 		EDD334952D10BEEB004516D0 /* UserDefaults+valueExists.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD334942D10BEEB004516D0 /* UserDefaults+valueExists.swift */; };
+		EDD592472FC0FF6F0015EF9E /* ModifiedCopyMacroTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD592462FC0FF690015EF9E /* ModifiedCopyMacroTests.swift */; };
+		EDD5924A2FC1090C0015EF9E /* ModifiedCopy in Frameworks */ = {isa = PBXBuildFile; productRef = EDD592492FC1090C0015EF9E /* ModifiedCopy */; };
 		EDDB13872D3184F300C4B165 /* Site+createSponsoredSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDB13862D3184EB00C4B165 /* Site+createSponsoredSite.swift */; };
 		EDDC4F6F2F68637000E0B8FA /* legacyOnboardingOn.json in Resources */ = {isa = PBXBuildFile; fileRef = EDDC4F6C2F68637000E0B8FA /* legacyOnboardingOn.json */; };
 		EDDC4F702F68637000E0B8FA /* modernKitOnboardingOn.json in Resources */ = {isa = PBXBuildFile; fileRef = EDDC4F6D2F68637000E0B8FA /* modernKitOnboardingOn.json */; };
@@ -11671,6 +11673,7 @@
 		EDD3348D2D109458004516D0 /* ShareTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTelemetryTests.swift; sourceTree = "<group>"; };
 		EDD3348F2D109A5B004516D0 /* ShareTelemetryActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTelemetryActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		EDD334942D10BEEB004516D0 /* UserDefaults+valueExists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+valueExists.swift"; sourceTree = "<group>"; };
+		EDD592462FC0FF690015EF9E /* ModifiedCopyMacroTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifiedCopyMacroTests.swift; sourceTree = "<group>"; };
 		EDDB13862D3184EB00C4B165 /* Site+createSponsoredSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Site+createSponsoredSite.swift"; sourceTree = "<group>"; };
 		EDDC4F6C2F68637000E0B8FA /* legacyOnboardingOn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = legacyOnboardingOn.json; sourceTree = "<group>"; };
 		EDDC4F6D2F68637000E0B8FA /* modernKitOnboardingOn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = modernKitOnboardingOn.json; sourceTree = "<group>"; };
@@ -11987,6 +11990,7 @@
 				AA459F872F630F3500D05D04 /* QuickAnswersKit in Frameworks */,
 				ED6C8DAC2CE6A4BB00D7F7F3 /* Sentry-Dynamic in Frameworks */,
 				AA93AB052F6B06BE002E5E88 /* MLPAKit in Frameworks */,
+				EDD5924A2FC1090C0015EF9E /* ModifiedCopy in Frameworks */,
 				5A984D362C8A3407007938C9 /* Kingfisher in Frameworks */,
 				819656172C80C6F300E62323 /* MenuKit in Frameworks */,
 				8AB30EC82B6C038600BD9A9B /* Lottie in Frameworks */,
@@ -14542,6 +14546,7 @@
 		8ACA8F722919870B00D3075D /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				EDD592462FC0FF690015EF9E /* ModifiedCopyMacroTests.swift */,
 				C705FA772EF30C4B00AC5EE7 /* PrivacyNoticeHelperTests.swift */,
 				8A83C58D2DDF887200FF60EF /* ProfilePrefsReaderTests.swift */,
 				8AC884202D5261FC0033ABF5 /* CrashTrackerTests.swift */,
@@ -17841,7 +17846,7 @@
 				AA459F862F630F3500D05D04 /* QuickAnswersKit */,
 				AA93AB042F6B06BE002E5E88 /* MLPAKit */,
 				AA93B7142F6D95D6002E5E88 /* LLMKit */,
-				EDD09DC02FCF6AB20038C8FA /* ModifiedCopy */,
+				EDD592492FC1090C0015EF9E /* ModifiedCopy */,
 			);
 			productName = Client;
 			productReference = F84B21BE1A090F8100AAB793 /* Client.app */;
@@ -18181,7 +18186,7 @@
 				8AB30EC62B6C038600BD9A9B /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				AB2AC6612BCFD0A200022AAB /* XCRemoteSwiftPackageReference "swift-certificates" */,
 				5A984D322C8A31A0007938C9 /* XCRemoteSwiftPackageReference "Kingfisher" */,
-				EDD09DBF2FCF6AB20038C8FA /* XCRemoteSwiftPackageReference "ModifiedCopyMacro" */,
+				EDD592482FC1090C0015EF9E /* XCRemoteSwiftPackageReference "ModifiedCopyMacro" */,
 			);
 			productRefGroup = F84B21BF1A090F8100AAB793 /* Products */;
 			projectDirPath = "";
@@ -20440,6 +20445,7 @@
 				2197DF8A287624BF00215624 /* LibraryViewModelTests.swift in Sources */,
 				5A3A7DDC2889EC5D0065F81A /* MockBookmarksHandler.swift in Sources */,
 				8015C8B52D0A31FE0093AED0 /* RecordedNimbusContextTests.swift in Sources */,
+				EDD592472FC0FF6F0015EF9E /* ModifiedCopyMacroTests.swift in Sources */,
 				AA742C7A2E90358400CF55B3 /* MockMicrosurveyTelemetry.swift in Sources */,
 				2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */,
 				8A04136B2825ABEA00D20B10 /* SponsoredTileTelemetryTests.swift in Sources */,
@@ -32910,7 +32916,7 @@
 				version = 1.2.0;
 			};
 		};
-		EDD09DBF2FCF6AB20038C8FA /* XCRemoteSwiftPackageReference "ModifiedCopyMacro" */ = {
+		EDD592482FC1090C0015EF9E /* XCRemoteSwiftPackageReference "ModifiedCopyMacro" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/WilhelmOks/ModifiedCopyMacro.git";
 			requirement = {
@@ -33243,6 +33249,11 @@
 		EDD2A7F72CDACE7C00ED464C /* UnifiedSearchKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = UnifiedSearchKit;
+		};
+		EDD592492FC1090C0015EF9E /* ModifiedCopy */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EDD592482FC1090C0015EF9E /* XCRemoteSwiftPackageReference "ModifiedCopyMacro" */;
+			productName = ModifiedCopy;
 		};
 		EDF5679F2C8B51DC00FDB09D /* SiteImageView */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "370de43cfe450f5957c41262676c1d8d8cae7684044fef4dc12c87a825c41eb2",
+  "originHash" : "080d5c14ff8b97f985991f02dd7321403b5a7e1b1243a154f2cdcc561b9bc212",
   "pins" : [
     {
       "identity" : "a-star",

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c6f0f60d95f13555a81ef7ed10d4a6edc8cf5dfe58e4b5ac8b630df7f18f1944",
+  "originHash" : "370de43cfe450f5957c41262676c1d8d8cae7684044fef4dc12c87a825c41eb2",
   "pins" : [
     {
       "identity" : "a-star",
@@ -92,6 +92,15 @@
       }
     },
     {
+      "identity" : "modifiedcopymacro",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/WilhelmOks/ModifiedCopyMacro.git",
+      "state" : {
+        "revision" : "13dee3de60d4614ac268ec822325a19812e6c6f6",
+        "version" : "2.2.0"
+      }
+    },
+    {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
@@ -139,7 +148,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"

--- a/firefox-ios/Client/Frontend/Home/Homepage/Bookmark/BookmarksSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Bookmark/BookmarksSectionState.swift
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
+import ModifiedCopy
 import Redux
 import Shared
 
 /// State for the bookmark section that is used in the homepage view
-@CopyWithUpdates
+@Copyable
 struct BookmarksSectionState: StateType, Equatable, Hashable {
     var windowUUID: WindowUUID
     var bookmarks: [BookmarkConfiguration]
@@ -70,7 +70,7 @@ struct BookmarksSectionState: StateType, Equatable, Hashable {
         else {
             return defaultState(from: state)
         }
-        return state.copyWithUpdates(
+        return state.copy(
             bookmarks: bookmarks
         )
     }
@@ -82,12 +82,16 @@ struct BookmarksSectionState: StateType, Equatable, Hashable {
             return defaultState(from: state)
         }
 
-        return state.copyWithUpdates(
+        return state.copy(
             shouldShowSection: isEnabled
         )
     }
 
     static func defaultState(from state: BookmarksSectionState) -> BookmarksSectionState {
-        return state.copyWithUpdates()
+        return BookmarksSectionState(
+            windowUUID: state.windowUUID,
+            bookmarks: state.bookmarks,
+            shouldShowSection: state.shouldShowSection
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Header/HeaderState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Header/HeaderState.swift
@@ -92,7 +92,7 @@ struct HeaderState: StateType, Equatable, Hashable {
         guard let worldCupAction = action as? WorldCupAction else {
             return defaultState(from: state)
         }
-        return state.copyWithUpdates(
+        return state.copy(
             isWorldCupSectionEnabled: worldCupAction.shouldShowHomepageWorldCupSection
         )
     }
@@ -113,7 +113,8 @@ struct HeaderState: StateType, Equatable, Hashable {
             windowUUID: state.windowUUID,
             isPrivate: state.isPrivate,
             showiPadSetup: state.showiPadSetup,
-            showQuickAnswersButton: state.showQuickAnswersButton
+            showQuickAnswersButton: state.showQuickAnswersButton,
+            isWorldCupSectionEnabled: state.isWorldCupSectionEnabled
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Header/HeaderState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Header/HeaderState.swift
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
+import ModifiedCopy
 import Foundation
 import Redux
 
 /// State for the header cell that is used in the homepage header section
-@CopyWithUpdates
+@Copyable
 struct HeaderState: StateType, Equatable, Hashable {
     var windowUUID: WindowUUID
     var isPrivate: Bool
@@ -72,10 +72,9 @@ struct HeaderState: StateType, Equatable, Hashable {
         else {
             return defaultState(from: state)
         }
-        return state.copyWithUpdates(
-            isPrivate: false,
-            showiPadSetup: showiPadSetup,
-        )
+        return state
+            .copy(isPrivate: false)
+            .copy(showiPadSetup: showiPadSetup)
     }
 
     private static func handleQuickAnswersAction(for state: HeaderState, with action: Action) -> HeaderState {
@@ -84,8 +83,8 @@ struct HeaderState: StateType, Equatable, Hashable {
         else {
             return defaultState(from: state)
         }
-        return state.copyWithUpdates(
-            showQuickAnswersButton: showQuickAnswers,
+        return state.copy(
+            showQuickAnswersButton: showQuickAnswers
         )
     }
 
@@ -104,12 +103,17 @@ struct HeaderState: StateType, Equatable, Hashable {
         else {
             return defaultState(from: state)
         }
-        return state.copyWithUpdates(
+        return state.copy(
             showiPadSetup: showiPadSetup
         )
     }
 
     static func defaultState(from state: HeaderState) -> HeaderState {
-        return state.copyWithUpdates()
+        return HeaderState(
+            windowUUID: state.windowUUID,
+            isPrivate: state.isPrivate,
+            showiPadSetup: state.showiPadSetup,
+            showQuickAnswersButton: state.showQuickAnswersButton
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/JumpBackInSectionState.swift
@@ -3,13 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
+import ModifiedCopy
 import Redux
 import Shared
 import Storage
 
 /// State for the jump back in section that is used in the homepage view
-@CopyWithUpdates
+@Copyable
 struct JumpBackInSectionState: StateType, Equatable, Hashable {
     var windowUUID: WindowUUID
     let jumpBackInTabs: [JumpBackInTabConfiguration]
@@ -90,7 +90,7 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
             return defaultState(from: state)
         }
 
-        return state.copyWithUpdates(
+        return state.copy(
             jumpBackInTabs: recentTabs.compactMap { tab in
                 let itemURL = tab.lastKnownUrl?.absoluteString ?? ""
                 let site = Site.createBasicSite(url: itemURL, title: tab.displayTitle)
@@ -118,7 +118,7 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
         let site = Site.createBasicSite(url: itemURL, title: mostRecentSyncedTab.tab.title)
         let descriptionText = mostRecentSyncedTab.client.name
 
-        return state.copyWithUpdates(
+        return state.copy(
             mostRecentSyncedTab: JumpBackInSyncedTabConfiguration(
                 titleText: site.title,
                 descriptionText: descriptionText,
@@ -134,12 +134,17 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
             return defaultState(from: state)
         }
 
-        return state.copyWithUpdates(
+        return state.copy(
             shouldShowSection: isEnabled
         )
     }
 
     static func defaultState(from state: JumpBackInSectionState) -> JumpBackInSectionState {
-        return state.copyWithUpdates()
+        return JumpBackInSectionState(
+            windowUUID: state.windowUUID,
+            jumpBackInTabs: state.jumpBackInTabs,
+            mostRecentSyncedTab: state.mostRecentSyncedTab,
+            shouldShowSection: state.shouldShowSection
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
@@ -3,13 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
+import ModifiedCopy
 import Foundation
 import Redux
 import Shared
 
 /// State for the Merino stories section that is used in the homepage
-@CopyWithUpdates
+@Copyable
 struct MerinoState: StateType, Equatable {
     var windowUUID: WindowUUID
     let merinoData: MerinoStoryResponse
@@ -22,6 +22,20 @@ struct MerinoState: StateType, Equatable {
             MerinoState.initializeSectionHeaderConfiguration()
         }
         static let footerURL = SupportUtils.URLForPocketLearnMore
+    }
+
+    var availableCategories: [MerinoCategoryConfiguration] {
+        (merinoData.categories ?? []).sorted { $0.rank < $1.rank }
+    }
+
+    func visibleStories(selectedNewsfeedCategoryID: String?) -> [MerinoStoryConfiguration] {
+        if !availableCategories.isEmpty {
+            if let selectedNewsfeedCategoryID {
+                return availableCategories.first(where: { $0.feedID == selectedNewsfeedCategoryID })?.recommendations ?? []
+            }
+            return availableCategories.flatMap(\.recommendations)
+        }
+        return merinoData.stories ?? []
     }
 
     init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {
@@ -75,12 +89,10 @@ struct MerinoState: StateType, Equatable {
         let merinoContentExists = !(merinoResponse.stories?.isEmpty ?? true) ||
                                   !(merinoResponse.categories?.isEmpty ?? true)
 
-        return MerinoState(
-            windowUUID: state.windowUUID,
-            merinoData: merinoResponse,
-            hasMerinoResponseContent: merinoContentExists,
-            shouldShowSection: merinoContentExists && state.shouldShowSection
-        )
+        return state
+            .copy(merinoData: merinoResponse)
+            .copy(hasMerinoResponseContent: merinoContentExists)
+            .copy(shouldShowSection: merinoContentExists && state.shouldShowSection)
     }
 
     private static func handleSettingsToggleAction(_ action: Action, state: MerinoState) -> MerinoState {
@@ -90,13 +102,18 @@ struct MerinoState: StateType, Equatable {
             return defaultState(from: state)
         }
 
-        return state.copyWithUpdates(
+        return state.copy(
             shouldShowSection: isEnabled
         )
     }
 
     static func defaultState(from state: MerinoState) -> MerinoState {
-        return state.copyWithUpdates()
+        return MerinoState(
+            windowUUID: state.windowUUID,
+            merinoData: state.merinoData,
+            hasMerinoResponseContent: state.hasMerinoResponseContent,
+            shouldShowSection: state.shouldShowSection
+        )
     }
 
     private static func initializeSectionHeaderConfiguration() -> SectionHeaderConfiguration {
@@ -105,24 +122,5 @@ struct MerinoState: StateType, Equatable {
             a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.merino,
             style: .newsAffordance
         )
-    }
-}
-
-/// `@CopyWithUpdates` currently treats computed properties declared inside the struct as
-/// initializer/copy fields, which breaks generation with "extra arguments" errors.
-/// Keep derived accessors in this extension as a workaround.
-extension MerinoState {
-    var availableCategories: [MerinoCategoryConfiguration] {
-        (merinoData.categories ?? []).sorted { $0.rank < $1.rank }
-    }
-
-    func visibleStories(selectedNewsfeedCategoryID: String?) -> [MerinoStoryConfiguration] {
-        if !availableCategories.isEmpty {
-            if let selectedNewsfeedCategoryID {
-                return availableCategories.first(where: { $0.feedID == selectedNewsfeedCategoryID })?.recommendations ?? []
-            }
-            return availableCategories.flatMap(\.recommendations)
-        }
-        return merinoData.stories ?? []
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/MessageCard/MessageCardState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/MessageCard/MessageCardState.swift
@@ -3,11 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
+import ModifiedCopy
 import Redux
 
 /// State for the message cell that is used in the homepage view
-@CopyWithUpdates
+@Copyable
 struct MessageCardState: StateType, Equatable, Hashable {
     var windowUUID: WindowUUID
     var messageCardConfiguration: MessageCardConfiguration?
@@ -49,19 +49,22 @@ struct MessageCardState: StateType, Equatable, Hashable {
         else {
             return defaultState(from: state)
         }
-        return state.copyWithUpdates(
+        return state.copy(
             messageCardConfiguration: messageCardConfiguration
         )
     }
 
     /// Tapping an action on the card should dismiss the message card and we do this by setting the configuration to nil
     private static func handleTappingAction(for state: MessageCardState, with action: Action) -> MessageCardState {
-        return state.copyWithUpdates(
+        return state.copy(
             messageCardConfiguration: nil
         )
     }
 
     static func defaultState(from state: MessageCardState) -> MessageCardState {
-        return state.copyWithUpdates()
+        return MessageCardState(
+            windowUUID: state.windowUUID,
+            messageCardConfiguration: state.messageCardConfiguration
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -3,10 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
+import ModifiedCopy
 import Redux
 
-@CopyWithUpdates
+@Copyable
 struct HomepageState: ScreenState, Equatable {
     var windowUUID: WindowUUID
 
@@ -57,7 +57,23 @@ struct HomepageState: ScreenState, Equatable {
             return
         }
 
-        self = homepageState.copyWithUpdates()
+        self.init(
+            windowUUID: homepageState.windowUUID,
+            headerState: homepageState.headerState,
+            messageState: homepageState.messageState,
+            topSitesState: homepageState.topSitesState,
+            searchState: homepageState.searchState,
+            jumpBackInState: homepageState.jumpBackInState,
+            bookmarkState: homepageState.bookmarkState,
+            worldcupState: homepageState.worldcupState,
+            merinoState: homepageState.merinoState,
+            wallpaperState: homepageState.wallpaperState,
+            isZeroSearch: homepageState.isZeroSearch,
+            shouldTriggerImpression: homepageState.shouldTriggerImpression,
+            shouldShowPrivacyNotice: homepageState.shouldShowPrivacyNotice,
+            availableContentHeight: homepageState.availableContentHeight,
+            availableWallpaperHeight: homepageState.availableWallpaperHeight
+        )
     }
 
     init(windowUUID: WindowUUID) {
@@ -144,37 +160,35 @@ struct HomepageState: ScreenState, Equatable {
 
     @MainActor
     private static func handleInitializeAndViewWillTransitionAction(state: HomepageState, action: Action) -> HomepageState {
-        return state.copyWithUpdates(
-            headerState: HeaderState.reducer(state.headerState, action),
-            messageState: MessageCardState.reducer(state.messageState, action),
-            topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
-            searchState: SearchBarState.reducer(state.searchState, action),
-            jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
-            bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
-            merinoState: MerinoState.reducer(state.merinoState, action),
-            wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
-            shouldTriggerImpression: false
-        )
+        return state
+            .copy(headerState: HeaderState.reducer(state.headerState, action))
+            .copy(messageState: MessageCardState.reducer(state.messageState, action))
+            .copy(topSitesState: TopSitesSectionState.reducer(state.topSitesState, action))
+            .copy(searchState: SearchBarState.reducer(state.searchState, action))
+            .copy(jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action))
+            .copy(bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action))
+            .copy(worldcupState: WorldCupSectionState.reducer(state.worldcupState, action))
+            .copy(merinoState: MerinoState.reducer(state.merinoState, action))
+            .copy(wallpaperState: WallpaperState.reducer(state.wallpaperState, action))
+            .copy(shouldTriggerImpression: false)
     }
 
     @MainActor
     private static func handleEmbeddedHomepageAction(state: HomepageState,
                                                      action: Action,
                                                      isZeroSearch: Bool) -> HomepageState {
-        return state.copyWithUpdates(
-            headerState: HeaderState.reducer(state.headerState, action),
-            messageState: MessageCardState.reducer(state.messageState, action),
-            topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
-            searchState: SearchBarState.reducer(state.searchState, action),
-            jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
-            bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
-            merinoState: MerinoState.reducer(state.merinoState, action),
-            wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
-            isZeroSearch: isZeroSearch,
-            shouldTriggerImpression: false
-        )
+        return state
+            .copy(headerState: HeaderState.reducer(state.headerState, action))
+            .copy(messageState: MessageCardState.reducer(state.messageState, action))
+            .copy(topSitesState: TopSitesSectionState.reducer(state.topSitesState, action))
+            .copy(searchState: SearchBarState.reducer(state.searchState, action))
+            .copy(jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action))
+            .copy(bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action))
+            .copy(worldcupState: WorldCupSectionState.reducer(state.worldcupState, action))
+            .copy(merinoState: MerinoState.reducer(state.merinoState, action))
+            .copy(wallpaperState: WallpaperState.reducer(state.wallpaperState, action))
+            .copy(isZeroSearch: isZeroSearch)
+            .copy(shouldTriggerImpression: false)
     }
 
     @MainActor
@@ -187,99 +201,93 @@ struct HomepageState: ScreenState, Equatable {
         let availableContentHeight = homepageAction.availableContentHeight ?? state.availableContentHeight
         let availableWallpaperHeight = homepageAction.availableWallpaperHeight ?? state.availableWallpaperHeight
 
-         return state.copyWithUpdates(
-            headerState: HeaderState.reducer(state.headerState, action),
-            messageState: MessageCardState.reducer(state.messageState, action),
-            topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
-            searchState: SearchBarState.reducer(state.searchState, action),
-            jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
-            bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
-            merinoState: MerinoState.reducer(state.merinoState, action),
-            wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
-            shouldTriggerImpression: false,
-            availableContentHeight: availableContentHeight,
-            availableWallpaperHeight: availableWallpaperHeight
-        )
+        return state
+            .copy(headerState: HeaderState.reducer(state.headerState, action))
+            .copy(messageState: MessageCardState.reducer(state.messageState, action))
+            .copy(topSitesState: TopSitesSectionState.reducer(state.topSitesState, action))
+            .copy(searchState: SearchBarState.reducer(state.searchState, action))
+            .copy(jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action))
+            .copy(bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action))
+            .copy(worldcupState: WorldCupSectionState.reducer(state.worldcupState, action))
+            .copy(merinoState: MerinoState.reducer(state.merinoState, action))
+            .copy(wallpaperState: WallpaperState.reducer(state.wallpaperState, action))
+            .copy(shouldTriggerImpression: false)
+            .copy(availableContentHeight: availableContentHeight)
+            .copy(availableWallpaperHeight: availableWallpaperHeight)
     }
 
     @MainActor
     private static func handlePrivacyNoticeCloseButtonTappedAction(state: HomepageState, action: Action) -> HomepageState {
-        return state.copyWithUpdates(
-            headerState: HeaderState.reducer(state.headerState, action),
-            messageState: MessageCardState.reducer(state.messageState, action),
-            topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
-            searchState: SearchBarState.reducer(state.searchState, action),
-            jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
-            bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
-            merinoState: MerinoState.reducer(state.merinoState, action),
-            wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
-            shouldTriggerImpression: false,
-            shouldShowPrivacyNotice: false
-        )
+        return state
+            .copy(headerState: HeaderState.reducer(state.headerState, action))
+            .copy(messageState: MessageCardState.reducer(state.messageState, action))
+            .copy(topSitesState: TopSitesSectionState.reducer(state.topSitesState, action))
+            .copy(searchState: SearchBarState.reducer(state.searchState, action))
+            .copy(jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action))
+            .copy(bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action))
+            .copy(worldcupState: WorldCupSectionState.reducer(state.worldcupState, action))
+            .copy(merinoState: MerinoState.reducer(state.merinoState, action))
+            .copy(wallpaperState: WallpaperState.reducer(state.wallpaperState, action))
+            .copy(shouldTriggerImpression: false)
+            .copy(shouldShowPrivacyNotice: false)
     }
 
     @MainActor
     private static func handleDidTabChangeToHomepageAction(state: HomepageState, action: Action) -> HomepageState {
-        return state.copyWithUpdates(
-            headerState: HeaderState.reducer(state.headerState, action),
-            messageState: MessageCardState.reducer(state.messageState, action),
-            topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
-            searchState: SearchBarState.reducer(state.searchState, action),
-            jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
-            bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
-            merinoState: MerinoState.reducer(state.merinoState, action),
-            wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
-            shouldTriggerImpression: true
-        )
+        return state
+            .copy(headerState: HeaderState.reducer(state.headerState, action))
+            .copy(messageState: MessageCardState.reducer(state.messageState, action))
+            .copy(topSitesState: TopSitesSectionState.reducer(state.topSitesState, action))
+            .copy(searchState: SearchBarState.reducer(state.searchState, action))
+            .copy(jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action))
+            .copy(bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action))
+            .copy(worldcupState: WorldCupSectionState.reducer(state.worldcupState, action))
+            .copy(merinoState: MerinoState.reducer(state.merinoState, action))
+            .copy(wallpaperState: WallpaperState.reducer(state.wallpaperState, action))
+            .copy(shouldTriggerImpression: true)
     }
 
     @MainActor
     private static func handlePrivacyNoticeInitialization(action: Action, state: Self) -> HomepageState {
-        return state.copyWithUpdates(
-            headerState: HeaderState.reducer(state.headerState, action),
-            messageState: MessageCardState.reducer(state.messageState, action),
-            topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
-            searchState: SearchBarState.reducer(state.searchState, action),
-            jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
-            bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
-            merinoState: MerinoState.reducer(state.merinoState, action),
-            wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
-            shouldTriggerImpression: false,
-            shouldShowPrivacyNotice: true
-        )
+        return state
+            .copy(headerState: HeaderState.reducer(state.headerState, action))
+            .copy(messageState: MessageCardState.reducer(state.messageState, action))
+            .copy(topSitesState: TopSitesSectionState.reducer(state.topSitesState, action))
+            .copy(searchState: SearchBarState.reducer(state.searchState, action))
+            .copy(jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action))
+            .copy(bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action))
+            .copy(worldcupState: WorldCupSectionState.reducer(state.worldcupState, action))
+            .copy(merinoState: MerinoState.reducer(state.merinoState, action))
+            .copy(wallpaperState: WallpaperState.reducer(state.wallpaperState, action))
+            .copy(shouldTriggerImpression: false)
+            .copy(shouldShowPrivacyNotice: true)
     }
 
     @MainActor
     private static func passthroughState(from state: HomepageState, action: Action) -> HomepageState {
-        return state.copyWithUpdates(
-            headerState: HeaderState.reducer(state.headerState, action),
-            messageState: MessageCardState.reducer(state.messageState, action),
-            topSitesState: TopSitesSectionState.reducer(state.topSitesState, action),
-            searchState: SearchBarState.reducer(state.searchState, action),
-            jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action),
-            bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action),
-            worldcupState: WorldCupSectionState.reducer(state.worldcupState, action),
-            merinoState: MerinoState.reducer(state.merinoState, action),
-            wallpaperState: WallpaperState.reducer(state.wallpaperState, action),
-            shouldTriggerImpression: false
-        )
+        return state
+            .copy(headerState: HeaderState.reducer(state.headerState, action))
+            .copy(messageState: MessageCardState.reducer(state.messageState, action))
+            .copy(topSitesState: TopSitesSectionState.reducer(state.topSitesState, action))
+            .copy(searchState: SearchBarState.reducer(state.searchState, action))
+            .copy(jumpBackInState: JumpBackInSectionState.reducer(state.jumpBackInState, action))
+            .copy(bookmarkState: BookmarksSectionState.reducer(state.bookmarkState, action))
+            .copy(worldcupState: WorldCupSectionState.reducer(state.worldcupState, action))
+            .copy(merinoState: MerinoState.reducer(state.merinoState, action))
+            .copy(wallpaperState: WallpaperState.reducer(state.wallpaperState, action))
+            .copy(shouldTriggerImpression: false)
     }
 
     static func defaultState(from state: HomepageState) -> HomepageState {
-        return state.copyWithUpdates(
-            messageState: MessageCardState.defaultState(from: state.messageState),
-            topSitesState: TopSitesSectionState.defaultState(from: state.topSitesState),
-            searchState: SearchBarState.defaultState(from: state.searchState),
-            jumpBackInState: JumpBackInSectionState.defaultState(from: state.jumpBackInState),
-            bookmarkState: BookmarksSectionState.defaultState(from: state.bookmarkState),
-            worldcupState: WorldCupSectionState.defaultState(from: state.worldcupState),
-            merinoState: MerinoState.defaultState(from: state.merinoState),
-            wallpaperState: WallpaperState.defaultState(from: state.wallpaperState),
-            shouldTriggerImpression: false
-        )
+        return state
+            .copy(messageState: MessageCardState.defaultState(from: state.messageState))
+            .copy(topSitesState: TopSitesSectionState.defaultState(from: state.topSitesState))
+            .copy(searchState: SearchBarState.defaultState(from: state.searchState))
+            .copy(jumpBackInState: JumpBackInSectionState.defaultState(from: state.jumpBackInState))
+            .copy(bookmarkState: BookmarksSectionState.defaultState(from: state.bookmarkState))
+            .copy(worldcupState: WorldCupSectionState.defaultState(from: state.worldcupState))
+            .copy(merinoState: MerinoState.defaultState(from: state.merinoState))
+            .copy(wallpaperState: WallpaperState.defaultState(from: state.wallpaperState))
+            .copy(shouldTriggerImpression: false)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/SearchBar/SearchBarState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SearchBar/SearchBarState.swift
@@ -3,13 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
+import ModifiedCopy
 import Foundation
 import Redux
 import Shared
 
 /// State for the search bar section that is used in the homepage
-@CopyWithUpdates
+@Copyable
 struct SearchBarState: StateType, Equatable {
     var windowUUID: WindowUUID
     let shouldShowSearchBar: Bool
@@ -54,18 +54,22 @@ struct SearchBarState: StateType, Equatable {
         guard let isSearchBarEnabled = (action as? HomepageAction)?.isSearchBarEnabled else {
             return defaultState(from: state)
         }
-        return state.copyWithUpdates(
+
+        return state.copy(
             shouldShowSearchBar: isSearchBarEnabled
         )
     }
 
     private static func handleHidingSearchBar(action: Action, state: Self) -> SearchBarState {
-        return state.copyWithUpdates(
+        return state.copy(
             shouldShowSearchBar: false
         )
     }
 
     static func defaultState(from state: SearchBarState) -> SearchBarState {
-        return state.copyWithUpdates()
+        return SearchBarState(
+            windowUUID: state.windowUUID,
+            shouldShowSearchBar: state.shouldShowSearchBar
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesSectionState.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import CopyWithUpdates
+import ModifiedCopy
 import Foundation
 import Redux
 import Shared
@@ -11,7 +11,7 @@ import Shared
 /// State for the top sites section that is used in the homepage
 /// The state does not only contain the top sites list, but needs to also know about the number of rows
 /// and tiles per row in order to only show a specific amount of the top sites data.
-@CopyWithUpdates
+@Copyable
 struct TopSitesSectionState: StateType, Equatable {
     var windowUUID: WindowUUID
     let topSitesData: [TopSiteConfiguration]
@@ -101,11 +101,10 @@ struct TopSitesSectionState: StateType, Equatable {
             shouldShowAddShortcutTile: shouldShowAddShortcutTile
         )
 
-        return state.copyWithUpdates(
-            topSitesData: sites,
-            shouldShowSectionHeader: shouldShowSectionHeader,
-            shouldShowAddShortcutTile: shouldShowAddShortcutTile
-        )
+        return state
+            .copy(topSitesData: sites)
+            .copy(shouldShowSectionHeader: shouldShowSectionHeader)
+            .copy(shouldShowAddShortcutTile: shouldShowAddShortcutTile)
     }
 
     private static func handleUpdatedNumberOfRowsAction(action: Action, state: Self) -> TopSitesSectionState {
@@ -122,10 +121,9 @@ struct TopSitesSectionState: StateType, Equatable {
             shouldShowAddShortcutTile: state.shouldShowAddShortcutTile
         )
 
-        return state.copyWithUpdates(
-            numberOfRows: numberOfRows,
-            shouldShowSectionHeader: shouldShowSectionHeader
-        )
+        return state
+            .copy(numberOfRows: numberOfRows)
+            .copy(shouldShowSectionHeader: shouldShowSectionHeader)
     }
 
     private static func handleViewChangeAction(action: Action, state: Self) -> TopSitesSectionState {
@@ -142,10 +140,9 @@ struct TopSitesSectionState: StateType, Equatable {
             shouldShowAddShortcutTile: state.shouldShowAddShortcutTile
         )
 
-        return state.copyWithUpdates(
-            numberOfTilesPerRow: numberOfTilesPerRow,
-            shouldShowSectionHeader: shouldShowSectionHeader
-        )
+        return state
+            .copy(numberOfTilesPerRow: numberOfTilesPerRow)
+            .copy(shouldShowSectionHeader: shouldShowSectionHeader)
     }
 
     private static func handleToggleShowSectionSettingAction(action: Action, state: Self) -> TopSitesSectionState {
@@ -155,13 +152,21 @@ struct TopSitesSectionState: StateType, Equatable {
             return defaultState(from: state)
         }
 
-        return state.copyWithUpdates(
+        return state.copy(
             shouldShowSection: isEnabled
         )
     }
 
     static func defaultState(from state: TopSitesSectionState) -> TopSitesSectionState {
-        return state.copyWithUpdates()
+        return TopSitesSectionState(
+            windowUUID: state.windowUUID,
+            topSitesData: state.topSitesData,
+            numberOfRows: state.numberOfRows,
+            numberOfTilesPerRow: state.numberOfTilesPerRow,
+            shouldShowSection: state.shouldShowSection,
+            shouldShowSectionHeader: state.shouldShowSectionHeader,
+            shouldShowAddShortcutTile: state.shouldShowAddShortcutTile
+        )
     }
 
     /// Shows the shortcuts section header with shortcuts library affordance

--- a/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/Redux/WallpaperState.swift
@@ -3,9 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import Redux
 import Common
-import CopyWithUpdates
+import ModifiedCopy
 
-@CopyWithUpdates
+@Copyable
 struct WallpaperState: ScreenState, Equatable {
     var windowUUID: WindowUUID
     let wallpaperConfiguration: WallpaperConfiguration
@@ -35,13 +35,16 @@ struct WallpaperState: ScreenState, Equatable {
 
     private static func handleWallpaperAction(action: Action, state: WallpaperState) -> WallpaperState {
         guard let wallpaperAction = action as? WallpaperAction else { return defaultState(from: state) }
-        return state.copyWithUpdates(
+        return state.copy(
             wallpaperConfiguration: wallpaperAction.wallpaperConfiguration
         )
     }
 
    static func defaultState(from state: WallpaperState) -> WallpaperState {
-        return state.copyWithUpdates()
+        return WallpaperState(
+            windowUUID: state.windowUUID,
+            wallpaperConfiguration: state.wallpaperConfiguration
+        )
    }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/ModifiedCopyMacroTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/ModifiedCopyMacroTests.swift
@@ -14,119 +14,6 @@ import Common
 /// macro in the past, these seem like a reasonable thing to include now.
 @MainActor
 final class ModifiedCopyMacroTests: XCTestCase {
-    // Fake Redux state reducer under test
-    @Copyable
-    fileprivate struct PersonReduxState: ScreenState {
-        var windowUUID: WindowUUID
-
-        let firstName: String
-        let lastName: String
-        let age: Int
-        var favoriteColor: String?
-
-        static let genus = "Homo Sapien"
-
-        var fullName: String {
-            "\(firstName) \(lastName)"
-        }
-
-        init(appState: AppState, uuid: WindowUUID) {
-            self.init(windowUUID: UUID())
-        }
-
-        init(windowUUID: WindowUUID) {
-            self.init(
-                windowUUID: windowUUID,
-                firstName: "Jane",
-                lastName: "Doe",
-                age: 33,
-                favoriteColor: nil
-            )
-        }
-
-        init(
-            windowUUID: WindowUUID,
-            firstName: String,
-            lastName: String,
-            age: Int,
-            favoriteColor: String?
-        ) {
-            self.windowUUID = windowUUID
-            self.firstName = firstName
-            self.lastName = lastName
-            self.age = age
-            self.favoriteColor = favoriteColor
-        }
-
-        static let reducer: Reducer<Self> = { state, action in
-            // Handles only PersonReduxActions
-            guard let action = action as? PersonReduxAction,
-                  let actionType = action.actionType as? PersonReduxActionType else {
-                return defaultState(from: state)
-            }
-
-            switch actionType {
-            case .didSetName:
-                guard let firstName = action.firstName,
-                      let lastName = action.lastName
-                else {
-                    return defaultState(from: state)
-                }
-
-                return state
-                    .copy(firstName: firstName)
-                    .copy(lastName: lastName)
-
-            case .didSetFavoriteColor:
-                return state
-                    .copy(favoriteColor: action.favoriteColor)
-            }
-        }
-
-        static func defaultState(from state: PersonReduxState) -> PersonReduxState {
-            return PersonReduxState(
-                windowUUID: state.windowUUID,
-                firstName: state.firstName,
-                lastName: state.lastName,
-                age: state.age,
-                favoriteColor: state.favoriteColor
-            )
-        }
-    }
-
-    // Test actions
-    fileprivate enum PersonReduxActionType: ActionType {
-        case didSetName
-        case didSetFavoriteColor
-    }
-
-    // Test action payload
-    fileprivate struct PersonReduxAction: Action {
-        let windowUUID: WindowUUID
-        let actionType: ActionType
-
-        let firstName: String?
-        let lastName: String?
-        let age: Int?
-        let favoriteColor: String?
-
-        init(
-            windowUUID: WindowUUID,
-            actionType: ActionType,
-            firstName: String? = nil,
-            lastName: String? = nil,
-            age: Int? = nil,
-            favoriteColor: String? = nil
-        ) {
-            self.windowUUID = windowUUID
-            self.actionType = actionType
-            self.firstName = firstName
-            self.lastName = lastName
-            self.age = age
-            self.favoriteColor = favoriteColor
-        }
-    }
-
     func testMacroIntegration_settingNonOptionalProperties() {
         let testWindowUUID = UUID()
         let testFirstName = "Haley"
@@ -216,5 +103,121 @@ final class ModifiedCopyMacroTests: XCTestCase {
         XCTAssertEqual(newState.lastName, testLastName)
         XCTAssertEqual(newState.age, testAge)
         XCTAssertEqual(newState.favoriteColor, nil)
+    }
+}
+
+// MARK: Fileprivate mock Redux state type and associated update actions for `@Copyable` macro integration tests.
+fileprivate extension ModifiedCopyMacroTests {
+    // Fake Redux state reducer under test
+    @Copyable
+    struct PersonReduxState: ScreenState {
+        var windowUUID: WindowUUID
+
+        let firstName: String
+        let lastName: String
+        let age: Int
+        var favoriteColor: String?
+
+        static let genus = "Homo Sapien"
+
+        var fullName: String {
+            "\(firstName) \(lastName)"
+        }
+
+        init(appState: AppState, uuid: WindowUUID) {
+            self.init(windowUUID: UUID())
+        }
+
+        init(windowUUID: WindowUUID) {
+            self.init(
+                windowUUID: windowUUID,
+                firstName: "Jane",
+                lastName: "Doe",
+                age: 33,
+                favoriteColor: nil
+            )
+        }
+
+        init(
+            windowUUID: WindowUUID,
+            firstName: String,
+            lastName: String,
+            age: Int,
+            favoriteColor: String?
+        ) {
+            self.windowUUID = windowUUID
+            self.firstName = firstName
+            self.lastName = lastName
+            self.age = age
+            self.favoriteColor = favoriteColor
+        }
+
+        static let reducer: Reducer<Self> = { state, action in
+            // Handles only PersonReduxActions
+            guard let action = action as? PersonReduxAction,
+                  let actionType = action.actionType as? PersonReduxActionType else {
+                return defaultState(from: state)
+            }
+
+            switch actionType {
+            case .didSetName:
+                guard let firstName = action.firstName,
+                      let lastName = action.lastName
+                else {
+                    return defaultState(from: state)
+                }
+
+                return state
+                    .copy(firstName: firstName)
+                    .copy(lastName: lastName)
+
+            case .didSetFavoriteColor:
+                return state
+                    .copy(favoriteColor: action.favoriteColor)
+            }
+        }
+
+        static func defaultState(from state: PersonReduxState) -> PersonReduxState {
+            return PersonReduxState(
+                windowUUID: state.windowUUID,
+                firstName: state.firstName,
+                lastName: state.lastName,
+                age: state.age,
+                favoriteColor: state.favoriteColor
+            )
+        }
+    }
+
+    // Test actions
+    enum PersonReduxActionType: ActionType {
+        case didSetName
+        case didSetFavoriteColor
+    }
+
+    // Test action payload
+    struct PersonReduxAction: Action {
+        let windowUUID: WindowUUID
+        let actionType: ActionType
+
+        let firstName: String?
+        let lastName: String?
+        let age: Int?
+        let favoriteColor: String?
+
+        init(
+            windowUUID: WindowUUID,
+            actionType: ActionType,
+            firstName: String? = nil,
+            lastName: String? = nil,
+            age: Int? = nil,
+            favoriteColor: String? = nil
+        ) {
+            self.windowUUID = windowUUID
+            self.actionType = actionType
+            self.firstName = firstName
+            self.lastName = lastName
+            self.age = age
+            self.favoriteColor = favoriteColor
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/ModifiedCopyMacroTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/ModifiedCopyMacroTests.swift
@@ -1,0 +1,220 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import XCTest
+import ModifiedCopy
+import Redux
+import Common
+
+@testable import Client
+
+/// These are technically integration tests and shouldn't be needed, but since we had integration issues with a different
+/// macro in the past, these seem like a reasonable thing to include now.
+@MainActor
+final class ModifiedCopyMacroTests: XCTestCase {
+    // Fake Redux state reducer under test
+    @Copyable
+    fileprivate struct PersonReduxState: ScreenState {
+        var windowUUID: WindowUUID
+
+        let firstName: String
+        let lastName: String
+        let age: Int
+        var favoriteColor: String?
+
+        static let genus = "Homo Sapien"
+
+        var fullName: String {
+            "\(firstName) \(lastName)"
+        }
+
+        init(appState: AppState, uuid: WindowUUID) {
+            self.init(windowUUID: UUID())
+        }
+
+        init(windowUUID: WindowUUID) {
+            self.init(
+                windowUUID: windowUUID,
+                firstName: "Jane",
+                lastName: "Doe",
+                age: 33,
+                favoriteColor: nil
+            )
+        }
+
+        init(
+            windowUUID: WindowUUID,
+            firstName: String,
+            lastName: String,
+            age: Int,
+            favoriteColor: String?
+        ) {
+            self.windowUUID = windowUUID
+            self.firstName = firstName
+            self.lastName = lastName
+            self.age = age
+            self.favoriteColor = favoriteColor
+        }
+
+        static let reducer: Reducer<Self> = { state, action in
+            // Handles only PersonReduxActions
+            guard let action = action as? PersonReduxAction,
+                  let actionType = action.actionType as? PersonReduxActionType else {
+                return defaultState(from: state)
+            }
+
+            switch actionType {
+            case .didSetName:
+                guard let firstName = action.firstName,
+                      let lastName = action.lastName
+                else {
+                    return defaultState(from: state)
+                }
+
+                return state
+                    .copy(firstName: firstName)
+                    .copy(lastName: lastName)
+
+            case .didSetFavoriteColor:
+                return state
+                    .copy(favoriteColor: action.favoriteColor)
+            }
+        }
+
+        static func defaultState(from state: PersonReduxState) -> PersonReduxState {
+            return PersonReduxState(
+                windowUUID: state.windowUUID,
+                firstName: state.firstName,
+                lastName: state.lastName,
+                age: state.age,
+                favoriteColor: state.favoriteColor
+            )
+        }
+    }
+
+    // Test actions
+    fileprivate enum PersonReduxActionType: ActionType {
+        case didSetName
+        case didSetFavoriteColor
+    }
+
+    // Test action payload
+    fileprivate struct PersonReduxAction: Action {
+        let windowUUID: WindowUUID
+        let actionType: ActionType
+
+        let firstName: String?
+        let lastName: String?
+        let age: Int?
+        let favoriteColor: String?
+
+        init(
+            windowUUID: WindowUUID,
+            actionType: ActionType,
+            firstName: String? = nil,
+            lastName: String? = nil,
+            age: Int? = nil,
+            favoriteColor: String? = nil
+        ) {
+            self.windowUUID = windowUUID
+            self.actionType = actionType
+            self.firstName = firstName
+            self.lastName = lastName
+            self.age = age
+            self.favoriteColor = favoriteColor
+        }
+    }
+
+    func testMacroIntegration_settingNonOptionalProperties() {
+        let testWindowUUID = UUID()
+        let testFirstName = "Haley"
+        let testLastName = "Emmett"
+        let testAge = 25
+        let testFavoriteColor: String? = nil
+
+        let state = PersonReduxState(
+            windowUUID: testWindowUUID,
+            firstName: testFirstName,
+            lastName: testLastName,
+            age: testAge,
+            favoriteColor: testFavoriteColor
+        )
+
+        let action = PersonReduxAction(
+            windowUUID: testWindowUUID,
+            actionType: PersonReduxActionType.didSetName,
+            firstName: "Bob",
+            lastName: "Jones"
+        )
+
+        let newState = PersonReduxState.reducer(state, action)
+
+        XCTAssertEqual(newState.windowUUID, testWindowUUID)
+        XCTAssertEqual(newState.firstName, "Bob")
+        XCTAssertEqual(newState.lastName, "Jones")
+        XCTAssertEqual(newState.age, testAge)
+        XCTAssertEqual(newState.favoriteColor, testFavoriteColor)
+    }
+
+    func testMacroIntegration_settingOptionalNilProperties_toValue() {
+        let testWindowUUID = UUID()
+        let testFirstName = "Haley"
+        let testLastName = "Emmett"
+        let testAge = 25
+        let testFavoriteColor: String? = nil
+
+        let state = PersonReduxState(
+            windowUUID: testWindowUUID,
+            firstName: testFirstName,
+            lastName: testLastName,
+            age: testAge,
+            favoriteColor: testFavoriteColor
+        )
+
+        let action = PersonReduxAction(
+            windowUUID: testWindowUUID,
+            actionType: PersonReduxActionType.didSetFavoriteColor,
+            favoriteColor: "green"
+        )
+
+        let newState = PersonReduxState.reducer(state, action)
+
+        XCTAssertEqual(newState.windowUUID, testWindowUUID)
+        XCTAssertEqual(newState.firstName, testFirstName)
+        XCTAssertEqual(newState.lastName, testLastName)
+        XCTAssertEqual(newState.age, testAge)
+        XCTAssertEqual(newState.favoriteColor, "green")
+    }
+
+    func testMacroIntegration_settingOptionalValueProperties_toNil() {
+        let testWindowUUID = UUID()
+        let testFirstName = "Haley"
+        let testLastName = "Emmett"
+        let testAge = 25
+        let testFavoriteColor: String? = "green"
+
+        let state = PersonReduxState(
+            windowUUID: testWindowUUID,
+            firstName: testFirstName,
+            lastName: testLastName,
+            age: testAge,
+            favoriteColor: testFavoriteColor
+        )
+
+        let action = PersonReduxAction(
+            windowUUID: testWindowUUID,
+            actionType: PersonReduxActionType.didSetFavoriteColor,
+            favoriteColor: nil
+        )
+
+        let newState = PersonReduxState.reducer(state, action)
+
+        XCTAssertEqual(newState.windowUUID, testWindowUUID)
+        XCTAssertEqual(newState.firstName, testFirstName)
+        XCTAssertEqual(newState.lastName, testLastName)
+        XCTAssertEqual(newState.age, testAge)
+        XCTAssertEqual(newState.favoriteColor, nil)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15901)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33989)

## :bulb: Description
This PR migrates various Redux States (`HeaderState` and its substates) off the flawed `CopyWithUpdates` macro to the `ModifiedCopy` [macro](https://github.com/WilhelmOks/ModifiedCopyMacro), which uses a slightly different API.

Related ADR: https://github.com/mozilla-mobile/firefox-ios/blob/main/adr/0011-redux-state-reducer-initializer-cleanup-with-copy-macro.md

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

