### PR TITLE
Add FXIOS-15982 [Tab manager deeplink] Screenshots prefetching in tab tray

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 		2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDB10921A9FBEC5006CF312 /* PrefsTests.swift */; };
 		31286F788EBE4BDE9BB9FF21 /* AutoTranslatePromptState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E805FFBBD74D9BA77BD057 /* AutoTranslatePromptState.swift */; };
 		318FB6EB1DB5600D0004E40F /* SQLiteHistoryFactories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318FB6EA1DB5600D0004E40F /* SQLiteHistoryFactories.swift */; };
+		319478509A7F45D09CBCEC18 /* PrivacyWindowHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3C8A4CBEAC46E58A977BF8 /* PrivacyWindowHelperTests.swift */; };
 		31ADB5DA1E58CEC300E87909 /* ClipboardBarDisplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31ADB5D91E58CEC300E87909 /* ClipboardBarDisplayHandler.swift */; };
 		354F8F612E098214007DFFEB /* SearchBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354F8F602E09820B007DFFEB /* SearchBarState.swift */; };
 		354F8FAB2E0985B9007DFFEB /* SearchBarStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354F8FAA2E0985A0007DFFEB /* SearchBarStateTests.swift */; };
@@ -1265,6 +1266,7 @@
 		8AE1E1D227B1ADC40024C45E /* TopBottomInterchangeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */; };
 		8AE1E1D927B1BD380024C45E /* UIStackViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1D827B1BD380024C45E /* UIStackViewExtensionsTests.swift */; };
 		8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1E1DA27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift */; };
+		8AE65C052FE219A500CBBE66 /* TabManagerRestoreScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE65C042FE219A500CBBE66 /* TabManagerRestoreScreenshotTests.swift */; };
 		8AE80BAF2891960300BC12EA /* MockTraitCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BAE2891960300BC12EA /* MockTraitCollection.swift */; };
 		8AE80BB62891AEA100BC12EA /* MockDispatchGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE80BB42891AE6700BC12EA /* MockDispatchGroup.swift */; };
 		8AE89C4E2F118D090002E9C1 /* UnifiedAdsUserDataRemover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE89C4D2F118CF50002E9C1 /* UnifiedAdsUserDataRemover.swift */; };
@@ -1681,7 +1683,6 @@
 		C4EFEECF1CEBB6F2009762A4 /* BackForwardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4EFEECE1CEBB6F2009762A4 /* BackForwardTableViewCell.swift */; };
 		C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F3B2991CFCF93A00966259 /* ButtonToast.swift */; };
 		C705FA782EF30C4F00AC5EE7 /* PrivacyNoticeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C705FA772EF30C4B00AC5EE7 /* PrivacyNoticeHelperTests.swift */; };
-		319478509A7F45D09CBCEC18 /* PrivacyWindowHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3C8A4CBEAC46E58A977BF8 /* PrivacyWindowHelperTests.swift */; };
 		C705FA7A2EF31F0500AC5EE7 /* MockPrivacyNoticeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C705FA792EF31F0000AC5EE7 /* MockPrivacyNoticeHelper.swift */; };
 		C705FD582EF354D300AC5EE7 /* PrivacyNoticeUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C705FD572EF3545500AC5EE7 /* PrivacyNoticeUpdate.swift */; };
 		C706CBEF2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C706CBEE2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift */; };
@@ -8723,6 +8724,7 @@
 		4AF54675A51AABF86F0B3AA5 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		4B1546C89B425483D5765BFE /* gu-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "gu-IN"; path = "gu-IN.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		4B3443A4B0BF4562A3EC96C7 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Storage.strings; sourceTree = "<group>"; };
+		4B3C8A4CBEAC46E58A977BF8 /* PrivacyWindowHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyWindowHelperTests.swift; sourceTree = "<group>"; };
 		4BC842B9BC3F325C5CEFC8D4 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		4BE040A0A216E94E9BEC1162 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		4C034CC1BFF8900EC3C2AEC2 /* hi-IN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hi-IN"; path = "hi-IN.lproj/Shared.strings"; sourceTree = "<group>"; };
@@ -9708,6 +9710,7 @@
 		8AE1E1D127B1ADC40024C45E /* TopBottomInterchangeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBottomInterchangeable.swift; sourceTree = "<group>"; };
 		8AE1E1D827B1BD380024C45E /* UIStackViewExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensionsTests.swift; sourceTree = "<group>"; };
 		8AE1E1DA27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSettingsViewModelTests.swift; sourceTree = "<group>"; };
+		8AE65C042FE219A500CBBE66 /* TabManagerRestoreScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerRestoreScreenshotTests.swift; sourceTree = "<group>"; };
 		8AE80BAE2891960300BC12EA /* MockTraitCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTraitCollection.swift; sourceTree = "<group>"; };
 		8AE80BB42891AE6700BC12EA /* MockDispatchGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDispatchGroup.swift; sourceTree = "<group>"; };
 		8AE89C4D2F118CF50002E9C1 /* UnifiedAdsUserDataRemover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedAdsUserDataRemover.swift; sourceTree = "<group>"; };
@@ -10558,7 +10561,6 @@
 		C6AF4D4DBE2C76759B1DDE6B /* anp */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = anp; path = anp.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C6C94C1CB6286845DEAF8EDD /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C705FA772EF30C4B00AC5EE7 /* PrivacyNoticeHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyNoticeHelperTests.swift; sourceTree = "<group>"; };
-		4B3C8A4CBEAC46E58A977BF8 /* PrivacyWindowHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyWindowHelperTests.swift; sourceTree = "<group>"; };
 		C705FA792EF31F0000AC5EE7 /* MockPrivacyNoticeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyNoticeHelper.swift; sourceTree = "<group>"; };
 		C705FD572EF3545500AC5EE7 /* PrivacyNoticeUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyNoticeUpdate.swift; sourceTree = "<group>"; };
 		C706CBEE2C3F0FDE00DC65F1 /* CreditCardSettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardSettingsViewControllerTests.swift; sourceTree = "<group>"; };
@@ -14689,6 +14691,7 @@
 				8AFC1B782FAAAA3D0070CA11 /* TabManagerPrivacyModeTests.swift */,
 				8AFC09542FA54A240070CA11 /* TabManagerRemoveTabTests.swift */,
 				8A3FD28F2FABB9BA001F5DE9 /* TabManagerReorderTabsTests.swift */,
+				8AE65C042FE219A500CBBE66 /* TabManagerRestoreScreenshotTests.swift */,
 				8AFC09552FA54A240070CA11 /* TabManagerRestoreTabsTests.swift */,
 				5A475E8929DB87F2009C13FD /* TabManagerTests.swift */,
 				8AFC09562FA54A240070CA11 /* TabManagerTestsBase.swift */,
@@ -20286,6 +20289,7 @@
 				8A13FA892AD82BC8007527AB /* AppSendTabDelegateTests.swift in Sources */,
 				C2A853E42F9BA3EA005D4C7E /* ClearablesTests.swift in Sources */,
 				0ABCD45D2D356015005D704A /* TermsOfServiceTelemetryTests.swift in Sources */,
+				8AE65C052FE219A500CBBE66 /* TabManagerRestoreScreenshotTests.swift in Sources */,
 				C8CD80D42A1E268C0097C3AE /* MockGleanPlumbEvaluationUtility.swift in Sources */,
 				C705FA782EF30C4F00AC5EE7 /* PrivacyNoticeHelperTests.swift in Sources */,
 				319478509A7F45D09CBCEC18 /* PrivacyWindowHelperTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -18,7 +18,6 @@ struct TabPanelViewAction: Action {
     let isPrivateModeActive: Bool?
     let urlRequest: URLRequest?
     let tabUUID: TabUUID?
-    let tabUUIDs: [TabUUID]?
     let selectedTabIndex: Int?
     let moveTabData: MoveTabData?
     let toastType: ToastType?
@@ -29,7 +28,6 @@ struct TabPanelViewAction: Action {
          isPrivateModeActive: Bool? = nil,
          urlRequest: URLRequest? = nil,
          tabUUID: TabUUID? = nil,
-         tabUUIDs: [TabUUID]? = nil,
          selectedTabIndex: Int? = nil,
          moveTabData: MoveTabData? = nil,
          toastType: ToastType? = nil,
@@ -43,7 +41,6 @@ struct TabPanelViewAction: Action {
         self.isPrivateModeActive = isPrivateModeActive
         self.urlRequest = urlRequest
         self.tabUUID = tabUUID
-        self.tabUUIDs = tabUUIDs
         self.selectedTabIndex = selectedTabIndex
         self.moveTabData = moveTabData
         self.toastType = toastType

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -18,6 +18,7 @@ struct TabPanelViewAction: Action {
     let isPrivateModeActive: Bool?
     let urlRequest: URLRequest?
     let tabUUID: TabUUID?
+    let tabUUIDs: [TabUUID]?
     let selectedTabIndex: Int?
     let moveTabData: MoveTabData?
     let toastType: ToastType?
@@ -28,6 +29,7 @@ struct TabPanelViewAction: Action {
          isPrivateModeActive: Bool? = nil,
          urlRequest: URLRequest? = nil,
          tabUUID: TabUUID? = nil,
+         tabUUIDs: [TabUUID]? = nil,
          selectedTabIndex: Int? = nil,
          moveTabData: MoveTabData? = nil,
          toastType: ToastType? = nil,
@@ -41,6 +43,7 @@ struct TabPanelViewAction: Action {
         self.isPrivateModeActive = isPrivateModeActive
         self.urlRequest = urlRequest
         self.tabUUID = tabUUID
+        self.tabUUIDs = tabUUIDs
         self.selectedTabIndex = selectedTabIndex
         self.moveTabData = moveTabData
         self.toastType = toastType
@@ -62,6 +65,7 @@ enum TabPanelViewActionType: ActionType {
     case moveTab
     case learnMorePrivateMode
     case selectTab
+    case prefetchScreenshots
 }
 
 struct TabPanelMiddlewareAction: Action {
@@ -106,4 +110,5 @@ struct ScreenshotAction: Action {
 
 enum ScreenshotActionType: ActionType {
     case screenshotTaken
+    case screenshotRestored
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -268,7 +268,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
         guard let tabManager = tabManager(for: windowUUID) else { return }
         for tabUUID in tabUUIDs {
             guard let tab = tabManager.getTabForUUID(uuid: tabUUID) else { continue }
-            tabManager.restoreScreenshot(for: tab, onComplete: nil) // laurie
+            tabManager.restoreScreenshot(for: tab)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -95,14 +95,14 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
         case ScreenshotActionType.screenshotTaken:
             tabManager(for: action.windowUUID)?.tabDidSetScreenshot(action.tab)
         case ScreenshotActionType.screenshotRestored:
-            // TODO: Laurie
-            // The screenshot was just loaded from disk, so we only need to refresh the
-            // tab tray. Saving back would be redundant work.
+            // The screenshot was just loaded from disk, so we only need to refresh the tab tray
             break
         default:
             return
         }
 
+        // Both screenshotTaken and screenshotRestored fall through here so the tab tray
+        // rebinds with the new `tab.screenshot`
         guard let tabsState = state.componentState(TabsPanelState.self,
                                                    for: .tabsPanel,
                                                    window: action.windowUUID) else { return }
@@ -254,22 +254,20 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
             didTapLearnMoreAboutPrivate(with: urlRequest, uuid: action.windowUUID)
 
         case TabPanelViewActionType.prefetchScreenshots:
-            guard let tabUUIDs = action.tabUUIDs else { return }
-            prefetchScreenshots(for: tabUUIDs, windowUUID: action.windowUUID)
+            guard let tabUUID = action.tabUUID else { return }
+            prefetchScreenshot(for: tabUUID, windowUUID: action.windowUUID)
 
         default:
             break
         }
     }
 
-    /// Asks the tab manager to load the screenshots for the upcoming visible cells. The
-    /// tab manager will not load tabs screenshots which are already in memory.
-    private func prefetchScreenshots(for tabUUIDs: [TabUUID], windowUUID: WindowUUID) {
-        guard let tabManager = tabManager(for: windowUUID) else { return }
-        for tabUUID in tabUUIDs {
-            guard let tab = tabManager.getTabForUUID(uuid: tabUUID) else { continue }
-            tabManager.restoreScreenshot(for: tab)
-        }
+    /// Asks the tab manager to load the screenshot for an upcoming visible cell. The
+    /// tab manager will no-op if the tab's screenshot is already in memory.
+    private func prefetchScreenshot(for tabUUID: TabUUID, windowUUID: WindowUUID) {
+        guard let tabManager = tabManager(for: windowUUID),
+              let tab = tabManager.getTabForUUID(uuid: tabUUID) else { return }
+        tabManager.restoreScreenshot(for: tab)
     }
 
     private func tabTrayDidLoad(for windowUUID: WindowUUID, panelType: TabTrayPanelType?) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -91,7 +91,17 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
             return
         }
 
-        tabManager(for: action.windowUUID)?.tabDidSetScreenshot(action.tab)
+        switch action.actionType {
+        case ScreenshotActionType.screenshotTaken:
+            tabManager(for: action.windowUUID)?.tabDidSetScreenshot(action.tab)
+        case ScreenshotActionType.screenshotRestored:
+            // TODO: Laurie
+            // The screenshot was just loaded from disk, so we only need to refresh the
+            // tab tray. Saving back would be redundant work.
+            break
+        default:
+            return
+        }
 
         guard let tabsState = state.componentState(TabsPanelState.self,
                                                    for: .tabsPanel,
@@ -243,8 +253,22 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
             guard let urlRequest = action.urlRequest else { return }
             didTapLearnMoreAboutPrivate(with: urlRequest, uuid: action.windowUUID)
 
+        case TabPanelViewActionType.prefetchScreenshots:
+            guard let tabUUIDs = action.tabUUIDs else { return }
+            prefetchScreenshots(for: tabUUIDs, windowUUID: action.windowUUID)
+
         default:
             break
+        }
+    }
+
+    /// Asks the tab manager to load the screenshots for the upcoming visible cells. The
+    /// tab manager will not load tabs screenshots which are already in memory.
+    private func prefetchScreenshots(for tabUUIDs: [TabUUID], windowUUID: WindowUUID) {
+        guard let tabManager = tabManager(for: windowUUID) else { return }
+        for tabUUID in tabUUIDs {
+            guard let tab = tabManager.getTabForUUID(uuid: tabUUID) else { continue }
+            tabManager.restoreScreenshot(for: tab, onComplete: nil) // laurie
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -278,11 +278,7 @@ final class TabDisplayView: UIView,
                         willDisplay cell: UICollectionViewCell,
                         forItemAt indexPath: IndexPath) {
         guard let tab = tabsState.tabs[safe: indexPath.row] else { return }
-        let action = TabPanelViewAction(panelType: panelType,
-                                        tabUUIDs: [tab.tabUUID],
-                                        windowUUID: windowUUID,
-                                        actionType: TabPanelViewActionType.prefetchScreenshots)
-        store.dispatch(action)
+        dispatchPrefetchScreenshot(for: tab.tabUUID)
     }
 
     func collectionView(_ collectionView: UICollectionView,
@@ -337,10 +333,15 @@ final class TabDisplayView: UIView,
     // MARK: - UICollectionViewDataSourcePrefetching
 
     func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
-        let tabUUIDs = indexPaths.compactMap { tabsState.tabs[safe: $0.row]?.tabUUID }
-        guard !tabUUIDs.isEmpty else { return }
+        for indexPath in indexPaths {
+            guard let tab = tabsState.tabs[safe: indexPath.row] else { continue }
+            dispatchPrefetchScreenshot(for: tab.tabUUID)
+        }
+    }
+
+    private func dispatchPrefetchScreenshot(for tabUUID: TabUUID) {
         let action = TabPanelViewAction(panelType: panelType,
-                                        tabUUIDs: tabUUIDs,
+                                        tabUUID: tabUUID,
                                         windowUUID: windowUUID,
                                         actionType: TabPanelViewActionType.prefetchScreenshots)
         store.dispatch(action)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -274,9 +274,6 @@ final class TabDisplayView: UIView,
         }
     }
 
-    /// ADR 0008: prefetchItemsAt only fires when the system predicts scrolling, so it misses cells
-    /// that are visible from initial layout (e.g. a small tab list that fits on one screen). This
-    /// hook covers that case by triggering a load for each cell as it actually appears.
     func collectionView(_ collectionView: UICollectionView,
                         willDisplay cell: UICollectionViewCell,
                         forItemAt indexPath: IndexPath) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -27,6 +27,7 @@ final class TabDisplayView: UIView,
                       ThemeApplicable,
                       UICollectionViewDelegate,
                       UICollectionViewDelegateFlowLayout,
+                      UICollectionViewDataSourcePrefetching,
                       TabCellDelegate,
                       SwipeAnimatorDelegate,
                       InsetUpdatable {
@@ -118,6 +119,7 @@ final class TabDisplayView: UIView,
         collectionView.delegate = self
         collectionView.dragDelegate = self
         collectionView.dropDelegate = self
+        collectionView.prefetchDataSource = self
         collectionView.collectionViewLayout = createLayout()
         collectionView.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.collectionView
         return collectionView
@@ -319,6 +321,22 @@ final class TabDisplayView: UIView,
     func updateInsets(top: CGFloat, bottom: CGFloat) {
         collectionView.contentInset.top = top
         collectionView.contentInset.bottom = bottom
+    }
+
+    // MARK: - UICollectionViewDataSourcePrefetching
+
+    func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
+        let tabUUIDs = indexPaths.compactMap { tabsState.tabs[safe: $0.row]?.tabUUID }
+        guard !tabUUIDs.isEmpty else { return }
+        let action = TabPanelViewAction(panelType: panelType,
+                                        tabUUIDs: tabUUIDs,
+                                        windowUUID: windowUUID,
+                                        actionType: TabPanelViewActionType.prefetchScreenshots)
+        store.dispatch(action)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cancelPrefetchingForItemsAt indexPaths: [IndexPath]) {
+        // TODO: FXIOS-16047 - Implement UICollectionViewDataSourcePrefetching cancelPrefetchingForItemsAt
     }
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -346,10 +346,6 @@ final class TabDisplayView: UIView,
                                         actionType: TabPanelViewActionType.prefetchScreenshots)
         store.dispatch(action)
     }
-
-    func collectionView(_ collectionView: UICollectionView, cancelPrefetchingForItemsAt indexPaths: [IndexPath]) {
-        // TODO: FXIOS-16047 - Implement UICollectionViewDataSourcePrefetching cancelPrefetchingForItemsAt
-    }
 }
 
 // MARK: - Drag and Drop delegates

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -274,6 +274,20 @@ final class TabDisplayView: UIView,
         }
     }
 
+    /// ADR 0008: prefetchItemsAt only fires when the system predicts scrolling, so it misses cells
+    /// that are visible from initial layout (e.g. a small tab list that fits on one screen). This
+    /// hook covers that case by triggering a load for each cell as it actually appears.
+    func collectionView(_ collectionView: UICollectionView,
+                        willDisplay cell: UICollectionViewCell,
+                        forItemAt indexPath: IndexPath) {
+        guard let tab = tabsState.tabs[safe: indexPath.row] else { return }
+        let action = TabPanelViewAction(panelType: panelType,
+                                        tabUUIDs: [tab.tabUUID],
+                                        windowUUID: windowUUID,
+                                        actionType: TabPanelViewActionType.prefetchScreenshots)
+        store.dispatch(action)
+    }
+
     func collectionView(_ collectionView: UICollectionView,
                         contextMenuConfigurationForItemAt indexPath: IndexPath,
                         point: CGPoint) -> UIContextMenuConfiguration? {

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -120,6 +120,11 @@ protocol TabManager: AnyObject {
     func addPopupForParentTab(profile: Profile, parentTab: Tab, configuration: WKWebViewConfiguration) -> Tab
     func tabDidSetScreenshot(_ tab: Tab)
     func offloadBackgroundWebViews() async
+
+    /// ADR 0008: load `tab`'s screenshot from disk if it isn't already in memory. Intended for
+    /// just-in-time loading driven by the tab tray's prefetch data source. No-op if the tab
+    /// already has a screenshot.
+    func restoreScreenshot(for tab: Tab, onComplete: (() -> Void)?)
 }
 
 extension TabManager {

--- a/firefox-ios/Client/TabManagement/TabManager.swift
+++ b/firefox-ios/Client/TabManagement/TabManager.swift
@@ -124,7 +124,7 @@ protocol TabManager: AnyObject {
     /// ADR 0008: load `tab`'s screenshot from disk if it isn't already in memory. Intended for
     /// just-in-time loading driven by the tab tray's prefetch data source. No-op if the tab
     /// already has a screenshot.
-    func restoreScreenshot(for tab: Tab, onComplete: (() -> Void)?)
+    func restoreScreenshot(for tab: Tab)
 }
 
 extension TabManager {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -710,13 +710,11 @@ final class TabManagerImplementation: NSObject,
         selectTab(newTab)
     }
 
-    // Laurie - todo; onComplete?
-    func restoreScreenshot(for tab: Tab, onComplete: (() -> Void)? = nil) {
+    func restoreScreenshot(for tab: Tab) {
         loadScreenshotFromDisk(for: tab) { [weak self] in
             Task { @MainActor [weak self] in
                 self?.dispatchDidSetScreenshotAction(for: tab)
                 self?.dispatchScreenshotRestoredAction(for: tab)
-                onComplete?()
             }
         }
     }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -710,10 +710,12 @@ final class TabManagerImplementation: NSObject,
         selectTab(newTab)
     }
 
+    // Laurie - todo; onComplete?
     func restoreScreenshot(for tab: Tab, onComplete: (() -> Void)? = nil) {
         loadScreenshotFromDisk(for: tab) { [weak self] in
             Task { @MainActor [weak self] in
                 self?.dispatchDidSetScreenshotAction(for: tab)
+                self?.dispatchScreenshotRestoredAction(for: tab)
                 onComplete?()
             }
         }
@@ -800,6 +802,21 @@ final class TabManagerImplementation: NSObject,
                 nextTabScreenshot: currentTabs[safe: index+1]?.screenshot,
                 windowUUID: windowUUID,
                 actionType: ToolbarActionType.didSetTabScreenshot
+            )
+        )
+    }
+
+    /// ADR 0008: notifies the tab tray that a lazily-loaded screenshot has settled in memory so the
+    /// affected cell can rebind. Gated behind the deeplink-optimization flag because the legacy path
+    /// would otherwise fan out one refresh per restored tab at startup.
+    @MainActor
+    private func dispatchScreenshotRestoredAction(for tab: Tab) {
+        guard isDeeplinkOptimizationRefactorEnabled else { return }
+        store.dispatch(
+            ScreenshotAction(
+                windowUUID: windowUUID,
+                tab: tab,
+                actionType: ScreenshotActionType.screenshotRestored
             )
         )
     }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -805,8 +805,7 @@ final class TabManagerImplementation: NSObject,
     }
 
     /// ADR 0008: notifies the tab tray that a lazily-loaded screenshot has settled in memory so the
-    /// affected cell can rebind. Gated behind the deeplink-optimization flag because the legacy path
-    /// would otherwise fan out one refresh per restored tab at startup.
+    /// affected cell can reload. Only needed when the deeplink-optimization flag is enabled.
     @MainActor
     private func dispatchScreenshotRestoredAction(for tab: Tab) {
         guard isDeeplinkOptimizationRefactorEnabled else { return }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -804,7 +804,7 @@ final class TabManagerImplementation: NSObject,
         )
     }
 
-    /// ADR 0008: notifies the tab tray that a lazily-loaded screenshot has settled in memory so the
+    /// Notifies the tab tray that a lazily-loaded screenshot has settled in memory so the
     /// affected cell can reload. Only needed when the deeplink-optimization flag is enabled.
     @MainActor
     private func dispatchScreenshotRestoredAction(for tab: Tab) {

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -711,7 +711,8 @@ final class TabManagerImplementation: NSObject,
     }
 
     func restoreScreenshot(for tab: Tab) {
-        loadScreenshotFromDisk(for: tab) { [weak self] in
+        loadScreenshotFromDisk(for: tab) { shouldReload in
+            guard shouldReload else { return }
             Task { @MainActor [weak self] in
                 self?.dispatchDidSetScreenshotAction(for: tab)
                 self?.dispatchScreenshotRestoredAction(for: tab)
@@ -722,14 +723,14 @@ final class TabManagerImplementation: NSObject,
     /// Loads `tab.screenshot` from disk in the background and fires `onComplete` when done.
     /// `onComplete` may run on a background thread, so callers must hop to the main thread
     /// themselves before touching UI or main-actor state.
-    private func loadScreenshotFromDisk(for tab: Tab, onComplete: @escaping () -> Void) {
+    private func loadScreenshotFromDisk(for tab: Tab, onComplete: @escaping (_ shouldReload: Bool) -> Void) {
         guard tab.screenshot == nil else {
-            onComplete()
+            onComplete(false)
             return
         }
         Task { [weak tab, weak self] in
             guard let tab else {
-                onComplete()
+                onComplete(false)
                 return
             }
             do {
@@ -739,7 +740,7 @@ final class TabManagerImplementation: NSObject,
                 self?.logger.log("Failed to restore screenshot: \(error)", level: .warning, category: .tabs)
                 tab.setScreenshot(nil)
             }
-            onComplete()
+            onComplete(true)
         }
     }
 
@@ -779,7 +780,9 @@ final class TabManagerImplementation: NSObject,
         let group = DispatchGroup()
         for tab in tabsToLoad {
             group.enter()
-            loadScreenshotFromDisk(for: tab) { group.leave() }
+            loadScreenshotFromDisk(for: tab) { _ in
+                group.leave()
+            }
         }
         group.notify(queue: .main) { [weak self] in
             guard let self, let selectedTab = self.selectedTab else { return }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -711,7 +711,7 @@ final class TabManagerImplementation: NSObject,
     }
 
     func restoreScreenshot(for tab: Tab) {
-        loadScreenshotFromDisk(for: tab) { shouldReload in
+        loadScreenshotFromDisk(for: tab) { [weak self] shouldReload in
             guard shouldReload else { return }
             Task { @MainActor [weak self] in
                 self?.dispatchDidSetScreenshotAction(for: tab)

--- a/firefox-ios/Client/TabManagement/TabRestorerDelegate.swift
+++ b/firefox-ios/Client/TabManagement/TabRestorerDelegate.swift
@@ -12,5 +12,5 @@ protocol TabRestorerDelegate: AnyObject {
 
     /// Asynchronously loads a tab's screenshot from disk and sets it on the tab.
     @MainActor
-    func restoreScreenshot(for tab: Tab, onComplete: (() -> Void)?)
+    func restoreScreenshot(for tab: Tab)
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -18,6 +18,8 @@ class MockTabManager: TabManager {
     var selectedTabUUID: UUID?
     // Use to return in getTabForUUID()
     var tabForUUID: Tab?
+    // Maps tabUUID → Tab; takes precedence over `tabForUUID` for callers that need per-UUID lookups.
+    var tabsByUUID: [TabUUID: Tab] = [:]
 
     var recentlyAccessedNormalTabs = [Tab]()
 
@@ -109,6 +111,7 @@ class MockTabManager: TabManager {
     func restoreTabs() {}
 
     func getTabForUUID(uuid: String) -> Tab? {
+        if let match = tabsByUUID[uuid] { return match }
         return tabForUUID
     }
 
@@ -154,6 +157,14 @@ class MockTabManager: TabManager {
         notifyCurrentTabDidFinishLoadingCalled += 1
     }
 
-    func tabDidSetScreenshot(_ tab: Client.Tab) {}
+    var tabDidSetScreenshotCalls = 0
+    func tabDidSetScreenshot(_ tab: Client.Tab) {
+        tabDidSetScreenshotCalls += 1
+    }
     func offloadBackgroundWebViews() async {}
+
+    var preloadScreenshotCalls: [Tab] = []
+    func preloadScreenshot(for tab: Tab) {
+        preloadScreenshotCalls.append(tab)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -163,8 +163,8 @@ class MockTabManager: TabManager {
     }
     func offloadBackgroundWebViews() async {}
 
-    var preloadScreenshotCalls: [Tab] = []
-    func preloadScreenshot(for tab: Tab) {
-        preloadScreenshotCalls.append(tab)
+    var restoreScreenshotCalls: [Tab] = []
+    func restoreScreenshot(for tab: Tab) {
+        restoreScreenshotCalls.append(tab)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockDiskImageStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockDiskImageStore.swift
@@ -6,6 +6,7 @@ import Foundation
 import Storage
 
 final class MockDiskImageStore: DiskImageStore, @unchecked Sendable {
+    private let lock = NSLock()
     var getImageForKeyCallCount = 0
     var getImageForKeyCalls: [String] = []
     var onGetImageForKey: (() -> Void)?
@@ -13,10 +14,16 @@ final class MockDiskImageStore: DiskImageStore, @unchecked Sendable {
     var deleteImageForKeyCallCount = 0
 
     func getImageForKey(_ key: String) async throws -> UIImage {
+        recordGetImageForKey(key)?()
+        return UIImage()
+    }
+
+    private func recordGetImageForKey(_ key: String) -> (() -> Void)? {
+        lock.lock()
+        defer { lock.unlock() }
         getImageForKeyCallCount += 1
         getImageForKeyCalls.append(key)
-        onGetImageForKey?()
-        return UIImage()
+        return onGetImageForKey
     }
 
     func saveImageForKey(_ key: String, image: UIImage) async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabRestorerDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/Mocks/MockTabRestorerDelegate.swift
@@ -24,8 +24,7 @@ final class MockTabRestorerDelegate: TabRestorerDelegate {
         return tab
     }
 
-    func restoreScreenshot(for tab: Tab, onComplete: (() -> Void)?) {
+    func restoreScreenshot(for tab: Tab) {
         screenshotRestoredTabs.append(tab)
-        onComplete?()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerRestoreScreenshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerRestoreScreenshotTests.swift
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Redux
+import UIKit
+import XCTest
+
+@testable import Client
+
+final class TabManagerRestoreScreenshotTests: TabManagerTestsBase, StoreTestUtility {
+    var mockStore: MockStoreForMiddleware<AppState>!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        setIsDeeplinkOptimizationRefactorEnabled(true)
+        setupStore()
+    }
+
+    override func tearDown() async throws {
+        resetStore()
+        mockStore = nil
+        try await super.tearDown()
+    }
+
+    @MainActor
+    func testRestoreScreenshot_doesNotDispatch_whenTabAlreadyHasScreenshot() {
+        let tabs = generateTabs(count: 1)
+        let tab = tabs[0]
+        tab.setScreenshot(UIImage())
+        let subject = createSubject(tabs: tabs)
+
+        subject.restoreScreenshot(for: tab)
+
+        XCTAssertTrue(
+            mockStore.dispatchedActions.isEmpty,
+            "restoreScreenshot must not dispatch any action when the tab's screenshot is already in memory."
+        )
+        XCTAssertTrue(
+            mockDiskImageStore.getImageForKeyCalls.isEmpty,
+            "The disk store should not be hit when the screenshot is already in memory."
+        )
+    }
+
+    @MainActor
+    func testRestoreScreenshot_dispatchesScreenshotRestored_whenTabHasNoScreenshot() {
+        let tabs = generateTabs(count: 1)
+        let tab = tabs[0]
+        XCTAssertNil(tab.screenshot, "Precondition: tab starts with no in-memory screenshot.")
+        let subject = createSubject(tabs: tabs)
+
+        let expectation = XCTestExpectation(description: "screenshotRestored is dispatched after the disk load.")
+        mockStore.dispatchCalled = { [weak mockStore] in
+            let isScreenshotRestored: (Action) -> Bool = {
+                ($0 as? ScreenshotAction)?.actionType as? ScreenshotActionType == .screenshotRestored
+            }
+            guard mockStore?.dispatchedActions.contains(where: isScreenshotRestored) == true else { return }
+            expectation.fulfill()
+        }
+
+        subject.restoreScreenshot(for: tab)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - StoreTestUtility
+
+    @MainActor
+    func setupAppState() -> AppState {
+        return AppState()
+    }
+
+    @MainActor
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    @MainActor
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -135,7 +135,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.tabsPanelProvider(appState, action)
 
         XCTAssertEqual(
-            mockTabManager.preloadScreenshotCalls.map { $0.tabUUID },
+            mockTabManager.restoreScreenshotCalls.map { $0.tabUUID },
             [tabA.tabUUID]
         )
     }
@@ -153,7 +153,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.tabsPanelProvider(appState, action)
 
-        XCTAssertTrue(mockTabManager.preloadScreenshotCalls.isEmpty)
+        XCTAssertTrue(mockTabManager.restoreScreenshotCalls.isEmpty)
     }
 
     // MARK: - Recent Tabs

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -120,15 +120,14 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         )
     }
 
-    func test_prefetchScreenshotsAction_callsPreloadScreenshotForEachUUID() {
+    func test_prefetchScreenshotsAction_callsPreloadScreenshotForTab() {
         let subject = createSubject()
         let tabA = createTab(profile: mockProfile, urlString: "https://firefox.com")
-        let tabB = createTab(profile: mockProfile, urlString: "https://mozilla.com")
-        mockTabManager.tabsByUUID = [tabA.tabUUID: tabA, tabB.tabUUID: tabB]
+        mockTabManager.tabsByUUID = [tabA.tabUUID: tabA]
 
         let action = TabPanelViewAction(
             panelType: .tabs,
-            tabUUIDs: [tabA.tabUUID, tabB.tabUUID],
+            tabUUID: tabA.tabUUID,
             windowUUID: .XCTestDefaultUUID,
             actionType: TabPanelViewActionType.prefetchScreenshots
         )
@@ -137,25 +136,24 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(
             mockTabManager.preloadScreenshotCalls.map { $0.tabUUID },
-            [tabA.tabUUID, tabB.tabUUID]
+            [tabA.tabUUID]
         )
     }
 
-    func test_prefetchScreenshotsAction_skipsUnknownUUIDs() {
+    func test_prefetchScreenshotsAction_skipsUnknownUUID() {
         let subject = createSubject()
-        let tabA = createTab(profile: mockProfile, urlString: "https://firefox.com")
-        mockTabManager.tabsByUUID = [tabA.tabUUID: tabA]
+        mockTabManager.tabsByUUID = [:]
 
         let action = TabPanelViewAction(
             panelType: .tabs,
-            tabUUIDs: [tabA.tabUUID, "not-a-real-uuid"],
+            tabUUID: "not-a-real-uuid",
             windowUUID: .XCTestDefaultUUID,
             actionType: TabPanelViewActionType.prefetchScreenshots
         )
 
         subject.tabsPanelProvider(appState, action)
 
-        XCTAssertEqual(mockTabManager.preloadScreenshotCalls.map { $0.tabUUID }, [tabA.tabUUID])
+        XCTAssertTrue(mockTabManager.preloadScreenshotCalls.isEmpty)
     }
 
     // MARK: - Recent Tabs

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -113,8 +113,11 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionType = try XCTUnwrap(actionCalled.actionType as? TabPanelMiddlewareActionType)
 
         XCTAssertEqual(actionType, TabPanelMiddlewareActionType.refreshTabs)
-        XCTAssertEqual(mockTabManager.tabDidSetScreenshotCalls, 0,
-                       "screenshotRestored should not write the loaded image back to disk.")
+        XCTAssertEqual(
+            mockTabManager.tabDidSetScreenshotCalls,
+            0,
+            "screenshotRestored should not write the loaded image back to disk."
+        )
     }
 
     func test_prefetchScreenshotsAction_callsPreloadScreenshotForEachUUID() {
@@ -132,8 +135,10 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.tabsPanelProvider(appState, action)
 
-        XCTAssertEqual(mockTabManager.preloadScreenshotCalls.map { $0.tabUUID },
-                       [tabA.tabUUID, tabB.tabUUID])
+        XCTAssertEqual(
+            mockTabManager.preloadScreenshotCalls.map { $0.tabUUID },
+            [tabA.tabUUID, tabB.tabUUID]
+        )
     }
 
     func test_prefetchScreenshotsAction_skipsUnknownUUIDs() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -122,8 +122,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
     func test_prefetchScreenshotsAction_callsPreloadScreenshotForEachUUID() {
         let subject = createSubject()
-        let tabA = createTab(profile: mockProfile, urlString: "https://a.example")
-        let tabB = createTab(profile: mockProfile, urlString: "https://b.example")
+        let tabA = createTab(profile: mockProfile, urlString: "https://firefox.com")
+        let tabB = createTab(profile: mockProfile, urlString: "https://mozilla.com")
         mockTabManager.tabsByUUID = [tabA.tabUUID: tabA, tabB.tabUUID: tabB]
 
         let action = TabPanelViewAction(
@@ -143,7 +143,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
     func test_prefetchScreenshotsAction_skipsUnknownUUIDs() {
         let subject = createSubject()
-        let tabA = createTab(profile: mockProfile, urlString: "https://a.example")
+        let tabA = createTab(profile: mockProfile, urlString: "https://firefox.com")
         mockTabManager.tabsByUUID = [tabA.tabUUID: tabA]
 
         let action = TabPanelViewAction(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -90,6 +90,69 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(mockWindowManager.windowsWereAccessed)
     }
 
+    func test_screenshotRestoredAction_triggersRefresh_withoutSavingToDisk() throws {
+        let subject = createSubject()
+        let tab = Tab(profile: mockProfile, windowUUID: .XCTestDefaultUUID)
+        let action = ScreenshotAction(
+            windowUUID: .XCTestDefaultUUID,
+            tab: tab,
+            actionType: ScreenshotActionType.screenshotRestored
+        )
+
+        let expectation = XCTestExpectation(description: "Refresh dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        mockWindowManager.overrideWindows = true
+
+        subject.tabsPanelProvider(appState, action)
+        wait(for: [expectation])
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabPanelMiddlewareAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? TabPanelMiddlewareActionType)
+
+        XCTAssertEqual(actionType, TabPanelMiddlewareActionType.refreshTabs)
+        XCTAssertEqual(mockTabManager.tabDidSetScreenshotCalls, 0,
+                       "screenshotRestored should not write the loaded image back to disk.")
+    }
+
+    func test_prefetchScreenshotsAction_callsPreloadScreenshotForEachUUID() {
+        let subject = createSubject()
+        let tabA = createTab(profile: mockProfile, urlString: "https://a.example")
+        let tabB = createTab(profile: mockProfile, urlString: "https://b.example")
+        mockTabManager.tabsByUUID = [tabA.tabUUID: tabA, tabB.tabUUID: tabB]
+
+        let action = TabPanelViewAction(
+            panelType: .tabs,
+            tabUUIDs: [tabA.tabUUID, tabB.tabUUID],
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TabPanelViewActionType.prefetchScreenshots
+        )
+
+        subject.tabsPanelProvider(appState, action)
+
+        XCTAssertEqual(mockTabManager.preloadScreenshotCalls.map { $0.tabUUID },
+                       [tabA.tabUUID, tabB.tabUUID])
+    }
+
+    func test_prefetchScreenshotsAction_skipsUnknownUUIDs() {
+        let subject = createSubject()
+        let tabA = createTab(profile: mockProfile, urlString: "https://a.example")
+        mockTabManager.tabsByUUID = [tabA.tabUUID: tabA]
+
+        let action = TabPanelViewAction(
+            panelType: .tabs,
+            tabUUIDs: [tabA.tabUUID, "not-a-real-uuid"],
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TabPanelViewActionType.prefetchScreenshots
+        )
+
+        subject.tabsPanelProvider(appState, action)
+
+        XCTAssertEqual(mockTabManager.preloadScreenshotCalls.map { $0.tabUUID }, [tabA.tabUUID])
+    }
+
     // MARK: - Recent Tabs
     func test_viewWillAppearHomeAction_returnsRecentTabs() throws {
         let subject = createSubject()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15982)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34256)

## :bulb: Description
Hooks `UICollectionViewDataSourcePrefetching` into the tab tray so screenshots load just in time as cells come on screen, rather than all at once during restore. There should be no visual changes for the end users. 

- `TabDisplayView` adopts `UICollectionViewDataSourcePrefetching` and wires `collectionView.prefetchDataSource`.
- `TabManagerMiddleware` handles `prefetchScreenshots` by calling `tabManager.restoreScreenshot(for:)`.
- After a lazy load lands, `TabManagerImplementation.restoreScreenshot(for:)` now also dispatches the new `ScreenshotActionType.screenshotRestored`. The middleware re-runs `triggerRefresh` for that path.
- `cancelPrefetchingForItemsAt` is intentionally not implemented. It shouldn't have any side effects to load extra screenshots in memory.
- `TabManager.restoreScreenshot(for:)` is now part of the protocol so the middleware can call it. `MockTabManager` records calls via `restoreScreenshotCalls`.

### What this doesn't do
There's no screenshot cleanup. Once they are loaded in memory, they are loaded. This can be another project at one point!

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

