### PR TITLE
Refactor AC-126 [Ads Client] Replace MozAdsClientProtocol with concrete MozAdsClient

### DIFF
--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/MozAdsClientFactory.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/MozAdsClientFactory.swift
@@ -7,11 +7,11 @@ import Foundation
 import MozillaAppServices
 
 protocol MozAdsClientFactory {
-    func createClient() -> MozAdsClientProtocol
+    func createClient() -> MozAdsClient
 }
 
 final class DefaultMozAdsClientFactory: MozAdsClientFactory {
-    func createClient() -> MozAdsClientProtocol {
+    func createClient() -> MozAdsClient {
         if CoreBuildFlags.isUsingStagingUnifiedAdsAPI {
             return RustAdsClient.staging
         }

--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsCallbackTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsCallbackTelemetry.swift
@@ -16,7 +16,7 @@ protocol UnifiedAdsCallbackTelemetry {
 }
 
 final class DefaultUnifiedAdsCallbackTelemetry: UnifiedAdsCallbackTelemetry, FeatureFlaggable {
-    private let adsClient: MozAdsClientProtocol
+    private let adsClient: MozAdsClient
     private let networking: UnifiedTileNetworking
     private let logger: Logger
     private let sponsoredTileGleanTelemetry: SponsoredTileGleanTelemetry

--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
@@ -26,7 +26,7 @@ extension UnifiedAdsProviderInterface {
 }
 
 final class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, FeatureFlaggable, Sendable {
-    private let adsClient: MozAdsClientProtocol
+    private let adsClient: MozAdsClient
     private static let prodResourceEndpoint = "https://ads.mozilla.org/v1/ads"
     static let stagingResourceEndpoint = "https://ads.allizom.org/v1/ads"
     let maxCacheAge: Shared.Timestamp = OneMinuteInMilliseconds * 30

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsProviderTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @testable import Client
 
-class MockMozAdsClient: MozAdsClientProtocol, @unchecked Sendable {
+class MockMozAdsClient: MozAdsClient, @unchecked Sendable {
     var mockAdsImages: [String: MozAdsImage]?
     var mockAdsTiles: [String: MozAdsTile]?
     var mockError: Error?
@@ -16,31 +16,27 @@ class MockMozAdsClient: MozAdsClientProtocol, @unchecked Sendable {
     var recordClickCalledWith: String?
     var recordImpressionCalledWith: String?
 
-    func clearCache() throws {}
-
-    func cycleContextId() throws -> String {
-        return "test-context-id"
+    init() {
+        super.init(noHandle: MozAdsClient.NoHandle())
     }
 
-    func recordClick(clickUrl: String, options: MozillaAppServices.MozAdsCallbackOptions?) throws {
+    required init(unsafeFromHandle handle: UInt64) {
+        super.init(unsafeFromHandle: handle)
+    }
+
+    override func recordClick(clickUrl: String, options: MozAdsCallbackOptions?) throws {
         if let error = mockError { throw error }
         recordClickCalledWith = clickUrl
     }
 
-    func recordImpression(impressionUrl: String, options: MozillaAppServices.MozAdsCallbackOptions?) throws {
+    override func recordImpression(impressionUrl: String, options: MozAdsCallbackOptions?) throws {
         if let error = mockError { throw error }
         recordImpressionCalledWith = impressionUrl
     }
 
-    func reportAd(
-        reportUrl: String,
-        reason: MozillaAppServices.MozAdsReportReason,
-        options: MozillaAppServices.MozAdsCallbackOptions?
-    ) throws {
-        // no-op for tests for now
-    }
+    override func reportAd(reportUrl: String, reason: MozAdsReportReason, options: MozAdsCallbackOptions?) throws {}
 
-    func requestImageAds(
+    override func requestImageAds(
         mozAdRequests: [MozAdsPlacementRequest],
         options: MozAdsRequestOptions?
     ) throws -> [String: MozAdsImage] {
@@ -48,16 +44,16 @@ class MockMozAdsClient: MozAdsClientProtocol, @unchecked Sendable {
         return mockAdsImages ?? [:]
     }
 
-    func requestSpocAds(
-        mozAdRequests: [MozillaAppServices.MozAdsPlacementRequestWithCount],
-        options: MozillaAppServices.MozAdsRequestOptions?
-    ) throws -> [String: [MozillaAppServices.MozAdsSpoc]] {
+    override func requestSpocAds(
+        mozAdRequests: [MozAdsPlacementRequestWithCount],
+        options: MozAdsRequestOptions?
+    ) throws -> [String: [MozAdsSpoc]] {
         return [:]
     }
 
-    func requestTileAds(
-        mozAdRequests: [MozillaAppServices.MozAdsPlacementRequest],
-        options: MozillaAppServices.MozAdsRequestOptions?
+    override func requestTileAds(
+        mozAdRequests: [MozAdsPlacementRequest],
+        options: MozAdsRequestOptions?
     ) throws -> [String: MozillaAppServices.MozAdsTile] {
         if let error = mockError { throw error }
         return mockAdsTiles ?? [:]

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockMozAdsClientFactory.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockMozAdsClientFactory.swift
@@ -8,13 +8,13 @@ import MozillaAppServices
 @testable import Client
 
 final class MockMozAdsClientFactory: MozAdsClientFactory {
-    private let mockClient: MozAdsClientProtocol
+    private let mockClient: MozAdsClient
 
-    init(mockClient: MozAdsClientProtocol) {
+    init(mockClient: MozAdsClient) {
         self.mockClient = mockClient
     }
 
-    func createClient() -> MozAdsClientProtocol {
+    func createClient() -> MozAdsClient {
         return mockClient
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/AC-126)

## :bulb: Description
The UniFFI-generated \`MozAdsClientProtocol\` changes whenever application-services adds or renames parameters. Each such change requires updating iOS mocks and conformances even when iOS doesn't use the new parameters.

This PR removes the dependency on the generated protocol entirely. \`MozAdsClient\` is an \`open class\` and UniFFI provides a \`NoHandle\` init specifically for test subclassing, so \`MockMozAdsClient\` now subclasses \`MozAdsClient\` directly and overrides only what tests need. Future upstream API additions are invisible to iOS unless explicitly adopted.

Changes:
- \`MozAdsClientFactory\`, \`UnifiedAdsProvider\`, \`UnifiedAdsCallbackTelemetry\` use \`MozAdsClient\` directly instead of \`MozAdsClientProtocol\`
- \`MockMozAdsClient\` subclasses \`MozAdsClient\` using \`noHandle:\` init, replacing the protocol conformance
- Removed stale \`cycleContextId\` stub that was never part of the protocol

No behaviour change. No UI, telemetry, or string changes.

## :movie_camera: Demos

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code