### PR TITLE
[no-ticket] Disable testSSL in smoke tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -403,6 +403,7 @@
         "NavigationTest\/testPopUpBlocker_TAE()",
         "NavigationTest\/testPopUpBlocker_tabTrayExperimentOff()",
         "NavigationTest\/testPopUpBlocker_tabTrayExperimentOn()",
+        "NavigationTest\/testSSL()",
         "NavigationTest\/testSSL_TAE()",
         "NavigationTest\/testScrollingBehaviorInAWebPage()",
         "NavigationTest\/testScrollsToTopWithMultipleTabs()",


### PR DESCRIPTION
## :scroll: Tickets

## :bulb: Description
`NavigationTest/testSSL()` is failing on Bitrise, but I cannot reproduce locally. Let me disable it temporarily so that other PRs can be merged.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

🤖 Generated with [Claude Code](https://claude.com/claude-code)