### PR TITLE
Refactor FXIOS-15747 [Tab manager deeplinks] Tab manager integration

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4861,6 +4861,13 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     func tabManagerDidRestoreTabs(_ tabManager: TabManager) {
+        // The deeplink-optimization restore path no longer fires `TabManagerDelegate.didAddTab` per restored tab,
+        // so `tab.tabDelegate` is never assigned during restoration otherwise.
+        if isDeeplinkOptimizationRefactorEnabled {
+            for tab in tabManager.tabs {
+                tab.tabDelegate = self
+            }
+        }
         updateTabCountUsingTabManager(tabManager)
     }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -97,6 +97,11 @@ final class TabManagerImplementation: NSObject,
         return uuid
     }
 
+    private var shouldClearPrivateTabs: Bool {
+        // FXIOS-9519: By default if no bool value is set we close the private tabs and mark it true
+        return profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs) ?? true
+    }
+
     init(profile: Profile,
          imageStore: DiskImageStore = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared,
@@ -406,13 +411,13 @@ final class TabManagerImplementation: NSObject,
         assert(Thread.isMainThread)
 
         if isDeeplinkOptimizationRefactorEnabled {
-            restoreTabsUsingRestorer()
+            startRestoreTabs()
         } else {
-            restoreTabsLegacy()
+            legacyRestoreTabs()
         }
     }
 
-    private func restoreTabsLegacy() {
+    private func legacyRestoreTabs() {
         guard !isRestoringTabs, tabs.isEmpty else {
             logger.log("No restore tabs running",
                        level: .debug,
@@ -437,15 +442,15 @@ final class TabManagerImplementation: NSObject,
         isRestoringTabs = true
         AppEventQueue.started(.tabRestoration(windowUUID))
 
-        startRestoreTabsTask()
+        startLegacyRestoreTabsTask()
     }
 
     /// Snapshot-and-merge restore path used when the deeplink-optimization refactor is enabled.
     /// Captures any pre-existing tabs (e.g. a deeplink tab added before restore ran), delegates
-    /// the actual restoration to `TabRestorer`, then merges the snapshot back at the end of the
+    /// the actual restoration to `TabRestorer`, then merges the snapshot back into the
     /// `tabs` array so deeplink tabs always land last. Guarded by `isRestoringTabs` to prevent
     /// concurrent re-entry while a restore is in flight.
-    private func restoreTabsUsingRestorer() {
+    private func startRestoreTabs() {
         guard !isRestoringTabs else {
             logger.log("Tab restore already in progress",
                        level: .debug,
@@ -471,12 +476,11 @@ final class TabManagerImplementation: NSObject,
         AppEventQueue.started(.tabRestoration(windowUUID))
 
         let preRestoreTabs = tabs
-//        tabs = [] // Laurie
         let restorer = DefaultTabRestorer(
             delegate: self,
             tabDataStore: tabDataStore,
-            shouldClearPrivateTabs: shouldClearPrivateTabs(),
-            uuid: ReservedWindowUUID(uuid: windowUUID, isNew: windowIsNew),
+            shouldClearPrivateTabs: shouldClearPrivateTabs,
+            windowIsNew: windowIsNew,
             logger: logger
         )
 
@@ -534,38 +538,18 @@ final class TabManagerImplementation: NSObject,
         }
     }
 
-    private func startRestoreTabsTask() {
+    private func startLegacyRestoreTabsTask() {
         Task { @MainActor in
             // Only attempt a tab data store fetch if we know we should have tabs on disk (ignore new windows)
             let windowData: WindowData? = windowIsNew ? nil : await tabDataStore.fetchWindowData(uuid: windowUUID)
-            buildTabRestore(window: windowData)
+            legacyBuildTabRestore(window: windowData)
             TabErrorTelemetryHelper.shared.validateTabCountAfterRestoringTabs(windowUUID)
             logger.log("Tabs restore ended after fetching window data", level: .debug, category: .tabs)
             logger.log("Normal tabs count; \(normalTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
         }
     }
 
-    private func blockPopUpDidChange() {
-        assert(Thread.isMainThread)
-        let allowPopups = !(profile.prefs.boolForKey(PrefsKeys.KeyBlockPopups) ?? true)
-        // Each tab may have its own configuration, so we should tell each of them in turn.
-        for tab in tabs {
-            tab.webView?.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
-        }
-        // The default tab configurations also need to change.
-        tabConfigurationProvider.updateAllowsPopups(allowPopups)
-    }
-
-    private func autoPlayDidChange() {
-        assert(Thread.isMainThread)
-        let mediaType = AutoplayAccessors.getMediaTypesRequiringUserActionForPlayback(profile.prefs)
-        // https://developer.apple.com/documentation/webkit/wkwebviewconfiguration
-        // The web view incorporates our configuration settings only at creation time; we cannot change
-        //  those settings dynamically later. So this change will apply to new webviews only.
-        tabConfigurationProvider.updateMediaTypesRequiringUserActionForPlayback(mediaType)
-    }
-
-    private func buildTabRestore(window: WindowData?) {
+    private func legacyBuildTabRestore(window: WindowData?) {
         defer {
             isRestoringTabs = false
             tabRestoreHasFinished = true
@@ -595,13 +579,34 @@ final class TabManagerImplementation: NSObject,
             return
         }
 
-        generateTabs(from: windowData)
+        legacyGenerateTabs(from: windowData)
         cleanUpUnusedScreenshots()
         cleanUpTabSessionData()
 
         for delegate in delegates {
             delegate.get()?.tabManagerDidRestoreTabs(self)
         }
+    }
+
+    /// Creates the webview so needs to live on the main thread
+    private func legacyGenerateTabs(from windowData: WindowData) {
+        // Clear in memory tabs for tab restore
+        tabs = [Tab]()
+        let filteredTabs = filterPrivateTabs(from: windowData,
+                                             clearPrivateTabs: shouldClearPrivateTabs)
+        var tabToSelect: Tab?
+
+        for tabData in filteredTabs {
+            let newTab = legacyConfigureNewTab(with: tabData)
+            if windowData.activeTabId == tabData.id {
+                tabToSelect = newTab
+            }
+        }
+
+        logger.log("There was \(filteredTabs.count) tabs restored",
+                   level: .debug,
+                   category: .tabs)
+        handleTabSelectionAfterRestore(tabToSelect: tabToSelect)
     }
 
     /// Applies the output of `TabRestorer` to this manager's state, merging `preRestoreTabs`
@@ -615,9 +620,14 @@ final class TabManagerImplementation: NSObject,
             AppEventQueue.completed(.tabRestoration(windowUUID))
         }
 
+        // TODO: generateEmptyTab() ?
+        // generateEmptyTab() on the no-window / no-non-private-tabs paths
+        // when result is empty
+
         tabs = result.restoredTabs + preRestoreTabs
 
         // TODO: FXIOS-15981 - Move screenshot restoration into TabRestorer
+        // This is here just for testing purposes so the feature flag is kind of in a working state
         for tab in result.restoredTabs {
             restoreScreenshot(for: tab)
         }
@@ -635,33 +645,7 @@ final class TabManagerImplementation: NSObject,
         }
     }
 
-    private func shouldClearPrivateTabs() -> Bool {
-        // FXIOS-9519: By default if no bool value is set we close the private tabs and mark it true
-        return profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs) ?? true
-    }
-
-    /// Creates the webview so needs to live on the main thread
-    private func generateTabs(from windowData: WindowData) {
-        // Clear in memory tabs for tab restore
-        tabs = [Tab]()
-        let filteredTabs = filterPrivateTabs(from: windowData,
-                                             clearPrivateTabs: shouldClearPrivateTabs())
-        var tabToSelect: Tab?
-
-        for tabData in filteredTabs {
-            let newTab = configureNewTab(with: tabData)
-            if windowData.activeTabId == tabData.id {
-                tabToSelect = newTab
-            }
-        }
-
-        logger.log("There was \(filteredTabs.count) tabs restored",
-                   level: .debug,
-                   category: .tabs)
-        handleTabSelectionAfterRestore(tabToSelect: tabToSelect)
-    }
-
-    private func configureNewTab(with tabData: TabData) -> Tab? {
+    private func legacyConfigureNewTab(with tabData: TabData) -> Tab? {
         let newTab: Tab
         newTab = addTab(flushToDisk: false, zombie: true, isPrivate: tabData.isPrivate)
         newTab.url = URL(string: tabData.siteUrl)
@@ -764,6 +748,26 @@ final class TabManagerImplementation: NSObject,
         }
     }
 
+    private func blockPopUpDidChange() {
+        assert(Thread.isMainThread)
+        let allowPopups = !(profile.prefs.boolForKey(PrefsKeys.KeyBlockPopups) ?? true)
+        // Each tab may have its own configuration, so we should tell each of them in turn.
+        for tab in tabs {
+            tab.webView?.configuration.preferences.javaScriptCanOpenWindowsAutomatically = allowPopups
+        }
+        // The default tab configurations also need to change.
+        tabConfigurationProvider.updateAllowsPopups(allowPopups)
+    }
+
+    private func autoPlayDidChange() {
+        assert(Thread.isMainThread)
+        let mediaType = AutoplayAccessors.getMediaTypesRequiringUserActionForPlayback(profile.prefs)
+        // https://developer.apple.com/documentation/webkit/wkwebviewconfiguration
+        // The web view incorporates our configuration settings only at creation time; we cannot change
+        //  those settings dynamically later. So this change will apply to new webviews only.
+        tabConfigurationProvider.updateMediaTypesRequiringUserActionForPlayback(mediaType)
+    }
+
     // MARK: - Redux
     @MainActor
     private func dispatchDidSetScreenshotAction(for tab: Tab) {
@@ -808,7 +812,7 @@ final class TabManagerImplementation: NSObject,
 
     private func generateTabDataForSaving() -> [TabData] {
         var tabsToSave = tabs
-        if shouldClearPrivateTabs() {
+        if shouldClearPrivateTabs {
             tabsToSave = normalTabs
         }
 
@@ -900,7 +904,7 @@ final class TabManagerImplementation: NSObject,
         willSelectTab(url)
 
         // Make sure to wipe the private tabs if the user has the pref turned on and there are private tabs to remove
-        if shouldClearPrivateTabs(), !tab.isPrivate && !privateTabs.isEmpty {
+        if shouldClearPrivateTabs, !tab.isPrivate && !privateTabs.isEmpty {
             removeAllPrivateTabs()
         }
 

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -628,6 +628,11 @@ final class TabManagerImplementation: NSObject,
             restoreScreenshot(for: tab)
         }
 
+        // Notify delegates of tabs restore before selecting a tab due to tab.tabDelegate assignment
+        for delegate in delegates {
+            delegate.get()?.tabManagerDidRestoreTabs(self)
+        }
+
         let tabToSelect: Tab? = result.selectedTabUUID.flatMap { uuid in
             result.restoredTabs.first(where: { $0.tabUUID == uuid })
         }
@@ -635,10 +640,6 @@ final class TabManagerImplementation: NSObject,
 
         cleanUpUnusedScreenshots()
         cleanUpTabSessionData()
-
-        for delegate in delegates {
-            delegate.get()?.tabManagerDidRestoreTabs(self)
-        }
     }
 
     private func legacyConfigureNewTab(with tabData: TabData) -> Tab? {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -14,7 +14,10 @@ enum SwitchPrivacyModeResult {
     case usedExistingTab
 }
 
-final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
+final class TabManagerImplementation: NSObject,
+                                      TabManager,
+                                      FeatureFlaggable,
+                                      TabRestorerDelegate {
     let windowUUID: WindowUUID
 
     var tabEventWindowResponseType: TabEventHandlerWindowResponseType { return .singleWindow(windowUUID) }
@@ -402,6 +405,14 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
     func restoreTabs() {
         assert(Thread.isMainThread)
 
+        if isDeeplinkOptimizationRefactorEnabled {
+            restoreTabsUsingRestorer()
+        } else {
+            restoreTabsLegacy()
+        }
+    }
+
+    private func restoreTabsLegacy() {
         guard !isRestoringTabs, tabs.isEmpty else {
             logger.log("No restore tabs running",
                        level: .debug,
@@ -427,6 +438,57 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         AppEventQueue.started(.tabRestoration(windowUUID))
 
         startRestoreTabsTask()
+    }
+
+    /// Snapshot-and-merge restore path used when the deeplink-optimization refactor is enabled.
+    /// Captures any pre-existing tabs (e.g. a deeplink tab added before restore ran), delegates
+    /// the actual restoration to `TabRestorer`, then merges the snapshot back at the end of the
+    /// `tabs` array so deeplink tabs always land last. Guarded by `isRestoringTabs` to prevent
+    /// concurrent re-entry while a restore is in flight.
+    private func restoreTabsUsingRestorer() {
+        guard !isRestoringTabs else {
+            logger.log("Tab restore already in progress",
+                       level: .debug,
+                       category: .tabs)
+            return
+        }
+
+        logger.log("Tabs restore started using TabRestorer; pre-restore tab count: \(tabs.count), crashed at last launch is \(logger.crashedLastLaunch)",
+                   level: .debug,
+                   category: .tabs)
+
+        guard !AppConstants.isRunningUITests,
+              !DebugSettingsBundleOptions.skipSessionRestore
+        else {
+            if tabs.isEmpty {
+                let newTab = addTab()
+                selectTab(newTab)
+            }
+            return
+        }
+
+        isRestoringTabs = true
+        AppEventQueue.started(.tabRestoration(windowUUID))
+
+        let preRestoreTabs = tabs
+//        tabs = [] // Laurie
+        let restorer = DefaultTabRestorer(
+            delegate: self,
+            tabDataStore: tabDataStore,
+            shouldClearPrivateTabs: shouldClearPrivateTabs(),
+            uuid: ReservedWindowUUID(uuid: windowUUID, isNew: windowIsNew),
+            logger: logger
+        )
+
+        Task { @MainActor in
+            let result = await restorer.restoreTabs(for: windowUUID)
+            applyRestorationResult(result, preRestoreTabs: preRestoreTabs)
+            TabErrorTelemetryHelper.shared.validateTabCountAfterRestoringTabs(windowUUID)
+            logger.log("Tabs restore ended using TabRestorer", level: .debug, category: .tabs)
+            logger.log("Normal tabs count; \(normalTabs.count), Private tabs count; \(privateTabs.count)",
+                       level: .debug,
+                       category: .tabs)
+        }
     }
 
     private func updateSelectedTabAfterRemovalOf(_ removedTab: Tab, deletedIndex: Int) {
@@ -542,6 +604,37 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
     }
 
+    /// Applies the output of `TabRestorer` to this manager's state, merging `preRestoreTabs`
+    /// (tabs added before restoration ran, e.g. a deeplink tab) at the end of the array so they
+    /// always land last. Picks a selected tab from the restoration result when available, falling
+    /// back to the most recent normal tab or a freshly created one.
+    private func applyRestorationResult(_ result: TabRestorationResult, preRestoreTabs: [Tab]) {
+        defer {
+            isRestoringTabs = false
+            tabRestoreHasFinished = true
+            AppEventQueue.completed(.tabRestoration(windowUUID))
+        }
+
+        tabs = result.restoredTabs + preRestoreTabs
+
+        // TODO: FXIOS-15981 - Move screenshot restoration into TabRestorer
+        for tab in result.restoredTabs {
+            restoreScreenshot(for: tab)
+        }
+
+        let tabToSelect: Tab? = result.selectedTabUUID.flatMap { uuid in
+            result.restoredTabs.first(where: { $0.tabUUID == uuid })
+        }
+        handleTabSelectionAfterRestore(tabToSelect: tabToSelect)
+
+        cleanUpUnusedScreenshots()
+        cleanUpTabSessionData()
+
+        for delegate in delegates {
+            delegate.get()?.tabManagerDidRestoreTabs(self)
+        }
+    }
+
     private func shouldClearPrivateTabs() -> Bool {
         // FXIOS-9519: By default if no bool value is set we close the private tabs and mark it true
         return profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs) ?? true
@@ -593,7 +686,7 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
 
         // Restore screenshot
-        restoreScreenshot(tab: newTab)
+        restoreScreenshot(for: newTab)
         return newTab
     }
 
@@ -612,6 +705,37 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         }
     }
 
+    /// Builds a zombie `Tab` from persisted `TabData` without mutating `tabs` or notifying delegates.
+    /// Used by `TabRestorer` through `TabRestorerDelegate` in the deeplink-optimization restore path;
+    /// the returned tabs are collected into a `TabRestorationResult` and applied via `applyRestorationResult`.
+    func createTab(with tabData: TabData) -> Tab {
+        let tab = Tab(profile: profile, isPrivate: tabData.isPrivate, windowUUID: windowUUID)
+        tab.url = URL(string: tabData.siteUrl)
+        tab.lastTitle = tabData.title
+        tab.tabUUID = tabData.id.uuidString
+        tab.screenshotUUID = tabData.id
+        tab.firstCreatedTime = tabData.createdAtTime.toTimestamp()
+        tab.lastExecutedTime = tabData.lastUsedTime.toTimestamp()
+        if let documentSession = tabData.temporaryDocumentSession {
+            tab.restoreTemporaryDocumentSession(documentSession)
+        }
+        tab.navigationDelegate = navigationDelegate
+        tab.nightMode = NightModeHelper.isActivated()
+        tab.noImageMode = NoImageModeHelper.isActivated(profile.prefs)
+
+        if tab.url == nil {
+            logger.log("Tab restored has empty URL",
+                       level: .debug,
+                       category: .tabs,
+                       extra: [
+                        "tabID": tabData.id.uuidString,
+                        "lastUsedTime": tabData.lastUsedTime.description
+                       ])
+        }
+
+        return tab
+    }
+
     private func filterPrivateTabs(from windowData: WindowData, clearPrivateTabs: Bool) -> [TabData] {
         var savedTabs = windowData.tabData
         if clearPrivateTabs {
@@ -626,7 +750,7 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
         selectTab(newTab)
     }
 
-    private func restoreScreenshot(tab: Tab) {
+    func restoreScreenshot(for tab: Tab) {
         Task { [weak tab, weak self] in
             guard let tab else { return }
             do {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -432,10 +432,7 @@ final class TabManagerImplementation: NSObject,
         guard !AppConstants.isRunningUITests,
               !DebugSettingsBundleOptions.skipSessionRestore
         else {
-            if tabs.isEmpty {
-                let newTab = addTab()
-                selectTab(newTab)
-            }
+            ensureAtLeastOneSelectedTab()
             return
         }
 
@@ -451,9 +448,9 @@ final class TabManagerImplementation: NSObject,
     /// `tabs` array so deeplink tabs always land last. Guarded by `isRestoringTabs` to prevent
     /// concurrent re-entry while a restore is in flight.
     private func startRestoreTabs() {
-        guard !isRestoringTabs else {
-            logger.log("Tab restore already in progress",
-                       level: .debug,
+        guard !isRestoringTabs, !tabRestoreHasFinished else {
+            logger.log("Tab restore already in progress or has already been ran.",
+                       level: .warning,
                        category: .tabs)
             return
         }
@@ -465,10 +462,7 @@ final class TabManagerImplementation: NSObject,
         guard !AppConstants.isRunningUITests,
               !DebugSettingsBundleOptions.skipSessionRestore
         else {
-            if tabs.isEmpty {
-                let newTab = addTab()
-                selectTab(newTab)
-            }
+            ensureAtLeastOneSelectedTab()
             return
         }
 
@@ -493,6 +487,12 @@ final class TabManagerImplementation: NSObject,
                        level: .debug,
                        category: .tabs)
         }
+    }
+
+    private func ensureAtLeastOneSelectedTab() {
+        guard tabs.isEmpty else { return }
+        let newTab = addTab()
+        selectTab(newTab)
     }
 
     private func updateSelectedTabAfterRemovalOf(_ removedTab: Tab, deletedIndex: Int) {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -561,7 +561,7 @@ final class TabManagerImplementation: NSObject,
         guard let windowData = window else {
             // Always make sure there is a single normal tab
             // Note: this is where the first tab in a newly-created browser window will be added
-            generateEmptyTab()
+            legacyGenerateEmptyTab()
             logger.log("Not restoring tabs because there is no window data.",
                        level: .warning,
                        category: .tabs)
@@ -572,7 +572,7 @@ final class TabManagerImplementation: NSObject,
               !nonPrivateTabs.isEmpty else {
             // Always make sure there is a single normal tab
             // Note: this is where the first tab in a newly-created browser window will be added
-            generateEmptyTab()
+            legacyGenerateEmptyTab()
             logger.log("Not restoring tabs because there is no tab data on the window data.",
                        level: .warning,
                        category: .tabs)
@@ -592,8 +592,8 @@ final class TabManagerImplementation: NSObject,
     private func legacyGenerateTabs(from windowData: WindowData) {
         // Clear in memory tabs for tab restore
         tabs = [Tab]()
-        let filteredTabs = filterPrivateTabs(from: windowData,
-                                             clearPrivateTabs: shouldClearPrivateTabs)
+        let filteredTabs = legacyFilterPrivateTabs(from: windowData,
+                                                   clearPrivateTabs: shouldClearPrivateTabs)
         var tabToSelect: Tab?
 
         for tabData in filteredTabs {
@@ -619,10 +619,6 @@ final class TabManagerImplementation: NSObject,
             tabRestoreHasFinished = true
             AppEventQueue.completed(.tabRestoration(windowUUID))
         }
-
-        // TODO: generateEmptyTab() ?
-        // generateEmptyTab() on the no-window / no-non-private-tabs paths
-        // when result is empty
 
         tabs = result.restoredTabs + preRestoreTabs
 
@@ -708,19 +704,21 @@ final class TabManagerImplementation: NSObject,
         tab.noImageMode = NoImageModeHelper.isActivated(profile.prefs)
 
         if tab.url == nil {
-            logger.log("Tab restored has empty URL",
-                       level: .debug,
-                       category: .tabs,
-                       extra: [
-                        "tabID": tabData.id.uuidString,
-                        "lastUsedTime": tabData.lastUsedTime.description
-                       ])
+            logger.log(
+                "Tab restored has empty URL",
+                level: .debug,
+                category: .tabs,
+                extra: [
+                    "tabID": tabData.id.uuidString,
+                    "lastUsedTime": tabData.lastUsedTime.description
+                ]
+            )
         }
 
         return tab
     }
 
-    private func filterPrivateTabs(from windowData: WindowData, clearPrivateTabs: Bool) -> [TabData] {
+    private func legacyFilterPrivateTabs(from windowData: WindowData, clearPrivateTabs: Bool) -> [TabData] {
         var savedTabs = windowData.tabData
         if clearPrivateTabs {
             savedTabs = windowData.tabData.filter { !$0.isPrivate }
@@ -729,7 +727,7 @@ final class TabManagerImplementation: NSObject,
     }
 
     /// Creates the webview so needs to live on the main thread
-    private func generateEmptyTab() {
+    private func legacyGenerateEmptyTab() {
         let newTab = addTab()
         selectTab(newTab)
     }
@@ -747,6 +745,8 @@ final class TabManagerImplementation: NSObject,
             await MainActor.run { [weak self] in self?.dispatchDidSetScreenshotAction(for: tab) }
         }
     }
+
+    // MARK: - Configuration
 
     private func blockPopUpDidChange() {
         assert(Thread.isMainThread)

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -642,32 +642,34 @@ final class TabManagerImplementation: NSObject,
     }
 
     private func legacyConfigureNewTab(with tabData: TabData) -> Tab? {
-        let newTab: Tab
-        newTab = addTab(flushToDisk: false, zombie: true, isPrivate: tabData.isPrivate)
-        newTab.url = URL(string: tabData.siteUrl)
-        newTab.lastTitle = tabData.title
-        newTab.tabUUID = tabData.id.uuidString
-        newTab.screenshotUUID = tabData.id
-        newTab.firstCreatedTime = tabData.createdAtTime.toTimestamp()
-        newTab.lastExecutedTime = tabData.lastUsedTime.toTimestamp()
+        let newTab = addTab(flushToDisk: false, zombie: true, isPrivate: tabData.isPrivate)
+        populateTab(newTab, from: tabData)
+        restoreScreenshot(for: newTab)
+        return newTab
+    }
+
+    /// Copies persisted `TabData` onto a `Tab`. Shared by the legacy restore path (after `addTab`)
+    /// and the deeplink-optimization restore path (after a bare `Tab` init in `createTab`).
+    private func populateTab(_ tab: Tab, from tabData: TabData) {
+        tab.url = URL(string: tabData.siteUrl)
+        tab.lastTitle = tabData.title
+        tab.tabUUID = tabData.id.uuidString
+        tab.screenshotUUID = tabData.id
+        tab.firstCreatedTime = tabData.createdAtTime.toTimestamp()
+        tab.lastExecutedTime = tabData.lastUsedTime.toTimestamp()
         if let documentSession = tabData.temporaryDocumentSession {
-            newTab.restoreTemporaryDocumentSession(documentSession)
+            tab.restoreTemporaryDocumentSession(documentSession)
         }
 
-        if newTab.url == nil {
+        if tab.url == nil {
             logger.log("Tab restored has empty URL",
                        level: .debug,
                        category: .tabs,
                        extra: [
                         "tabID": tabData.id.uuidString,
                         "lastUsedTime": tabData.lastUsedTime.description
-                       ]
-            )
+                       ])
         }
-
-        // Restore screenshot
-        restoreScreenshot(for: newTab)
-        return newTab
     }
 
     private func handleTabSelectionAfterRestore(tabToSelect: Tab?) {
@@ -690,31 +692,12 @@ final class TabManagerImplementation: NSObject,
     /// the returned tabs are collected into a `TabRestorationResult` and applied via `applyRestorationResult`.
     func createTab(with tabData: TabData) -> Tab {
         let tab = Tab(profile: profile, isPrivate: tabData.isPrivate, windowUUID: windowUUID)
-        tab.url = URL(string: tabData.siteUrl)
-        tab.lastTitle = tabData.title
-        tab.tabUUID = tabData.id.uuidString
-        tab.screenshotUUID = tabData.id
-        tab.firstCreatedTime = tabData.createdAtTime.toTimestamp()
-        tab.lastExecutedTime = tabData.lastUsedTime.toTimestamp()
-        if let documentSession = tabData.temporaryDocumentSession {
-            tab.restoreTemporaryDocumentSession(documentSession)
-        }
+        populateTab(tab, from: tabData)
+        // Setting those here since `configureTab` applies those on the legacy path. Inlined here because the
+        // deeplink-optimization path intentionally bypasses `addTab` / `configureTab`.
         tab.navigationDelegate = navigationDelegate
         tab.nightMode = NightModeHelper.isActivated()
         tab.noImageMode = NoImageModeHelper.isActivated(profile.prefs)
-
-        if tab.url == nil {
-            logger.log(
-                "Tab restored has empty URL",
-                level: .debug,
-                category: .tabs,
-                extra: [
-                    "tabID": tabData.id.uuidString,
-                    "lastUsedTime": tabData.lastUsedTime.description
-                ]
-            )
-        }
-
         return tab
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
@@ -745,6 +745,22 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, .navigationButtonDoubleTapped)
     }
 
+    // MARK: - Tab manager restore
+
+    @MainActor
+    func testTabManagerDidRestoreTabs_withDeeplinkFlagEnabled_assignsTabDelegateForAllTabs() {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        let subject = createSubject()
+        let tab1 = Tab(profile: profile, windowUUID: .XCTestDefaultUUID)
+        let tab2 = Tab(profile: profile, windowUUID: .XCTestDefaultUUID)
+        tabManager.tabs = [tab1, tab2]
+
+        subject.tabManagerDidRestoreTabs(tabManager)
+
+        XCTAssertTrue(tab1.tabDelegate === subject)
+        XCTAssertTrue(tab2.tabDelegate === subject)
+    }
+
     // MARK: - Private
 
     private func createSubject(file: StaticString = #filePath,
@@ -777,6 +793,12 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
     private func setIsHostedSummarizerEnabled(_ isEnabled: Bool) {
         FxNimbus.shared.features.hostedSummarizerFeature.with { _, _ in
             return HostedSummarizerFeature()
+        }
+    }
+
+    private func setIsDeeplinkOptimizationRefactorEnabled(_ isEnabled: Bool) {
+        FxNimbus.shared.features.deeplinkOptimizationRefactorFeature.with { _, _ in
+            return DeeplinkOptimizationRefactorFeature(enabled: isEnabled)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerRestoreTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerRestoreTabsTests.swift
@@ -31,5 +31,132 @@ final class TabManagerRestoreTabsTests: TabManagerTestsBase {
         wait(for: [expectation])
     }
 
-    // TODO: FXIOS-15742 - Add tests as part of the deeplink improvements refactor
+    // MARK: - Deeplink-optimization refactor path (snapshot-and-merge)
+
+    @MainActor
+    func testRestoreTabs_withDeeplinkFlagEnabled_restoresPersistedTabs() {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        let testUUID = UUID()
+        let subject = createSubject(windowUUID: testUUID)
+        let expectation = XCTestExpectation(description: "Tab restoration event should have been called")
+        mockTabStore.fetchTabWindowData = WindowData(id: UUID(),
+                                                     activeTabId: UUID(),
+                                                     tabData: getMockTabData(count: 3))
+
+        subject.restoreTabs()
+
+        AppEventQueue.wait(for: .tabRestoration(testUUID)) { [mockTabStore] in
+            ensureMainThread {
+                XCTAssertEqual(subject.tabs.count, 3)
+                XCTAssertEqual(mockTabStore?.fetchWindowDataCalledCount, 1)
+                XCTAssertTrue(subject.tabRestoreHasFinished)
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation])
+    }
+
+    @MainActor
+    func testRestoreTabs_withDeeplinkFlagEnabled_mergesPreRestoreTabsAtEndOfArray() {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        let testUUID = UUID()
+        // Simulate a deeplink tab added before restore ran.
+        let deeplinkTabs = generateTabs(ofType: .normal, count: 1)
+        let subject = createSubject(tabs: deeplinkTabs, windowUUID: testUUID)
+        let expectation = XCTestExpectation(description: "Tab restoration event should have been called")
+        mockTabStore.fetchTabWindowData = WindowData(id: UUID(),
+                                                     activeTabId: UUID(),
+                                                     tabData: getMockTabData(count: 2))
+
+        subject.restoreTabs()
+
+        AppEventQueue.wait(for: .tabRestoration(testUUID)) {
+            ensureMainThread {
+                XCTAssertEqual(subject.tabs.count, 3, "2 restored + 1 pre-restore deeplink tab")
+                XCTAssertIdentical(subject.tabs.last, deeplinkTabs.first, "Deeplink tab should land at the end")
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation])
+    }
+
+    @MainActor
+    func testRestoreTabs_withDeeplinkFlagEnabled_isOneShotPerSession() {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        let testUUID = UUID()
+        let subject = createSubject(windowUUID: testUUID)
+        let expectation = XCTestExpectation(description: "Tab restoration event should have been called")
+        mockTabStore.fetchTabWindowData = WindowData(id: UUID(),
+                                                     activeTabId: UUID(),
+                                                     tabData: getMockTabData(count: 2))
+
+        subject.restoreTabs()
+        // Second call must be a no-op even though tabs are no longer empty post-restore.
+        subject.restoreTabs()
+
+        AppEventQueue.wait(for: .tabRestoration(testUUID)) { [mockTabStore] in
+            ensureMainThread {
+                XCTAssertEqual(mockTabStore?.fetchWindowDataCalledCount,
+                               1,
+                               "Data store should be fetched at most once per session")
+                XCTAssertEqual(subject.tabs.count, 2)
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation])
+    }
+
+    @MainActor
+    func testRestoreTabs_withDeeplinkFlagEnabled_selectsActiveTabFromRestorationResult() {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        let testUUID = UUID()
+        let subject = createSubject(windowUUID: testUUID)
+        let expectation = XCTestExpectation(description: "Tab restoration event should have been called")
+
+        let activeId = UUID()
+        let tabData = getMockTabData(count: 3)
+        var taggedTabData = tabData
+        taggedTabData[1] = TabData(id: activeId,
+                                   title: tabData[1].title,
+                                   siteUrl: tabData[1].siteUrl,
+                                   faviconURL: tabData[1].faviconURL,
+                                   isPrivate: false,
+                                   lastUsedTime: tabData[1].lastUsedTime,
+                                   createdAtTime: tabData[1].createdAtTime,
+                                   temporaryDocumentSession: tabData[1].temporaryDocumentSession)
+        mockTabStore.fetchTabWindowData = WindowData(id: UUID(),
+                                                     activeTabId: activeId,
+                                                     tabData: taggedTabData)
+
+        subject.restoreTabs()
+
+        AppEventQueue.wait(for: .tabRestoration(testUUID)) {
+            ensureMainThread {
+                XCTAssertEqual(subject.selectedTab?.tabUUID, activeId.uuidString)
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation])
+    }
+
+    @MainActor
+    func testRestoreTabs_withDeeplinkFlagEnabled_createsNewTabWhenNothingToRestore() {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        let testUUID = UUID()
+        let subject = createSubject(windowUUID: testUUID)
+        let expectation = XCTestExpectation(description: "Tab restoration event should have been called")
+        // No persisted window data — restoration result will be empty.
+        mockTabStore.fetchTabWindowData = nil
+
+        subject.restoreTabs()
+
+        AppEventQueue.wait(for: .tabRestoration(testUUID)) {
+            ensureMainThread {
+                XCTAssertEqual(subject.tabs.count, 1, "Should fall back to creating a fresh tab")
+                XCTAssertNotNil(subject.selectedTab)
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation])
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerRestoreTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerRestoreTabsTests.swift
@@ -114,19 +114,18 @@ final class TabManagerRestoreTabsTests: TabManagerTestsBase {
         let expectation = XCTestExpectation(description: "Tab restoration event should have been called")
 
         let activeId = UUID()
-        let tabData = getMockTabData(count: 3)
-        var taggedTabData = tabData
-        taggedTabData[1] = TabData(id: activeId,
-                                   title: tabData[1].title,
-                                   siteUrl: tabData[1].siteUrl,
-                                   faviconURL: tabData[1].faviconURL,
-                                   isPrivate: false,
-                                   lastUsedTime: tabData[1].lastUsedTime,
-                                   createdAtTime: tabData[1].createdAtTime,
-                                   temporaryDocumentSession: tabData[1].temporaryDocumentSession)
+        var tabData = getMockTabData(count: 3)
+        tabData[1] = TabData(id: activeId,
+                             title: tabData[1].title,
+                             siteUrl: tabData[1].siteUrl,
+                             faviconURL: tabData[1].faviconURL,
+                             isPrivate: false,
+                             lastUsedTime: tabData[1].lastUsedTime,
+                             createdAtTime: tabData[1].createdAtTime,
+                             temporaryDocumentSession: [:])
         mockTabStore.fetchTabWindowData = WindowData(id: UUID(),
                                                      activeTabId: activeId,
-                                                     tabData: taggedTabData)
+                                                     tabData: tabData)
 
         subject.restoreTabs()
 
@@ -154,6 +153,66 @@ final class TabManagerRestoreTabsTests: TabManagerTestsBase {
             ensureMainThread {
                 XCTAssertEqual(subject.tabs.count, 1, "Should fall back to creating a fresh tab")
                 XCTAssertNotNil(subject.selectedTab)
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation])
+    }
+
+    @MainActor
+    func testRestoreTabs_withDeeplinkFlagEnabled_preservesDeeplinkWhenRestorationResultIsEmpty() {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        let testUUID = UUID()
+        let deeplinkTabs = generateTabs(ofType: .normal, count: 1)
+        let subject = createSubject(tabs: deeplinkTabs, windowUUID: testUUID)
+        let expectation = XCTestExpectation(description: "Tab restoration event should have been called")
+        // No persisted window data — restoration result will be empty, but deeplink must survive.
+        mockTabStore.fetchTabWindowData = nil
+
+        subject.restoreTabs()
+
+        AppEventQueue.wait(for: .tabRestoration(testUUID)) {
+            ensureMainThread {
+                XCTAssertEqual(subject.tabs.count, 1, "Deeplink should be preserved; no extra empty tab created")
+                XCTAssertIdentical(subject.tabs.first, deeplinkTabs.first)
+                XCTAssertIdentical(subject.selectedTab, deeplinkTabs.first, "Deeplink should be selected")
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation])
+    }
+
+    @MainActor
+    func testRestoreTabs_withDeeplinkFlagEnabled_selectsActiveRestoredTabOverDeeplink() {
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        let testUUID = UUID()
+        let deeplinkTabs = generateTabs(ofType: .normal, count: 1)
+        let subject = createSubject(tabs: deeplinkTabs, windowUUID: testUUID)
+        let expectation = XCTestExpectation(description: "Tab restoration event should have been called")
+
+        let activeId = UUID()
+        var tabData = getMockTabData(count: 3)
+        tabData[1] = TabData(id: activeId,
+                             title: tabData[1].title,
+                             siteUrl: tabData[1].siteUrl,
+                             faviconURL: tabData[1].faviconURL,
+                             isPrivate: false,
+                             lastUsedTime: tabData[1].lastUsedTime,
+                             createdAtTime: tabData[1].createdAtTime,
+                             temporaryDocumentSession: [:])
+        mockTabStore.fetchTabWindowData = WindowData(id: UUID(),
+                                                     activeTabId: activeId,
+                                                     tabData: tabData)
+
+        subject.restoreTabs()
+
+        AppEventQueue.wait(for: .tabRestoration(testUUID)) {
+            ensureMainThread {
+                XCTAssertEqual(subject.tabs.count, 4, "3 restored + 1 pre-restore deeplink tab")
+                XCTAssertEqual(subject.selectedTab?.tabUUID,
+                               activeId.uuidString,
+                               "Active restored tab should win over deeplink")
+                XCTAssertIdentical(subject.tabs.last, deeplinkTabs.first, "Deeplink should still land at the end")
                 expectation.fulfill()
             }
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15747)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33678)

## :bulb: Description
- The changes here is mostly to start using the new `TabRestorer` class into the tab manager. This PRs renames all functions that are `legacy` to `legacy` so it will be easy to know what can be cleaned up at a later point.
- Main change in this new flow is that whenever we restore tabs, we're not calling `addTab` which calls `configureTab`. We don't want to trigger that whole flow which would append tabs in the array for us. We delay that to a later point. But it did mean we needed to add a tab in the tab manager. It's now called `createTab(with:)` and the legacy equivalent one is called `legacyConfigureNewTab(with:)`
- `shouldClearPrivateTabs` was changed to be a variable instead of a function. Just makes more sense to me that way.

### What's missing still
- The current code path still uses the `.tabRestoration(windowUUID)` app event as-is out of simplicity. I have a follow-up task to investigate what can be improved there with the deeplink feature flag path (so we don't wait for the tab restoration before making certain actions in our code). Unit tests also depend on `.tabRestoration`, I want to look at that in there.
- Screenshots restore changes, this will be done in subsequent tasks
- `restoreScreenshot` isn't private anymore since it's called from the new delegate `TabRestorerDelegate`

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

