### PR TITLE
Remove SYNC-5275 - Remove public OAuth APIs

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/PersistedFirefoxAccount.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/PersistedFirefoxAccount.swift
@@ -68,39 +68,8 @@ class PersistedFirefoxAccount {
         }
     }
 
-    func beginOAuthFlow(
-        scopes: [String],
-        entrypoint: String
-    ) throws -> URL {
-        return try notifyAuthErrors {
-            try URL(string: self.inner.beginOauthFlow(
-                scopes: scopes,
-                entrypoint: entrypoint
-            ))!
-        }
-    }
-
     func getPairingAuthorityURL() throws -> URL {
         return try URL(string: inner.getPairingAuthorityUrl())!
-    }
-
-    func beginPairingFlow(
-        pairingUrl: String,
-        scopes: [String],
-        entrypoint: String
-    ) throws -> URL {
-        return try notifyAuthErrors {
-            try URL(string: self.inner.beginPairingFlow(pairingUrl: pairingUrl,
-                                                        scopes: scopes,
-                                                        entrypoint: entrypoint))!
-        }
-    }
-
-    func completeOAuthFlow(code: String, state: String) throws {
-        defer { tryPersistState() }
-        try notifyAuthErrors {
-            try self.inner.completeOauthFlow(code: code, state: state)
-        }
     }
 
     func checkAuthorizationStatus() throws -> AuthorizationInfo {

--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/FxAccountMocks.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/FxAccountMocks.swift
@@ -99,13 +99,6 @@ class MockFxAccount: PersistedFirefoxAccount {
         queue.sync { invocations.append(.getProfile) }
         return Profile(uid: "uid", email: "foo@bar.bobo", displayName: "Bobo the Foo", avatar: "https://example.com/avatar.png", isDefaultAvatar: false)
     }
-
-    override func beginOAuthFlow(
-        scopes _: [String],
-        entrypoint _: String
-    ) throws -> URL {
-        return URL(string: "https://foo.bar/oauth?state=bobo")!
-    }
 }
 
 final class MockFxAccountManager: FxAccountManager, @unchecked Sendable {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
With iOS now using the a-s state machine we should remove any direct usage of public oauth and should route through the state machine. See https://github.com/mozilla-mobile/firefox-ios/pull/32716 for the move to the state machine. 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

