### PR TITLE
Add FXIOS-15988 [Add Shortcut Tile] Save Add Shortcut URLs as pinned homepage shortcuts

### DIFF
--- a/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
@@ -93,7 +93,7 @@ extension UIAlertController {
     }
 
     /// FXIOS-15928 - App crashes when dynamic type changes on iOS 26
-    class func addShortcutAlert() -> UIAlertController {
+    class func addShortcutAlert(saveHandler: @escaping (URL) -> Void) -> UIAlertController {
         let alert = UIAlertController(
             title: .FirefoxHomepage.Shortcuts.AddShortcut.AlertTitle,
             message: .FirefoxHomepage.Shortcuts.AddShortcut.AlertDescription,
@@ -108,7 +108,13 @@ extension UIAlertController {
         let saveAction = UIAlertAction(
             title: .FirefoxHomepage.Shortcuts.AddShortcut.SaveButtonTitle,
             style: .default
-        )
+        ) { [weak alert] _ in
+            guard let text = alert?.textFields?.first?.text,
+                  let url = URIFixup.getURL(text)
+            else { return }
+
+            saveHandler(url)
+        }
         saveAction.isEnabled = false
 
         alert.addTextField { textField in

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -75,6 +75,7 @@ final class HomepageViewController: UIViewController,
     }
 
     // MARK: - Private constants
+    private let profile: Profile
     private let tabManager: TabManager
     private let homepageTabStateStore: HomepageTabStateStoring
     private let overlayManager: OverlayModeManager
@@ -102,6 +103,7 @@ final class HomepageViewController: UIViewController,
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
+        self.profile = profile
         self.tabManager = tabManager
         self.homepageTabStateStore = homepageTabStateStore
         self.overlayManager = overlayManager
@@ -1323,8 +1325,18 @@ final class HomepageViewController: UIViewController,
     }
 
     private func presentAddShortcutAlert() {
-        let alert = UIAlertController.addShortcutAlert()
+        let alert = UIAlertController.addShortcutAlert { [weak self] url in
+            self?.addPinnedShortcut(url: url)
+        }
         present(alert, animated: true)
+    }
+
+    private func addPinnedShortcut(url: URL) {
+        let site = Site.createBasicSite(
+            url: url.absoluteString,
+            title: url.shortDisplayString.capitalized
+        )
+        profile.pinnedSites.addPinnedTopSite(site)
     }
 
     /// Sends telemetry data associated with tapping on a card item. The jump back in synced card item

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryDiffableDataSource.swift
@@ -45,7 +45,7 @@ final class ShortcutsLibraryDiffableDataSource:
             snapshot.appendItems(shortcuts, toSection: .shortcuts)
         }
 
-        apply(snapshot, animatingDifferences: false)
+        apply(snapshot, animatingDifferences: true)
     }
 
     private func getShortcuts(with state: ShortcutsLibraryState) -> [ShortcutsLibraryDiffableDataSource.Item]? {

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -5,6 +5,7 @@
 import Common
 import Foundation
 import Redux
+import Storage
 
 class ShortcutsLibraryViewController: UIViewController,
                                       UICollectionViewDelegate,
@@ -26,6 +27,7 @@ class ShortcutsLibraryViewController: UIViewController,
     }
 
     // MARK: - Private constants
+    private let profile: Profile
     private let logger: Logger
 
     // MARK: - Private variables
@@ -42,11 +44,13 @@ class ShortcutsLibraryViewController: UIViewController,
 
     // MARK: Initializers
     init(windowUUID: WindowUUID,
+         profile: Profile = AppContainer.shared.resolve(),
          themeManager: ThemeManager = AppContainer.shared.resolve(),
          notificationCenter: NotificationProtocol = NotificationCenter.default,
          logger: Logger = DefaultLogger.shared
     ) {
         self.windowUUID = windowUUID
+        self.profile = profile
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
         self.logger = logger
@@ -392,8 +396,18 @@ class ShortcutsLibraryViewController: UIViewController,
     }
 
     private func presentAddShortcutAlert() {
-        let alert = UIAlertController.addShortcutAlert()
+        let alert = UIAlertController.addShortcutAlert { [weak self] url in
+            self?.addPinnedShortcut(url: url)
+        }
         present(alert, animated: true)
+    }
+
+    private func addPinnedShortcut(url: URL) {
+        let site = Site.createBasicSite(
+            url: url.absoluteString,
+            title: url.shortDisplayString.capitalized
+        )
+        profile.pinnedSites.addPinnedTopSite(site)
     }
 
     // MARK: - DismissalNotifiable

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/UIAlertControllerExtensionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/UIAlertControllerExtensionTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @MainActor
 final class UIAlertControllerExtensionTests: XCTestCase {
     func testAddShortcutAlertEnablesSaveButtonForValidURL() throws {
-        let alert = UIAlertController.addShortcutAlert()
+        let alert = UIAlertController.addShortcutAlert { _ in }
 
         let saveAction = try XCTUnwrap(alert.actions.last)
         let textField = try XCTUnwrap(alert.textFields?.first)
@@ -24,7 +24,7 @@ final class UIAlertControllerExtensionTests: XCTestCase {
     }
 
     func testAddShortcutAlertDisablesSaveButtonForInvalidURL() throws {
-        let alert = UIAlertController.addShortcutAlert()
+        let alert = UIAlertController.addShortcutAlert { _ in }
 
         let saveAction = try XCTUnwrap(alert.actions.last)
         let textField = try XCTUnwrap(alert.textFields?.first)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15988)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- Enabled valid Add Shortcut URLs to be saved as pinned homepage shortcuts.

### 📝 Technical Notes:
- Titles for these shortcuts are generated with `url.shortDisplayString.capitalized` (Similar to JBI cell) instead of fetching page metadata via network request because that would turn it into an async, time-consuming task which introduces extra complexity. Doubly-so when the future plan is to allow users to enter in a custom title for these shortcuts
- Favicons for these shortcuts are resolved lazily by the existing `FaviconImageView` pipeline when tiles render on the homepage/shortcuts library.

## :movie_camera: Demos
https://github.com/user-attachments/assets/ae68acb8-34de-4e6c-8c11-a9f42c6f2a54

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

