### PR TITLE
Refactor MTE-5224 Add TestPages.mozillaOrg and TestLabels.exampleDomain constants

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -294,7 +294,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         app.launch()
         addWebsiteToShortcut(website: url_3)
         let itemCell = app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
-        let cell = itemCell.staticTexts["Example Domain"]
+        let cell = itemCell.staticTexts[TestLabels.exampleDomain]
         mozWaitForElementToExist(cell)
     }
 
@@ -324,7 +324,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
 
         // Verify shortcuts are displayed on the homepage
         let itemCell = app.links[AccessibilityIdentifiers.FirefoxHomepage.TopSites.itemCell]
-        let firstWebsite = itemCell.staticTexts["Example Domain"]
+        let firstWebsite = itemCell.staticTexts[TestLabels.exampleDomain]
         let secondWebsite = itemCell.staticTexts["Internet for people, not profit — Mozilla"]
         mozWaitForElementToExist(firstWebsite)
         mozWaitForElementToExist(secondWebsite)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -7,7 +7,7 @@ import MappaMundi
 import XCTest
 import Shared
 
-let page1 = "http://localhost:\(serverPort)/test-fixture/find-in-page-test.html"
+let page1 = "http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)"
 let page2 = "http://localhost:\(serverPort)/test-fixture/test-example.html"
 let serverPort = ProcessInfo.processInfo.environment["WEBSERVER_PORT"] ?? "\(Int.random(in: 1025..<65000))"
 @MainActor
@@ -359,12 +359,12 @@ class BaseTestCase: XCTestCase {
 
     func addContentToReaderView(isHomePageOn: Bool = true) {
         updateScreenGraph()
-        userState.url = path(forTestPage: "test-mozilla-book.html")
+        userState.url = path(forTestPage: TestPages.mozillaBook)
         if isHomePageOn {
             navigator.nowAt(HomePanelsScreen)
             navigator.goto(URLBarOpen)
         }
-        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaBook))
         mozWaitForElementToExist(app.buttons["Reader View"])
 
         app.buttons["Reader View"].waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -6,8 +6,8 @@ import Common
 import XCTest
 
 let url_1 = TestPages.exampleHTML
-let url_2 = ["url": "test-mozilla-org.html", "bookmarkLabel": "Internet for people, not profit — Mozilla"]
-let urlLabelExample_3 = "Example Domain"
+let url_2 = ["url": TestPages.mozillaOrg, "bookmarkLabel": "Internet for people, not profit — Mozilla"]
+let urlLabelExample_3 = TestLabels.exampleDomain
 let url_3 = "localhost:\(serverPort)/test-fixture/test-example.html"
 
 class BookmarksTests: FeatureFlaggedTestBase {
@@ -98,7 +98,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
         waitForTabsButton()
         navigator.goto(TabTray)
         let identifier = "\(AccessibilityIdentifiers.TabTray.tabCell)_0_0"
-        XCTAssertEqual(app.cells[identifier].label, "Example Domain")
+        XCTAssertEqual(app.cells[identifier].label, TestLabels.exampleDomain)
         app.cells[identifier].waitAndTap()
         navigator.nowAt(BrowserTab)
         toolbarScreen.assertTabsButtonExists()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
@@ -9,7 +9,7 @@ final class CookiePersistenceTests: BaseTestCase {
     private var toolbarScreen: ToolbarScreen!
     private var tabTrayScreen: TabTrayScreen!
 
-    let cookieSiteURL = "http://localhost:\(serverPort)/test-fixture/test-cookie-store.html"
+    let cookieSiteURL = "http://localhost:\(serverPort)/test-fixture/\(TestPages.cookieStore)"
     let topSitesTitle = ["Facebook", "YouTube", "Wikipedia"]
 
     override func setUp() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
@@ -30,7 +30,7 @@ class DataManagementTests: BaseTestCase {
     func testWebSiteDataOptions() {
         cleanAllData()
         navigator.nowAt(BrowserTab)
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         navigator.nowAt(BrowserTab)
         navigator.openURL(path(forTestPage: TestPages.exampleHTML))
         navigator.nowAt(NewTabScreen)
@@ -85,7 +85,7 @@ class DataManagementTests: BaseTestCase {
     func testFilterWebsiteData() {
         cleanAllData()
         navigator.nowAt(BrowserTab)
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         navigator.nowAt(BrowserTab)
         navigator.openURL(path(forTestPage: TestPages.exampleHTML))
         navigator.nowAt(NewTabScreen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -8,15 +8,15 @@ import XCTest
 let firstWebsite = (
     url: path(forTestPage: TestPages.mozillaOrg),
     tabName: "Internet for people, not profit — Mozilla",
-    browserTabName: "http://localhost:7777/test-fixture/test-mozilla-book.html. Currently selected tab."
+    browserTabName: "http://localhost:7777/test-fixture/\(TestPages.mozillaBook). Currently selected tab."
 )
 let secondWebsite = (
-    url: path(forTestPage: "test-mozilla-book.html"),
+    url: path(forTestPage: TestPages.mozillaBook),
     tabName: "The Book of Mozilla. Currently selected tab.",
-    browserTabName: "http://localhost:7777/test-fixture/test-mozilla-book.html. Currently selected tab."
+    browserTabName: "http://localhost:7777/test-fixture/\(TestPages.mozillaBook). Currently selected tab."
 )
 let secondWebsiteUnselected = (
-    url: path(forTestPage: "test-mozilla-book.html"),
+    url: path(forTestPage: TestPages.mozillaBook),
     tabName: "The Book of Mozilla"
 )
 let homeTabName = "Homepage"

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -6,7 +6,7 @@ import Common
 import XCTest
 
 let firstWebsite = (
-    url: path(forTestPage: "test-mozilla-org.html"),
+    url: path(forTestPage: TestPages.mozillaOrg),
     tabName: "Internet for people, not profit — Mozilla",
     browserTabName: "http://localhost:7777/test-fixture/test-mozilla-book.html. Currently selected tab."
 )

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -40,7 +40,7 @@ class FindInPageTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323463
     func testFindInLargeDoc() {
-        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        navigator.openURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
@@ -64,7 +64,7 @@ class FindInPageTests: BaseTestCase {
         browserScreen = BrowserScreen(app: app)
         findInPageScreen = FindInPageScreen(app: app)
         let searchTerm = "Book"
-        userState.url = path(forTestPage: "test-mozilla-book.html")
+        userState.url = path(forTestPage: TestPages.mozillaBook)
         navigateToOpenFindInPage(openSite: userState.url!)
 
         findInPageScreen.waitForFindInPageBarToAppear()
@@ -90,7 +90,7 @@ class FindInPageTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323705
     func testFindInPageTwoWordsSearch() {
-        userState.url = path(forTestPage: "test-mozilla-book.html")
+        userState.url = path(forTestPage: TestPages.mozillaBook)
         openFindInPageFromMenu(openSite: userState.url!)
         // Enter some text to start finding
         if #available(iOS 16, *) {
@@ -106,7 +106,7 @@ class FindInPageTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323714
     func testFindInPageTwoWordsSearchLargeDoc() {
-        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        navigator.openURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         navigator.goto(FindInPage)
@@ -124,7 +124,7 @@ class FindInPageTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323718
     func testFindInPageResultsPageShowHideContent() {
-        userState.url = path(forTestPage: "test-mozilla-book.html")
+        userState.url = path(forTestPage: TestPages.mozillaBook)
         openFindInPageFromMenu(openSite: userState.url!)
         // Enter some text to start finding
         if #available(iOS 16, *) {
@@ -140,7 +140,7 @@ class FindInPageTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323801
     func testQueryWithNoMatches() {
-        userState.url = path(forTestPage: "test-mozilla-book.html")
+        userState.url = path(forTestPage: TestPages.mozillaBook)
         openFindInPageFromMenu(openSite: userState.url!)
 
         // Try to find text which does not match and check that there are not results
@@ -155,7 +155,7 @@ class FindInPageTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323802
     func testBarDisappearsWhenReloading() {
-        userState.url = path(forTestPage: "test-mozilla-book.html")
+        userState.url = path(forTestPage: TestPages.mozillaBook)
         openFindInPageFromMenu(openSite: userState.url!)
 
         // Before reloading, it is necessary to hide the keyboard
@@ -177,7 +177,7 @@ class FindInPageTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323803
     func testBarDisappearsWhenOpeningTabsTray() {
-        userState.url = path(forTestPage: "test-mozilla-book.html")
+        userState.url = path(forTestPage: TestPages.mozillaBook)
         openFindInPageFromMenu(openSite: userState.url!)
 
         // Dismiss keyboard
@@ -196,7 +196,7 @@ class FindInPageTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323467
     func testFindFromLongTap() {
-        userState.url = path(forTestPage: "test-mozilla-book.html")
+        userState.url = path(forTestPage: TestPages.mozillaBook)
         openFindInPageFromMenu(openSite: userState.url!)
         let textToFind = "from"
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -20,9 +20,9 @@ let emptyRecentlyClosedMesg = "Websites you’ve visited recently will show up h
 // This is part of the info the user will see in recent closed tabs once the default
 // visited website (https://www.mozilla.org/en-US/book/) is closed
 let bookOfMozilla = [
-    "file": "test-mozilla-book.html",
+    "file": TestPages.mozillaBook,
     "title": "The Book of Mozilla",
-    "label": "localhost:\(serverPort)/test-fixture/test-mozilla-book.html"
+    "label": "localhost:\(serverPort)/test-fixture/\(TestPages.mozillaBook)"
 ]
 
 class HistoryTests: BaseTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -14,7 +14,7 @@ let webpage = [
 let oldHistoryEntries: [String] = [
     "Internet for people, not profit — Mozilla (US)",
     "Explore / Twitter",
-    "Example Domain"
+    TestLabels.exampleDomain
 ]
 let emptyRecentlyClosedMesg = "Websites you’ve visited recently will show up here."
 // This is part of the info the user will see in recent closed tabs once the default
@@ -381,7 +381,7 @@ class HistoryTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         navigator.openURL(path(forTestPage: bookOfMozilla["file"]!))
         waitUntilPageLoad()
-        navigator.openNewURL(urlString: path(forTestPage: "test-mozilla-org.html"))
+        navigator.openNewURL(urlString: path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
 
         // Close the private tab "Book of Mozilla" by tapping 'x' button
@@ -460,7 +460,7 @@ class HistoryTests: BaseTestCase {
         waitForElementsToExist(
             [
                 app.tables[HistoryPanelA11y.tableView],
-                app.tables.cells.staticTexts["Example Domain"]
+                app.tables.cells.staticTexts[TestLabels.exampleDomain]
             ]
         )
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
@@ -39,7 +39,7 @@ class HomeButtonTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2306883
     func testSwitchHomepageKeyboardRaisedUp() {
         // Open a new tab and load a web page
-        browserScreen.navigateToURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        browserScreen.navigateToURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
         waitUntilPageLoad()
 
         // Switch to Homepage by taping the home button

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
@@ -21,14 +21,14 @@ class HomeButtonTests: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306925
     func testGoHome() throws {
-        browserScreen.navigateToURL(path(forTestPage: "test-mozilla-org.html"))
+        browserScreen.navigateToURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         toolbarScreen.tapHomeButton()
         waitForTabsButton()
         if !iPad() {
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
         }
-        browserScreen.navigateToURL(path(forTestPage: "test-mozilla-org.html"))
+        browserScreen.navigateToURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         toolbarScreen.assertNewTabButtonExists()
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -10,7 +10,7 @@ let websiteUrl1 = "www.mozilla.org"
 let websiteUrl2 = "developer.mozilla.org"
 let invalidUrl = "1-2-3"
 let exampleUrl = TestPages.exampleHTML
-let urlExampleLabel = "Example Domain"
+let urlExampleLabel = TestLabels.exampleDomain
 let urlMozillaLabel = "Internet for people, not profit — Mozilla (US)"
 
 class HomePageSettingsUITests: FeatureFlaggedTestBase {
@@ -84,7 +84,7 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
         mozWaitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "http://example.com")
 
         // Check that it is actually set by opening a different website and going to Home
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
 
         // Now check open home page should load the previously saved home page
@@ -126,7 +126,7 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
         XCTAssertTrue(app.tables.cells["HomeAsFirefoxHome"].isSelected, "Firefox Home is not selected by default")
         navigator.goto(SettingsScreen)
         navigator.goto(NewTabScreen)
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         // Add a new tab

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -144,7 +144,7 @@ class IntegrationTests: BaseTestCase {
         // Wait for initial sync to complete
         waitForInitialSyncComplete()
         navigator.goto(LibraryPanel_Bookmarks)
-        mozWaitForElementToExist(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"])
+        mozWaitForElementToExist(app.tables["Bookmarks List"].cells.staticTexts[TestLabels.exampleDomain])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3895151
@@ -266,7 +266,7 @@ class IntegrationTests: BaseTestCase {
         // Check Bookmarks
         navigator.goto(LibraryPanel_Bookmarks)
         mozWaitForElementToExist(app.tables["Bookmarks List"])
-        mozWaitForElementToExist(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"])
+        mozWaitForElementToExist(app.tables["Bookmarks List"].cells.staticTexts[TestLabels.exampleDomain])
 
         // Check Login
         navigator.performAction(Action.CloseBookmarkPanel)
@@ -316,7 +316,7 @@ class IntegrationTests: BaseTestCase {
 
         // Check Bookmarks
         navigator.goto(LibraryPanel_Bookmarks)
-        mozWaitForElementToExist(app.tables["Bookmarks List"].cells.staticTexts["Example Domain"])
+        mozWaitForElementToExist(app.tables["Bookmarks List"].cells.staticTexts[TestLabels.exampleDomain])
 
         // Check Logins
         navigator.performAction(Action.CloseBookmarkPanel)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -106,7 +106,7 @@ class JumpBackInTests: FeatureFlaggedTestBase {
         // Amazon and Twitter are visible in the "Jump Back In" section
         jumpBackInScreen.scrollToJumpBackInSection()
         jumpBackInScreen.assertSectionExists()
-        jumpBackInScreen.assertItemExists(title: "Example Domain")
+        jumpBackInScreen.assertItemExists(title: TestLabels.exampleDomain)
         jumpBackInScreen.assertItemExists(title: "Wikipedia")
         jumpBackInScreen.assertItemNotExists(title: "YouTube")
 
@@ -126,12 +126,12 @@ class JumpBackInTests: FeatureFlaggedTestBase {
         jumpBackInScreen.assertSectionExists()
 
         // Amazon is visible in "Jump Back In"
-        jumpBackInScreen.assertItemExists(title: "Example Domain")
+        jumpBackInScreen.assertItemExists(title: TestLabels.exampleDomain)
 
         // Close the amazon tab
         waitForTabsButton()
         toolbarScreen.tapOnTabsButton()
-        tabTrayScreen.closeTab(title: "Example Domain")
+        tabTrayScreen.closeTab(title: TestLabels.exampleDomain)
 
         // Revisit the "Jump Back In" section
         tabTrayScreen.assertNewTabButtonExist()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -69,7 +69,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
         XCTAssertFalse(app.buttons[AccessibilityIdentifiers.Toolbar.forwardButton].isEnabled)
 
         // Once a second url is open, back button is enabled but not the forward one till we go back to url_1
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         mozWaitForValueContains(url, value: "localhost")
         XCTAssertTrue(app.buttons[AccessibilityIdentifiers.Toolbar.backButton].isEnabled)
@@ -451,7 +451,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
         let switchValueAfter = switchBlockPopUps.value!
         XCTAssertEqual(switchValueAfter as? String, "0")
         navigator.goto(HomePanelsScreen)
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         navigator.openURL(path(forTestPage: "test-window-opener.html"))
         mozWaitForElementToExist(app.links["link-created-by-parent"])
@@ -483,7 +483,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
         // A new tab loading the article page should open
         waitForTabsButton()
         navigator.goto(TabTray)
-        mozWaitForElementToExist(app.cells.elementContainingText("Example Domain"))
+        mozWaitForElementToExist(app.cells.elementContainingText(TestLabels.exampleDomain))
         let numTabs = app.otherElements[tabsTray].cells.count
         XCTAssertEqual(numTabs, 2, "Total number of opened tabs should be 2")
         mozWaitForElementToExist(app.otherElements[tabsTray].cells.elementContainingText("Example Domain."))

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
@@ -14,7 +14,7 @@ class OpeningScreenTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2307039
     func testLastOpenedTab() {
         // Open a web page
-        browserScreen.navigateToURL(path(forTestPage: "test-mozilla-org.html"))
+        browserScreen.navigateToURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         // Close the app from app switcher. Relaunch the app
         closeFromAppSwitcherAndRelaunch()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -50,14 +50,14 @@ class PhotonActionSheetTests: BaseTestCase {
         browserScreen.tapCancelButtonIfExist()
 
         // Verify that the site is pinned to top
-        topSitesScreen.assertTopSiteExists(named: "Example Domain")
-        topSitesScreen.assertTopSitePinned(named: "Example Domain")
+        topSitesScreen.assertTopSiteExists(named: TestLabels.exampleDomain)
+        topSitesScreen.assertTopSitePinned(named: TestLabels.exampleDomain)
 
         // Remove pin
-        topSitesScreen.longPressOnPinnedSite(named: "Example Domain")
+        topSitesScreen.longPressOnPinnedSite(named: TestLabels.exampleDomain)
         topSitesScreen.tapPinSlashIcon()
-        topSitesScreen.assertTopSiteNotPinned(named: "Example Domain")
-        topSitesScreen.assertTopSiteDoesNotExist(named: "Example Domain")
+        topSitesScreen.assertTopSiteNotPinned(named: TestLabels.exampleDomain)
+        topSitesScreen.assertTopSiteDoesNotExist(named: TestLabels.exampleDomain)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306841

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrintTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrintTests.swift
@@ -13,7 +13,7 @@ class PrintTests: BaseTestCase {
     }
 
     private func openUrlAndValidatePrintOptions() {
-        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaBook))
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         navigator.goto(BrowserTabMenuMore)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -5,11 +5,11 @@
 import XCTest
 
 let url1 = "example.com"
-let url2 = path(forTestPage: "test-mozilla-org.html")
+let url2 = path(forTestPage: TestPages.mozillaOrg)
 let url3 = path(forTestPage: TestPages.exampleHTML)
 let urlIndexedDB = path(forTestPage: "test-indexeddb-private.html")
 
-let url1And3Label = "Example Domain"
+let url1And3Label = TestLabels.exampleDomain
 let url2Label = "Mozilla - Internet for people, not profit (US)"
 let url3Label = "Internet for people, not profit — Mozilla"
 
@@ -192,7 +192,7 @@ class PrivateBrowsingTest: BaseTestCase {
             app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].waitAndTap()
             navigator.nowAt(BrowserTab)
         }
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         // Wait until the page loads and go to regular browser
         waitUntilPageLoad()
         waitForTabsButton()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
@@ -26,7 +26,7 @@ class ReadingListTests: FeatureFlaggedTestBase {
         app.launch()
         navigator.nowAt(HomePanelsScreen)
         navigator.goto(URLBarOpen)
-        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaBook))
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         readingListScreen.assertFennecAlertNotExists()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReportSiteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReportSiteTests.swift
@@ -28,7 +28,7 @@ class ReportSiteTests: FeatureFlaggedTestBase {
     func launchAndGoToMenu() {
         app.launch()
         
-        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaBook))
         navigator.goto(ToolsBrowserTabMenu)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -231,7 +231,7 @@ class SearchTests: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2436091
     func testSearchWithFirefoxOption() {
         app.launch()
-        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaBook))
         waitUntilPageLoad()
         mozWaitForElementToExist(app.webViews.staticTexts["cloud"])
         // Select some text and long press to find the option
@@ -342,7 +342,7 @@ class SearchTests: FeatureFlaggedTestBase {
             throw XCTSkip("Test fails intermittently for iOS 15")
         }
         // Go to localhost website and check the page displays correctly
-        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        navigator.openURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
         waitUntilPageLoad()
         // Open new tab
         validateSearchSuggestionText(typeText: "localhost")
@@ -390,7 +390,7 @@ class SearchTests: FeatureFlaggedTestBase {
             validateUrlHasFocusAndKeyboardIsDisplayed()
 
             // Open a website
-            navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+            navigator.openURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
 
             // The keyboard is dismissed and page is correctly loaded
             let keyboardCount = app.keyboards.count
@@ -466,7 +466,7 @@ class SearchTests: FeatureFlaggedTestBase {
 
         // Bookmark The Book of Mozilla (on localhost)
         navigator.createNewTab()
-        navigator.openURL("localhost:\(serverPort)/test-fixture/test-mozilla-book.html")
+        navigator.openURL("localhost:\(serverPort)/test-fixture/\(TestPages.mozillaBook)")
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         navigator.goto(BrowserTabMenu)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
@@ -90,7 +90,7 @@ struct BrowserSelectors: BrowserSelectorsSet {
     )
 
     let STATIC_TEXT_EXAMPLE_DOMAIN = Selector.staticTextByExactLabel(
-        "Example Domain",
+        TestLabels.exampleDomain,
         description: "Static text 'Example Domain'",
         groups: ["browser"]
     )

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/PhotonActionSheetSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/PhotonActionSheetSelectors.swift
@@ -25,7 +25,7 @@ struct PhotonActionSheetSelectors: PhotonActionSheetSelectorsSet {
     private enum IDs {
         static let settingsMenuButton = AccessibilityIdentifiers.Toolbar.settingsMenuButton
         static let photonActionSheetNavigationBar = "UIActivityContentView"
-        static let photonActionSheetWebsiteTitle = "Example Domain"
+        static let photonActionSheetWebsiteTitle = TestLabels.exampleDomain
         static let photonActionSheetWebsiteURL = "example.com"
         static let photonActionSheetCopyButton = "Copy"
         static let shareView = "ShareTo.ShareView"

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -221,7 +221,7 @@ class SettingsTests: FeatureFlaggedTestBase {
     func testSummarizeContentSettingsWithToggleOnOff_hostedSummarizeExperimentOn() {
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "hosted-summarizer-feature")
         app.launch()
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         navigator.nowAt(BrowserTab)
         navigator.goto(BrowserTabMenu)
         let summarizeContentMenuOption = app.tables.cells[AccessibilityIdentifiers.MainMenu.summarizePage]

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
@@ -248,7 +248,7 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
         navigator.goto(LibraryPanel_Bookmarks)
         // Long-press on a bookmarked website
         let contextMenu = app.tables["Context Menu"]
-        app.tables.cells.staticTexts["Example Domain"].pressWithRetry(duration: 1.5, element: contextMenu)
+        app.tables.cells.staticTexts[TestLabels.exampleDomain].pressWithRetry(duration: 1.5, element: contextMenu)
         // Tap the Share button in the context menu
         contextMenu.buttons["shareLarge"].waitAndTap()
         // Tap the Reminders button in the menu

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
@@ -128,7 +128,7 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
             waitForElementsToExist(
                 [
                     app.navigationBars["Reminders"],
-                    app.links.elementContainingText("test-mozilla-book.html")
+                    app.links.elementContainingText(TestPages.mozillaBook)
                 ]
             )
         }
@@ -158,7 +158,7 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
         app.launch()
         longPressReadingListAndReachShareOptions(option: "Copy")
         app.buttons["Done"].waitAndTap()
-        openNewTabAndValidateURLisPaste(url: "test-mozilla-book.html")
+        openNewTabAndValidateURLisPaste(url: TestPages.mozillaBook)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864476
@@ -198,7 +198,7 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
     }
 
     private func longPressReadingListAndReachShareOptions(option: String) {
-        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaBook))
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
@@ -66,7 +66,7 @@ class ShareMenuTests: BaseTestCase {
             waitForElementsToExist(
                 [
                     app.navigationBars["Reminders"],
-                    app.links.elementContainingText("test-mozilla-book.html")
+                    app.links.elementContainingText(TestPages.mozillaBook)
                 ]
             )
         }
@@ -81,7 +81,7 @@ class ShareMenuTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2864079
     func testShareWebsiteReaderModeCopy() {
         reachReaderModeShareMenuLayoutAndSelectOption(option: "Copy")
-        openNewTabAndValidateURLisPaste(url: "test-mozilla-book.html")
+        openNewTabAndValidateURLisPaste(url: TestPages.mozillaBook)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864080
@@ -153,7 +153,7 @@ class ShareMenuTests: BaseTestCase {
     }
 
     private func reachReaderModeShareMenuLayoutAndSelectOption(option: String) {
-        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaBook))
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -71,7 +71,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
             waitForElementsToExist(
                 [
                     app.navigationBars["Reminders"],
-                    app.links.elementContainingText("test-mozilla-book.html")
+                    app.links.elementContainingText(TestPages.mozillaBook)
                 ]
             )
         }
@@ -94,7 +94,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
         app.launchArguments.append(LaunchArguments.SkipAppleIntelligence)
         app.launch()
         reachReaderModeShareMenuLayoutAndSelectOption(option: "Copy")
-        openNewTabAndValidateURLisPaste(url: "test-mozilla-book.html")
+        openNewTabAndValidateURLisPaste(url: TestPages.mozillaBook)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864308
@@ -189,7 +189,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
     }
 
     private func reachReaderModeShareMenuLayoutAndSelectOption(option: String) {
-        navigator.openURL(path(forTestPage: "test-mozilla-book.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaBook))
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -361,7 +361,7 @@ class TabsTests: BaseTestCase {
         tabTrayScreen = TabTrayScreen(app: app)
 
         toolBarScreen.assertTabsButtonExists()
-        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        navigator.openURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
         waitUntilPageLoad()
 
         waitForTabsButton()
@@ -384,7 +384,7 @@ class TabsTests: BaseTestCase {
         tabTrayScreen = TabTrayScreen(app: app)
 
         toolBarScreen.assertTabsButtonExists()
-        navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        navigator.openURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
         waitUntilPageLoad()
 
         waitForTabsButton()
@@ -400,7 +400,7 @@ class TabsTests: BaseTestCase {
         /*
          // Open a few tabs
          waitForTabsButton()
-         navigator.openURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+         navigator.openURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
          waitUntilPageLoad()
          navigator.createNewTab()
          navigator.openURL("http://localhost:\(serverPort)/test-fixture/test-example.html")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -12,7 +12,7 @@ let urlValue = "mozilla.org"
 let urlValueLong = "localhost"
 
 let urlExample = path(forTestPage: TestPages.exampleHTML)
-let urlLabelExample = "Example Domain"
+let urlLabelExample = TestLabels.exampleDomain
 let urlValueExample = "example"
 let urlValueLongExample = "localhost:\(serverPort)/test-fixture/test-example.html"
 
@@ -34,7 +34,7 @@ class TabsTests: BaseTestCase {
         toolBarScreen.assertTabsButtonExists()
         navigator.goto(TabTray)
         navigator.performAction(Action.OpenNewTabFromTabTray)
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         toolBarScreen.assertTabsButtonExists()
         // The tabs counter shows the correct number
@@ -77,7 +77,7 @@ class TabsTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2354447
     func testSwitchBetweenTabs() {
         // Open two urls from tab tray and switch between them
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         waitForTabsButton()
         navigator.goto(TabTray)
@@ -121,7 +121,7 @@ class TabsTests: BaseTestCase {
          firefoxHomePageScreen = FirefoxHomePageScreen(app: app)
          tabTrayScreen = TabTrayScreen(app: app)
          // A different tab than home is open to do the proper checks
-         navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+         navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
          waitUntilPageLoad()
          toolBarScreen.assertTabsButtonExists()
          navigator.nowAt(BrowserTab)
@@ -148,7 +148,7 @@ class TabsTests: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.nowAt(BrowserTab)
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         toolBarScreen.assertTabsButtonExists()
 
@@ -173,7 +173,7 @@ class TabsTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2354579
     func testCloseAllTabs() {
         // A different tab than home is open to do the proper checks
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         waitForTabsButton()
         // Add several tabs from tab tray menu and check that the  number is correct before closing all
@@ -199,7 +199,7 @@ class TabsTests: BaseTestCase {
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
         navigator.performAction(Action.OpenNewTabFromTabTray)
         navigator.nowAt(BrowserTab)
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         waitForTabsButton()
         // Add several tabs from tab tray menu and check that the  number is correct before closing all
@@ -219,7 +219,7 @@ class TabsTests: BaseTestCase {
         XCUIDevice.shared.orientation = .landscapeLeft
         // Verify the '+' icon is shown and open a tab with it
         navigator.nowAt(BrowserTab)
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
         toolBarScreen.assertNewTabButtonExists()
 
@@ -406,7 +406,7 @@ class TabsTests: BaseTestCase {
          navigator.openURL("http://localhost:\(serverPort)/test-fixture/test-example.html")
          waitUntilPageLoad()
          navigator.createNewTab()
-         navigator.openURL("localhost:\(serverPort)/test-fixture/test-mozilla-org.html")
+         navigator.openURL("localhost:\(serverPort)/test-fixture/\(TestPages.mozillaOrg)")
          waitUntilPageLoad()
          waitForTabsButton()
          navigator.goto(TabTray)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TestConstants.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TestConstants.swift
@@ -6,4 +6,9 @@ import Foundation
 
 enum TestPages {
     static let exampleHTML = "test-example.html"
+    static let mozillaOrg = "test-mozilla-org.html"
+}
+
+enum TestLabels {
+    static let exampleDomain = "Example Domain"
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TestConstants.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TestConstants.swift
@@ -7,6 +7,9 @@ import Foundation
 enum TestPages {
     static let exampleHTML = "test-example.html"
     static let mozillaOrg = "test-mozilla-org.html"
+    static let findInPage = "find-in-page-test.html"
+    static let mozillaBook = "test-mozilla-book.html"
+    static let cookieStore = "test-cookie-store.html"
 }
 
 enum TestLabels {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -5,10 +5,10 @@
 import XCTest
 
 let website1: [String: String] = [
-    "url": path(forTestPage: "test-mozilla-org.html"),
+    "url": path(forTestPage: TestPages.mozillaOrg),
     "label": "Internet for people, not profit — Mozilla",
     "value": "localhost",
-    "longValue": "localhost:\(serverPort)/test-fixture/test-mozilla-org.html"
+    "longValue": "localhost:\(serverPort)/test-fixture/\(TestPages.mozillaOrg)"
 ]
 let website2 = path(forTestPage: TestPages.exampleHTML)
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -102,7 +102,7 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.performAction(Action.SwitchETP)
 
         // Verify it is turned off
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
 
         // The lock icon should still be there
@@ -111,7 +111,7 @@ class TrackingProtectionTests: BaseTestCase {
 
         // Switch to Private Browsing
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
-        navigator.openURL(path(forTestPage: "test-mozilla-org.html"))
+        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
 
         // Make sure TP is also there in PBM

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/UrlBarTests.swift
@@ -24,7 +24,7 @@ class UrlBarTests: BaseTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2306888
     func testNewTabUrlBar() {
         // Visit any website and select the URL bar
-        browserScreen.navigateToURL("http://localhost:\(serverPort)/test-fixture/find-in-page-test.html")
+        browserScreen.navigateToURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
         waitUntilPageLoad()
         browserScreen.tapOnAddressBar()
         // The keyboard is brought up.

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
@@ -119,7 +119,7 @@ final class ZoomingTests: BaseTestCase {
 
     // Helpers
     private func openURLAndNavigateToZoom(index: Int) {
-        let websites: [String] = ["http://localhost:\(serverPort)/test-fixture/find-in-page-test.html",
+        let websites: [String] = ["http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)",
                                   "www.mozilla.org",
                                   "www.google.com"
         ]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5224)

## :bulb: Description
Follow-up to #34088 (which established `TestConstants.swift` and `TestPages.exampleHTML`). This part continues replacing hard-coded values in the XCUITests suite with shared constants:

- Adds `mozillaOrg`, `findInPage`, `mozillaBook` and `cookieStore` to `TestLabels. Replace the respective html test pages with the constants.
- Adds a new `TestLabels` with `exampleDomain = "Example Domain"`. Replaces all occurrences.

Not included 
- The `"Bookmarks"` label
- The `localhost:\(serverPort)` URL pattern

No production code changes; tests only.

## :movie_camera: Demos

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

🤖 Generated with [Claude Code](https://claude.com/claude-code)