### PR TITLE
BugFix FXIOS-15967 Reset settings stack on Deeplink

### DIFF
--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -79,6 +79,7 @@ final class SettingsCoordinator: BaseCoordinator,
         // We might already know the sub-settings page we want to show, but in some case we don't and
         // the flow decision needs to be figured out by the view controller
         if let viewController = getSettingsViewController(settingsSection: settingsSection) {
+            // If the user is currently viewing a sub-setting page, reset back to the root and navigate to this new route
             if let root = router.rootViewController,
                router.navigationController.viewControllers.count > 1 {
                 router.navigationController.setViewControllers([root, viewController], animated: false)

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -79,8 +79,16 @@ final class SettingsCoordinator: BaseCoordinator,
         // We might already know the sub-settings page we want to show, but in some case we don't and
         // the flow decision needs to be figured out by the view controller
         if let viewController = getSettingsViewController(settingsSection: settingsSection) {
-            router.push(viewController)
+            if let root = router.rootViewController,
+               router.navigationController.viewControllers.count > 1 {
+                router.navigationController.setViewControllers([root, viewController], animated: false)
+            } else {
+                router.push(viewController)
+            }
         } else {
+            if let root = router.rootViewController {
+                router.popToViewController(root, reason: .deeplink, animated: false)
+            }
             assert(settingsViewController != nil)
             settingsViewController?.handle(route: settingsSection)
         }

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -75,12 +75,12 @@ final class SettingsCoordinator: BaseCoordinator,
         router.setRootViewController(settingsViewController)
     }
 
-    func start(with settingsSection: Route.SettingsSection, fromExternalRoute: Bool = false) {
+    func start(with settingsSection: Route.SettingsSection, shouldResetNavigationStack: Bool = false) {
         // We might already know the sub-settings page we want to show, but in some case we don't and
         // the flow decision needs to be figured out by the view controller
         if let viewController = getSettingsViewController(settingsSection: settingsSection) {
-            // If the user is currently viewing a sub-setting page, reset back to the root and navigate to this new route
-            if fromExternalRoute,
+            // If Settings is already showing a subpage, reset to root before opening the routed destination.
+            if shouldResetNavigationStack,
                let root = router.rootViewController,
                router.navigationController.viewControllers.count > 1 {
                 router.navigationController.setViewControllers([root, viewController], animated: false)
@@ -88,7 +88,7 @@ final class SettingsCoordinator: BaseCoordinator,
                 router.push(viewController)
             }
         } else {
-            if fromExternalRoute, let root = router.rootViewController {
+            if shouldResetNavigationStack, let root = router.rootViewController {
                 router.popToViewController(root, reason: .deeplink, animated: false)
             }
             assert(settingsViewController != nil)
@@ -108,7 +108,7 @@ final class SettingsCoordinator: BaseCoordinator,
     override func handle(route: Route) {
         switch route {
         case let .settings(section):
-            start(with: section, fromExternalRoute: true)
+            start(with: section, shouldResetNavigationStack: true)
         default:
             break
         }
@@ -208,7 +208,9 @@ final class SettingsCoordinator: BaseCoordinator,
             return contentBlockerVC
 
         case .browser:
-            return BrowsingSettingsViewController(profile: profile, windowUUID: windowUUID)
+            let viewController = BrowsingSettingsViewController(profile: profile, windowUUID: windowUUID)
+            viewController.parentCoordinator = self
+            return viewController
 
         case .toolbar:
             // Toolbar position cannot be changed on iPad

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -75,19 +75,20 @@ final class SettingsCoordinator: BaseCoordinator,
         router.setRootViewController(settingsViewController)
     }
 
-    func start(with settingsSection: Route.SettingsSection) {
+    func start(with settingsSection: Route.SettingsSection, fromExternalRoute: Bool = false) {
         // We might already know the sub-settings page we want to show, but in some case we don't and
         // the flow decision needs to be figured out by the view controller
         if let viewController = getSettingsViewController(settingsSection: settingsSection) {
             // If the user is currently viewing a sub-setting page, reset back to the root and navigate to this new route
-            if let root = router.rootViewController,
+            if fromExternalRoute,
+               let root = router.rootViewController,
                router.navigationController.viewControllers.count > 1 {
                 router.navigationController.setViewControllers([root, viewController], animated: false)
             } else {
                 router.push(viewController)
             }
         } else {
-            if let root = router.rootViewController {
+            if fromExternalRoute, let root = router.rootViewController {
                 router.popToViewController(root, reason: .deeplink, animated: false)
             }
             assert(settingsViewController != nil)
@@ -107,7 +108,7 @@ final class SettingsCoordinator: BaseCoordinator,
     override func handle(route: Route) {
         switch route {
         case let .settings(section):
-            start(with: section)
+            start(with: section, fromExternalRoute: true)
         default:
             break
         }
@@ -346,11 +347,11 @@ final class SettingsCoordinator: BaseCoordinator,
     }
 
     func pressedCreditCard() {
-        findAndHandle(route: .settings(section: .creditCard))
+        settingsViewController?.handle(route: .creditCard)
     }
 
     func pressedRelayMask() {
-        findAndHandle(route: .settings(section: .relayMask))
+        settingsViewController?.handle(route: .relayMask)
     }
 
     func pressedClearPrivateData() {
@@ -367,7 +368,7 @@ final class SettingsCoordinator: BaseCoordinator,
     }
 
     func pressedPasswords() {
-        findAndHandle(route: .settings(section: .password))
+        settingsViewController?.handle(route: .password)
     }
 
     func pressedNotifications() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -192,7 +192,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         let navigationController = try XCTUnwrap(mockRouter.navigationController as? MockNavigationController)
         navigationController.viewControllers = [root, UIViewController()]
 
-        subject.start(with: .appIcon)
+        subject.handle(route: .settings(section: .appIcon))
 
         XCTAssertEqual(mockRouter.pushCalled, 0)
         XCTAssertEqual(navigationController.setViewControllersCalled, 1)
@@ -210,7 +210,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         )
         navigationController.viewControllers = [root, existingAppIcon]
 
-        subject.start(with: .appIcon)
+        subject.handle(route: .settings(section: .appIcon))
 
         XCTAssertEqual(mockRouter.pushCalled, 0)
         XCTAssertEqual(navigationController.viewControllers.count, 2)
@@ -224,7 +224,7 @@ final class SettingsCoordinatorTests: XCTestCase {
         let navigationController = try XCTUnwrap(mockRouter.navigationController as? MockNavigationController)
         navigationController.viewControllers = [root, UIViewController()]
 
-        subject.start(with: .general)
+        subject.handle(route: .settings(section: .general))
 
         XCTAssertEqual(mockRouter.popToViewControllerCalled, 1)
         XCTAssertEqual(mockRouter.pushCalled, 0)
@@ -543,6 +543,20 @@ final class SettingsCoordinatorTests: XCTestCase {
 
         subject.pressedPasswords()
 
+        XCTAssertEqual(mockSettingsVC.handleRouteCalled, 1)
+        XCTAssertEqual(mockSettingsVC.savedRoute, .password)
+    }
+
+    func testPasswordSettingsRoute_whenStackIsDeep_handlesWithoutPopping() throws {
+        let subject = createSubject()
+        subject.settingsViewController = mockSettingsVC
+        let root = try XCTUnwrap(mockRouter.rootViewController)
+        let navigationController = try XCTUnwrap(mockRouter.navigationController as? MockNavigationController)
+        navigationController.viewControllers = [root, UIViewController()]
+
+        subject.pressedPasswords()
+
+        XCTAssertEqual(mockRouter.popToViewControllerCalled, 0)
         XCTAssertEqual(mockSettingsVC.handleRouteCalled, 1)
         XCTAssertEqual(mockSettingsVC.savedRoute, .password)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -186,6 +186,47 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(mockRouter.pushedViewController is UIHostingController<AppIconSelectionView>)
     }
 
+    func testAppIconSettingsRoute_whenStackIsDeep_replacesNavigationStack() throws {
+        let subject = createSubject()
+        let root = try XCTUnwrap(mockRouter.rootViewController)
+        let navigationController = try XCTUnwrap(mockRouter.navigationController as? MockNavigationController)
+        navigationController.viewControllers = [root, UIViewController()]
+
+        subject.start(with: .appIcon)
+
+        XCTAssertEqual(mockRouter.pushCalled, 0)
+        XCTAssertEqual(navigationController.setViewControllersCalled, 1)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssertTrue(navigationController.viewControllers.first === root)
+        XCTAssertTrue(navigationController.viewControllers.last is UIHostingController<AppIconSelectionView>)
+    }
+
+    func testGeneralSettingsRoute_whenStackIsDeep_popsToRoot() throws {
+        let subject = createSubject()
+        let root = try XCTUnwrap(mockRouter.rootViewController)
+        let navigationController = try XCTUnwrap(mockRouter.navigationController as? MockNavigationController)
+        navigationController.viewControllers = [root, UIViewController()]
+
+        subject.start(with: .general)
+
+        XCTAssertEqual(mockRouter.popToViewControllerCalled, 1)
+        XCTAssertEqual(mockRouter.pushCalled, 0)
+        XCTAssertEqual(navigationController.setViewControllersCalled, 0)
+    }
+
+    func testHandleSettingsRoute_whenStackIsDeep_replacesNavigationStack() throws {
+        let subject = createSubject()
+        let root = try XCTUnwrap(mockRouter.rootViewController)
+        let navigationController = try XCTUnwrap(mockRouter.navigationController as? MockNavigationController)
+        navigationController.viewControllers = [root, UIViewController()]
+
+        _ = testCanHandleAndHandle(subject, route: .settings(section: .appIcon))
+
+        XCTAssertEqual(mockRouter.pushCalled, 0)
+        XCTAssertEqual(navigationController.setViewControllersCalled, 1)
+        XCTAssertTrue(navigationController.viewControllers.last is UIHostingController<AppIconSelectionView>)
+    }
+
     // MARK: - Delegate
     func testParentCoordinatorDelegate_calledWithURL() {
         let subject = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -201,6 +201,23 @@ final class SettingsCoordinatorTests: XCTestCase {
         XCTAssertTrue(navigationController.viewControllers.last is UIHostingController<AppIconSelectionView>)
     }
 
+    func testAppIconSettingsRoute_whenAlreadyOnAppIcon_doesNotPushDuplicate() throws {
+        let subject = createSubject()
+        let root = try XCTUnwrap(mockRouter.rootViewController)
+        let navigationController = try XCTUnwrap(mockRouter.navigationController as? MockNavigationController)
+        let existingAppIcon = UIHostingController(
+            rootView: AppIconSelectionView(windowUUID: .XCTestDefaultUUID)
+        )
+        navigationController.viewControllers = [root, existingAppIcon]
+
+        subject.start(with: .appIcon)
+
+        XCTAssertEqual(mockRouter.pushCalled, 0)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssertTrue(navigationController.viewControllers.first === root)
+        XCTAssertTrue(navigationController.viewControllers.last is UIHostingController<AppIconSelectionView>)
+    }
+
     func testGeneralSettingsRoute_whenStackIsDeep_popsToRoot() throws {
         let subject = createSubject()
         let root = try XCTUnwrap(mockRouter.rootViewController)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SettingsCoordinatorTests.swift
@@ -147,7 +147,9 @@ final class SettingsCoordinatorTests: XCTestCase {
         subject.start(with: .browser)
 
         XCTAssertEqual(mockRouter.pushCalled, 1)
-        XCTAssertTrue(mockRouter.pushedViewController is BrowsingSettingsViewController)
+        let viewController = mockRouter.pushedViewController as? BrowsingSettingsViewController
+        XCTAssertNotNil(viewController)
+        XCTAssertTrue(viewController?.parentCoordinator === subject)
     }
 
     func testToolbarSettingsRoute_showsToolbarSettingsPage() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNavigationController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNavigationController.swift
@@ -19,6 +19,7 @@ class MockNavigationController: NavigationController {
     var pushCalled = 0
     var popViewCalled = 0
     var popToViewControllerCalled = 0
+    var setViewControllersCalled = 0
 
     func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
         presentCalled += 1
@@ -43,7 +44,9 @@ class MockNavigationController: NavigationController {
     }
 
     func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {
+        setViewControllersCalled += 1
         self.viewControllers = viewControllers
+        topViewController = viewControllers.last
     }
 
     func popToViewController(_ viewController: UIViewController, animated: Bool) -> [UIViewController]? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15967)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34090)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Fix settings deeplinks opening at wrong nav depth when user already on a sub-screen
- Reset stack to `[root (main settings), destination (deep link)]` via `setViewControllers` when settings already open


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

https://github.com/user-attachments/assets/b7256a51-5014-45b4-8914-3ac06768d5fd


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

