### PR TITLE
Bugfix FXIOS-16033 [SKAN] Don't update postback conversion values on 16.1.0

### DIFF
--- a/firefox-ios/Client/Application/ConversionTracking/ConversionValueUpdater.swift
+++ b/firefox-ios/Client/Application/ConversionTracking/ConversionValueUpdater.swift
@@ -19,7 +19,11 @@ struct SKAdNetworkUpdater: ConversionValueUpdater {
     }
 
     func update(conversionValue: ConversionValue) {
-        if #available(iOS 16.1, *) {
+        // Apple declares the `coarseValue:lockWindow:` overload as available from iOS 16.1,
+        // but it seems like the selector is missing on iOS 16.1.0 devices and only present from 16.1.1
+        // onwards. Calling it on 16.1.0 crashes with an unrecognized selector exception,
+        // so we gate on the patch version here. See https://github.com/adjust/ios_sdk/issues/641
+        if #available(iOS 16.1.1, *) {
             SKAdNetwork.updatePostbackConversionValue(
                 conversionValue.fine,
                 coarseValue: conversionValue.coarse.value,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16033)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
There is a crash on 16.1.0 with a missing selector https://mozilla.sentry.io/issues/7538733899/?environment=Production&project=6176941&query=firstRelease%3Aorg.mozilla.ios.Firefox%40151.3&referrer=issue-stream&sort=freq and a corresponding issue on the adjust sdk https://github.com/adjust/ios_sdk/issues/641. It is possible that the api is not actually available on 16.1.0, so we check for 16.1.1 instead.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

