### PR TITLE
[MTE-5332] - multiple auto fixes

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -253,6 +253,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
             newTabsScreen.assertSwitchButtonExists()
         }
         toolbarScreen.tapOnTabsButton()
+        tabTrayScreen.assertNewTabButtonExist()
         tabTrayScreen.assertTabCount(2)
         // The selected website is opened in the new tab
         if #available(iOS 26, *) {
@@ -274,6 +275,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
         // The selected website is opened in a new private tab
         toolbarScreen.tapOnTabsButton()
         tabTrayScreen.switchToPrivateMode()
+        tabTrayScreen.assertNewTabButtonExist()
         tabTrayScreen.assertTabCount(1)
         if #available(iOS 26, *) {
             // To avoid flakiness, this validation will be performed only on iOS 26 and above

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -159,6 +159,9 @@ class FindInPageTests: BaseTestCase {
         openFindInPageFromMenu(openSite: userState.url!)
 
         // Before reloading, it is necessary to hide the keyboard
+        if !iPad() {
+            app.webViews.element(boundBy: 0).waitAndTap()
+        }
         app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField].waitAndTap()
         urlBarAddress.typeText("\n")
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -421,7 +421,7 @@ class SearchTests: FeatureFlaggedTestBase {
         typeTextAndValidateSearchSuggestions(text: "g", isSwitchOn: true)
 
         // Tap on the "Append Arrow button"
-        app.tables.buttons[StandardImageIdentifiers.Large.appendUpLeft].firstMatch.waitAndTap()
+        app.tables.cells.buttons.firstMatch.waitAndTap()
 
         // The search suggestion fills the URL bar but does not conduct the search
         waitForValueContains(urlBarAddress, value: "g")
@@ -516,7 +516,7 @@ class SearchTests: FeatureFlaggedTestBase {
     private func typeTextAndValidateSearchSuggestions(text: String, isSwitchOn: Bool) {
         typeOnSearchBar(text: text)
         // Search suggestions are shown
-        let appendArrowBtn = app.tables.cells.buttons.matching(identifier: "appendUpLeftLarge")
+        let appendArrowBtn = app.tables.cells.buttons
         if isSwitchOn {
             mozWaitForElementToExist(app.staticTexts.elementContainingText("google"))
             mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["Google Search"])


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5332

## :bulb: Description
Included in this PR fixes for multiple tests:
testBarDisappearsWhenReloading started to fail after the toolbar got moved to the bottom. 
The solution here was to tap inside the page to dismiss the keyboard and perform the reload after that.
For testSearchSuggestions the query for appendArrowBtn element changed
On the bookmark side, testBookmarkSearchResultOpenInNewPrivateTab and testBookmarkSearchResultOpenInNewTab are flaky, here the solution was to add an extra assert to make sure tab tray has time to fully open. Locally this passes, but monitoring the nightly builds is still required to see if the solution works.
