### PR TITLE
Add FXIOS-15991 [WC] Add telemetry for share and wallpaper buttons

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
@@ -58,31 +58,23 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable, WorldCupPagerView {
         let changeTeamAction = UIAction(
             title: .WorldCup.HomepageWidget.ChangeTeamLabel,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.soccerBall),
-            handler: { [weak self] _ in
-                self?.navigateToTeamSelection()
-            }
+            handler: { [weak self] _ in self?.navigateToTeamSelection() }
         )
         let wallpaperAction = UIAction(
             title: .WorldCup.HomepageWidget.GetCustomWallpaperLabel,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.image),
-            handler: { [weak self] _ in
-                self?.navigateToWallpaperSettings()
-            }
+            handler: { [weak self] _ in self?.navigateToWallpaperSettings() }
         )
         let shareAction = UIAction(
             title: .WorldCup.HomepageWidget.ShareLabel,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.share),
-            handler: { [weak self] _ in
-                self?.shareSchedule()
-            }
+            handler: { [weak self] _ in self?.shareSchedule() }
         )
         let removeAction = UIAction(
             title: .WorldCup.HomepageWidget.RemoveLabel,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
             attributes: .destructive,
-            handler: { [weak self] _ in
-                self?.dismiss()
-            }
+            handler: { [weak self] _ in self?.dismiss() }
         )
         return UIMenu(children: [changeTeamAction, wallpaperAction, shareAction, removeAction])
     }
@@ -290,6 +282,7 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable, WorldCupPagerView {
     }
 
     func navigateToWallpaperSettings() {
+        telemetry.wallpaperButtonTapped()
         store.dispatch(
             NavigationBrowserAction(
                 navigationDestination: NavigationDestination(.settings(.wallpaper)),
@@ -322,6 +315,7 @@ final class WorldCupMatchCardView: UIView, ThemeApplicable, WorldCupPagerView {
     func shareSchedule() {
         let query = "\(String.Settings.Homepage.CustomizeFirefoxHome.WorldCup) schedule"
         guard let url = searchEnginesManager.defaultEngine?.searchURLForQuery(query) else { return }
+        telemetry.shareButtonTapped()
         let shareTitle = "\(String.WorldCup.HomepageWidget.FollowTeamCard.Title) 🦊⚽️"
         let configuration = ShareSheetConfiguration(
             shareType: .site(url: url),

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupTelemetry.swift
@@ -45,6 +45,14 @@ struct WorldCupTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.countrySelectorDisplayed)
     }
 
+    func wallpaperButtonTapped() {
+        gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.wallpaperButton)
+    }
+
+    func shareButtonTapped() {
+        gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.shareButton)
+    }
+
     func cardSwiped(view: String, isImpression: Bool) {
         let extra = GleanMetrics.WorldCupWidget.CardSwipedExtra(isImpression: isImpression, view: view)
         gleanWrapper.recordEvent(for: GleanMetrics.WorldCupWidget.cardSwiped, extras: extra)

--- a/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
+++ b/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
@@ -117,9 +117,9 @@ world_cup_widget:
       Records when the user taps the "Get custom wallpaper" option in the
       WorldCup widget's more options menu.
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15991
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34128
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-12-01"
@@ -129,9 +129,9 @@ world_cup_widget:
       Records when the user taps the "Share" option in the WorldCup widget's
       more options menu to share the schedule.
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15991
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34128
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-12-01"

--- a/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
+++ b/firefox-ios/Client/Glean/probes/world_cup_widget.yaml
@@ -111,6 +111,30 @@ world_cup_widget:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-12-01"
+  wallpaper_button:
+    type: event
+    description: |
+      Records when the user taps the "Get custom wallpaper" option in the
+      WorldCup widget's more options menu.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-12-01"
+  share_button:
+    type: event
+    description: |
+      Records when the user taps the "Share" option in the WorldCup widget's
+      more options menu to share the schedule.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-15836
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/33878
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-12-01"
   card_swiped:
     type: event
     description: |

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupTelemetryTests.swift
@@ -166,6 +166,34 @@ final class WorldCupTelemetryTests: XCTestCase {
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 
+    func test_wallpaperButtonTapped_recordsEvent() throws {
+        let subject = createSubject()
+
+        subject.wallpaperButtonTapped()
+
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.WorldCupWidget.wallpaperButton)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
+    func test_shareButtonTapped_recordsEvent() throws {
+        let subject = createSubject()
+
+        subject.shareButtonTapped()
+
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
+        let expectedMetricType = type(of: GleanMetrics.WorldCupWidget.shareButton)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+    }
+
     func test_multipleEvents_recordedIndependently() {
         let subject = createSubject()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15991)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34129)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Adds ping for share button tapped.
- Adds ping for wallpaper button tapped.
- Adds tests.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

