### PR TITLE
Bugfix FXIOS-16023 [Toolbar] Page address lost after closing/reopening app during network error, preventing page reload

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2567,8 +2567,9 @@ class BrowserViewController: UIViewController,
             return
         }
 
-        // To prevent spoofing, if the origins are equal update the UI always
-        if tab.url?.origin == url?.origin {
+        // Require a non-nil incoming URL before comparing origins.
+        // Prevents false matches during error-page restore when both origins are nil.
+        if let url, tab.url?.origin == url.origin {
             tab.url = url
             // Update UI to reflect the URL we have set the tab to
             if tab === tabManager.selectedTab {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -713,8 +713,12 @@ class Tab: NSObject,
         if cancelTemporaryDocumentDownload() {
             return
         }
-        // If the current page is an error page, and the reload button is tapped, load the original URL
-        if let url = webView?.url, let internalUrl = InternalURL(url), let page = internalUrl.originalURLFromErrorPage {
+
+        // Prefer the tab URL over the webView URL when restoring an error page.
+        // The webView URL may be nil/about:blank after restore.
+        if let currentURL = url ?? webView?.url,
+           let internalUrl = InternalURL(currentURL),
+           let page = internalUrl.originalURLFromErrorPage {
             let request = URLRequest(url: page, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData)
             webView?.load(request)
             return

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
@@ -120,6 +120,25 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(topTabsViewController.privateModeButton.tintColor, DarkTheme().colors.iconOnColor)
     }
 
+    @MainActor
+    func testObserveValueURL_whenWebViewURLIsNil_andTabShowsErrorPage_doesNotClearTabURL() {
+        let subject = createSubject()
+        let tab = Tab(profile: profile, windowUUID: .XCTestDefaultUUID)
+        let mockTabWebView = MockTabWebView(tab: tab)
+        tab.webView = mockTabWebView
+        let errorPageURL = URL(string: "internal://local/errorpage?url=https://www.amazon.ca/&code=-1009")!
+        tab.url = errorPageURL
+        tabManager.tabs = [tab]
+        tabManager.selectedTab = tab
+
+        // Simulate the webView URL KVO firing with a transient nil value, as happens during the
+        // restore/reload cycle of an error page. `URL.origin` is nil for internal:// URLs, so before
+        // the fix the spoofing guard treated `nil == nil` as a match and nil'd out tab.url.
+        subject.observeValue(forKeyPath: KVOConstants.URL.rawValue, of: mockTabWebView, change: [:], context: nil)
+
+        XCTAssertEqual(tab.url, errorPageURL, "A transient nil URL KVO must not clear a valid error-page tab URL")
+    }
+
     func test_didSelectedTabChange_fromHomepageToHomepage_triggersAppropriateDispatchAction() throws {
         let subject = createSubject()
         let testTab = Tab(profile: profile, isPrivate: true, windowUUID: .XCTestDefaultUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTests.swift
@@ -349,6 +349,28 @@ class TabTests: XCTestCase {
     }
 
     @MainActor
+    func testReload_whenTabIsErrorPage_andWebViewURLIsBlank_loadsOriginalURL() {
+        let subject = createSubject()
+        subject.webView = mockTabWebView
+        // Simulate a restored error-page tab: the tab still points at the error page, but the
+        // webView itself shows about:blank (it didn't re-render the error page on restore).
+        mockTabWebView.loadedURL = URL(string: "about:blank")
+        subject.url = URL(string: "internal://local/errorpage?url=https://www.amazon.ca/&code=-1009")
+
+        subject.reload()
+        // remove it so in Tab deinit there is no crash for KVO
+        subject.webView = nil
+
+        XCTAssertEqual(mockTabWebView.loadCalled, 1)
+        XCTAssertEqual(
+            mockTabWebView.loadedRequest?.url,
+            URL(string: "https://www.amazon.ca/"),
+            "reload should recover the original URL from the error page, not reload about:blank"
+        )
+        XCTAssertEqual(mockTabWebView.reloadFromOriginCalled, 0)
+    }
+
+    @MainActor
     func testGoBack_whenDocumentIsDownloading_cancelDownload() {
         let subject = createSubject()
         let document = MockTemporaryDocument(withFileURL: url)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16023)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- `handleURL:` require a non-nil incoming URL before the same-origin update, so a transient nil URL KVO can't nil out a valid internal:// error-page tab.url (their origins both being nil spuriously matched).
- `Tab.reload:` prefer tab.url over webView.url when extracting the original URL from an error page, so reload after restore loads the page instead of about:blank.
- Regressed when the `needsReloadRefactor` experiment removed the error-page reload-on-restore that previously masked the mid-state nil.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->



https://github.com/user-attachments/assets/62b787bb-2fcb-4492-af54-2f0c257525eb


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

