### PR TITLE
Bugfix FXIOS-16034 [Tab tray] The last section in Sync Tabs is not accessible when there are multiple synced tabs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
@@ -489,6 +489,7 @@ class RemoteTabsViewController: UIViewController,
             }
 
             emptyView.updateInsets(top: 0, bottom: bottomInset)
+            tableView.contentInset.bottom = view.safeAreaInsets.bottom
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16034)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34208)

## :bulb: Description
Adds an inset to the bottom of the table view.

## :movie_camera: Demos
<img width="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-10 at 10 52 28" src="https://github.com/user-attachments/assets/403d1662-012a-40dc-b713-4c26e084c4da" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

