### PR TITLE
Refactor FXIOS-15020 [Needs reload refactor] Turn on needs reload refactor by default

### DIFF
--- a/firefox-ios/nimbus-features/needsReloadRefactor.yaml
+++ b/firefox-ios/nimbus-features/needsReloadRefactor.yaml
@@ -8,7 +8,7 @@ features:
         description: >
           Whether or not this refactor is enabled
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15020)

## :bulb: Description
[This experiment](https://experimenter.services.mozilla.com/nimbus/needs-reload-selected-tab-refactor-release-experiment-v2/summary/) is at 80% release. It's been in rollout for the past month and nothing has been worrisome so I want to turn this ON by default in release to stop relying on the experiment. I'll let this sit for a while, then in a month will clean up the old code path with FXIOS-15994 🎉 (unless something unexpected happens of course).

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

