### PR TITLE
Remove FXIOS-16009 Dead "upgrade" onboarding config + retire strings

### DIFF
--- a/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
+++ b/firefox-ios/RustFxA/FirefoxAccountSignInViewController.swift
@@ -170,6 +170,8 @@ class FirefoxAccountSignInViewController: UIViewController, Themeable {
         }
         switch notificationPermissionBehavior {
         case .automatic:
+            // TODO: FXIOS-16035 Remove OnboardingNotificationCardHelper + the legacy NimbusOnboardingFeatureLayer
+            // (modern onboarding has no notifications card, so this helper never finds one).
             self.shouldAskForNotificationPermission = OnboardingNotificationCardHelper().shouldAskForNotificationsPermission(
                 telemetryObj: self.telemetryObject
             )

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2859,47 +2859,6 @@ extension String {
     }
 }
 
-// MARK: - Upgrade CoverSheet
-extension String {
-    public struct Upgrade {
-        public struct Welcome {
-            public static let Title = MZLocalizedString(
-                key: "Upgrade.Welcome.Title.v114",
-                tableName: "Upgrade",
-                value: "Welcome to a more personal internet",
-                comment: "Title string used to welcome back users in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
-            public static let Description = MZLocalizedString(
-                key: "Upgrade.Welcome.Description.v114",
-                tableName: "Upgrade",
-                value: "New colors. New convenience. Same commitment to people over profits.",
-                comment: "Description string used to welcome back users in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
-            public static let Action = MZLocalizedString(
-                key: "Upgrade.Welcome.Action.v114",
-                tableName: "Upgrade",
-                value: "Set as Default Browser",
-                comment: "Describes the action on the first upgrade page in the Upgrade screen. This string will be on a button so user can continue the Upgrade.")
-        }
-
-        public struct Sync {
-            public static let Title = MZLocalizedString(
-                key: "Upgrade.SyncSign.Title.v114",
-                tableName: "Upgrade",
-                value: "Switching screens is easier than ever",
-                comment: "Title string used to sign in to sync in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
-            public static let Description = MZLocalizedString(
-                key: "Upgrade.SyncSign.Description.v114",
-                tableName: "Upgrade",
-                value: "Pick up where you left off with tabs from other devices now on your homepage.",
-                comment: "Description string used to sign in to sync in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
-            public static let Action = MZLocalizedString(
-                key: "Upgrade.SyncSign.Action.v114",
-                tableName: "Upgrade",
-                value: "Sign In",
-                comment: "Describes an action on the sync upgrade page in our Upgrade screens. This string will be on a button so user can sign up or login directly in the upgrade.")
-        }
-    }
-}
-
 // MARK: - Research Surface
 extension String {
     public struct ResearchSurface {
@@ -9162,6 +9121,38 @@ extension String {
                 tableName: "WorldCup",
                 value: "Full time • Penalties",
                 comment: "The label indicating the displaying match has ended after penalties.")
+        }
+        struct v153 {
+            public static let UpgradeWelcomeTitle = MZLocalizedString(
+                key: "Upgrade.Welcome.Title.v114",
+                tableName: "Upgrade",
+                value: "Welcome to a more personal internet",
+                comment: "Title string used to welcome back users in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
+            public static let UpgradeWelcomeDescription = MZLocalizedString(
+                key: "Upgrade.Welcome.Description.v114",
+                tableName: "Upgrade",
+                value: "New colors. New convenience. Same commitment to people over profits.",
+                comment: "Description string used to welcome back users in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
+            public static let UpgradeWelcomeAction = MZLocalizedString(
+                key: "Upgrade.Welcome.Action.v114",
+                tableName: "Upgrade",
+                value: "Set as Default Browser",
+                comment: "Describes the action on the first upgrade page in the Upgrade screen. This string will be on a button so user can continue the Upgrade.")
+            public static let UpgradeSyncTitle = MZLocalizedString(
+                key: "Upgrade.SyncSign.Title.v114",
+                tableName: "Upgrade",
+                value: "Switching screens is easier than ever",
+                comment: "Title string used to sign in to sync in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
+            public static let UpgradeSyncDescription = MZLocalizedString(
+                key: "Upgrade.SyncSign.Description.v114",
+                tableName: "Upgrade",
+                value: "Pick up where you left off with tabs from other devices now on your homepage.",
+                comment: "Description string used to sign in to sync in the Upgrade screens. This screen is shown after user upgrades Firefox version.")
+            public static let UpgradeSyncAction = MZLocalizedString(
+                key: "Upgrade.SyncSign.Action.v114",
+                tableName: "Upgrade",
+                value: "Sign In",
+                comment: "Describes an action on the sync upgrade page in our Upgrade screens. This string will be on a button so user can sign up or login directly in the upgrade.")
         }
     }
 }

--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -211,36 +211,6 @@ features:
               onboarding-type: fresh-install
               prerequisites:
                 - ALWAYS
-            # TODO: FXIOS-16009 Remove these dead "upgrade" onboarding cards; the upgrade flow was retired in FXIOS-15164
-            update-welcome:
-              card-type: basic
-              order: 10
-              title: Upgrade/Upgrade.Welcome.Title.v114
-              body: Upgrade/Upgrade.Welcome.Description.v114
-              image: welcome-globe
-              buttons:
-                primary:
-                  title: Upgrade/Upgrade.Welcome.Action.v114
-                  action: forward-one-card
-              onboarding-type: upgrade
-              prerequisites:
-                - NEVER
-            update-sign-to-sync:
-              card-type: basic
-              order: 20
-              title: Upgrade/Upgrade.SyncSign.Title.v114
-              body: Upgrade/Upgrade.SyncSign.Description.v114
-              image: sync-devices
-              buttons:
-                primary:
-                  title: Upgrade/Upgrade.SyncSign.Action.v114
-                  action: sync-sign-in
-                secondary:
-                  title: Onboarding/Onboarding.LaterAction.v114
-                  action: forward-one-card
-              onboarding-type: upgrade
-              prerequisites:
-                - NEVER
             welcome-modern:
               card-type: basic
               order: 10


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16009)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34204)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

The "What's New" upgrade flow was retired in FXIOS-15164, leaving its Nimbus config and strings dead.

- Remove the two `onboarding-type: upgrade` cards (update-welcome, update-sign-to-sync) from onboardingFrameworkFeature.yaml; FxNimbus regenerates without them.
- Retire the orphaned Upgrade.* strings into OldStrings.v153 (keys, values and comments preserved) per the string-removal convention.
- Add a TODO at FirefoxAccountSignInViewController for FXIOS-16035 (remove OnboardingNotificationCardHelper + legacy NimbusOnboardingFeatureLayer).

OnboardingType.upgrade enum is kept (still used by getOnboardingModel signatures and tests).

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


