### PR TITLE
Refactor FXIOS-15993 [Sponsored tiles] Turn on ads client by default for next release

### DIFF
--- a/firefox-ios/nimbus-features/adsClient.yaml
+++ b/firefox-ios/nimbus-features/adsClient.yaml
@@ -6,11 +6,11 @@ features:
       status:
         description: If true, we will enable the rust ads client
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:
-          status: false
+          status: true
       - channel: developer
         value:
           status: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15993)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Following conversation in [#ads-client-support](https://mozilla.slack.com/archives/C09B31FN8FJ/p1780520518430439?thread_ts=1780514920.198169&cid=C09B31FN8FJ), the experiment has been rollout to 100% with success. Let's turn the flag by default ON in beta and release so we're not relying on the experiment anymore to run this code. Once that's shipped, then we can clean up the dead code path with [FXIOS-15992](https://mozilla-hub.atlassian.net/browse/FXIOS-15992)

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code



[FXIOS-15992]: https://mozilla-hub.atlassian.net/browse/FXIOS-15992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ