### PR TITLE
Remove FXIOS-16025 Consolidate legacy-variant onboarding telemetry tests

### DIFF
--- a/BrowserKit/Sources/OnboardingKit/Models/OnboardingVariant.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/OnboardingVariant.swift
@@ -7,6 +7,7 @@ import Foundation
 /// Enum representing the different onboarding variants available.
 /// This mirrors the Nimbus OnboardingVariant configuration.
 public enum OnboardingVariant: String, Sendable {
+    // TODO: FXIOS-16036 Remove this dead `legacy` case (and `OnboardingType.upgrade`)
     case legacy
     case modern
     case japan

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryUtilityTests.swift
@@ -27,24 +27,8 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     // MARK: - Card View telemetry
-    func testSendOnboardingCardView_WelcomeCard_Success() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
-        let event = GleanMetrics.Onboarding.cardView
-        typealias EventExtrasType = GleanMetrics.Onboarding.CardViewExtra
-
-        subject.sendCardViewTelemetry(from: CardNames.welcome.rawValue)
-
-        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
-
-        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.cardType, CardNames.welcome.rawValue)
-        XCTAssertEqual(savedExtras.onboardingVariant, "legacy")
-        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
-    }
-
     func testSendOnboardingCardView_SyncCard_Success() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
         let event = GleanMetrics.Onboarding.cardView
         typealias EventExtrasType = GleanMetrics.Onboarding.CardViewExtra
 
@@ -59,7 +43,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     func testSendOnboardingCardView_NotificationsCard_Success() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
         let event = GleanMetrics.Onboarding.cardView
         typealias EventExtrasType = GleanMetrics.Onboarding.CardViewExtra
 
@@ -73,79 +57,10 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
-    func testSendOnboardingCardView_UpgradeSyncCard_Success() throws {
-        let subject = createTelemetryUtility(for: .upgrade)
-        let event = GleanMetrics.Onboarding.cardView
-        typealias EventExtrasType = GleanMetrics.Onboarding.CardViewExtra
-
-        subject.sendCardViewTelemetry(from: CardNames.updateSync.rawValue)
-
-        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
-
-        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.cardType, CardNames.updateSync.rawValue)
-        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
-    }
-
-    func testSendOnboardingCardView_UpgradeWelcomeCard_Success() throws {
-        let subject = createTelemetryUtility(for: .upgrade)
-        let event = GleanMetrics.Onboarding.cardView
-        typealias EventExtrasType = GleanMetrics.Onboarding.CardViewExtra
-
-        subject.sendCardViewTelemetry(from: CardNames.updateWelcome.rawValue)
-
-        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
-
-        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.cardType, CardNames.updateWelcome.rawValue)
-        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
-    }
-
-    // MARK: - Primary tap
-    func testSendOnboardingPrimaryTap_WelcomeCard() throws {
-        let isPrimaryButton = true
-        let subject = createTelemetryUtility(for: .freshInstall)
-        let event = GleanMetrics.Onboarding.primaryButtonTap
-        typealias EventExtrasType = GleanMetrics.Onboarding.PrimaryButtonTapExtra
-
-        subject.sendButtonActionTelemetry(from: CardNames.welcome.rawValue,
-                                          with: .forwardOneCard,
-                                          and: isPrimaryButton)
-
-        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
-
-        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.cardType, CardNames.welcome.rawValue)
-        XCTAssertEqual(savedExtras.buttonAction, OnboardingActions.forwardOneCard.rawValue)
-        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
-    }
-
-    func testSendOnboardingPrimaryTap_UpgradeWelcomeCard() throws {
-        let isPrimaryButton = true
-        let subject = createTelemetryUtility(for: .upgrade)
-        let event = GleanMetrics.Onboarding.primaryButtonTap
-        typealias EventExtrasType = GleanMetrics.Onboarding.PrimaryButtonTapExtra
-
-        subject.sendButtonActionTelemetry(from: CardNames.updateWelcome.rawValue,
-                                          with: .setDefaultBrowser,
-                                          and: isPrimaryButton)
-
-        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
-
-        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.cardType, CardNames.updateWelcome.rawValue)
-        XCTAssertEqual(savedExtras.buttonAction, OnboardingActions.setDefaultBrowser.rawValue)
-        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
-    }
-
     // MARK: - Secondary tap
     func testSendOnboardingSecondaryTap_SyncCard() throws {
         let isPrimaryButton = false
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
         let event = GleanMetrics.Onboarding.secondaryButtonTap
         typealias EventExtrasType = GleanMetrics.Onboarding.SecondaryButtonTapExtra
 
@@ -162,28 +77,9 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
-    func testSendOnboardingSecondaryTap_UpdateSyncCard() throws {
-        let isPrimaryButton = false
-        let subject = createTelemetryUtility(for: .upgrade)
-        let event = GleanMetrics.Onboarding.secondaryButtonTap
-        typealias EventExtrasType = GleanMetrics.Onboarding.SecondaryButtonTapExtra
-
-        subject.sendButtonActionTelemetry(from: CardNames.updateSync.rawValue,
-                                          with: .forwardOneCard,
-                                          and: isPrimaryButton)
-
-        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
-
-        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.cardType, CardNames.updateSync.rawValue)
-        XCTAssertEqual(savedExtras.buttonAction, OnboardingActions.forwardOneCard.rawValue)
-        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
-    }
-
     // MARK: - Multiple Choice Buttons
     func testSendOnboardingMultipleChoiceButton() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
         let event = GleanMetrics.Onboarding.multipleChoiceButtonTap
         typealias EventExtrasType = GleanMetrics.Onboarding.MultipleChoiceButtonTapExtra
 
@@ -201,7 +97,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
 
     // MARK: - Close
     func testSendOnboardingClose_NotificationsCard() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
         let event = GleanMetrics.Onboarding.closeTap
         typealias EventExtrasType = GleanMetrics.Onboarding.CloseTapExtra
 
@@ -273,22 +169,20 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
 
     // MARK: - Go To Settings Button Tapped Telemetry
     func testSendGoToSettingsButtonTappedTelemetry_RecordsEvent() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
         let event = GleanMetrics.OnboardingDefaultBrowserSheet.goToSettingsButtonTapped
         typealias EventExtrasType = GleanMetrics.OnboardingDefaultBrowserSheet.GoToSettingsButtonTappedExtra
 
         subject.sendGoToSettingsButtonTappedTelemetry()
 
-        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
 
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.onboardingVariant, "legacy")
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
     func testSendGoToSettingsButtonTappedTelemetry_MultipleCalls_RecordsMultipleEvents() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
 
         subject.sendGoToSettingsButtonTappedTelemetry()
         subject.sendGoToSettingsButtonTappedTelemetry()
@@ -296,16 +190,6 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
 
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 3)
         XCTAssertEqual(mockGleanWrapper.savedExtras.count, 3)
-    }
-
-    func testSendGoToSettingsButtonTappedTelemetry_WorksWithLegacyOnboarding() throws {
-        let subject = createTelemetryUtility(for: .upgrade)
-        typealias EventExtrasType = GleanMetrics.OnboardingDefaultBrowserSheet.GoToSettingsButtonTappedExtra
-
-        subject.sendGoToSettingsButtonTappedTelemetry()
-
-        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
-        XCTAssertEqual(savedExtras.onboardingVariant, "legacy")
     }
 
     func testSendGoToSettingsButtonTappedTelemetry_WorksWithModernOnboarding() throws {
@@ -320,22 +204,20 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
 
     // MARK: - Dismiss Button Tapped Telemetry
     func testSendDismissButtonTappedTelemetry_RecordsEvent() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
         let event = GleanMetrics.OnboardingDefaultBrowserSheet.dismissButtonTapped
         typealias EventExtrasType = GleanMetrics.OnboardingDefaultBrowserSheet.DismissButtonTappedExtra
 
         subject.sendDismissButtonTappedTelemetry()
 
-        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
 
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.onboardingVariant, "legacy")
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
     func testSendDismissButtonTappedTelemetry_MultipleCalls_RecordsMultipleEvents() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
 
         subject.sendDismissButtonTappedTelemetry()
         subject.sendDismissButtonTappedTelemetry()
@@ -343,16 +225,6 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
 
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 3)
         XCTAssertEqual(mockGleanWrapper.savedExtras.count, 3)
-    }
-
-    func testSendDismissButtonTappedTelemetry_WorksWithLegacyOnboarding() throws {
-        let subject = createTelemetryUtility(for: .upgrade)
-        typealias EventExtrasType = GleanMetrics.OnboardingDefaultBrowserSheet.DismissButtonTappedExtra
-
-        subject.sendDismissButtonTappedTelemetry()
-
-        let savedExtras = try XCTUnwrap(mockGleanWrapper.savedExtras.first as? EventExtrasType)
-        XCTAssertEqual(savedExtras.onboardingVariant, "legacy")
     }
 
     func testSendDismissButtonTappedTelemetry_WorksWithModernOnboarding() throws {
@@ -378,7 +250,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     // MARK: - onboarding.shown tests
 
     func testSendOnboardingShown_NewUser_RecordsCorrectEvent() throws {
-        let subject = createTelemetryUtility(for: .freshInstall, onboardingReason: .newUser)
+        let subject = createModernTelemetryUtility(for: .freshInstall, onboardingReason: .newUser)
         let event = GleanMetrics.Onboarding.shown
         typealias EventExtrasType = GleanMetrics.Onboarding.ShownExtra
 
@@ -393,7 +265,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     func testSendOnboardingShown_ShowTour_RecordsCorrectReason() throws {
-        let subject = createTelemetryUtility(for: .freshInstall, onboardingReason: .showTour)
+        let subject = createModernTelemetryUtility(for: .freshInstall, onboardingReason: .showTour)
         typealias EventExtrasType = GleanMetrics.Onboarding.ShownExtra
 
         subject.sendOnboardingShownTelemetry()
@@ -403,7 +275,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     func testSendOnboardingShown_SubmitsPing() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
 
         subject.sendOnboardingShownTelemetry()
 
@@ -413,7 +285,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     // MARK: - onboarding.dismissed tests
 
     func testSendOnboardingDismissed_Skipped_RecordsCorrectMethod() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
         let event = GleanMetrics.Onboarding.dismissed
         typealias EventExtrasType = GleanMetrics.Onboarding.DismissedExtra
 
@@ -428,7 +300,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     func testSendOnboardingDismissed_Completed_RecordsCorrectMethod() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
         typealias EventExtrasType = GleanMetrics.Onboarding.DismissedExtra
 
         subject.sendOnboardingDismissedTelemetry(outcome: .completed)
@@ -438,7 +310,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     func testSendOnboardingDismissed_IncludesOnboardingReason() throws {
-        let subject = createTelemetryUtility(for: .freshInstall, onboardingReason: .showTour)
+        let subject = createModernTelemetryUtility(for: .freshInstall, onboardingReason: .showTour)
         typealias EventExtrasType = GleanMetrics.Onboarding.DismissedExtra
 
         subject.sendOnboardingDismissedTelemetry(outcome: .skipped)
@@ -448,7 +320,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     func testSendOnboardingDismissed_SubmitsPing() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
 
         subject.sendOnboardingDismissedTelemetry(outcome: .completed)
 
@@ -458,7 +330,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     // MARK: - onboardingReason in existing events
 
     func testCardViewTelemetry_IncludesOnboardingReason_NewUser() throws {
-        let subject = createTelemetryUtility(for: .freshInstall, onboardingReason: .newUser)
+        let subject = createModernTelemetryUtility(for: .freshInstall, onboardingReason: .newUser)
         typealias EventExtrasType = GleanMetrics.Onboarding.CardViewExtra
 
         subject.sendCardViewTelemetry(from: CardNames.welcome.rawValue)
@@ -468,7 +340,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     func testCardViewTelemetry_IncludesOnboardingReason_ShowTour() throws {
-        let subject = createTelemetryUtility(for: .freshInstall, onboardingReason: .showTour)
+        let subject = createModernTelemetryUtility(for: .freshInstall, onboardingReason: .showTour)
         typealias EventExtrasType = GleanMetrics.Onboarding.CardViewExtra
 
         subject.sendCardViewTelemetry(from: CardNames.welcome.rawValue)
@@ -478,7 +350,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     func testCardViewTelemetry_SubmitsPing() throws {
-        let subject = createTelemetryUtility(for: .freshInstall)
+        let subject = createModernTelemetryUtility(for: .freshInstall)
 
         subject.sendCardViewTelemetry(from: CardNames.welcome.rawValue)
 
@@ -486,7 +358,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     func testCloseTapTelemetry_IncludesOnboardingReason() throws {
-        let subject = createTelemetryUtility(for: .freshInstall, onboardingReason: .showTour)
+        let subject = createModernTelemetryUtility(for: .freshInstall, onboardingReason: .showTour)
         typealias EventExtrasType = GleanMetrics.Onboarding.CloseTapExtra
 
         subject.sendDismissOnboardingTelemetry(from: CardNames.welcome.rawValue)
@@ -496,28 +368,6 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
     }
 
     // MARK: Private
-    // TODO: FXIOS-16025 Consolidate these onto the modern telemetry helper and remove the legacy `.legacy` usage
-    private func createTelemetryUtility(
-        for onboardingType: Client.OnboardingType,
-        onboardingReason: OnboardingReason = .newUser,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) -> OnboardingTelemetryUtility {
-        let nimbusConfigUtility = NimbusOnboardingTestingConfigUtility()
-        nimbusConfigUtility.setupNimbus(withOrder: NimbusOnboardingTestingConfigUtility.CardOrder.allCards)
-        let model = NimbusOnboardingFeatureLayer().getOnboardingModel(for: onboardingType)
-
-        let telemetryUtility = OnboardingTelemetryUtility(
-            with: model,
-            onboardingVariant: .legacy,
-            onboardingReason: onboardingReason,
-            gleanWrapper: mockGleanWrapper
-        )
-        trackForMemoryLeaks(telemetryUtility, file: file, line: line)
-
-        return telemetryUtility
-    }
-
     private func createModernTelemetryUtility(
         for onboardingType: Client.OnboardingType,
         variant: Client.OnboardingVariant = .modern,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16025)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34206)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

The legacy onboarding (FXIOS-15164) and the "What's New" upgrade flow are gone, leaving dead and duplicate telemetry tests behind.

- Delete the legacy-variant tests that duplicate modern equivalents: testSendOnboardingCardView_WelcomeCard_Success, testSendOnboardingPrimaryTap_WelcomeCard, and the _WorksWithLegacyOnboarding go-to-settings/dismiss tests.
- Delete the dead upgrade-flow tests (Upgrade*/UpdateSync card view, primary and secondary tap).
- Repoint the remaining tests from the legacy createTelemetryUtility helper to createModernTelemetryUtility and remove the legacy helper.
- No test references OnboardingVariant.legacy anymore.

Coverage is preserved by the existing modern/japan tests.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


