### PR TITLE
Bugfix NO-TICKET [Translations] Add accessibility identifier to Phase 2 settings toggles

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -779,6 +779,7 @@ struct AccessibilityIdentifiers {
             static let title = "Settings.Translation.Title"
             // This is based on `PrefsKeys.Settings.translationsFeature`
             static let toggleSwitch = "settings.translationFeature"
+            static let autoTranslateSwitch = "settings.translationAutoTranslate"
             static let navigationBar = "Settings.Translation.navigationBar"
             static let backButtoniOS26 = "BackButton"
             static let backButton = "Settings"

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
@@ -174,6 +174,7 @@ final class TranslationPickerSettingsViewController: UIViewController,
             cell.configure(
                 title: .Settings.Translation.ToggleTitle,
                 isOn: state.isTranslationsEnabled,
+                accessibilityIdentifier: AccessibilityIdentifiers.Settings.Translation.toggleSwitch,
                 target: self,
                 action: #selector(didToggleTranslations(_:)),
                 theme: themeManager.getCurrentTheme(for: windowUUID)
@@ -187,6 +188,7 @@ final class TranslationPickerSettingsViewController: UIViewController,
             cell.configure(
                 title: .Settings.Translation.AutoTranslate.Title,
                 isOn: state.isAutoTranslateEnabled,
+                accessibilityIdentifier: AccessibilityIdentifiers.Settings.Translation.autoTranslateSwitch,
                 target: self,
                 action: #selector(didToggleAutoTranslate(_:)),
                 theme: themeManager.getCurrentTheme(for: windowUUID)

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationToggleCell.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationToggleCell.swift
@@ -9,11 +9,19 @@ import UIKit
 final class TranslationToggleCell: UICollectionViewListCell, ThemeApplicable {
     private let toggle = UISwitch()
 
-    func configure(title: String, isOn: Bool, target: Any?, action: Selector, theme: Theme) {
+    func configure(
+        title: String,
+        isOn: Bool,
+        accessibilityIdentifier: String?,
+        target: Any?,
+        action: Selector,
+        theme: Theme
+    ) {
         var content = defaultContentConfiguration()
         content.text = title
         contentConfiguration = content
         toggle.isOn = isOn
+        toggle.accessibilityIdentifier = accessibilityIdentifier
         toggle.addTarget(target, action: action, for: .valueChanged)
         accessories = [.customView(configuration: .init(customView: toggle, placement: .trailing(displayed: .always)))]
         applyTheme(theme: theme)


### PR DESCRIPTION
## :scroll: Tickets
No dedicated ticket — follow-up bug from FXIOS-15983 (Phase 2 enabled by default, #34115).

## :bulb: Description
Enabling Phase 2 (`translationsFeature.languagePickerEnabled` default `true`, #34115) routes **Settings → Translation** to the new `TranslationPickerSettingsViewController`. Its `TranslationToggleCell` never set the toggle's `accessibilityIdentifier`, whereas the legacy `BoolSetting`-based screen set it for free. As a result these UI tests timed out waiting for the `settings.translationFeature` switch:

- `TranslationsTests/testTranslationSettingsShouldShow_translationExperimentOn`
- `TranslationsTests/testTranslationSettingsFromToggleOnToOff_translationExperimentOn`

Fix passes the identifier through `configure(...)` and assigns it on the `UISwitch`:
- enable toggle → `settings.translationFeature`
- auto-translate toggle → `settings.translationAutoTranslate` (new id, so the two switches aren't ambiguous)

Both tests pass locally via `FullFunctionalTestPlan`. No behavior change — identifier only.

> Note: the third translation UI test, `testTranslationFlow_withDifferentStates_translationExperimentOn`, is flaky for an unrelated reason (live model/WASM download racing a fixed 10s wait) and is tracked separately under FXIOS-15246. Out of scope here.

## :movie_camera: Demos
N/A — accessibility-identifier-only change, no visible UI difference.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the data stewardship requirements and will request a data review
- [x] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
