### PR TITLE
Bugfix [MTE-5443] - Fix testLoginDetails L10n screenshot tests for RTL locales

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -118,20 +118,20 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         }
     }
 
-    func tapKeyboardKey(_ key: Int) {
-        let key = app.keyboards.keys.element(boundBy: key)
-        if app.buttons["Continue"].isHittable {
-            // Attempt to find and tap the Continue button
-            // of the keyboard onboarding screen.
-            app.buttons.staticTexts["Continue"].waitAndTap()
-            app.tables["Add Credential"].cells.element(boundBy: 1).waitAndTap()
-        }
-        key.waitAndTap(timeout: 5)
+    @MainActor
+    private func pasteText(_ text: String, intoCellAt index: Int) {
+        UIPasteboard.general.string = text
+        let cell = app.tables["Add Credential"].cells.element(boundBy: index)
+        cell.waitAndTap(timeout: 15)
+        cell.press(forDuration: 1.0)
+        // The system edit-menu items expose no accessibility identifiers and have localized labels,
+        // but "Paste" is consistently the first item when the clipboard has content, so tap by
+        // position to stay locale-independent.
+        app.menuItems.element(boundBy: 0).waitAndTap(timeout: 5)
     }
 
     @MainActor
     func testLoginDetails() {
-        let key = 15
         navigator.nowAt(NewTabScreen)
         navigator.goto(SettingsScreen)
         navigator.goto(LoginsSettings)
@@ -153,13 +153,17 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         snapshot("CreateLogin")
         app.buttons["addCredentialButton"].waitAndTap()
 
+        // Paste explicit, valid credentials (keyboard-independent). Typing is unreliable here: these
+        // cells aggregate accessibility (typeText finds no focus), and on non-ASCII .URL keyboards a
+        // positional key tap yields an invalid hostname (FXIOS-16021).
         app.tables["Add Credential"].cells.element(boundBy: 0).waitAndTap(timeout: 15)
-        tapKeyboardKey(key)
-
-        app.tables["Add Credential"].cells.element(boundBy: 1).waitAndTap(timeout: 15)
-        tapKeyboardKey(key)
-        app.tables["Add Credential"].cells.element(boundBy: 2).waitAndTap(timeout: 5)
-        tapKeyboardKey(key)
+        // Dismiss the one-time keyboard onboarding overlay if shown.
+        if app.buttons["Continue"].isHittable {
+            app.buttons.staticTexts["Continue"].waitAndTap()
+        }
+        pasteText("https://mozilla.org", intoCellAt: 0)
+        pasteText("firefox", intoCellAt: 1)
+        pasteText("challenge-the-default", intoCellAt: 2)
         app.navigationBars["Client.AddCredentialView"].buttons.element(boundBy: 1).waitAndTap(timeout: 5)
 
         mozWaitForElementToExist(app.tables["Login List"], timeout: 15)

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -163,12 +163,18 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         app.navigationBars["Client.AddCredentialView"].buttons.element(boundBy: 1).waitAndTap(timeout: 5)
 
         mozWaitForElementToExist(app.tables["Login List"], timeout: 15)
-        mozWaitForElementToExist(app.sheets.firstMatch)
-        mozWaitForElementToExist(app.sheets.firstMatch.staticTexts.firstMatch)
-        mozWaitForElementToExist(app.sheets.firstMatch.buttons.firstMatch)
-        mozWaitForElementToExist(app.sheets.firstMatch.buttons.element(boundBy: 1))
-        app.sheets.firstMatch.buttons.firstMatch.waitAndTap()
-        mozWaitForElementToNotExist(app.sheets.firstMatch)
+        // The "Save password?" sheet ([Not Now / Save]) can be tapped before it finishes animating
+        // in, so the tap is ignored and the sheet lingers, timing out the test. Wait until the
+        // dismiss button is actually hittable before tapping it.
+        let saveSheet = app.sheets.firstMatch
+        mozWaitForElementToExist(saveSheet)
+        let dismissButton = saveSheet.buttons.firstMatch
+        mozWaitForElementToExist(dismissButton)
+        let hittable = XCTNSPredicateExpectation(predicate: NSPredicate(format: "hittable == true"),
+                                                 object: dismissButton)
+        _ = XCTWaiter().wait(for: [hittable], timeout: TIMEOUT)
+        dismissButton.tap()
+        mozWaitForElementToNotExist(saveSheet)
         snapshot("CreatedLoginView")
 
         // Tap the saved login (row 0 is the "Save passwords" toggle; the entry is the next row).

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -141,9 +141,11 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
             app.buttons[AccessibilityIdentifiers.Settings.Passwords.onboardingContinue].waitAndTap()
         }
 
+        // Use a numeric passcode so entry is keyboard-layout independent (non-Latin keyboards
+        // can't type Latin characters, which previously broke authentication on RTL/non-Latin locales).
         let passcodeInput = springboard.secureTextFields.firstMatch
         mozWaitForElementToExist(passcodeInput)
-        passcodeInput.tapAndTypeText("foo\n")
+        passcodeInput.tapAndTypeText("1234\n")
         mozWaitForElementToNotExist(passcodeInput)
 
         mozWaitForElementToExist(app.tables["Login List"], timeout: 25)
@@ -169,7 +171,9 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         mozWaitForElementToNotExist(app.sheets.firstMatch)
         snapshot("CreatedLoginView")
 
-        app.tables["Login List"].cells.staticTexts["p"].waitAndTap()
+        // Tap the saved login (row 0 is the "Save passwords" toggle; the entry is the next row).
+        // Selecting by index is keyboard/URL independent, unlike matching the website text.
+        app.tables["Login List"].cells.element(boundBy: 1).waitAndTap()
         snapshot("CreatedLoginDetailedView")
 
         app.tables["Login Detail List"].cells.element(boundBy: 4).waitAndTap()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5443)

## :bulb: Description

Fixes the `testLoginDetails` L10n snapshot test (`L10nSuite2SnapshotTests`), which failed on every **right-to-left / non-Latin-keyboard** locale and produced 0 of its 4 Login screenshots.

The test made Latin-keyboard assumptions that break whenever the active keyboard is non-ASCII. Locales affected: ar, fa he, ug, ur.


## :movie_camera: Demos

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
