### PR TITLE
Refactor FXIOS-16081 [Stories] Improvements to merino caching

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
@@ -25,7 +25,9 @@ struct MerinoState: StateType, Equatable {
     }
 
     var availableCategories: [MerinoCategoryConfiguration] {
-        (merinoData.categories ?? []).sorted { $0.rank < $1.rank }
+        (merinoData.categories ?? [])
+            .filter { !$0.recommendations.isEmpty }
+            .sorted { $0.rank < $1.rank }
     }
 
     func visibleStories(selectedNewsfeedCategoryID: String?) -> [MerinoStoryConfiguration] {
@@ -86,8 +88,8 @@ struct MerinoState: StateType, Equatable {
             return defaultState(from: state)
         }
 
-        let merinoContentExists = !(merinoResponse.stories?.isEmpty ?? true) ||
-                                  !(merinoResponse.categories?.isEmpty ?? true)
+        let categoriesContainStories = merinoResponse.categories?.contains { !$0.recommendations.isEmpty } == true
+        let merinoContentExists = !(merinoResponse.stories?.isEmpty ?? true) || categoriesContainStories
 
         return state
             .copy(merinoData: merinoResponse)

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -60,7 +60,7 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
 
         if let cachedResponse = cache.loadResponse(),
            cacheUpdateThresholdHasNotPassed(),
-           cachedResponseMatchesCurrentHomepageStoriesMode(cachedResponse) {
+           responseHasDisplayableContent(cachedResponse) {
             return cachedResponse
         }
 
@@ -99,7 +99,7 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
                 // Only cache items if we have a response, and it has some sort
                 // of data we'd like to actually save
                 if let response,
-                   !response.data.isEmpty || response.feeds != nil {
+                   responseHasDisplayableContent(response) {
                     cache.clearCache()
                     cache.save(response)
                 }
@@ -132,15 +132,8 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
         return Date() < lastUpdate.addingTimeInterval(thresholdInSeconds)
     }
 
-    /// Returns whether the cached response shape matches the current homepage stories mode.
-    /// When categories are enabled we require non-empty `feeds`, otherwise we require
-    /// non-empty top-level story `data`. If the shapes do not match, we bypass the cache
-    /// and fetch again so a mode switch is reflected immediately.
-    private func cachedResponseMatchesCurrentHomepageStoriesMode(_ response: CuratedRecommendationsResponse) -> Bool {
-        if isHomepageStoryCategoriesEnabled {
-            return !(response.feeds?.isEmpty ?? true)
-        }
-
-        return !response.data.isEmpty
+    private func responseHasDisplayableContent(_ response: CuratedRecommendationsResponse) -> Bool {
+        let hasCategoryRecommendations = response.feeds?.contains { !$0.recommendations.isEmpty } == true
+        return hasCategoryRecommendations || !response.data.isEmpty
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
@@ -99,7 +99,9 @@ final class MerinoStateTests: XCTestCase {
             MerinoCategoryConfiguration(
                 category: MerinoCategory(
                     feedID: "technology",
-                    recommendations: [],
+                    recommendations: [
+                        createStoryConfiguration(title: "technology1"),
+                    ],
                     isBlocked: false,
                     isFollowed: false,
                     title: "Technology",
@@ -110,12 +112,41 @@ final class MerinoStateTests: XCTestCase {
             MerinoCategoryConfiguration(
                 category: MerinoCategory(
                     feedID: "science",
-                    recommendations: [],
+                    recommendations: [
+                        createStoryConfiguration(title: "science1"),
+                    ],
                     isBlocked: false,
                     isFollowed: false,
                     title: "Science",
                     subtitle: nil,
                     receivedFeedRank: 1
+                )
+            ),
+        ]
+        let state = pocketReducer()(
+            createSubject(),
+            MerinoAction(
+                merinoStoryResponse: MerinoStoryResponse(categories: categories),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
+            )
+        )
+
+        XCTAssertEqual(state.availableCategories.map(\.feedID), ["science", "technology"])
+    }
+
+    @MainActor
+    func test_availableCategories_filtersCategoriesWithoutRecommendations() {
+        let categories = createTestCategories() + [
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "empty",
+                    recommendations: [],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Empty",
+                    subtitle: nil,
+                    receivedFeedRank: 0
                 )
             ),
         ]
@@ -166,6 +197,40 @@ final class MerinoStateTests: XCTestCase {
     }
 
     @MainActor
+    func test_visibleStories_withEmptyCategories_returnsFlatStories() {
+        let stories = [
+            createStoryConfiguration(title: "story1"),
+            createStoryConfiguration(title: "story2"),
+        ]
+        let categories = [
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "empty",
+                    recommendations: [],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Empty",
+                    subtitle: nil,
+                    receivedFeedRank: 0
+                )
+            ),
+        ]
+        let state = pocketReducer()(
+            createSubject(),
+            MerinoAction(
+                merinoStoryResponse: MerinoStoryResponse(stories: stories, categories: categories),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
+            )
+        )
+
+        XCTAssertEqual(
+            state.visibleStories(selectedNewsfeedCategoryID: nil).map(\.title),
+            ["story1", "story2"]
+        )
+    }
+
+    @MainActor
     func test_handleMerinoStoriesAction_withCategories_setsHasMerinoResponseContentTrue() {
         let state = pocketReducer()(
             createSubject(),
@@ -178,6 +243,34 @@ final class MerinoStateTests: XCTestCase {
 
         XCTAssertTrue(state.hasMerinoResponseContent)
         XCTAssertTrue(state.shouldShowSection)
+    }
+
+    @MainActor
+    func test_handleMerinoStoriesAction_withEmptyCategoriesAndNoStories_setsHasMerinoResponseContentFalse() {
+        let categories = [
+            MerinoCategoryConfiguration(
+                category: MerinoCategory(
+                    feedID: "empty",
+                    recommendations: [],
+                    isBlocked: false,
+                    isFollowed: false,
+                    title: "Empty",
+                    subtitle: nil,
+                    receivedFeedRank: 0
+                )
+            ),
+        ]
+        let state = pocketReducer()(
+            createSubject(),
+            MerinoAction(
+                merinoStoryResponse: MerinoStoryResponse(stories: [], categories: categories),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: MerinoMiddlewareActionType.retrievedUpdatedHomepageStories
+            )
+        )
+
+        XCTAssertFalse(state.hasMerinoResponseContent)
+        XCTAssertFalse(state.shouldShowSection)
     }
 
     func test_initialState_returnsExpectedSectionHeaderConfiguration() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Merino/MerinoProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Merino/MerinoProviderTests.swift
@@ -211,7 +211,7 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(control.fetcher.callCount, 0)
     }
 
-    func test_fetchContent_fetchesFromNetwork_whenCategoriesEnabledAndCachedResponseHasNoFeeds() async throws {
+    func test_fetchContent_returnsCached_whenCategoriesEnabledAndCachedResponseHasFlatStoriesOnly() async throws {
         FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
             HomepageRedesignFeature(categoriesEnabled: true)
         }
@@ -221,18 +221,17 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
             items: [.makeItem("cached-story")],
             feeds: nil
         )
-        let networkFeeds = [FeedSection.makeSection(feedId: "technology", recommendations: [.makeItem("tech-story")])]
         control.cache.seed(response: cachedResponse, lastUpdated: Date())
         control.fetcher.stubbedResponse = CuratedRecommendationsResponse.makeResponse(
             items: [.makeItem("network-story")],
-            feeds: networkFeeds
+            feeds: [FeedSection.makeSection(feedId: "technology", recommendations: [.makeItem("tech-story")])]
         )
 
         let result = try await control.subject.fetchContent()
 
-        XCTAssertEqual(control.fetcher.callCount, 1)
-        XCTAssertEqual(result.feeds?.first?.feedId, "technology")
-        XCTAssertTrue(control.cache.didClear)
+        XCTAssertEqual(control.fetcher.callCount, 0)
+        XCTAssertEqual(result.data.map(\.title), ["cached-story"])
+        XCTAssertFalse(control.cache.didClear)
     }
 
     func test_fetchContent_returnsCached_whenCategoriesEnabledAndCachedResponseHasFeeds() async throws {
@@ -259,7 +258,7 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
         XCTAssertFalse(control.cache.didClear)
     }
 
-    func test_fetchContent_fetchesFromNetwork_whenCategoriesDisabledAndCachedResponseHasNoStories() async throws {
+    func test_fetchContent_returnsCached_whenCategoriesDisabledAndCachedResponseHasCategoryStoriesOnly() async throws {
         FxNimbus.shared.features.homepageRedesignFeature.with { _, _ in
             HomepageRedesignFeature(categoriesEnabled: false)
         }
@@ -269,6 +268,25 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
         let cachedResponse = CuratedRecommendationsResponse.makeResponse(
             items: [],
             feeds: cachedFeeds
+        )
+        control.cache.seed(response: cachedResponse, lastUpdated: Date())
+        control.fetcher.stubbedResponse = CuratedRecommendationsResponse.makeResponse(
+            items: [.makeItem("network-story")],
+            feeds: nil
+        )
+
+        let result = try await control.subject.fetchContent()
+
+        XCTAssertEqual(control.fetcher.callCount, 0)
+        XCTAssertEqual(result.feeds?.first?.feedId, "technology")
+        XCTAssertFalse(control.cache.didClear)
+    }
+
+    func test_fetchContent_fetchesFromNetwork_whenCachedResponseHasNoDisplayableContent() async throws {
+        let control = await createSubject(thresholdHours: 1)
+        let cachedResponse = CuratedRecommendationsResponse.makeResponse(
+            items: [],
+            feeds: [FeedSection.makeSection(feedId: "technology", recommendations: [])]
         )
         control.cache.seed(response: cachedResponse, lastUpdated: Date())
         control.fetcher.stubbedResponse = CuratedRecommendationsResponse.makeResponse(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16081)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Changes:
- Cache reuse now depends on displayable content, not the local category mode. A cached response is valid if it has flat stories or category feeds with recommendations.
- `availableCategories` now filters out categories with no recommendations, so empty category payloads do not mask flat stories.
- Content existence now treats categories as content only when they contain recommendations.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

