### PR TITLE
Add FXIOS-15746 [Deeplink improvements] Create tab restorer objects

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -975,6 +975,8 @@
 		8A3FD2912FABB9BA001F5DE9 /* TabManagerGetTabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28E2FABB9BA001F5DE9 /* TabManagerGetTabTests.swift */; };
 		8A3FD2922FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28F2FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift */; };
 		8A3FDEB82FAE5A4E001F5DE9 /* SceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FDEB72FAE5A4E001F5DE9 /* SceneDelegateTests.swift */; };
+		8A3FF9CD2FB408A1001F5DE9 /* TabRestorationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FF9CB2FB408A1001F5DE9 /* TabRestorationResult.swift */; };
+		8A3FF9CE2FB408A1001F5DE9 /* TabRestorerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FF9CC2FB408A1001F5DE9 /* TabRestorerDelegate.swift */; };
 		8A4190D22A6B0848001E8401 /* StatusBarOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */; };
 		8A4490922BF3BC2700E7E682 /* MicrosurveyPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4490912BF3BC2700E7E682 /* MicrosurveyPromptView.swift */; };
 		8A4490952BF3C42B00E7E682 /* MicrosurveyConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4490942BF3C42B00E7E682 /* MicrosurveyConfirmationView.swift */; };
@@ -9449,6 +9451,8 @@
 		8A3FD28E2FABB9BA001F5DE9 /* TabManagerGetTabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerGetTabTests.swift; sourceTree = "<group>"; };
 		8A3FD28F2FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerReorderTabsTests.swift; sourceTree = "<group>"; };
 		8A3FDEB72FAE5A4E001F5DE9 /* SceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegateTests.swift; sourceTree = "<group>"; };
+		8A3FF9CB2FB408A1001F5DE9 /* TabRestorationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabRestorationResult.swift; sourceTree = "<group>"; };
+		8A3FF9CC2FB408A1001F5DE9 /* TabRestorerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabRestorerDelegate.swift; sourceTree = "<group>"; };
 		8A4190D02A6B0843001E8401 /* StatusBarOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarOverlayTests.swift; sourceTree = "<group>"; };
 		8A4490912BF3BC2700E7E682 /* MicrosurveyPromptView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicrosurveyPromptView.swift; sourceTree = "<group>"; };
 		8A4490942BF3C42B00E7E682 /* MicrosurveyConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyConfirmationView.swift; sourceTree = "<group>"; };
@@ -14078,6 +14082,8 @@
 		8A590C6228C13E1D0032F1AA /* TabManagement */ = {
 			isa = PBXGroup;
 			children = (
+				8A3FF9CB2FB408A1001F5DE9 /* TabRestorationResult.swift */,
+				8A3FF9CC2FB408A1001F5DE9 /* TabRestorerDelegate.swift */,
 				8A9BA6BC2F7C4CDF00D892C4 /* RemoteTabCreator.swift */,
 				0B1278DF2DDB1D6E00406656 /* BackForwardList.swift */,
 				0B7B957B2DCA305D007DC749 /* Document */,
@@ -19821,6 +19827,8 @@
 				F00CA4032F00000000000001 /* WorldCupMatch.swift in Sources */,
 				F00CA4032F00000000000003 /* WorldCupMatches.swift in Sources */,
 				F00CA4012F00000000000007 /* WorldCupAPIClient.swift in Sources */,
+				8A3FF9CD2FB408A1001F5DE9 /* TabRestorationResult.swift in Sources */,
+				8A3FF9CE2FB408A1001F5DE9 /* TabRestorerDelegate.swift in Sources */,
 				F00CA4012F0000000000000D /* WorldCupAPIClientProtocol.swift in Sources */,
 				F00CA4012F0000000000000F /* WorldCupFetchStrategyProtocol.swift in Sources */,
 				F00CA4012F00000000000011 /* WorldCupNormalFetchStrategy.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -971,6 +971,9 @@
 		8A3EF8132A2FD07A00796E3A /* ResetContextualHints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF8122A2FD07A00796E3A /* ResetContextualHints.swift */; };
 		8A3EF8152A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF8142A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift */; };
 		8A3EF8172A2FD2B900796E3A /* AdvancedAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3EF8162A2FD2B900796E3A /* AdvancedAccountSettings.swift */; };
+		8A3F08AC2FB40B8B001F5DE9 /* TabRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3F08AB2FB40B8B001F5DE9 /* TabRestorer.swift */; };
+		8A3F08AE2FB40BD0001F5DE9 /* TabRestorerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3F08AD2FB40BD0001F5DE9 /* TabRestorerTests.swift */; };
+		8A3F08B02FB40BDC001F5DE9 /* MockTabRestorerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3F08AF2FB40BDC001F5DE9 /* MockTabRestorerDelegate.swift */; };
 		8A3FD2902FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28D2FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift */; };
 		8A3FD2912FABB9BA001F5DE9 /* TabManagerGetTabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28E2FABB9BA001F5DE9 /* TabManagerGetTabTests.swift */; };
 		8A3FD2922FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3FD28F2FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift */; };
@@ -9447,6 +9450,9 @@
 		8A3EF8122A2FD07A00796E3A /* ResetContextualHints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetContextualHints.swift; sourceTree = "<group>"; };
 		8A3EF8142A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenFiftyTabsDebugOption.swift; sourceTree = "<group>"; };
 		8A3EF8162A2FD2B900796E3A /* AdvancedAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedAccountSettings.swift; sourceTree = "<group>"; };
+		8A3F08AB2FB40B8B001F5DE9 /* TabRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabRestorer.swift; sourceTree = "<group>"; };
+		8A3F08AD2FB40BD0001F5DE9 /* TabRestorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabRestorerTests.swift; sourceTree = "<group>"; };
+		8A3F08AF2FB40BDC001F5DE9 /* MockTabRestorerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabRestorerDelegate.swift; sourceTree = "<group>"; };
 		8A3FD28D2FABB9BA001F5DE9 /* TabManagerClearHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerClearHistoryTests.swift; sourceTree = "<group>"; };
 		8A3FD28E2FABB9BA001F5DE9 /* TabManagerGetTabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerGetTabTests.swift; sourceTree = "<group>"; };
 		8A3FD28F2FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerReorderTabsTests.swift; sourceTree = "<group>"; };
@@ -13391,6 +13397,7 @@
 			children = (
 				5A475E9029DB8AA7009C13FD /* MockDiskImageStore.swift */,
 				5A475E8C29DB888E009C13FD /* MockTabDataStore.swift */,
+				8A3F08AF2FB40BDC001F5DE9 /* MockTabRestorerDelegate.swift */,
 				5AC7110629F822E60011ED11 /* MockTabSessionStore.swift */,
 			);
 			path = Mocks;
@@ -14082,12 +14089,10 @@
 		8A590C6228C13E1D0032F1AA /* TabManagement */ = {
 			isa = PBXGroup;
 			children = (
-				8A3FF9CB2FB408A1001F5DE9 /* TabRestorationResult.swift */,
-				8A3FF9CC2FB408A1001F5DE9 /* TabRestorerDelegate.swift */,
-				8A9BA6BC2F7C4CDF00D892C4 /* RemoteTabCreator.swift */,
 				0B1278DF2DDB1D6E00406656 /* BackForwardList.swift */,
 				0B7B957B2DCA305D007DC749 /* Document */,
 				39F819C51FD70F5D009E31E4 /* GlobalTabEventHandlers.swift */,
+				8A9BA6BC2F7C4CDF00D892C4 /* RemoteTabCreator.swift */,
 				D3A994961A3686BD008AD1AC /* Tab.swift */,
 				C82CDD45233E8996002E2743 /* Tab+ChangeUserAgent.swift */,
 				61C92A002DEF39F9004ACF49 /* TabConfigurationProvider.swift */,
@@ -14096,6 +14101,9 @@
 				D3968F241A38FE8500CEFD3B /* TabManager.swift */,
 				5A64225029CB506500EEC3E5 /* TabManagerDelegate.swift */,
 				5A8017DF29CE15D90047120D /* TabManagerImplementation.swift */,
+				8A3FF9CB2FB408A1001F5DE9 /* TabRestorationResult.swift */,
+				8A3F08AB2FB40B8B001F5DE9 /* TabRestorer.swift */,
+				8A3FF9CC2FB408A1001F5DE9 /* TabRestorerDelegate.swift */,
 				8A0A7C3F2F61F03200D00820 /* TabWebView.swift */,
 				BD0D40792D83124E00C38511 /* TabWebViewPreview.swift */,
 				BDE2DB322DB1024E002FAE26 /* TabWebViewPreviewAppearanceConfiguration.swift */,
@@ -14727,6 +14735,7 @@
 				8AFC09552FA54A240070CA11 /* TabManagerRestoreTabsTests.swift */,
 				5A475E8929DB87F2009C13FD /* TabManagerTests.swift */,
 				8AFC09562FA54A240070CA11 /* TabManagerTestsBase.swift */,
+				8A3F08AD2FB40BD0001F5DE9 /* TabRestorerTests.swift */,
 				8AD08D1627E91AC800B8E907 /* TabsTelemetryTests.swift */,
 			);
 			path = TabManagement;
@@ -19597,6 +19606,7 @@
 				D0E89A2920910917001CE5C7 /* DownloadsPanel.swift in Sources */,
 				D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */,
 				8AC0B1C02D1D935C004237FD /* ContextMenuConfiguration.swift in Sources */,
+				8A3F08AC2FB40B8B001F5DE9 /* TabRestorer.swift in Sources */,
 				8A0A7C2D2F61E3E600D00820 /* TabContentScriptManager.swift in Sources */,
 				BCB769192E4F80650046AA37 /* StylingViewModifiers.swift in Sources */,
 				BD011FB82D89B0D400FE1A32 /* AddressBarPanGestureHandler.swift in Sources */,
@@ -20560,6 +20570,7 @@
 				03D9946A2EE821190081D209 /* TermsOfUseLinkTypeTests.swift in Sources */,
 				ED7A08E12CF679CE0035EC8F /* MockShareTab.swift in Sources */,
 				1D4D79462BF2F4E7007C6796 /* SimpleTab.swift in Sources */,
+				8A3F08B02FB40BDC001F5DE9 /* MockTabRestorerDelegate.swift in Sources */,
 				21E78A7028F9A8C500F8D687 /* MockUIDevice.swift in Sources */,
 				C27EF6152EBA2EE500BED719 /* LanguageDetectorTests.swift in Sources */,
 				81DAB2F92C8901AC00F4BE98 /* MainMenuStateTests.swift in Sources */,
@@ -20859,6 +20870,7 @@
 				E1D8BC7A21FF7A0000B100BD /* TPStatsBlocklistsTests.swift in Sources */,
 				8A552AC82CB43AB400564C98 /* HeaderStateTests.swift in Sources */,
 				8AFC4E472CAF53E100C54B43 /* RemoteDataTypeTests.swift in Sources */,
+				8A3F08AE2FB40BD0001F5DE9 /* TabRestorerTests.swift in Sources */,
 				8A7AF0C72C9A119A009691B5 /* TabPeekStateTests.swift in Sources */,
 				0AFF7F642C7784D600265214 /* MockDataCleaner.swift in Sources */,
 				EDADF77F2D70D35B00C39295 /* AppIconSelectionTelemetryTests.swift in Sources */,

--- a/firefox-ios/Client/TabManagement/TabRestorationResult.swift
+++ b/firefox-ios/Client/TabManagement/TabRestorationResult.swift
@@ -4,8 +4,11 @@
 
 import Common
 
+/// The output of a tab restoration pass, consumed by `TabManagerImplementation.applyRestorationResult(_:)`.
 struct TabRestorationResult {
+    /// The tabs built from persisted data, in the order they were stored.
     let restoredTabs: [Tab]
+    /// The UUID of the tab that was active at the time of the last save, or `nil` if it did not survive filtering.
     let selectedTabUUID: TabUUID?
     let windowUUID: WindowUUID
 }

--- a/firefox-ios/Client/TabManagement/TabRestorationResult.swift
+++ b/firefox-ios/Client/TabManagement/TabRestorationResult.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+
+struct TabRestorationResult {
+    let restoredTabs: [Tab]
+    let selectedTabUUID: TabUUID?
+    let windowUUID: WindowUUID
+}

--- a/firefox-ios/Client/TabManagement/TabRestorer.swift
+++ b/firefox-ios/Client/TabManagement/TabRestorer.swift
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import TabDataStore
+
+protocol TabRestorer: AnyObject {
+    func restoreTabs(for windowUUID: WindowUUID) async -> TabRestorationResult
+}
+
+@MainActor
+final class DefaultTabRestorer: TabRestorer {
+    private weak var delegate: TabRestorerDelegate?
+    private let tabDataStore: TabDataStore
+    private let shouldClearPrivateTabs: Bool
+    private let logger: Logger
+
+    init(
+        delegate: TabRestorerDelegate,
+        tabDataStore: TabDataStore,
+        shouldClearPrivateTabs: Bool,
+        logger: Logger = DefaultLogger.shared
+    ) {
+        self.delegate = delegate
+        self.tabDataStore = tabDataStore
+        self.shouldClearPrivateTabs = shouldClearPrivateTabs
+        self.logger = logger
+    }
+
+    func restoreTabs(for windowUUID: WindowUUID) async -> TabRestorationResult {
+        let windowData = await tabDataStore.fetchWindowData(uuid: windowUUID)
+        return buildResult(from: windowData, windowUUID: windowUUID)
+    }
+
+    private func buildResult(from windowData: WindowData?, windowUUID: WindowUUID) -> TabRestorationResult {
+        let empty = TabRestorationResult(restoredTabs: [], selectedTabUUID: nil, windowUUID: windowUUID)
+
+        guard let windowData else {
+            logger.log("Not restoring tabs: no window data", level: .warning, category: .tabs)
+            return empty
+        }
+
+        let filteredTabData = filterPrivateTabs(from: windowData)
+
+        guard !filteredTabData.isEmpty else {
+            logger.log("Not restoring tabs: no tab data after filtering", level: .warning, category: .tabs)
+            return empty
+        }
+
+        var restoredTabs: [Tab] = []
+        var selectedTabUUID: TabUUID?
+
+        for tabData in filteredTabData {
+            guard let tab = delegate?.createTab(with: tabData) else { continue }
+            restoredTabs.append(tab)
+            if windowData.activeTabId == tabData.id {
+                selectedTabUUID = tab.tabUUID
+            }
+            delegate?.restoreScreenshot(for: tab)
+        }
+
+        return TabRestorationResult(
+            restoredTabs: restoredTabs,
+            selectedTabUUID: selectedTabUUID,
+            windowUUID: windowUUID
+        )
+    }
+
+    private func filterPrivateTabs(from windowData: WindowData) -> [TabData] {
+        guard shouldClearPrivateTabs else { return windowData.tabData }
+        return windowData.tabData.filter { !$0.isPrivate }
+    }
+}

--- a/firefox-ios/Client/TabManagement/TabRestorer.swift
+++ b/firefox-ios/Client/TabManagement/TabRestorer.swift
@@ -6,7 +6,16 @@ import Common
 import Foundation
 import TabDataStore
 
+/// Owns the full tab restoration lifecycle for a single window.
+///
+/// `DefaultTabRestorer` fetches persisted window data, filters private tabs, and builds
+/// `Tab` objects through `TabRestorerDelegate`, keeping `TabManagerImplementation`
+/// agnostic of how tabs are fetched or filtered.
+///
+/// See ADR 0007 (Deeplink Startup Flow Refactor) for the rationale behind this separation.
 protocol TabRestorer: AnyObject {
+    /// Fetches persisted tab data for `windowUUID`, builds the corresponding `Tab` objects,
+    /// and returns a `TabRestorationResult` ready to be applied by the caller.
     func restoreTabs(for windowUUID: WindowUUID) async -> TabRestorationResult
 }
 

--- a/firefox-ios/Client/TabManagement/TabRestorer.swift
+++ b/firefox-ios/Client/TabManagement/TabRestorer.swift
@@ -75,7 +75,7 @@ final class DefaultTabRestorer: TabRestorer {
             // delegate?.restoreScreenshot(for: tab)
         }
 
-        logger.log("There was \(filteredTabData.count) tabs restored",
+        logger.log("There were \(filteredTabData.count) tabs restored",
                    level: .debug,
                    category: .tabs)
 

--- a/firefox-ios/Client/TabManagement/TabRestorer.swift
+++ b/firefox-ios/Client/TabManagement/TabRestorer.swift
@@ -25,21 +25,25 @@ final class DefaultTabRestorer: TabRestorer {
     private let tabDataStore: TabDataStore
     private let shouldClearPrivateTabs: Bool
     private let logger: Logger
+    private let windowIsNew: Bool
 
     init(
         delegate: TabRestorerDelegate,
         tabDataStore: TabDataStore,
         shouldClearPrivateTabs: Bool,
+        uuid: ReservedWindowUUID,
         logger: Logger = DefaultLogger.shared
     ) {
         self.delegate = delegate
         self.tabDataStore = tabDataStore
         self.shouldClearPrivateTabs = shouldClearPrivateTabs
         self.logger = logger
+        self.windowIsNew = uuid.isNew
     }
 
     func restoreTabs(for windowUUID: WindowUUID) async -> TabRestorationResult {
-        let windowData = await tabDataStore.fetchWindowData(uuid: windowUUID)
+        // Only attempt a tab data store fetch if we know we should have tabs on disk (ignore new windows)
+        let windowData: WindowData? = windowIsNew ? nil : await tabDataStore.fetchWindowData(uuid: windowUUID)
         return buildResult(from: windowData, windowUUID: windowUUID)
     }
 
@@ -67,8 +71,13 @@ final class DefaultTabRestorer: TabRestorer {
             if windowData.activeTabId == tabData.id {
                 selectedTabUUID = tab.tabUUID
             }
-            delegate?.restoreScreenshot(for: tab)
+            // TODO: FXIOS-15981 - Implement TabRestorer logic for screenshots
+            // delegate?.restoreScreenshot(for: tab)
         }
+
+        logger.log("There was \(filteredTabData.count) tabs restored",
+                   level: .debug,
+                   category: .tabs)
 
         return TabRestorationResult(
             restoredTabs: restoredTabs,

--- a/firefox-ios/Client/TabManagement/TabRestorer.swift
+++ b/firefox-ios/Client/TabManagement/TabRestorer.swift
@@ -31,14 +31,14 @@ final class DefaultTabRestorer: TabRestorer {
         delegate: TabRestorerDelegate,
         tabDataStore: TabDataStore,
         shouldClearPrivateTabs: Bool,
-        uuid: ReservedWindowUUID,
+        windowIsNew: Bool,
         logger: Logger = DefaultLogger.shared
     ) {
         self.delegate = delegate
         self.tabDataStore = tabDataStore
         self.shouldClearPrivateTabs = shouldClearPrivateTabs
         self.logger = logger
-        self.windowIsNew = uuid.isNew
+        self.windowIsNew = windowIsNew
     }
 
     func restoreTabs(for windowUUID: WindowUUID) async -> TabRestorationResult {

--- a/firefox-ios/Client/TabManagement/TabRestorerDelegate.swift
+++ b/firefox-ios/Client/TabManagement/TabRestorerDelegate.swift
@@ -6,9 +6,11 @@ import Common
 import TabDataStore
 
 protocol TabRestorerDelegate: AnyObject {
+    /// Creates and configures a `Tab` from persisted `TabData`, without loading its web content.
     @MainActor
     func createTab(with tabData: TabData) -> Tab
 
+    /// Asynchronously loads a tab's screenshot from disk and sets it on the tab.
     @MainActor
     func restoreScreenshot(for tab: Tab)
 }

--- a/firefox-ios/Client/TabManagement/TabRestorerDelegate.swift
+++ b/firefox-ios/Client/TabManagement/TabRestorerDelegate.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import TabDataStore
+
+protocol TabRestorerDelegate: AnyObject {
+    @MainActor
+    func createTab(with tabData: TabData) -> Tab
+
+    @MainActor
+    func restoreScreenshot(for tab: Tab)
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabRestorerDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabRestorerDelegate.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import TabDataStore
+import Common
+@testable import Client
+
+@MainActor
+final class MockTabRestorerDelegate: TabRestorerDelegate {
+    var createdTabs: [Tab] = []
+    var screenshotRestoredTabs: [Tab] = []
+    private let profile: MockProfile
+
+    init(profile: MockProfile) {
+        self.profile = profile
+    }
+
+    func createTab(with tabData: TabData) -> Tab {
+        let tab = Tab(profile: profile, windowUUID: .XCTestDefaultUUID)
+        tab.tabUUID = tabData.id.uuidString
+        createdTabs.append(tab)
+        return tab
+    }
+
+    func restoreScreenshot(for tab: Tab) {
+        screenshotRestoredTabs.append(tab)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabRestorerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabRestorerTests.swift
@@ -1,0 +1,138 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import TabDataStore
+import Common
+@testable import Client
+
+@MainActor
+final class TabRestorerTests: XCTestCase {
+    private var mockDataStore: MockTabDataStore!
+    private var mockDelegate: MockTabRestorerDelegate!
+    private var mockProfile: MockProfile!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockProfile = MockProfile()
+        DependencyHelperMock().bootstrapDependencies(injectedProfile: mockProfile)
+        mockDataStore = MockTabDataStore()
+        mockDelegate = MockTabRestorerDelegate(profile: mockProfile)
+    }
+
+    override func tearDown() async throws {
+        mockProfile = nil
+        mockDataStore = nil
+        mockDelegate = nil
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func testRestoreTabs_returnsEmptyResult_whenNoWindowData() async {
+        let subject = createSubject()
+
+        let result = await subject.restoreTabs(for: .XCTestDefaultUUID)
+
+        XCTAssertTrue(result.restoredTabs.isEmpty)
+        XCTAssertNil(result.selectedTabUUID)
+        XCTAssertEqual(result.windowUUID, WindowUUID.XCTestDefaultUUID)
+    }
+
+    func testRestoreTabs_returnsEmptyResult_whenAllTabsArePrivate() async {
+        mockDataStore.fetchTabWindowData = WindowData(
+            id: UUID(),
+            activeTabId: UUID(),
+            tabData: [makeTabData(isPrivate: true), makeTabData(isPrivate: true)]
+        )
+        let subject = createSubject(shouldClearPrivateTabs: true)
+
+        let result = await subject.restoreTabs(for: .XCTestDefaultUUID)
+
+        XCTAssertTrue(result.restoredTabs.isEmpty)
+        XCTAssertNil(result.selectedTabUUID)
+    }
+
+    func testRestoreTabs_restoresNormalTabs() async {
+        mockDataStore.fetchTabWindowData = WindowData(
+            id: UUID(),
+            activeTabId: UUID(),
+            tabData: [makeTabData(), makeTabData(), makeTabData()]
+        )
+        let subject = createSubject()
+
+        let result = await subject.restoreTabs(for: .XCTestDefaultUUID)
+
+        XCTAssertEqual(result.restoredTabs.count, 3)
+        XCTAssertEqual(mockDelegate.createdTabs.count, 3)
+    }
+
+    func testRestoreTabs_setsSelectedTabUUID_forActiveTab() async {
+        let activeTabId = UUID()
+        mockDataStore.fetchTabWindowData = WindowData(
+            id: UUID(),
+            activeTabId: activeTabId,
+            tabData: [makeTabData(id: activeTabId), makeTabData()]
+        )
+        let subject = createSubject()
+
+        let result = await subject.restoreTabs(for: .XCTestDefaultUUID)
+
+        XCTAssertEqual(result.selectedTabUUID, activeTabId.uuidString)
+    }
+
+    func testRestoreTabs_callsRestoreScreenshot_forEachRestoredTab() async {
+        mockDataStore.fetchTabWindowData = WindowData(
+            id: UUID(),
+            activeTabId: UUID(),
+            tabData: [makeTabData(), makeTabData()]
+        )
+        let subject = createSubject()
+
+        await subject.restoreTabs(for: .XCTestDefaultUUID)
+
+        XCTAssertEqual(mockDelegate.screenshotRestoredTabs.count, 2)
+    }
+
+    func testRestoreTabs_keepsPrivateTabs_whenClearPrivateTabsIsDisabled() async {
+        mockDataStore.fetchTabWindowData = WindowData(
+            id: UUID(),
+            activeTabId: UUID(),
+            tabData: [makeTabData(isPrivate: true), makeTabData(), makeTabData()]
+        )
+        let subject = createSubject(shouldClearPrivateTabs: false)
+
+        let result = await subject.restoreTabs(for: .XCTestDefaultUUID)
+
+        XCTAssertEqual(result.restoredTabs.count, 3)
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject(shouldClearPrivateTabs: Bool = true,
+                               file: StaticString = #filePath,
+                               line: UInt = #line) -> DefaultTabRestorer {
+        let subject = DefaultTabRestorer(
+            delegate: mockDelegate,
+            tabDataStore: mockDataStore,
+            shouldClearPrivateTabs: shouldClearPrivateTabs
+        )
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
+    private func makeTabData(id: UUID = UUID(), isPrivate: Bool = false) -> TabData {
+        return TabData(
+            id: id,
+            title: "Firefox",
+            siteUrl: "https://mozilla.com",
+            faviconURL: nil,
+            isPrivate: isPrivate,
+            lastUsedTime: Date(),
+            createdAtTime: Date(),
+            temporaryDocumentSession: nil
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabRestorerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabRestorerTests.swift
@@ -126,6 +126,38 @@ final class TabRestorerTests: XCTestCase {
         XCTAssertEqual(result.restoredTabs.count, 1)
     }
 
+    func testRestoreTabs_selectedTabUUIDIsNil_whenActiveTabFilteredOut() async {
+        let activeTabId = UUID()
+        mockDataStore.fetchTabWindowData = WindowData(
+            id: UUID(),
+            activeTabId: activeTabId,
+            tabData: [makeTabData(id: activeTabId, isPrivate: true), makeTabData(), makeTabData()]
+        )
+        let subject = createSubject(shouldClearPrivateTabs: true)
+
+        let result = await subject.restoreTabs(for: .XCTestDefaultUUID)
+
+        XCTAssertEqual(result.restoredTabs.count, 2)
+        XCTAssertNil(result.selectedTabUUID)
+    }
+
+    func testRestoreTabs_preservesOrderOfPersistedTabs() async {
+        let firstId = UUID()
+        let secondId = UUID()
+        let thirdId = UUID()
+        mockDataStore.fetchTabWindowData = WindowData(
+            id: UUID(),
+            activeTabId: UUID(),
+            tabData: [makeTabData(id: firstId), makeTabData(id: secondId), makeTabData(id: thirdId)]
+        )
+        let subject = createSubject()
+
+        let result = await subject.restoreTabs(for: .XCTestDefaultUUID)
+
+        XCTAssertEqual(result.restoredTabs.map { $0.tabUUID },
+                       [firstId.uuidString, secondId.uuidString, thirdId.uuidString])
+    }
+
     // MARK: - Helpers
 
     private func createSubject(shouldClearPrivateTabs: Bool = true,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabRestorerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabRestorerTests.swift
@@ -83,19 +83,6 @@ final class TabRestorerTests: XCTestCase {
         XCTAssertEqual(result.selectedTabUUID, activeTabId.uuidString)
     }
 
-    func testRestoreTabs_callsRestoreScreenshot_forEachRestoredTab() async {
-        mockDataStore.fetchTabWindowData = WindowData(
-            id: UUID(),
-            activeTabId: UUID(),
-            tabData: [makeTabData(), makeTabData()]
-        )
-        let subject = createSubject()
-
-        await subject.restoreTabs(for: .XCTestDefaultUUID)
-
-        XCTAssertEqual(mockDelegate.screenshotRestoredTabs.count, 2)
-    }
-
     func testRestoreTabs_keepsPrivateTabs_whenClearPrivateTabsIsDisabled() async {
         mockDataStore.fetchTabWindowData = WindowData(
             id: UUID(),
@@ -109,15 +96,47 @@ final class TabRestorerTests: XCTestCase {
         XCTAssertEqual(result.restoredTabs.count, 3)
     }
 
+    func testRestoreTabs_skipsDataStoreFetch_whenWindowIsNew() async {
+        mockDataStore.fetchTabWindowData = WindowData(
+            id: UUID(),
+            activeTabId: UUID(),
+            tabData: [makeTabData(), makeTabData()]
+        )
+        let subject = createSubject(isNew: true)
+
+        let result = await subject.restoreTabs(for: .XCTestDefaultUUID)
+
+        XCTAssertEqual(mockDataStore.fetchWindowDataCalledCount, 0)
+        XCTAssertTrue(result.restoredTabs.isEmpty)
+        XCTAssertNil(result.selectedTabUUID)
+        XCTAssertEqual(result.windowUUID, WindowUUID.XCTestDefaultUUID)
+    }
+
+    func testRestoreTabs_fetchesFromDataStore_whenWindowIsNotNew() async {
+        mockDataStore.fetchTabWindowData = WindowData(
+            id: UUID(),
+            activeTabId: UUID(),
+            tabData: [makeTabData()]
+        )
+        let subject = createSubject(isNew: false)
+
+        let result = await subject.restoreTabs(for: .XCTestDefaultUUID)
+
+        XCTAssertEqual(mockDataStore.fetchWindowDataCalledCount, 1)
+        XCTAssertEqual(result.restoredTabs.count, 1)
+    }
+
     // MARK: - Helpers
 
     private func createSubject(shouldClearPrivateTabs: Bool = true,
+                               isNew: Bool = false,
                                file: StaticString = #filePath,
                                line: UInt = #line) -> DefaultTabRestorer {
         let subject = DefaultTabRestorer(
             delegate: mockDelegate,
             tabDataStore: mockDataStore,
-            shouldClearPrivateTabs: shouldClearPrivateTabs
+            shouldClearPrivateTabs: shouldClearPrivateTabs,
+            uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: isNew)
         )
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
@@ -132,7 +151,7 @@ final class TabRestorerTests: XCTestCase {
             isPrivate: isPrivate,
             lastUsedTime: Date(),
             createdAtTime: Date(),
-            temporaryDocumentSession: nil
+            temporaryDocumentSession: [:]
         )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabRestorerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabRestorerTests.swift
@@ -168,7 +168,7 @@ final class TabRestorerTests: XCTestCase {
             delegate: mockDelegate,
             tabDataStore: mockDataStore,
             shouldClearPrivateTabs: shouldClearPrivateTabs,
-            uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: isNew)
+            windowIsNew: isNew
         )
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15744) -> TabRestorationResult
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33677)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15745) -> TabRestorerDelegate
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33680)

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15746) -> TabRestorer
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33673)

## :bulb: Description
[[ADR-0007]](https://github.com/mozilla-mobile/firefox-ios/blob/main/adr/0007-deeplink-startup-flow-refactor.md)

Tasks were really small, so bundling those files creation together.

- In short, I am basically creating a new class that takes the logic of the tab restoration out of the `TabManagerImplementation`. The key change here is that instead of replacing the tabs array under the `TabManagerImplementation` right away, we only notify the `TabManagerImplementation` when the full `TabRestorationResult` is completed. You can look at `startRestoreTabsTask` under the `TabManagerImplementation` to have a good idea of what was "moved" to this new class.
- The tab creation is done in `TabManagerImplementation` still, through the `TabRestorerDelegate`.
- It seems `shouldClearPrivateTabs` could be simplified (it has repetition in `TabManagerImplementation`), so doing that within this new tab restorer.
- Next step will be to integrate this `TabRestorer` under the `TabManagerImplementation` with the feature flag.
- Screenshots will be handled with [FXIOS-15981](https://mozilla-hub.atlassian.net/browse/FXIOS-15981)

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

[FXIOS-15981]: https://mozilla-hub.atlassian.net/browse/FXIOS-15981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ