### PR TITLE
Add [World Cup] FXIOS-16071 half time label when a match is in a break

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
@@ -21,6 +21,9 @@ struct WorldCupMatch: Equatable, Hashable {
     /// FIFA Key of the winning team for this match, or `nil` if there is no winner
     /// (draw, in-progress, or missing teams).
     let winnerKey: String?
+    /// Whether the match is currently in the half-time break (regular or
+    /// extra-time half-time). Used to surface a "Half time" label.
+    let isInBreak: Bool
 
     init(homeFlagAssetName: String,
          homeCode: String,
@@ -28,7 +31,8 @@ struct WorldCupMatch: Equatable, Hashable {
          awayCode: String,
          date: String,
          score: Score?,
-         winnerKey: String? = nil) {
+         winnerKey: String? = nil,
+         isInBreak: Bool = false) {
         self.homeFlagAssetName = homeFlagAssetName
         self.homeCode = homeCode
         self.awayFlagAssetName = awayFlagAssetName
@@ -36,6 +40,7 @@ struct WorldCupMatch: Equatable, Hashable {
         self.date = date
         self.score = score
         self.winnerKey = winnerKey
+        self.isInBreak = isInBreak
     }
 
     init(_ match: WorldCupMatchesResponse.Match,
@@ -50,6 +55,7 @@ struct WorldCupMatch: Equatable, Hashable {
         self.date = datePrefix.map { "\($0) • \(formatted)" } ?? formatted
         self.score = Self.score(from: match)
         self.winnerKey = match.winnerTeam?.key
+        self.isInBreak = match.isInBreak
     }
 
     static let missingTeamPlaceholder = "--"

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatch.swift
@@ -22,7 +22,7 @@ struct WorldCupMatch: Equatable, Hashable {
     /// (draw, in-progress, or missing teams).
     let winnerKey: String?
     /// Whether the match is currently in the half-time break (regular or
-    /// extra-time half-time). Used to surface a "Half time" label.
+    /// extra-time half-time).
     let isInBreak: Bool
 
     init(homeFlagAssetName: String,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchCardView.swift
@@ -566,7 +566,7 @@ private final class FeaturedMatchView: UIView, ThemeApplicable {
             dateLabel.isHidden = true
             scoreSection.isHidden = false
             scoreLabel.text = score.score
-            clockLabel.text = score.clock
+            clockLabel.text = match.isInBreak ? .WorldCup.HomepageWidget.HalfTimeLabel : score.clock
         } else {
             dateLabel.isHidden = false
             scoreSection.isHidden = true

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchesResponse.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchesResponse.swift
@@ -73,6 +73,8 @@ struct WorldCupMatchesResponse: Decodable, Equatable, Sendable {
         /// `.unknown(raw)` so a new merino value doesn't fail decode and the
         /// raw label is still available for logging.
         let stage: Stage?
+        /// The game status, e.g. "Scheduled", "Delayed", "Postponed", "Break".
+        let status: String?
 
         init(date: String,
              globalEventId: Int,
@@ -88,6 +90,7 @@ struct WorldCupMatchesResponse: Decodable, Equatable, Sendable {
              clock: String? = nil,
              updated: Int? = nil,
              statusType: String? = nil,
+             status: String? = nil,
              stage: Stage? = nil) {
             self.date = date
             self.globalEventId = globalEventId
@@ -103,6 +106,7 @@ struct WorldCupMatchesResponse: Decodable, Equatable, Sendable {
             self.clock = clock
             self.updated = updated
             self.statusType = statusType
+            self.status = status
             self.stage = stage
         }
 
@@ -125,6 +129,17 @@ struct WorldCupMatchesResponse: Decodable, Equatable, Sendable {
             if homeTotal > awayTotal { return homeTeam }
             if awayTotal > homeTotal { return awayTeam }
             return nil
+        }
+        
+        /// Whether the match is currently in a half-time break, either the
+        /// regulation half-time or the extra-time half-time break.
+        var isInBreak: Bool {
+            // During a penalty shootout we ignore the "Break" status: a
+            // half-time label makes no sense in a shootout, so don't show it.
+            if ["pen", "penaltyshootout"].contains(period?.lowercased() ?? "") || homePenalty != nil || awayPenalty != nil {
+                return false
+            }
+            return status == "Break"
         }
 
         /// Closed set of tournament stages emitted by merino's `stage` field.

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchesResponse.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMatchesResponse.swift
@@ -130,7 +130,7 @@ struct WorldCupMatchesResponse: Decodable, Equatable, Sendable {
             if awayTotal > homeTotal { return awayTeam }
             return nil
         }
-        
+
         /// Whether the match is currently in a half-time break, either the
         /// regulation half-time or the extra-time half-time break.
         var isInBreak: Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMatchesTests.swift
@@ -767,6 +767,39 @@ struct WorldCupMatchesTests {
         #expect(match.score == nil)
     }
 
+    @Test
+    func test_match_isInBreak_isTrue_whenStatusIsBreak() {
+        let match = WorldCupMatch(
+            makeMatch(id: 0, home: "ENG", away: "USA", homeScore: 1, awayScore: 0, clock: "45", status: "Break")
+        )
+        #expect(match.isInBreak)
+    }
+
+    @Test
+    func test_match_isInBreak_isFalse_whenStatusIsNotBreak() {
+        let match = WorldCupMatch(
+            makeMatch(id: 0, home: "ENG", away: "USA", homeScore: 1, awayScore: 0, clock: "67")
+        )
+        #expect(!match.isInBreak)
+    }
+
+    @Test
+    func test_match_isInBreak_isFalse_duringPenaltyShootout() {
+        let match = WorldCupMatch(makeMatch(
+            id: 0,
+            home: "GER",
+            away: "FRA",
+            homeScore: 1,
+            awayScore: 1,
+            homePenalty: 5,
+            awayPenalty: 4,
+            clock: "120",
+            period: "pen",
+            status: "Break"
+        ))
+        #expect(!match.isInBreak)
+    }
+
     // MARK: - missing team fallbacks
 
     @Test
@@ -1072,6 +1105,8 @@ struct WorldCupMatchesTests {
                            homePenalty: Int? = nil,
                            awayPenalty: Int? = nil,
                            clock: String? = nil,
+                           period: String? = nil,
+                           status: String? = nil,
                            group: String? = nil,
                            stage: WorldCupMatchesResponse.Match.Stage? = .groupStage)
     -> WorldCupMatchesResponse.Match {
@@ -1098,7 +1133,7 @@ struct WorldCupMatchesTests {
             globalEventId: id,
             homeTeam: homeTeam,
             awayTeam: awayTeam,
-            period: nil,
+            period: period,
             homeScore: homeScore,
             awayScore: awayScore,
             homeExtra: homeExtra,
@@ -1107,6 +1142,7 @@ struct WorldCupMatchesTests {
             awayPenalty: awayPenalty,
             clock: clock,
             statusType: nil,
+            status: status,
             stage: stage
         )
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16071)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34250)

## :bulb: Description
Add Half time label when a match is in a break.

## :movie_camera: Demos

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

