### PR TITLE
[MTE-5444] - fix activity stream tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -12,7 +12,7 @@ let newTopSite = [
     "topSiteLabel": "Mozilla",
     "bookmarkLabel": "Mozilla - Internet for people, not profit (US)"
 ]
-let allDefaultTopSites = ["Facebook", "YouTube", "Amazon", "Wikipedia", "X"]
+let allDefaultTopSites = ["Facebook", "YouTube", "Amazon", "Wikipedia"]
 let tabsTray = AccessibilityIdentifiers.TabTray.tabsTray
 
 class ActivityStreamTest: FeatureFlaggedTestBase {
@@ -71,7 +71,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
     func testTopSites2Add() {
         app.launch()
         if iPad() {
-            checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 12)
+            checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 10)
         } else {
             checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 8)
         }
@@ -83,7 +83,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         waitForExistence(app.links.staticTexts["Internet for people, not profit — Mozilla (US)"], timeout: TIMEOUT_LONG)
         // A new site has been added to the top sites
         if iPad() {
-            checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 12)
+            checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 11)
         } else {
             checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 8)
         }
@@ -96,7 +96,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
             navigator.nowAt(ClearPrivateDataSettings)
             navigator.goto(BrowserTab)
         }
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 4)
         mozWaitForElementToNotExist(app.cells.staticTexts[newTopSite["bookmarkLabel"]!])
     }
 
@@ -132,7 +132,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         } else {
             waitForExistence(topSitesCells.staticTexts["Mozilla — Internet for people, not profit"], timeout: TIMEOUT_LONG)
         }
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
         if #available(iOS 16, *) {
             topSitesCells.staticTexts[newTopSite["bookmarkLabel"]!].press(forDuration: 1)
         } else {
@@ -155,7 +155,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         } else {
             waitForExistence(topSitesCells.staticTexts["Mozilla — Internet for people, not profit"], timeout: TIMEOUT_LONG)
         }
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 6)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 5)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2272514
@@ -177,7 +177,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
         }
         mozWaitForElementToExist(allTopSites.staticTexts[topSiteSecondCell])
         mozWaitForElementToNotExist(allTopSites.staticTexts[topSiteFirstCell])
-        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 4)
+        checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 3)
         // Check top site in first cell now
         let updatedAllTopSites = app.collectionViews.links.matching(identifier: "TopSitesCell")
         waitForExistence(updatedAllTopSites.element(boundBy: 0))

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
@@ -36,13 +36,21 @@ final class TabTrayScreen {
         return cv.cells.containing(predicate).firstMatch
     }
 
+    // A tab cell is a single accessibility element whose label may be decorated with the
+    // "Currently selected tab" suffix (e.g. "Wikipedia. Currently selected tab"), so the
+    // selected tab can't be matched by the exact `cells[name]` subscript. Match the bare
+    // title or any label that begins with it.
+    private func cell(named name: String) -> XCUIElement {
+        let predicate = NSPredicate(format: "label == %@ OR label BEGINSWITH %@", name, "\(name).")
+        return collectionView.cells.matching(predicate).firstMatch
+    }
+
     func assertCellExists(named name: String, timeout: TimeInterval = TIMEOUT) {
-        let cell = collectionView.cells[name]
-        BaseTestCase().mozWaitForElementToExist(cell, timeout: timeout)
+        BaseTestCase().mozWaitForElementToExist(cell(named: name), timeout: timeout)
     }
 
     func tapOnCell(named name: String, timeout: TimeInterval = TIMEOUT) {
-        let cell = collectionView.cells[name]
+        let cell = cell(named: name)
         BaseTestCase().mozWaitForElementToExist(cell, timeout: timeout)
         cell.waitAndTap()
     }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5444

## :bulb: Description
x.com has been removed from the top sites list: https://github.com/mozilla-mobile/firefox-ios/pull/34134
Updated activitystream tests accordingly 
