### PR TITLE
[FXIOS-16076] Avoid fatal Sentry errors for `TabErrorTelemetryHelper`

### DIFF
--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -125,7 +125,8 @@ final class TabErrorTelemetryHelper {
     }
 
     private func getTotalTabCount(window: WindowUUID) -> Int? {
-        guard let tabManager = windowManager.tabManager(for: window) else {
+        guard windowManager.windows.keys.contains(window),
+              let tabManager = windowManager.tabManager(for: window) else {
             assertionFailure("getTabCount() should not be called prior to TabManager config.")
             return nil
         }


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16076)

## :bulb: Description

Squelch excessive Sentry logging for this use case. Currently one of our top issues in Sentry but this is not a user-facing bug, so the events are probably not providing enough value to justify the noise.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

