### PR TITLE
Add FXIOS-14874 [Deeplinks] Normal mode deeplink overlay experiment

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1680,6 +1680,7 @@
 		C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */; };
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
 		C705FA782EF30C4F00AC5EE7 /* PrivacyNoticeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C705FA772EF30C4B00AC5EE7 /* PrivacyNoticeHelperTests.swift */; };
+		319478509A7F45D09CBCEC18 /* PrivacyWindowHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3C8A4CBEAC46E58A977BF8 /* PrivacyWindowHelperTests.swift */; };
 		C705FA7A2EF31F0500AC5EE7 /* MockPrivacyNoticeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C705FA792EF31F0000AC5EE7 /* MockPrivacyNoticeHelper.swift */; };
 		C705FD582EF354D300AC5EE7 /* PrivacyNoticeUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C705FD572EF3545500AC5EE7 /* PrivacyNoticeUpdate.swift */; };
 		C706CBEF2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C706CBEE2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift */; };
@@ -10565,6 +10566,7 @@
 		C6AF4D4DBE2C76759B1DDE6B /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C6C94C1CB6286845DEAF8EDD /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C705FA772EF30C4B00AC5EE7 /* PrivacyNoticeHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyNoticeHelperTests.swift; sourceTree = "<group>"; };
+		4B3C8A4CBEAC46E58A977BF8 /* PrivacyWindowHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyWindowHelperTests.swift; sourceTree = "<group>"; };
 		C705FA792EF31F0000AC5EE7 /* MockPrivacyNoticeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyNoticeHelper.swift; sourceTree = "<group>"; };
 		C705FD572EF3545500AC5EE7 /* PrivacyNoticeUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyNoticeUpdate.swift; sourceTree = "<group>"; };
 		C706CBEE2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardSettingsViewControllerTests.swift; sourceTree = "<group>"; };
@@ -14534,6 +14536,7 @@
 			children = (
 				EDD592462FC0FF690015EF9E /* ModifiedCopyMacroTests.swift */,
 				C705FA772EF30C4B00AC5EE7 /* PrivacyNoticeHelperTests.swift */,
+				4B3C8A4CBEAC46E58A977BF8 /* PrivacyWindowHelperTests.swift */,
 				8A83C58D2DDF887200FF60EF /* ProfilePrefsReaderTests.swift */,
 				8AC884202D5261FC0033ABF5 /* CrashTrackerTests.swift */,
 				8A967E412D30418A00B1017D /* TelemetryDebugMessage.swift */,
@@ -20335,6 +20338,7 @@
 				0ABCD45D2D356015005D704A /* TermsOfServiceTelemetryTests.swift in Sources */,
 				C8CD80D42A1E268C0097C3AE /* MockGleanPlumbEvaluationUtility.swift in Sources */,
 				C705FA782EF30C4F00AC5EE7 /* PrivacyNoticeHelperTests.swift in Sources */,
+				319478509A7F45D09CBCEC18 /* PrivacyWindowHelperTests.swift in Sources */,
 				8A7AE4472BAC78230072DAEC /* MockLibraryNavigationHandler.swift in Sources */,
 				C25020842ECDE75D0071506F /* MockTranslationsSchemeHandler.swift in Sources */,
 				8A7A26E829D4C0FE00EA76F1 /* IntroScreenManagerTests.swift in Sources */,

--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -17,6 +17,7 @@ enum FeatureFlagID: String, CaseIterable {
     case bookmarksSearchFeature
     case customReaderModeScheme
     case deeplinkOptimizationRefactor
+    case deeplinkOverlay
     case downloadLiveActivities
     case firefoxJpGuideDefaultSite
     case firefoxSuggestFeature
@@ -99,6 +100,7 @@ enum FeatureFlagID: String, CaseIterable {
                 .bookmarksSearchFeature,
                 .customReaderModeScheme,
                 .deeplinkOptimizationRefactor,
+                .deeplinkOverlay,
                 .downloadLiveActivities,
                 .homepageAddShortcutTile,
                 .homepagePinnedHeader,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -826,8 +826,12 @@ class BrowserViewController: UIViewController,
     }
 
     private var canShowPrivacyWindow: Bool {
-        // Ensure the selected tab is private and determine if the privacy window can be shown.
-        guard let privateTab = tabManager.selectedTab, privateTab.isPrivate else { return false }
+        // The overlay is shown for private tabs (privacy) or for any tab when the
+        // deeplinkOverlay flag is enabled (to mask the stale tab while a deep link
+        // is being handled on resume).
+        guard let selectedTab = tabManager.selectedTab else { return false }
+        let isDeeplinkOverlayEnabled = featureFlagsProvider.isEnabled(.deeplinkOverlay)
+        guard selectedTab.isPrivate || isDeeplinkOverlayEnabled else { return false }
         // Show privacy window if no view controller is presented
         // or if the presented view is a PhotonActionSheet.
         return self.presentedViewController == nil || presentedViewController is PhotonActionSheet

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -795,7 +795,11 @@ class BrowserViewController: UIViewController,
               currentWindowScene === windowScene else { return }
         guard canShowPrivacyWindow else { return }
 
-        privacyWindowHelper.showWindow(windowScene: currentWindowScene, withThemedColor: currentTheme().colors.layer3)
+        privacyWindowHelper.showWindow(
+            windowScene: currentWindowScene,
+            withThemedColor: currentTheme().colors.layer3,
+            showLogo: shouldShowOverlayLogo
+        )
     }
 
     func sceneDidActivateNotification() {
@@ -822,7 +826,18 @@ class BrowserViewController: UIViewController,
         }
 
         guard canShowPrivacyWindow else { return }
-        privacyWindowHelper.showWindow(windowScene: view.window?.windowScene, withThemedColor: currentTheme().colors.layer3)
+        privacyWindowHelper.showWindow(
+            windowScene: view.window?.windowScene,
+            withThemedColor: currentTheme().colors.layer3,
+            showLogo: shouldShowOverlayLogo
+        )
+    }
+
+    /// Show the Firefox logo on the overlay only for normal-mode tabs when the
+    /// deeplinkOverlay flag is on. Private-mode overlay stays a plain color.
+    private var shouldShowOverlayLogo: Bool {
+        guard let selectedTab = tabManager.selectedTab, !selectedTab.isPrivate else { return false }
+        return featureFlagsProvider.isEnabled(.deeplinkOverlay)
     }
 
     private var canShowPrivacyWindow: Bool {

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -95,6 +95,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .deeplinkOverlay,
+                titleText: format(string: "Deeplink Overlay"),
+                statusText: format(string: "Toggle to show the background overlay for all tabs")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .downloadLiveActivities,
                 titleText: format(string: "Download Live Activities"),
                 statusText: format(string: "Toggle to enable download live activities")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -51,6 +51,9 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .deeplinkOptimizationRefactor:
             return checkDeeplinkOptimizationRefactorFeature()
 
+        case .deeplinkOverlay:
+            return checkDeeplinkOverlayFeature()
+
         case .downloadLiveActivities:
             return checkDownloadLiveActivitiesFeature()
 
@@ -350,6 +353,10 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
     private func checkDeeplinkOptimizationRefactorFeature() -> Bool {
         let config = nimbus.features.deeplinkOptimizationRefactorFeature.value()
         return config.enabled
+    }
+
+    private func checkDeeplinkOverlayFeature() -> Bool {
+        return nimbus.features.deeplinkOverlayFeature.value().enabled
     }
 
     private func checkDownloadLiveActivitiesFeature() -> Bool {

--- a/firefox-ios/Client/PrivacyWindowHelper.swift
+++ b/firefox-ios/Client/PrivacyWindowHelper.swift
@@ -5,15 +5,36 @@
 import UIKit
 
 final class PrivacyWindowHelper {
+    private struct UX {
+        static let logoSize: CGFloat = 80
+    }
+
     private var privacyWindow: UIWindow?
 
     @MainActor
-    func showWindow(windowScene: UIWindowScene?, withThemedColor color: UIColor) {
+    func showWindow(windowScene: UIWindowScene?, withThemedColor color: UIColor, showLogo: Bool = false) {
         guard let windowScene else { return }
 
+        let rootViewController = UIViewController()
+        rootViewController.view.backgroundColor = color
+
+        if showLogo {
+            let logoImageView = UIImageView(
+                image: UIImage(named: ImageIdentifiers.homeHeaderLogoBall)
+            )
+            logoImageView.contentMode = .scaleAspectFit
+            logoImageView.translatesAutoresizingMaskIntoConstraints = false
+            rootViewController.view.addSubview(logoImageView)
+            NSLayoutConstraint.activate([
+                logoImageView.centerXAnchor.constraint(equalTo: rootViewController.view.centerXAnchor),
+                logoImageView.centerYAnchor.constraint(equalTo: rootViewController.view.centerYAnchor),
+                logoImageView.widthAnchor.constraint(equalToConstant: UX.logoSize),
+                logoImageView.heightAnchor.constraint(equalToConstant: UX.logoSize)
+            ])
+        }
+
         privacyWindow = UIWindow(windowScene: windowScene)
-        privacyWindow?.rootViewController = UIViewController()
-        privacyWindow?.rootViewController?.view.backgroundColor = color
+        privacyWindow?.rootViewController = rootViewController
         // Set the privacy window level to be above alert windows (highest in importance).
         privacyWindow?.windowLevel = .alert + 1
         // Avoid makeKeyAndVisible(), becoming key steals first responder

--- a/firefox-ios/Client/PrivacyWindowHelper.swift
+++ b/firefox-ios/Client/PrivacyWindowHelper.swift
@@ -38,7 +38,7 @@ final class PrivacyWindowHelper {
         // Set the privacy window level to be above alert windows (highest in importance).
         privacyWindow?.windowLevel = .alert + 1
         // Avoid makeKeyAndVisible(), becoming key steals first responder
-        // and causses iOS keyboard to dismiss on background/foreground in private mode.
+        // and causes iOS keyboard to dismiss on background/foreground in private mode.
         privacyWindow?.isHidden = false
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/PrivacyWindowHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/PrivacyWindowHelperTests.swift
@@ -1,0 +1,127 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class PrivacyWindowHelperTests: XCTestCase {
+    func test_showWindow_withNilScene_doesNotCreatePrivacyWindow() throws {
+        let windowScene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        let windowsBefore = windowScene.windows
+        let subject = createSubject()
+
+        subject.showWindow(windowScene: nil, withThemedColor: .red)
+
+        XCTAssertEqual(windowScene.windows.count, windowsBefore.count)
+        XCTAssertNil(privacyWindow(in: windowScene))
+    }
+
+    func test_showWindow_withValidScene_addsPrivacyWindowToScene() throws {
+        let windowScene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        let subject = createSubject()
+
+        subject.showWindow(windowScene: windowScene, withThemedColor: .red)
+
+        XCTAssertNotNil(privacyWindow(in: windowScene))
+    }
+
+    func test_showWindow_setsRootViewBackgroundColorToProvidedColor() throws {
+        let windowScene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        let expectedColor = UIColor.systemPink
+        let subject = createSubject()
+
+        subject.showWindow(windowScene: windowScene, withThemedColor: expectedColor)
+
+        let window = try XCTUnwrap(privacyWindow(in: windowScene))
+        XCTAssertEqual(window.rootViewController?.view.backgroundColor, expectedColor)
+    }
+
+    func test_showWindow_setsWindowLevelAboveAlert() throws {
+        let windowScene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        let subject = createSubject()
+
+        subject.showWindow(windowScene: windowScene, withThemedColor: .red)
+
+        let window = try XCTUnwrap(privacyWindow(in: windowScene))
+        XCTAssertEqual(window.windowLevel, .alert + 1)
+    }
+
+    func test_showWindow_doesNotHideWindow() throws {
+        let windowScene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        let subject = createSubject()
+
+        subject.showWindow(windowScene: windowScene, withThemedColor: .red)
+
+        let window = try XCTUnwrap(privacyWindow(in: windowScene))
+        XCTAssertFalse(window.isHidden)
+    }
+
+    func test_showWindow_withDefaultShowLogo_doesNotAddLogoSubview() throws {
+        let windowScene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        let subject = createSubject()
+
+        subject.showWindow(windowScene: windowScene, withThemedColor: .red)
+
+        let window = try XCTUnwrap(privacyWindow(in: windowScene))
+        let rootView = try XCTUnwrap(window.rootViewController?.view)
+        XCTAssertTrue(rootView.subviews.isEmpty)
+    }
+
+    func test_showWindow_withShowLogoFalse_doesNotAddLogoSubview() throws {
+        let windowScene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        let subject = createSubject()
+
+        subject.showWindow(windowScene: windowScene, withThemedColor: .red, showLogo: false)
+
+        let window = try XCTUnwrap(privacyWindow(in: windowScene))
+        let rootView = try XCTUnwrap(window.rootViewController?.view)
+        XCTAssertTrue(rootView.subviews.isEmpty)
+    }
+
+    func test_showWindow_withShowLogoTrue_addsLogoImageView() throws {
+        let windowScene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        let subject = createSubject()
+
+        subject.showWindow(windowScene: windowScene, withThemedColor: .red, showLogo: true)
+
+        let window = try XCTUnwrap(privacyWindow(in: windowScene))
+        let rootView = try XCTUnwrap(window.rootViewController?.view)
+        let imageViews = rootView.subviews.compactMap { $0 as? UIImageView }
+        XCTAssertEqual(imageViews.count, 1)
+    }
+
+    func test_removeWindow_afterShowWindow_hidesPrivacyWindow() throws {
+        let windowScene = try XCTUnwrap(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+        let subject = createSubject()
+        subject.showWindow(windowScene: windowScene, withThemedColor: .red)
+        let window = try XCTUnwrap(privacyWindow(in: windowScene))
+
+        subject.removeWindow()
+
+        XCTAssertTrue(window.isHidden)
+    }
+
+    func test_removeWindow_withoutPriorShow_doesNotCrash() {
+        let subject = createSubject()
+
+        subject.removeWindow()
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> PrivacyWindowHelper {
+        let subject = PrivacyWindowHelper()
+        addTeardownBlock { @MainActor in
+            subject.removeWindow()
+        }
+        return subject
+    }
+
+    /// Finds the privacy window in the scene by its distinguishing windowLevel (.alert + 1).
+    private func privacyWindow(in scene: UIWindowScene) -> UIWindow? {
+        return scene.windows.first { $0.windowLevel == .alert + 1 }
+    }
+}

--- a/firefox-ios/nimbus-features/deeplinkOverlayFeature.yaml
+++ b/firefox-ios/nimbus-features/deeplinkOverlayFeature.yaml
@@ -1,0 +1,21 @@
+# The configuration for the deeplinkOverlayFeature feature
+features:
+  deeplink-overlay-feature:
+    description: >
+      Controls whether a privacy-style overlay is shown when the app moves to
+      the background, regardless of tab privacy state. Used to mask the
+      previously displayed tab while a deep link is being handled on resume.
+    variables:
+      enabled:
+        description: >
+          If true, show the background overlay for all tabs (private and
+          normal). If false, the overlay is only shown for private tabs.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: false

--- a/firefox-ios/nimbus-features/deeplinkOverlayFeature.yaml
+++ b/firefox-ios/nimbus-features/deeplinkOverlayFeature.yaml
@@ -11,11 +11,11 @@ features:
           If true, show the background overlay for all tabs (private and
           normal). If false, the overlay is only shown for private tabs.
         type: Boolean
-        default: false
+        default: true
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
       - channel: developer
         value:
-          enabled: false
+          enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -20,6 +20,7 @@ include:
   - nimbus-features/bookmarksSearchFeature.yaml
   - nimbus-features/customReaderModeSchemeFeature.yaml
   - nimbus-features/deeplinkOptimizationRefactorFeature.yaml
+  - nimbus-features/deeplinkOverlayFeature.yaml
   - nimbus-features/downloadLiveActivitiesFeature.yaml
   - nimbus-features/firefoxJpGuideDefaultSite.yaml
   - nimbus-features/firefoxSuggestFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14874)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32071)

## :bulb: Description
The issue has been determined to be that whenever we move our application to background (in the App Switcher) the OS takes a screenshot of our application. Whenever we come back to our application with a deeplink, the OS shows that screenshot before we’re able to change the content on-screen. It makes it appear as if we’re on the previous tab, even though we are in fact navigating to the deeplink as soon as possible.

A solution investigated is to show an overlay (which we already have code for, since we have a privacy overlay for private tabs). When we move our app to the background, the OS will take a screenshot of that overlay instead of the previous tab. The transition to deeplinks is smoother in that case. This functions like Focus does basically (which always shows an overlay).

This is all feature flag protected, i.e if the flag deeplinkOverlayFeature is disabled we will have the existing behavior of showing an overlay on private tabs. If the feature flag is ON, then we have an overlay for normal tabs as well (which has a logo since the overlay was white otherwise). The privacy overlay doesn’t have the logo.

## :movie_camera: Demos
https://github.com/user-attachments/assets/c15a8300-82a8-42b3-bc57-868eeccb70da

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

