### PR TITLE
Add FXIOS-15850 [Add Shortcut Tile] Alert URL validation

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		212985E72A72B39D00546684 /* ThemeSettingsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212985E52A72B22800546684 /* ThemeSettingsControllerTests.swift */; };
 		213046B92F202F27007ECEDA /* UIFontExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213046B82F202F27007ECEDA /* UIFontExtensionsTests.swift */; };
 		213046BB2F212BCC007ECEDA /* CGRectExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213046BA2F212BCC007ECEDA /* CGRectExtensionsTests.swift */; };
+		213046BD2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213046BC2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift */; };
 		213047E62F2153B1007ECEDA /* PageZoomSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213047E52F2153AB007ECEDA /* PageZoomSettingsViewModelTests.swift */; };
 		21304C8C2F217A59007ECEDA /* ThemeSettingsStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21304C8B2F217A59007ECEDA /* ThemeSettingsStateTests.swift */; };
 		21365E392F30FD700000C369 /* BrowserViewControllerLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21365E382F30FD580000C369 /* BrowserViewControllerLayoutManager.swift */; };
@@ -3138,6 +3139,7 @@
 		212985E52A72B22800546684 /* ThemeSettingsControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsControllerTests.swift; sourceTree = "<group>"; };
 		213046B82F202F27007ECEDA /* UIFontExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtensionsTests.swift; sourceTree = "<group>"; };
 		213046BA2F212BCC007ECEDA /* CGRectExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGRectExtensionsTests.swift; sourceTree = "<group>"; };
+		213046BC2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAlertControllerExtensionTests.swift; sourceTree = "<group>"; };
 		213047E52F2153AB007ECEDA /* PageZoomSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageZoomSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		21304C8B2F217A59007ECEDA /* ThemeSettingsStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsStateTests.swift; sourceTree = "<group>"; };
 		21365E382F30FD580000C369 /* BrowserViewControllerLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerLayoutManager.swift; sourceTree = "<group>"; };
@@ -14403,6 +14405,7 @@
 				213046B82F202F27007ECEDA /* UIFontExtensionsTests.swift */,
 				8ADED7EB27691351009C19E6 /* CalendarExtensionsTests.swift */,
 				2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */,
+				213046BC2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift */,
 				A83E5B1C1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift */,
 				8AE1E1D827B1BD380024C45E /* UIStackViewExtensionsTests.swift */,
 				E169C6E72979CA0E0017B8D7 /* URLMailTests.swift */,
@@ -20805,6 +20808,7 @@
 				4A59B58AD11B5EE1F80BBDEB /* TestHistory.swift in Sources */,
 				C2126EFA2F447A46001C01FE /* SummarizerNimbusUtilsTests.swift in Sources */,
 				A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */,
+				213046BD2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift in Sources */,
 				8A01FE402DF0CE4E002C483B /* MockDateProvider.swift in Sources */,
 				213046BB2F212BCC007ECEDA /* CGRectExtensionsTests.swift in Sources */,
 				8A9BA6BF2F7C4D6000D892C4 /* RemoteTabCreatorTests.swift in Sources */,

--- a/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
@@ -92,6 +92,7 @@ extension UIAlertController {
         return deleteAlert
     }
 
+    /// FXIOS-15928 - App crashes when dynamic type changes on iOS 26
     class func addShortcutAlert() -> UIAlertController {
         let alert = UIAlertController(
             title: .FirefoxHomepage.Shortcuts.AddShortcut.AlertTitle,
@@ -120,8 +121,8 @@ extension UIAlertController {
             textField.accessibilityIdentifier =
                 AccessibilityIdentifiers.FirefoxHomepage.TopSites.AddShortcutAlert.urlTextField
             textField.addAction(UIAction { [weak textField, weak saveAction] _ in
-                let text = textField?.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                saveAction?.isEnabled = !text.isEmpty
+                let text = textField?.text ?? ""
+                saveAction?.isEnabled = URIFixup.getURL(text) != nil
             }, for: .editingChanged)
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/UIAlertControllerExtensionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/UIAlertControllerExtensionTests.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class UIAlertControllerExtensionTests: XCTestCase {
+    func testAddShortcutAlertEnablesSaveButtonForValidURL() throws {
+        let alert = UIAlertController.addShortcutAlert()
+
+        let saveAction = try XCTUnwrap(alert.actions.last)
+        let textField = try XCTUnwrap(alert.textFields?.first)
+
+        XCTAssertFalse(saveAction.isEnabled)
+
+        textField.text = "facebook.com"
+        textField.sendActions(for: .editingChanged)
+
+        XCTAssertTrue(saveAction.isEnabled)
+    }
+
+    func testAddShortcutAlertDisablesSaveButtonForInvalidURL() throws {
+        let alert = UIAlertController.addShortcutAlert()
+
+        let saveAction = try XCTUnwrap(alert.actions.last)
+        let textField = try XCTUnwrap(alert.textFields?.first)
+
+        textField.text = "facebook.com"
+        textField.sendActions(for: .editingChanged)
+
+        XCTAssertTrue(saveAction.isEnabled)
+
+        textField.text = "foo bar"
+        textField.sendActions(for: .editingChanged)
+
+        XCTAssertFalse(saveAction.isEnabled)
+    }
+}


### PR DESCRIPTION
:scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15850)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33902)

## :bulb: Description
- Validate Add Shortcut URL Alert input before allowing the URL to be saved

### 📝 Technical Notes:
-  The "Save" action now enables only when `URIFixup.getURL(text)` returns a URL
   - This matches address bar behavior for valid vs search input

## :movie_camera: Demos
https://github.com/user-attachments/assets/0c597387-2209-44d6-a337-c054ef7b0c97

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

