### PR TITLE
Bugfix FXIOS-16078 [Telemetry] Don't assert on tab count when window isn't configured

### DIFF
--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -32,6 +32,12 @@ protocol WindowManager {
     /// Convenience. Returns the TabManager for a specific window.
     func tabManager(for windowUUID: WindowUUID) -> TabManager?
 
+    /// Whether the given window has a fully configured browser (and TabManager).
+    /// Lets code that can legitimately run before a window exists — e.g. telemetry
+    /// during the onboarding/ToS flow — branch without going through the asserting
+    /// `tabManager(for:)`.
+    func isWindowConfigured(_ windowUUID: WindowUUID) -> Bool
+
     /// Convenience. Returns all TabManagers for all open windows.
     func allWindowTabManagers() -> [TabManager]
 
@@ -149,6 +155,10 @@ final class WindowManagerImplementation: WindowManager {
         }
 
         return manager
+    }
+
+    func isWindowConfigured(_ windowUUID: WindowUUID) -> Bool {
+        return window(for: windowUUID)?.tabManager != nil
     }
 
     func allWindowTabManagers() -> [TabManager] {

--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -125,11 +125,9 @@ final class TabErrorTelemetryHelper {
     }
 
     private func getTotalTabCount(window: WindowUUID) -> Int? {
-        guard let tabManager = windowManager.tabManager(for: window) else {
-            assertionFailure("getTabCount() should not be called prior to TabManager config.")
-            return nil
-        }
-        return tabManager.normalTabs.count
+        // Telemetry can fire during ToS/onboarding before this window's browser exists.
+        guard windowManager.isWindowConfigured(window) else { return nil }
+        return windowManager.tabManager(for: window)?.normalTabs.count
     }
 
     private func sendTelemetryTabLossDetectedEvent(expected: Int, actual: Int, entryPoint: EntryPoint) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
@@ -41,6 +41,10 @@ final class MockWindowManager: WindowManager {
         return tabManager
     }
 
+    func isWindowConfigured(_ windowUUID: WindowUUID) -> Bool {
+        return windows[windowUUID]?.tabManager != nil
+    }
+
     func allWindowTabManagers() -> [TabManager] {
         wrappedManager.allWindowTabManagers()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -397,6 +397,22 @@ class WindowManagerTests: XCTestCase {
         XCTAssertNil(tabManager)
     }
 
+    func test_isWindowConfigured_returnsTrueForConfiguredWindow() {
+        let subject = createSubject()
+        let uuid = WindowUUID.XCTestDefaultUUID
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: uuid)
+
+        XCTAssertTrue(subject.isWindowConfigured(uuid))
+    }
+
+    // Regression for FXIOS-16078: querying an unconfigured window (e.g. telemetry during
+    // the ToS/onboarding flow) must report false rather than asserting.
+    func test_isWindowConfigured_returnsFalseForUnconfiguredWindow() {
+        let subject = createSubject()
+
+        XCTAssertFalse(subject.isWindowConfigured(.unavailable))
+    }
+
     // MARK: - Test Subject
 
     private func createSubject() -> WindowManager {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16078)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34268)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

TabErrorTelemetryHelper could fire an assertionFailure when a scene is backgrounded during the Terms of Service / onboarding flow, before the browser window and its TabManager have been configured. The helper is documented to tolerate a missing window in this case, but it routed through WindowManager.tabManager(for:), which asserts before returning nil. Guard on windows[window] first so the onboarding path is skipped silently, and drop the redundant assertion in getTotalTabCount.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


