### PR TITLE
Bugfix MTE-5449 Option to ensure element to be in the view before taking action

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -32833,7 +32833,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mozilla-mobile/MappaMundi.git";
 			requirement = {
-				branch = master;
+				branch = "cs/MTE-5449-scrollIntoViewWithin-settings";
 				kind = branch;
 			};
 		};

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla-mobile/MappaMundi.git",
       "state" : {
-        "branch" : "master",
-        "revision" : "f56a6e483163a761adc8cd25c337db0ed1eac524"
+        "branch" : "cs/MTE-5449-scrollIntoViewWithin-settings",
+        "revision" : "2eb6cc4282303e8614925e33bdbc3bd3677a2bf9"
       }
     },
     {

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -249,6 +249,10 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
 
         allSettingsScreens.forEach { nodeName in
             self.navigator.goto(SettingsScreen)
+            // Returning from the previous subscreen taps the nav-bar back button but does not wait
+            // for the Settings list to come back; without this the next navigation can race the
+            // back transition and fail (e.g. "Cannot get from SettingsScreen to NewTabSettings").
+            table.mozWaitElementHittable(timeout: TIMEOUT)
             self.navigator.goto(nodeName)
             if nodeName == "DisplaySettings" {
                 snapshot("Settings-\(nodeName)")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -382,11 +382,20 @@ extension XCUIElement {
             eachScreen(screenNum)
 
             let firstCell = self.cells.element(boundBy: Int(cellNum))
-            cellNum = firstInvisibleCell(cellNum)
-            if cellNum == UInt.min {
+            let nextCellNum = firstInvisibleCell(cellNum)
+            // Stop when every cell is visible, or when scrolling made no progress (the same cell is
+            // still the first one offscreen) — otherwise the table-swipe fallback below can spin.
+            if nextCellNum == UInt.min || nextCellNum == cellNum {
                 return
             }
-            firstCell.swipeUp()
+            cellNum = nextCellNum
+            // Swiping the cell fails ("visible frame is empty") when it is offscreen, which can happen
+            // for tall localized rows; fall back to swiping the table itself in that case.
+            if firstCell.isHittable {
+                firstCell.swipeUp()
+            } else {
+                self.swipeUp()
+            }
             screenNum += 1
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerSettingsNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerSettingsNavigation.swift
@@ -9,34 +9,68 @@ import MappaMundi
 func registerSettingsNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
     let table = app.tables.element(boundBy: 0)
 
+    // swiftlint:disable:next closure_body_length
     map.addScreenState(SettingsScreen) { screenState in
-        screenState.tap(table.cells["Sync"], to: SyncSettings, if: "fxaUsername != nil")
-        screenState.tap(table.cells["SignInToSync"], to: Intro_FxASignin, if: "fxaUsername == nil")
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Search.searchNavigationBar], to: SearchSettings)
-        screenState.tap(table.cells["NewTab"], to: NewTabSettings)
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Homepage.homeSettings], to: HomeSettings)
-        screenState.tap(table.cells["DisplayThemeOption"], to: DisplaySettings)
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting], to: ToolbarSettings)
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Browsing.title], to: BrowsingSettings)
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Summarize.title], to: SummarizeSettings)
-        screenState.tap(table.cells["SiriSettings"], to: SiriSettings)
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.AutofillsPasswords.title],
-                        to: AutofillPasswordSettings)
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.ClearData.title], to: ClearPrivateDataSettings)
+        // `scrollIntoViewWithin: table` lets MappaMundi scroll a target row into view before tapping;
+        // localized Settings rows are often pushed off-screen (still in the a11y tree but not hittable),
+        // which would otherwise fail the tap.
+        screenState.tap(table.cells["Sync"], to: SyncSettings, scrollIntoViewWithin: table, if: "fxaUsername != nil")
+        screenState.tap(
+            table.cells["SignInToSync"],
+            to: Intro_FxASignin,
+            scrollIntoViewWithin: table,
+            if: "fxaUsername == nil")
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.Search.searchNavigationBar],
+            to: SearchSettings,
+            scrollIntoViewWithin: table)
+        screenState.tap(table.cells["NewTab"], to: NewTabSettings, scrollIntoViewWithin: table)
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.Homepage.homeSettings],
+            to: HomeSettings,
+            scrollIntoViewWithin: table)
+        screenState.tap(table.cells["DisplayThemeOption"], to: DisplaySettings, scrollIntoViewWithin: table)
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting],
+            to: ToolbarSettings,
+            scrollIntoViewWithin: table)
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.Browsing.title],
+            to: BrowsingSettings,
+            scrollIntoViewWithin: table)
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.Summarize.title],
+            to: SummarizeSettings,
+            scrollIntoViewWithin: table)
+        screenState.tap(table.cells["SiriSettings"], to: SiriSettings, scrollIntoViewWithin: table)
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.AutofillsPasswords.title],
+            to: AutofillPasswordSettings,
+            scrollIntoViewWithin: table)
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.ClearData.title],
+            to: ClearPrivateDataSettings,
+            scrollIntoViewWithin: table)
         screenState.tap(
             table.cells[AccessibilityIdentifiers.Settings.ContentBlocker.title],
-            to: TrackingProtectionSettings
-        )
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.ShowIntroduction.title],
-                        to: ShowTourInSettings)
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Notifications.title],
-                        to: NotificationsSettings)
+            to: TrackingProtectionSettings,
+            scrollIntoViewWithin: table)
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.ShowIntroduction.title],
+            to: ShowTourInSettings,
+            scrollIntoViewWithin: table)
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.Notifications.title],
+            to: NotificationsSettings,
+            scrollIntoViewWithin: table)
         screenState.gesture(forAction: Action.ToggleNoImageMode) { userState in
             app.otherElements.tables.cells.switches[
                 AccessibilityIdentifiers.Settings.BlockImages.title].waitAndTap()
         }
         screenState.tap(
-            table.cells[AccessibilityIdentifiers.Settings.AppIconSelection.settingsRowTitle], to: AppIconSettings)
+            table.cells[AccessibilityIdentifiers.Settings.AppIconSelection.settingsRowTitle],
+            to: AppIconSettings,
+            scrollIntoViewWithin: table)
         screenState.backAction = navigationControllerBackAction(for: app)
     }
 
@@ -50,7 +84,8 @@ func registerSettingsNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApp
     map.addScreenState(SearchSettings) { screenState in
         screenState.tap(
             table.cells[AccessibilityIdentifiers.Settings.Search.customEngineViewButton],
-            to: AddCustomSearchSettings
+            to: AddCustomSearchSettings,
+            scrollIntoViewWithin: table
         )
         screenState.backAction = navigationControllerBackAction(for: app)
         screenState.gesture(forAction: Action.RemoveCustomSearchEngine) {userSTate in
@@ -66,8 +101,11 @@ func registerSettingsNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApp
     }
 
     map.addScreenState(BrowsingSettings) { screenState in
-        screenState.tap(table.cells[AccessibilityIdentifiers.Settings.Browsing.autoPlay], to: AutoplaySettings)
-        screenState.tap(table.cells["OpenWith.Setting"], to: MailAppSettings)
+        screenState.tap(
+            table.cells[AccessibilityIdentifiers.Settings.Browsing.autoPlay],
+            to: AutoplaySettings,
+            scrollIntoViewWithin: table)
+        screenState.tap(table.cells["OpenWith.Setting"], to: MailAppSettings, scrollIntoViewWithin: table)
 
         screenState.backAction = navigationControllerBackAction(for: app)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5449)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

***Important***: Must be used together with updated MappaMundi: https://github.com/mozilla-mobile/MappaMundi/pull/24. This change would ***NOT*** compile without it.

Some non Latin locales (including km, my, ru, ur, ab, bg) fail to have all settings L10n screenshots available. The L10n test `testSettings` attempts to tap on the menu item that's outside of the view. While this approach works in en-US, fr, es etc, but this approach does not work consistently mainly for Cyrillic character based locales.

Summary of before and after the change. After the change, I get all `testSettings` screenshots for 6 out of 7 problematic locales.
```
┌──────────────┬────────────┬──────────┬──────────┬───────────────────────┐
│    Locale    │   Script   │  Before  │  After   │        Status         │
├──────────────┼────────────┼──────────┼──────────┼───────────────────────┤
│ km (Khmer)   │ Khmer      │ 18       │ 21       │ ✅ full               │
├──────────────┼────────────┼──────────┼──────────┼───────────────────────┤
│ my (Burmese) │ Burmese    │ 18       │ 22       │ ✅ full               │
├──────────────┼────────────┼──────────┼──────────┼───────────────────────┤
│ ru (Russian) │ Cyrillic   │ 18       │ 21       │ ✅ full               │
├──────────────┼────────────┼──────────┼──────────┼───────────────────────┤
│ ur (Urdu)    │ Arabic/RTL │ 18       │ 21       │ ✅ full               │
├──────────────┼────────────┼──────────┼──────────┼───────────────────────┤
│ ab           │ Cyrillic   │ ~8       │ 21       │ ✅ full (former worst │
│ (Abkhazian)  │            │          │          │  case)                │
├──────────────┼────────────┼──────────┼──────────┼───────────────────────┤
│ zh-TW        │ Han        │ (flaked) │ complete │ ✅ all 15 screens +   │
│ (Chinese)    │            │          │          │ main                  │
├──────────────┼────────────┼──────────┼──────────┼───────────────────────┤
│ en-US        │ Latin      │ pass     │ pass     │ ✅ no regression      │
│ (control)    │            │          │          │                       │
├──────────────┼────────────┼──────────┼──────────┼───────────────────────┤
│ bg           │            │          │          │ ⚠️ known-flaky        │
│ (Bulgarian)  │ Cyrillic   │ 18       │ flaky    │ (gate-signal issue,   │
│              │            │          │          │ likely fixable)       │
└──────────────┴────────────┴──────────┴──────────┴───────────────────────┘
```

I have run all smoke tests and all full functional tests. No new test failures have been introduced.

*Open issue*
`bg` locale still has issues navigating the settings menu.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

`testSettings` in `en-US` locale:
https://github.com/user-attachments/assets/da2da999-b490-4c20-b30e-0e28621ab771

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

