### PR TITLE
Refactor FXIOS [Stale bot] Stale bot does not stale Contributor ok tickets anymore

### DIFF
--- a/.github/workflows/firefox-ios-stale.yml
+++ b/.github/workflows/firefox-ios-stale.yml
@@ -42,7 +42,7 @@ jobs:
           close-issue-reason: not_planned
 
           # Labels on issues exempted from stale
-          exempt-issue-labels: "do not stale,Feature-Request"
+          exempt-issue-labels: "do not stale,Feature-Request,Contributor OK"
 
           # Label to apply on staled issues
           stale-issue-label: "stale"


### PR DESCRIPTION
## :scroll: Tickets
No tickets

## :bulb: Description
As discussed, we want contributor OK tickets not to be staled for now. 

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

