### PR TITLE
BugFix [World Cup] FXIOS-16011-16027-16031 Accessibility issues and WorldCupCell not resizing correctly on iOS 18 and versions before

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -89,6 +89,21 @@ private final class PageContainer: UIView, ThemeApplicable {
     }
 }
 
+/// A page control that forwards VoiceOver's adjustable gesture (one-finger swipe up/down) as a
+/// `.valueChanged` action so the host can move the paged content, which `UIPageControl` does not do
+/// on its own for accessibility-driven page changes.
+private final class WorldCupPageControl: UIPageControl {
+    override func accessibilityIncrement() {
+        currentPage += 1
+        sendActions(for: .valueChanged)
+    }
+
+    override func accessibilityDecrement() {
+        currentPage -= 1
+        sendActions(for: .valueChanged)
+    }
+}
+
 final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCell, ThemeApplicable, Blurrable {
     private struct UX {
         static let rootContainerCornerRadius: CGFloat = 16
@@ -126,7 +141,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
         stack.semanticContentAttribute = .forceLeftToRight
     }
 
-    private let pageControl: UIPageControl = .build { control in
+    private let pageControl: WorldCupPageControl = .build { control in
         control.hidesForSinglePage = true
         control.isUserInteractionEnabled = false
         control.semanticContentAttribute = .forceLeftToRight
@@ -168,6 +183,7 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
     private func setupLayout() {
         scrollView.addSubview(pagesStack)
         rootContainer.addSubviews(scrollView, pageControl)
+        pageControl.addTarget(self, action: #selector(pageControlAccessibilityValueChanged), for: .valueChanged)
         contentView.addSubview(winnerBackgroundView)
         contentView.addSubview(rootContainer)
 
@@ -320,6 +336,11 @@ final class WorldCupCell: UICollectionViewCell, UIScrollViewDelegate, ReusableCe
     }
 
     // MARK: - Accessibility
+
+    @objc
+    private func pageControlAccessibilityValueChanged() {
+        goToPage(pageControl.currentPage)
+    }
 
     override func accessibilityScroll(_ direction: UIAccessibilityScrollDirection) -> Bool {
         let total = pagesStack.arrangedSubviews.count

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupCell.swift
@@ -89,9 +89,6 @@ private final class PageContainer: UIView, ThemeApplicable {
     }
 }
 
-/// A page control that forwards VoiceOver's adjustable gesture (one-finger swipe up/down) as a
-/// `.valueChanged` action so the host can move the paged content, which `UIPageControl` does not do
-/// on its own for accessibility-driven page changes.
 private final class WorldCupPageControl: UIPageControl {
     override func accessibilityIncrement() {
         currentPage += 1

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
@@ -441,13 +441,14 @@ private final class FeaturedMatchView: UIView, ThemeApplicable {
         stack.axis = .horizontal
         stack.alignment = .center
         stack.spacing = UX.horizontalStackSpace
-        stack.accessibilityElements = [homeColumn.container, centerStack, awayColumn.container]
         return stack
     }()
 
     init() {
         super.init(frame: .zero)
         setupLayout()
+        isAccessibilityElement = true
+        accessibilityTraits = .link
         isUserInteractionEnabled = true
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
     }
@@ -509,7 +510,7 @@ private final class FeaturedMatchView: UIView, ThemeApplicable {
 
         NSLayoutConstraint.activate([
             flagView.widthAnchor.constraint(equalToConstant: UX.flagSize.width),
-            flagView.heightAnchor.constraint(equalToConstant: UX.flagSize.height),
+            flagView.heightAnchor.constraint(equalToConstant: UX.flagSize.height).priority(.defaultHigh),
         ])
 
         return FeaturedColumn(container: stack, flagView: flagView, codeLabel: codeLabel)
@@ -526,6 +527,7 @@ private final class FeaturedMatchView: UIView, ThemeApplicable {
         homeColumn.codeLabel.text = match.homeCode
         awayColumn.flagView.image = UIImage(named: match.awayFlagAssetName)
         awayColumn.codeLabel.text = match.awayCode
+        accessibilityLabel = match.matchAccessibilityLabel
 
         if let score = match.score {
             dateLabel.isHidden = true
@@ -612,6 +614,8 @@ private final class UpcomingMatchRow: UIView, ThemeApplicable {
     init() {
         super.init(frame: .zero)
         setupLayout()
+        isAccessibilityElement = true
+        accessibilityTraits = .link
         isUserInteractionEnabled = true
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap)))
     }
@@ -657,9 +661,9 @@ private final class UpcomingMatchRow: UIView, ThemeApplicable {
             ),
 
             homeFlagView.widthAnchor.constraint(equalToConstant: UX.flagSize.width),
-            homeFlagView.heightAnchor.constraint(equalToConstant: UX.flagSize.height),
+            homeFlagView.heightAnchor.constraint(equalToConstant: UX.flagSize.height).priority(.defaultHigh),
             awayFlagView.widthAnchor.constraint(equalToConstant: UX.flagSize.width),
-            awayFlagView.heightAnchor.constraint(equalToConstant: UX.flagSize.height),
+            awayFlagView.heightAnchor.constraint(equalToConstant: UX.flagSize.height).priority(.defaultHigh),
         ])
     }
 
@@ -683,6 +687,8 @@ private final class UpcomingMatchRow: UIView, ThemeApplicable {
         } else {
             infoLabel.text = match.date
         }
+
+        accessibilityLabel = match.matchAccessibilityLabel
     }
 
     // MARK: - ThemeApplicable
@@ -695,5 +701,19 @@ private final class UpcomingMatchRow: UIView, ThemeApplicable {
         homeFlagView.backgroundColor = theme.colors.borderSecondary
         awayFlagView.layer.borderColor = theme.colors.borderSecondary.cgColor
         awayFlagView.backgroundColor = theme.colors.borderSecondary
+    }
+}
+
+private extension WorldCupMatch {
+    /// Reads the match as a single VoiceOver phrase: "Home team, date or score, Away team".
+    var matchAccessibilityLabel: String {
+        let homeName = WorldCupCountry.localizedName(forID: homeCode) ?? homeCode
+        let awayName = WorldCupCountry.localizedName(forID: awayCode) ?? awayCode
+        let middle: String = if let score {
+            "\(score.score), \(score.clock)"
+        } else {
+            date
+        }
+        return "\(homeName), \(middle), \(awayName)"
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupWinnerBackgroundView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupWinnerBackgroundView.swift
@@ -143,6 +143,7 @@ final class WorldCupWinnerBackgroundView: UIView, ThemeApplicable, Blurrable {
     func configure(teamName: String, subtitle: String) {
         flagView.image = UIImage(named: teamName)
         teamNameLabel.text = teamName
+        teamNameLabel.accessibilityLabel = WorldCupCountry.localizedName(forID: teamName) ?? teamName
         subtitleLabel.text = subtitle
     }
 


### PR DESCRIPTION
## :scroll: Tickets

### WorldCupCell not resizing correctly on iOS 18 and before
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16011)
~~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~~ ticket missing

### Accessibility gesture not working on UIPageControl
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16027)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34193)

### Featured match and Upcoming match are not exposed correctly to VoiceOver
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16031)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34195)

## :bulb: Description
This PR fixes:
- WorldCupCell not resizing correctly on iOS 18 and before devices
- UIPageControl voice over not working when swiping up or swiping down
- Featured matches and Upcoming Matches not announced correctly by the VoiceOver

## :movie_camera: Demos

### Voice Over
https://github.com/user-attachments/assets/a4dfd92d-ca51-4744-b455-66207386ba1d

### Cell resize
https://github.com/user-attachments/assets/95885e6a-381f-4bf0-9c57-713982cf5489

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

