### PR TITLE
[MTE-5442] - multiple fixes for flaky tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -217,6 +217,22 @@ class BaseTestCase: XCTestCase {
         }
     }
 
+    /// Polls `condition` until it returns true or `timeout` elapses, sleeping briefly between checks.
+    /// Useful when a screen keeps updating after its first element appears (e.g. a collection view
+    /// still populating cells). Unlike the `mozWaitFor*` helpers, it does not assert on timeout;
+    /// it returns whether the condition was met so the caller can decide how to react.
+    @discardableResult
+    func waitForCondition(timeout: TimeInterval = TIMEOUT, _ condition: () -> Bool) -> Bool {
+        let startTime = Date()
+        while !condition() {
+            if Date().timeIntervalSince(startTime) > timeout {
+                return false
+            }
+            usleep(10000) // waits for 0.01 seconds
+        }
+        return true
+    }
+
     func waitForValueContains(_ element: XCUIElement, value: String, file: String = #filePath, line: UInt = #line) {
         waitFor(element, with: "value CONTAINS '\(value)'", file: file, line: line)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -199,6 +199,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3936976
+    // Smoketest
     func testSearchBookmarkIconDisplay() throws {
         if !isFennec {
             throw XCTSkip("Skipping test because bookmark search bar is off on Firefox")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -619,8 +619,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
         }
         springBoardScreen.tapNewPrivateButton()
         onboardingScreen.handleTermsOfService()
-        onboardingScreen.waitForCurrentScreenElements(waitForImage: false)
-        onboardingScreen.closeTourIfNeeded()
+        onboardingScreen.closeTour()
         browserScreen.assertPrivateModeMessageCardExists()
         navigator.openURL(website_1["url"]!)
         waitUntilPageLoad()
@@ -663,8 +662,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
 
         // Close onboarding if it appears
         onboardingScreen.handleTermsOfService()
-        onboardingScreen.waitForCurrentScreenElements(waitForImage: false)
-        onboardingScreen.closeTourIfNeeded()
+        onboardingScreen.closeTour()
 
         // Verify the bookmarked page opens
         waitUntilPageLoad()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/OnboardingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/OnboardingScreen.swift
@@ -104,8 +104,16 @@ final class OnboardingScreen {
     /// Handles the initial ToS screen based on app channel (Firefox Beta, Firefox, Fennec). ToS must be accepted before the
     /// onboarding flow begins.
     func handleTermsOfService() {
-        BaseTestCase().mozWaitForElementToExist(tosContinueButton, timeout: TIMEOUT_LONG)
-        tosContinueButton.tap()
+        let continueButton = tosContinueButton
+        BaseTestCase().mozWaitForElementToExist(continueButton, timeout: TIMEOUT_LONG)
+        // The ToS is presented over full screen with a cross-dissolve transition, so the button
+        // can exist before it is hittable and an early tap gets absorbed. Wait for it to be
+        // hittable, then tap again if the screen has not advanced past the button.
+        BaseTestCase().mozWaitElementHittable(element: continueButton, timeout: TIMEOUT)
+        continueButton.tap()
+        if continueButton.exists {
+            continueButton.tap()
+        }
     }
 
     func assertContinueButtonIsOnTheBottom() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
@@ -50,6 +50,9 @@ final class TabTrayScreen {
     func assertTabCount(_ expected: Int, file: StaticString = #filePath, line: UInt = #line) {
         let cells = collectionView.cells
         BaseTestCase().mozWaitForElementToExist(cells.firstMatch)
+        // The tab tray may still be populating after the first cell appears, so poll
+        // until the expected number of cells is rendered (bounded by TIMEOUT) before asserting.
+        BaseTestCase().waitForCondition { cells.count == expected }
         XCTAssertEqual(cells.count, expected, "The number of tabs is not correct", file: file, line: line)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5442

## :bulb: Description
Improved bookmark and navigation flaky tests
The bookmark tests were flaky on jenkins because the tab tray didn't have time to fully load all the tabs.
Improved assertTabCount to make sure we wait until all the tabs are there.
The navigation tests failed on jenkins because waitForCurrentScreenElements(waitForImage: false) secretly waited for the firefoxLoader launch-splash image, which isn't on any onboarding card. Replaced it with closeTour(), which just waits for the onboarding "Skip" button  (CloseButton) and taps it — that dismisses the entire flow regardless of which card shows. We have separate tests that validates the onboarding cards, we dont need to do that here, we just need to dismiss it.
Improved handleTermsOfService()  by waiting for continue button to be hittable, taps, and taps again if it's still there.
