### PR TITLE
Bugfix FXIOS-16070 [Homepage] Homepage should be restored when it has navigation state

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -738,9 +738,15 @@ final class TabManagerImplementation: NSObject, TabManager, FeatureFlaggable {
 
     private func saveAllTabData() {
         // Only preserve tabs after the restore has finished
-        guard tabRestoreHasFinished, let url = selectedTab?.url, !url.isFxHomeUrl else { return }
+        guard tabRestoreHasFinished, let tab = selectedTab, let url = tab.url else { return }
+        // Skip a plain Firefox Home tab with no navigation history, but still save when home was
+        // reached by navigating back/forward, otherwise restoration replays the stale forward URL
+        // instead of the home page the user left on.
+        let webView = tab.webView
+        let hasNavigationHistory = (webView?.canGoBack ?? false) || (webView?.canGoForward ?? false)
+        guard !url.isFxHomeUrl || hasNavigationHistory else { return }
 
-        saveSessionData(forTab: selectedTab)
+        saveSessionData(forTab: tab)
         preserveTabs(forced: true)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabWebView.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabWebView.swift
@@ -20,6 +20,9 @@ final class MockTabWebView: TabWebView {
     var takeSnapshotWasCalled = false
     var takeSnapshotShouldFail = false
     var mockHasOnlySecureContent = false
+    var mockCanGoBack = false
+    var mockCanGoForward = false
+    var mockInteractionState: Data?
 
     override var title: String? {
         return mockTitle
@@ -31,6 +34,19 @@ final class MockTabWebView: TabWebView {
 
     override var hasOnlySecureContent: Bool {
         return mockHasOnlySecureContent
+    }
+
+    override var canGoBack: Bool {
+        return mockCanGoBack
+    }
+
+    override var canGoForward: Bool {
+        return mockCanGoForward
+    }
+
+    override var interactionState: Any? {
+        get { return mockInteractionState }
+        set { mockInteractionState = newValue as? Data }
     }
 
     override init(frame: CGRect, configuration: WKWebViewConfiguration, windowUUID: WindowUUID) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerPreserveTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerPreserveTabsTests.swift
@@ -79,6 +79,47 @@ final class TabManagerPreserveTabsTests: TabManagerTestsBase {
         XCTAssertEqual(mockTabStore.saveWindowDataForcedValue, false)
     }
 
+    /// Navigating back to the homepage then backgrounding must still persist the
+    /// session, otherwise restoration replays the stale forward URL instead of the home page.
+    @MainActor
+    func testWillResignActive_whenHomeTabHasNavigationHistory_savesSession() async throws {
+        let subject = createSubject(tabs: generateTabs(count: 1))
+        subject.tabRestoreHasFinished = true
+        let tab = subject.tabs[0]
+        subject.selectTab(tab)
+
+        tab.url = URL(string: "internal://local/about/home")
+        let webView = MockTabWebView(tab: tab)
+        webView.mockCanGoForward = true
+        webView.mockInteractionState = Data()
+        tab.webView = webView
+        mockSessionStore.saveTabSessionCallCount = 0
+
+        subject.handleNotifications(Notification(name: UIApplication.willResignActiveNotification))
+        try await Task.sleep(nanoseconds: sleepTime)
+
+        XCTAssertEqual(mockSessionStore.saveTabSessionCallCount, 1)
+    }
+
+    @MainActor
+    func testWillResignActive_whenHomeTabHasNoNavigationHistory_doesNotSaveSession() async throws {
+        let subject = createSubject(tabs: generateTabs(count: 1))
+        subject.tabRestoreHasFinished = true
+        let tab = subject.tabs[0]
+        subject.selectTab(tab)
+
+        tab.url = URL(string: "internal://local/about/home")
+        let webView = MockTabWebView(tab: tab)
+        webView.mockInteractionState = Data()
+        tab.webView = webView
+        mockSessionStore.saveTabSessionCallCount = 0
+
+        subject.handleNotifications(Notification(name: UIApplication.willResignActiveNotification))
+        try await Task.sleep(nanoseconds: sleepTime)
+
+        XCTAssertEqual(mockSessionStore.saveTabSessionCallCount, 0)
+    }
+
     // MARK: - Save preview screenshot
 
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16070)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34247)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Adds check to also save tab state for restoring when homepage has navigation state.
- Adds regression test

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->


| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/28a79933-6f89-4957-af0d-089ce4635ada"/> | <video src="https://github.com/user-attachments/assets/d36dd4db-315c-40c6-82b4-19c6d7257f18"/> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

