### PR TITLE
Bugfix FXIOS-16017 Fix privacy screen not showing in some scenarios after device is locked

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1163,59 +1163,95 @@ class BrowserViewController: UIViewController,
     }
 
     // MARK: - Notifiable
+
+    nonisolated private func shouldHandleNotificationSynchronously(_ notification: Notification.Name) -> Bool {
+        switch notification {
+        case UIApplication.willResignActiveNotification:
+            return true
+        default:
+            return false
+        }
+    }
+
     func handleNotifications(_ notification: Notification) {
         let notificationName = notification.name
-
         let windowScene = notification.object as? UIWindowScene
         let announcementText = notification.userInfo?[UIAccessibility.announcementStringValueUserInfoKey] as? String
         let dictionary = notification.object as? NSDictionary
         let searchBarPosition = dictionary?[PrefsKeys.FeatureFlags.SearchBarPosition] as? SearchBarPosition
         let windowUUID = notification.windowUUID
         let zoomSetting = notification.userInfo?["zoom"] as? DomainZoomLevel
-        // swiftlint:disable:next closure_body_length
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            switch notificationName {
-            case UIApplication.willTerminateNotification:
-                applicationWillTerminate()
-            case UIApplication.willResignActiveNotification:
-                appWillResignActiveNotification()
-            case UIApplication.didBecomeActiveNotification:
-                appDidBecomeActiveNotification()
-            case UIApplication.didEnterBackgroundNotification:
-                appDidEnterBackgroundNotification()
-            case UIScene.didEnterBackgroundNotification:
-                sceneDidEnterBackgroundNotification(windowScene: windowScene)
-            case UIScene.didActivateNotification:
-                sceneDidActivateNotification()
-            case UIAccessibility.announcementDidFinishNotification:
-                didFinishAnnouncement(announcementText: announcementText)
-            case UIAccessibility.reduceTransparencyStatusDidChangeNotification:
-                onReduceTransparencyStatusDidChange()
-            case .FirefoxAccountStateChange:
-                appMenuBadgeUpdate()
-            case .SearchBarPositionDidChange:
-                searchBarPositionDidChange(newSearchBarPosition: searchBarPosition)
-            case .DidTapUndoCloseAllTabToast:
-                didTapUndoCloseAllTabToast(notificationWindowUUID: windowUUID)
-            case .PendingBlobDownloadAddedToQueue:
-                didAddPendingBlobDownloadToQueue()
-            case .SearchSettingsDidUpdateDefaultSearchEngine:
-                updateForDefaultSearchEngineDidChange()
-            case .PageZoomLevelUpdated:
-                handlePageZoomLevelUpdated(notificationWindowUUID: windowUUID, zoomSetting: zoomSetting)
-            case .PageZoomSettingsChanged:
-                handlePageZoomSettingsChanged()
-            case .RemoteTabNotificationTapped:
-                openRecentlyClosedTabs()
-            case .StopDownloads:
-                onStopDownloads(notificationWindowUUID: windowUUID)
-            case .SettingsDismissed:
-                onSettingsDismissed()
-            case .ReadingListUpdated:
-                updateReaderModeBar()
-            default: break
+
+        if shouldHandleNotificationSynchronously(notificationName) {
+            ensureMainThread {
+                self.performNotificationHandler(notificationName,
+                                                windowScene: windowScene,
+                                                announcementText: announcementText,
+                                                zoomSetting: zoomSetting,
+                                                windowUUID: windowUUID,
+                                                searchBarPosition: searchBarPosition)
             }
+        } else {
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.performNotificationHandler(notificationName,
+                                                windowScene: windowScene,
+                                                announcementText: announcementText,
+                                                zoomSetting: zoomSetting,
+                                                windowUUID: windowUUID,
+                                                searchBarPosition: searchBarPosition)
+            }
+        }
+    }
+
+    @MainActor
+    private func performNotificationHandler(_ notificationName: Notification.Name,
+                                            windowScene: UIWindowScene?,
+                                            announcementText: String?,
+                                            zoomSetting: DomainZoomLevel?,
+                                            windowUUID: WindowUUID?,
+                                            searchBarPosition: SearchBarPosition?) {
+        // swiftlint:disable:next closure_body_length
+        switch notificationName {
+        case UIApplication.willTerminateNotification:
+            applicationWillTerminate()
+        case UIApplication.willResignActiveNotification:
+            appWillResignActiveNotification()
+        case UIApplication.didBecomeActiveNotification:
+            appDidBecomeActiveNotification()
+        case UIApplication.didEnterBackgroundNotification:
+            appDidEnterBackgroundNotification()
+        case UIScene.didEnterBackgroundNotification:
+            sceneDidEnterBackgroundNotification(windowScene: windowScene)
+        case UIScene.didActivateNotification:
+            sceneDidActivateNotification()
+        case UIAccessibility.announcementDidFinishNotification:
+            didFinishAnnouncement(announcementText: announcementText)
+        case UIAccessibility.reduceTransparencyStatusDidChangeNotification:
+            onReduceTransparencyStatusDidChange()
+        case .FirefoxAccountStateChange:
+            appMenuBadgeUpdate()
+        case .SearchBarPositionDidChange:
+            searchBarPositionDidChange(newSearchBarPosition: searchBarPosition)
+        case .DidTapUndoCloseAllTabToast:
+            didTapUndoCloseAllTabToast(notificationWindowUUID: windowUUID)
+        case .PendingBlobDownloadAddedToQueue:
+            didAddPendingBlobDownloadToQueue()
+        case .SearchSettingsDidUpdateDefaultSearchEngine:
+            updateForDefaultSearchEngineDidChange()
+        case .PageZoomLevelUpdated:
+            handlePageZoomLevelUpdated(notificationWindowUUID: windowUUID, zoomSetting: zoomSetting)
+        case .PageZoomSettingsChanged:
+            handlePageZoomSettingsChanged()
+        case .RemoteTabNotificationTapped:
+            openRecentlyClosedTabs()
+        case .StopDownloads:
+            onStopDownloads(notificationWindowUUID: windowUUID)
+        case .SettingsDismissed:
+            onSettingsDismissed()
+        case .ReadingListUpdated:
+            updateReaderModeBar()
+        default: break
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1173,7 +1173,7 @@ class BrowserViewController: UIViewController,
         let windowUUID = notification.windowUUID
         let zoomSetting = notification.userInfo?["zoom"] as? DomainZoomLevel
         // swiftlint:disable:next closure_body_length
-        Task { @MainActor [weak self] in
+        ensureMainThread { [weak self] in
             guard let self else { return }
             switch notificationName {
             case UIApplication.willTerminateNotification:

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1173,7 +1173,7 @@ class BrowserViewController: UIViewController,
         let windowUUID = notification.windowUUID
         let zoomSetting = notification.userInfo?["zoom"] as? DomainZoomLevel
         // swiftlint:disable:next closure_body_length
-        ensureMainThread { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self else { return }
             switch notificationName {
             case UIApplication.willTerminateNotification:

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1163,95 +1163,59 @@ class BrowserViewController: UIViewController,
     }
 
     // MARK: - Notifiable
-
-    nonisolated private func shouldHandleNotificationSynchronously(_ notification: Notification.Name) -> Bool {
-        switch notification {
-        case UIApplication.willResignActiveNotification:
-            return true
-        default:
-            return false
-        }
-    }
-
     func handleNotifications(_ notification: Notification) {
         let notificationName = notification.name
+
         let windowScene = notification.object as? UIWindowScene
         let announcementText = notification.userInfo?[UIAccessibility.announcementStringValueUserInfoKey] as? String
         let dictionary = notification.object as? NSDictionary
         let searchBarPosition = dictionary?[PrefsKeys.FeatureFlags.SearchBarPosition] as? SearchBarPosition
         let windowUUID = notification.windowUUID
         let zoomSetting = notification.userInfo?["zoom"] as? DomainZoomLevel
-
-        if shouldHandleNotificationSynchronously(notificationName) {
-            ensureMainThread {
-                self.performNotificationHandler(notificationName,
-                                                windowScene: windowScene,
-                                                announcementText: announcementText,
-                                                zoomSetting: zoomSetting,
-                                                windowUUID: windowUUID,
-                                                searchBarPosition: searchBarPosition)
-            }
-        } else {
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                self.performNotificationHandler(notificationName,
-                                                windowScene: windowScene,
-                                                announcementText: announcementText,
-                                                zoomSetting: zoomSetting,
-                                                windowUUID: windowUUID,
-                                                searchBarPosition: searchBarPosition)
-            }
-        }
-    }
-
-    @MainActor
-    private func performNotificationHandler(_ notificationName: Notification.Name,
-                                            windowScene: UIWindowScene?,
-                                            announcementText: String?,
-                                            zoomSetting: DomainZoomLevel?,
-                                            windowUUID: WindowUUID?,
-                                            searchBarPosition: SearchBarPosition?) {
         // swiftlint:disable:next closure_body_length
-        switch notificationName {
-        case UIApplication.willTerminateNotification:
-            applicationWillTerminate()
-        case UIApplication.willResignActiveNotification:
-            appWillResignActiveNotification()
-        case UIApplication.didBecomeActiveNotification:
-            appDidBecomeActiveNotification()
-        case UIApplication.didEnterBackgroundNotification:
-            appDidEnterBackgroundNotification()
-        case UIScene.didEnterBackgroundNotification:
-            sceneDidEnterBackgroundNotification(windowScene: windowScene)
-        case UIScene.didActivateNotification:
-            sceneDidActivateNotification()
-        case UIAccessibility.announcementDidFinishNotification:
-            didFinishAnnouncement(announcementText: announcementText)
-        case UIAccessibility.reduceTransparencyStatusDidChangeNotification:
-            onReduceTransparencyStatusDidChange()
-        case .FirefoxAccountStateChange:
-            appMenuBadgeUpdate()
-        case .SearchBarPositionDidChange:
-            searchBarPositionDidChange(newSearchBarPosition: searchBarPosition)
-        case .DidTapUndoCloseAllTabToast:
-            didTapUndoCloseAllTabToast(notificationWindowUUID: windowUUID)
-        case .PendingBlobDownloadAddedToQueue:
-            didAddPendingBlobDownloadToQueue()
-        case .SearchSettingsDidUpdateDefaultSearchEngine:
-            updateForDefaultSearchEngineDidChange()
-        case .PageZoomLevelUpdated:
-            handlePageZoomLevelUpdated(notificationWindowUUID: windowUUID, zoomSetting: zoomSetting)
-        case .PageZoomSettingsChanged:
-            handlePageZoomSettingsChanged()
-        case .RemoteTabNotificationTapped:
-            openRecentlyClosedTabs()
-        case .StopDownloads:
-            onStopDownloads(notificationWindowUUID: windowUUID)
-        case .SettingsDismissed:
-            onSettingsDismissed()
-        case .ReadingListUpdated:
-            updateReaderModeBar()
-        default: break
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            switch notificationName {
+            case UIApplication.willTerminateNotification:
+                applicationWillTerminate()
+            case UIApplication.willResignActiveNotification:
+                appWillResignActiveNotification()
+            case UIApplication.didBecomeActiveNotification:
+                appDidBecomeActiveNotification()
+            case UIApplication.didEnterBackgroundNotification:
+                appDidEnterBackgroundNotification()
+            case UIScene.didEnterBackgroundNotification:
+                sceneDidEnterBackgroundNotification(windowScene: windowScene)
+            case UIScene.didActivateNotification:
+                sceneDidActivateNotification()
+            case UIAccessibility.announcementDidFinishNotification:
+                didFinishAnnouncement(announcementText: announcementText)
+            case UIAccessibility.reduceTransparencyStatusDidChangeNotification:
+                onReduceTransparencyStatusDidChange()
+            case .FirefoxAccountStateChange:
+                appMenuBadgeUpdate()
+            case .SearchBarPositionDidChange:
+                searchBarPositionDidChange(newSearchBarPosition: searchBarPosition)
+            case .DidTapUndoCloseAllTabToast:
+                didTapUndoCloseAllTabToast(notificationWindowUUID: windowUUID)
+            case .PendingBlobDownloadAddedToQueue:
+                didAddPendingBlobDownloadToQueue()
+            case .SearchSettingsDidUpdateDefaultSearchEngine:
+                updateForDefaultSearchEngineDidChange()
+            case .PageZoomLevelUpdated:
+                handlePageZoomLevelUpdated(notificationWindowUUID: windowUUID, zoomSetting: zoomSetting)
+            case .PageZoomSettingsChanged:
+                handlePageZoomSettingsChanged()
+            case .RemoteTabNotificationTapped:
+                openRecentlyClosedTabs()
+            case .StopDownloads:
+                onStopDownloads(notificationWindowUUID: windowUUID)
+            case .SettingsDismissed:
+                onSettingsDismissed()
+            case .ReadingListUpdated:
+                updateReaderModeBar()
+            default: break
+            }
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1197,6 +1197,7 @@ class BrowserViewController: UIViewController,
                                                 searchBarPosition: searchBarPosition)
             }
         } else {
+            // TODO: [FXIOS-16160] We should migrate all of our handlers to ensureMainThread. 
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 performNotificationHandler(notificationName,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1165,8 +1165,13 @@ class BrowserViewController: UIViewController,
     // MARK: - Notifiable
 
     nonisolated private func shouldHandleNotificationSynchronously(_ notification: Notification.Name) -> Bool {
+        // Whether to respond to the notification synchronously. Main thread notifications will (by default)
+        // be handled in a Task which allows the concurrency engine to schedule the work asynchronously.
+        // If a notification returns `true` here, then it will instead be wrapped in an `ensureMainThread`
+        // which (if the notification arrives on the MT) will perform the notification handler immediately.
         switch notification {
         case UIApplication.willResignActiveNotification:
+            // Handle immediately since this is where we display the PBM privacy screen
             return true
         default:
             return false
@@ -1194,12 +1199,12 @@ class BrowserViewController: UIViewController,
         } else {
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                self.performNotificationHandler(notificationName,
-                                                windowScene: windowScene,
-                                                announcementText: announcementText,
-                                                zoomSetting: zoomSetting,
-                                                windowUUID: windowUUID,
-                                                searchBarPosition: searchBarPosition)
+                performNotificationHandler(notificationName,
+                                           windowScene: windowScene,
+                                           announcementText: announcementText,
+                                           zoomSetting: zoomSetting,
+                                           windowUUID: windowUUID,
+                                           searchBarPosition: searchBarPosition)
             }
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16017)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34164)

## :bulb: Description

Moves the `appWillResignActiveNotification()` to be synchronous and execute it immediately on the MT, rather than enqueuing it as a MainActor task. This ensures the privacy screen is setup immediately.

This introduces a subtle but important change to the code for this notification, which is that the screenshot and dismiss popover code will also run synchronously now. This seems reasonable to me and I couldn't see any issues when testing it, but I'd like to get extra eyes on this. An alternative is that we could simplify this fix and just perform the critical privacy screen update via `ensureMainThread` and keep all of the previous code the same, however that would change the ordering of the operations that are performed in `appWillResignActiveNotification()` and I don't believe that would be safe since the screenshot and popover dismissal would be then running after the privacy screen went up.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

