### PR TITLE
Bugfix FXIOS-15932 [Toolbar] Search engines and toolbar background disappear after rotating from landscape to portrait during a search

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -81,6 +81,7 @@ struct AccessibilityIdentifiers {
         static let statusBarOverlay = "Browser.statusBarOverlay"
         static let topBlurView = "Browser.topBlurView"
         static let bottomBlurView = "Browser.bottomBlurView"
+        static let keyboardSpacer = "AddressToolbar.keyboardSpacer"
     }
 
     struct ContextualHints {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -99,6 +99,9 @@ class BrowserViewController: UIViewController,
     var clipboardBarDisplayHandler: ClipboardBarDisplayHandler?
     var readerModeBar: ReaderModeBarView?
     var searchController: SearchViewController?
+    /// Bottom constraint of `searchController.view`. The anchor it targets depends on the search bar
+    /// position (`overKeyboardContainer.top` for bottom bar, `view.bottom` for top bar)
+    private var searchControllerBottomConstraint: NSLayoutConstraint?
     var searchSessionState: SearchSessionState?
     var searchLoader: SearchLoader?
     var iOS15FindInPageBar: FindInPageBar? /* TODO: Remove once we drop iOS 15 support */
@@ -356,6 +359,13 @@ class BrowserViewController: UIViewController,
         && header.arrangedSubviews.isEmpty
     }
 
+    /// The anchor `searchController.view`'s bottom is pinned to, based on the current search bar position.
+    /// - Bottom search bar: `overKeyboardContainer.top`, which sits above the keyboard.
+    /// - Top search bar: `view.bottom`, so the search view fills the screen
+    private var searchControllerBottomAnchor: NSLayoutYAxisAnchor {
+        return isBottomSearchBar ? overKeyboardContainer.topAnchor : view.bottomAnchor
+    }
+
     // MARK: Data management
 
     let profile: Profile
@@ -576,6 +586,7 @@ class BrowserViewController: UIViewController,
         updateSwipingTabs()
 
         searchController?.viewModel.updateBottomSearchBarState(isBottomSearchBar: isBottomSearchBar)
+        updateSearchControllerConstraints()
     }
 
     private func updateToolbarDisplay(scrollOffset: CGFloat? = nil, shouldUpdateBlurViews: Bool = true) {
@@ -2189,6 +2200,8 @@ class BrowserViewController: UIViewController,
         }
     }
 
+    // MARK: - SearchViewController
+
     fileprivate func createSearchControllerIfNeeded() {
         guard self.searchController == nil else { return }
 
@@ -2233,12 +2246,13 @@ class BrowserViewController: UIViewController,
         view.addSubview(searchController.view)
         searchController.view.translatesAutoresizingMaskIntoConstraints = false
 
-        let constraintTarget = isBottomSearchBar ? overKeyboardContainer.topAnchor : view.bottomAnchor
+        let bottomConstraint = searchController.view.bottomAnchor.constraint(equalTo: searchControllerBottomAnchor)
+        searchControllerBottomConstraint = bottomConstraint
         NSLayoutConstraint.activate([
             searchController.view.topAnchor.constraint(equalTo: header.bottomAnchor),
             searchController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             searchController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            searchController.view.bottomAnchor.constraint(equalTo: constraintTarget)
+            bottomConstraint
         ])
 
         searchController.didMove(toParent: self)
@@ -2248,6 +2262,17 @@ class BrowserViewController: UIViewController,
         // be read by VoiceOver when reading in the
         // Search Controller
         contentContainer.accessibilityElementsHidden = true
+    }
+
+    /// Updates `searchController.view`'s bottom constraint to match the current search bar position
+    private func updateSearchControllerConstraints() {
+        guard let searchController, searchController.view.superview != nil else { return }
+
+        searchControllerBottomConstraint?.isActive = false
+        searchControllerBottomConstraint = searchController.view.bottomAnchor.constraint(
+            equalTo: searchControllerBottomAnchor
+        )
+        searchControllerBottomConstraint?.isActive = true
     }
 
     private func setupKeyboardBackdropConstraints(for backdrop: UIView?) {
@@ -2267,6 +2292,7 @@ class BrowserViewController: UIViewController,
         searchController.willMove(toParent: nil)
         searchController.view.removeFromSuperview()
         searchController.removeFromParent()
+        searchControllerBottomConstraint = nil
 
         contentContainer.accessibilityElementsHidden = false
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2242,6 +2242,13 @@ class BrowserViewController: UIViewController,
 
         guard let searchController = self.searchController else { return }
 
+        // If searchController is already presented only update the bottom anchor
+        // based in `bottomSearchBar` position
+        guard searchController.view.superview == nil else {
+            updateSearchControllerConstraints()
+            return
+        }
+
         addChild(searchController)
         view.addSubview(searchController.view)
         searchController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -143,6 +143,7 @@ class SearchViewController: SiteTableViewController,
         searchEngineScrollView.addSubview(searchEngineStackView)
 
         layoutTable()
+        setupSearchEngineScrollViewConstraints()
         layoutSearchEngineScrollView()
         layoutSearchEngineScrollViewContent()
 
@@ -185,14 +186,16 @@ class SearchViewController: SiteTableViewController,
         super.viewWillDisappear(animated)
     }
 
-    private func layoutSearchEngineScrollView() {
-        let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(self.view) ?? 0
-
+    private func setupSearchEngineScrollViewConstraints() {
         NSLayoutConstraint.activate([
             searchEngineScrollView.leadingAnchor.constraint(equalTo: searchEngineContainerView.leadingAnchor),
             searchEngineScrollView.trailingAnchor.constraint(equalTo: searchEngineContainerView.trailingAnchor),
             searchEngineScrollView.topAnchor.constraint(equalTo: searchEngineContainerView.topAnchor)
         ])
+    }
+
+    private func layoutSearchEngineScrollView() {
+        let keyboardHeight = KeyboardHelper.defaultHelper.currentState?.intersectionHeightForView(self.view) ?? 0
 
         // Remove existing keyboard-related bottom constraints (if any)
         bottomConstraintWithKeyboard?.isActive = false
@@ -383,13 +386,6 @@ class SearchViewController: SiteTableViewController,
     func keyboardHelper(
         _ keyboardHelper: KeyboardHelper,
         keyboardWillHideWithState state: KeyboardState
-    ) {
-        layoutSearchEngineScrollView()
-    }
-
-    func keyboardHelper(
-        _ keyboardHelper: KeyboardHelper,
-        keyboardWillChangeWithState state: KeyboardState
     ) {
         layoutSearchEngineScrollView()
     }

--- a/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
+++ b/firefox-ios/Client/Frontend/Components/BaseAlphaStackView.swift
@@ -47,6 +47,7 @@ class BaseAlphaStackView: UIStackView, AlphaDimmable, ThemeApplicable {
         keyboardSpacer?.removeFromSuperview()
         if keyboardSpacer == nil {
             keyboardSpacer = UIView()
+            keyboardSpacer?.accessibilityIdentifier = AccessibilityIdentifiers.Browser.keyboardSpacer
         }
         addArrangedViewToBottom(keyboardSpacer!)
         setKeyboardSpacerHeight(height: spacerHeight)


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-15932](https://mozilla-hub.atlassian.net/browse/FXIOS-15932)
[FXIOS-15996](https://mozilla-hub.atlassian.net/browse/FXIOS-15996)

## :bulb: Description
- Issue #1- Fixes re-adding constraints for `searchEngineScrollView` adding a setup function and use existing layoutSearchEngineScrollView to update `searchControllerBottomConstraint`.
- Issue # 2: Attempt to fix the bug unfortunately is still reproducible intermitent due to race condition in our layout paths and keyboard handling
The bug happens because SearchViewController is created in landscape mode so it extends behind the keyboard and the user rotates to portrait we don't udpate the bottom constraint to pin to overKeyboardContainer.top in this PR I've added support fot this to fix but the issue still reproduces due to race condition.

Race condition: The remaining issue is a layout-timing race during rotation: when the device returns to portrait, the bottom toolbar (bottomContainer) and the keyboard both update on separate, uncoordinated passes. If the keyboard's frame is applied before the toolbar has committed its new height, the search engine row gets positioned against the old toolbar height and ends up behind the keyboard, with nothing re-laying it out afterward. 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code



[FXIOS-15932]: https://mozilla-hub.atlassian.net/browse/FXIOS-15932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-15996]: https://mozilla-hub.atlassian.net/browse/FXIOS-15996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ