### PR TITLE
Add FXIOS-16056 [Google Lens] Strings

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -7982,12 +7982,19 @@ extension String {
             comment: "Label for button in the address toolbar, that cancels editing the address field when tapped.")
 
         public struct GoogleLens {
+            public static let A11yLabel = MZLocalizedString(
+                key: "AddressToolbar.GoogleLens.A11yLabel.v153",
+                tableName: "AddressToolbar",
+                value: "Search with Google Lens",
+                comment: "Accessibility label describing the Google Lens button on the address toolbar that prompts a menu to allow the user to take a new photo or select an existing photo from their photo library to search with Google Lens.")
+
             public struct ContextMenu {
                 public static let TakePhotoActionTitle = MZLocalizedString(
                     key: "AddressToolbar.GoogleLens.ContextMenu.TakePhotoActionTitle.v153",
                     tableName: "AddressToolbar",
                     value: "Take Photo",
                     comment: "Action title in the Google Lens address toolbar context menu. Opens the camera so the user can take a new photo to search with Google Lens.")
+
                 public static let PhotoLibraryActionTitle = MZLocalizedString(
                     key: "AddressToolbar.GoogleLens.ContextMenu.PhotoLibraryActionTitle.v153",
                     tableName: "AddressToolbar",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -3491,6 +3491,21 @@ extension String {
                     )
                 }
 
+                public struct GoogleLensSection {
+                    public static let Title = MZLocalizedString(
+                        key: "Settings.AIControls.AIPoweredFeaturesSection.GoogleLensSection.Title.v153",
+                        tableName: "Settings",
+                        value: "Google Lens",
+                        comment: "In the AI Controls settings, in the AI powered features section, this is the title that describes the Google Lens feature"
+                    )
+
+                    public static let Message = MZLocalizedString(
+                        key: "Settings.AIControls.AIPoweredFeaturesSection.GoogleLensSection.Message.v153",
+                        tableName: "Settings",
+                        value: "Sends images and photos to Google for visual search.",
+                        comment: "In the AI Controls settings, in the AI powered features section, this is the message that describes the Google Lens feature"
+                    )
+
                 public static let BlockedStatus = MZLocalizedString(
                     key: "Settings.AIControls.AIPoweredFeaturesSection.BlockedStatus.v151",
                     tableName: "Settings",
@@ -5695,6 +5710,11 @@ extension String {
         tableName: nil,
         value: "Copy Image Link",
         comment: "Context menu item for copying an image URL to the clipboard")
+    public static let ContextMenuGoogleLens = MZLocalizedString(
+        key: "ContextMenu.GoogleLensButtonTitle.v153",
+        tableName: "WebContextMenu",
+        value: "Search Image with Google Lens",
+        comment: "Context menu item to search for an image using Google Lens")
 }
 
 // MARK: - Photo Library access
@@ -7959,6 +7979,21 @@ extension String {
             tableName: "AddressToolbar",
             value: "Cancel",
             comment: "Label for button in the address toolbar, that cancels editing the address field when tapped.")
+
+        public struct GoogleLens {
+            public struct ContextMenu {
+                public static let TakePhotoActionTitle = MZLocalizedString(
+                    key: "AddressToolbar.GoogleLens.ContextMenu.TakePhotoActionTitle.v153",
+                    tableName: "AddressToolbar",
+                    value: "Take Photo",
+                    comment: "Action title in the Google Lens address toolbar context menu. Opens the camera so the user can take a new photo to search with Google Lens.")
+                public static let PhotoLibraryActionTitle = MZLocalizedString(
+                    key: "AddressToolbar.GoogleLens.ContextMenu.PhotoLibraryActionTitle.v153",
+                    tableName: "AddressToolbar",
+                    value: "Photo Library",
+                    comment: "Action title in the Google Lens address toolbar context menu. Opens the photo library picker so the user can choose an existing photo to search with Google Lens.")
+            }
+        }
     }
 }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -3505,6 +3505,7 @@ extension String {
                         value: "Sends images and photos to Google for visual search.",
                         comment: "In the AI Controls settings, in the AI powered features section, this is the message that describes the Google Lens feature"
                     )
+                }
 
                 public static let BlockedStatus = MZLocalizedString(
                     key: "Settings.AIControls.AIPoweredFeaturesSection.BlockedStatus.v151",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16056)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- Add strings for Google Lens integration

### 📝 Open Questions:
- Do we need an a11y label for the address toolbar icon button?
- The `Sends images and photos to Google for visual search.` string's content seems redundant (images and photos are the same thing?)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

