### PR TITLE
[MTE-5452] - fixes for flaky iPad failures

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ActivityStreamTest.swift
@@ -71,7 +71,7 @@ class ActivityStreamTest: FeatureFlaggedTestBase {
     func testTopSites2Add() {
         app.launch()
         if iPad() {
-            checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 10)
+            checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 11)
         } else {
             checkNumberOfExpectedTopSites(numberOfExpectedTopSites: 8)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -12,6 +12,7 @@ let urlIndexedDB = path(forTestPage: "test-indexeddb-private.html")
 let url1And3Label = TestLabels.exampleDomain
 let url2Label = "Mozilla - Internet for people, not profit (US)"
 let url3Label = "Internet for people, not profit — Mozilla"
+let url4Label = "Form Autofill Demo: Basic @autocomplete"
 
 class PrivateBrowsingTest: BaseTestCase {
     typealias HistoryPanelA11y = AccessibilityIdentifiers.LibraryPanels.HistoryPanel
@@ -422,8 +423,8 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
     // https://mozilla.testrail.io/index.php?/cases/view/2307010
     func testiPadDirectAccessPrivateModeBrowserTab() {
         if skipPlatform { return }
-        navigator.openURL("www.mozilla.org")
-        waitForTabsButton()
+        navigator.openURL("https://mozilla.github.io/form-fill-examples/basic.html")
+        waitUntilPageLoad()
         navigator.toggleOn(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarBrowserTab)
 
         // A Tab opens directly in HomePanels view
@@ -431,6 +432,7 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
 
         // Open website and check it does not appear under history once going back to regular mode
         navigator.openURL("http://example.com")
+        waitUntilPageLoad()
         navigator.toggleOff(userState.isPrivate, withAction: Action.TogglePrivateModeFromTabBarBrowserTab)
         navigator.goto(LibraryPanel_History)
         mozWaitForElementToExist(app.tables[HistoryPanelA11y.tableView])
@@ -441,6 +443,6 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
             .cells.element(boundBy: 1)
             .staticTexts.element(boundBy: 1)
         mozWaitForElementToExist(savedToHistory)
-        XCTAssertNotNil(savedToHistory.label.range(of: url2Label))
+        XCTAssertNotNil(savedToHistory.label.range(of: url4Label))
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5452

## :bulb: Description
Fix for testTopSites2Add by updating the correct number of expected top sites
Fix for testiPadDirectAccessPrivateModeBrowserTab by changing the website used, because mozilla.org started to have an unusual reload making it to appear twice in the history tab.
