### PR TITLE
Enable FXIOS-15983 [Translations] Enable Phase 2 by default on all channels

### DIFF
--- a/firefox-ios/nimbus-features/translationsFeature.yaml
+++ b/firefox-ios/nimbus-features/translationsFeature.yaml
@@ -13,13 +13,4 @@ features:
         description: >
           Whether or not to enable the translations language picker (Phase 2).
         type: Boolean
-        default: false
-    defaults:
-      - channel: beta
-        value:
-          enabled: true
-          languagePickerEnabled: false
-      - channel: developer
-        value:
-          enabled: true
-          languagePickerEnabled: false
+        default: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15983)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34116)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Flip the translations-feature languagePickerEnabled default to true and drop the now-redundant per-channel defaults block so Phase 2 (language picker) is on by default on every channel.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


