### PR TITLE
Remove FXIOS-16036 dead OnboardingVariant.legacy and OnboardingType.ugrade enum cases

### DIFF
--- a/BrowserKit/Sources/OnboardingKit/Models/OnboardingVariant.swift
+++ b/BrowserKit/Sources/OnboardingKit/Models/OnboardingVariant.swift
@@ -7,8 +7,6 @@ import Foundation
 /// Enum representing the different onboarding variants available.
 /// This mirrors the Nimbus OnboardingVariant configuration.
 public enum OnboardingVariant: String, Sendable {
-    // TODO: FXIOS-16036 Remove this dead `legacy` case (and `OnboardingType.upgrade`)
-    case legacy
     case modern
     case japan
     case brandRefresh
@@ -16,7 +14,7 @@ public enum OnboardingVariant: String, Sendable {
     /// Whether the UI for the Onboarding should be according to the brand refresh.
     var shouldShowBrandRefreshUI: Bool {
         switch self {
-        case .legacy, .modern:
+        case .modern:
             return false
         case .brandRefresh, .japan:
             return true

--- a/BrowserKit/Sources/OnboardingKit/Preview/PreviewModel.swift
+++ b/BrowserKit/Sources/OnboardingKit/Preview/PreviewModel.swift
@@ -51,7 +51,6 @@ private struct PreviewModel: OnboardingCardInfoModelProtocol {
 
 enum OnboardingType: String, Codable, Sendable {
     case freshInstall = "fresh-install"
-    case upgrade
 }
 
 enum OnboardingMultipleChoiceAction: String, CaseIterable, Codable, Sendable {

--- a/BrowserKit/Tests/OnboardingKitTests/OnboardingVariantTests.swift
+++ b/BrowserKit/Tests/OnboardingKitTests/OnboardingVariantTests.swift
@@ -9,7 +9,6 @@ import Testing
 struct OnboardingVariantTests {
     @Test
     func test_shouldShowBrandRefreshUI() {
-        #expect(!OnboardingVariant.legacy.shouldShowBrandRefreshUI)
         #expect(!OnboardingVariant.modern.shouldShowBrandRefreshUI)
         #expect(OnboardingVariant.japan.shouldShowBrandRefreshUI)
         #expect(OnboardingVariant.brandRefresh.shouldShowBrandRefreshUI)

--- a/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingKitFeatureLayer.swift
+++ b/firefox-ios/Client/Nimbus/OnboardingFeatureLayer/NimbusOnboardingKitFeatureLayer.swift
@@ -90,7 +90,6 @@ class NimbusOnboardingKitFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
         withConditions conditionTable: [String: String]
     ) -> [OnboardingKitCardInfoModel] {
         let a11yOnboarding = AccessibilityIdentifiers.Onboarding.onboarding
-        let a11yUpgrade = AccessibilityIdentifiers.Upgrade.upgrade
 
         // If `NimbusMessagingHelper` creation fails, we cannot continue with
         // evaluating card triggers based on their JEXL prerequisites.
@@ -114,7 +113,7 @@ class NimbusOnboardingKitFeatureLayer: NimbusOnboardingFeatureLayerProtocol {
                     buttons: getOnboardingCardButtons(from: cardData.buttons),
                     multipleChoiceButtons: getOnboardingMultipleChoiceButtons_(from: cardData.multipleChoiceButtons),
                     onboardingType: cardData.onboardingType,
-                    a11yIdRoot: cardData.onboardingType == .freshInstall ? a11yOnboarding : a11yUpgrade,
+                    a11yIdRoot: a11yOnboarding,
                     imageID: getOnboardingHeaderImageID(from: cardData.image),
                     instructionsPopup: getPopupInfoModel(
                         from: cardData.instructionsPopup,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Helpers/NimbusOnboardingTestingConfigUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/Helpers/NimbusOnboardingTestingConfigUtility.swift
@@ -15,7 +15,6 @@ struct NimbusOnboardingTestingConfigUtility {
         static let popupSecondInstruction = "second instruction"
         static let popupThirdInstruction = "third instruction"
         static let a11yIDOnboarding = "onboarding."
-        static let a11yIDUpgrade = "upgrade."
         static let linkTitle = "MacRumors"
         static let linkURL = "https://www.mozilla.org/en-US/privacy/firefox/"
         static let primaryButtonTitle = "Primary Button"
@@ -28,10 +27,8 @@ struct NimbusOnboardingTestingConfigUtility {
         case welcome
         case notifications = "notificationPermissions"
         case sync = "signToSync"
-        case updateWelcome = "update.welcome"
-        case updateSync = "update.signToSync"
 
-        static let allCards: [CardOrder] = [.welcome, .notifications, .sync, .updateWelcome, .updateSync]
+        static let allCards: [CardOrder] = [.welcome, .notifications, .sync]
         static let welcomeNotificationSync: [CardOrder] = [.welcome, .notifications, .sync]
         static let welcomeSync: [CardOrder] = [.welcome, .sync]
     }
@@ -124,13 +121,12 @@ struct NimbusOnboardingTestingConfigUtility {
         andOrder order: Int,
         uiVariant: OnboardingVariant? = nil
     ) -> NimbusOnboardingCardData {
-        let shouldAddLink: [CardOrder] = [.welcome, .updateWelcome]
-        let isUpdate: [CardOrder] = [.updateWelcome, .updateSync]
+        let shouldAddLink: [CardOrder] = [.welcome]
         let image: NimbusOnboardingHeaderImage = {
             switch id {
             case .notifications: return .notifications
-            case .welcome, .updateWelcome: return .welcomeGlobe
-            case .sync, .updateSync: return .syncDevices
+            case .welcome: return .welcomeGlobe
+            case .sync: return .syncDevices
             }
         }()
 
@@ -142,7 +138,7 @@ struct NimbusOnboardingTestingConfigUtility {
             image: image,
             instructionsPopup: buildInfoPopup(),
             link: shouldAddLink.contains(where: { $0 == id }) ? buildLink() : nil,
-            onboardingType: isUpdate.contains(where: { $0 == id }) ? .upgrade : .freshInstall,
+            onboardingType: .freshInstall,
             order: order,
             prerequisites: ["ALWAYS"],
             title: "title text",
@@ -174,7 +170,7 @@ struct NimbusOnboardingTestingConfigUtility {
 
     private func createButtons(for id: CardOrder) -> NimbusOnboardingButtons {
         switch id {
-        case .welcome, .updateWelcome:
+        case .welcome:
             return NimbusOnboardingButtons(
                 primary: NimbusOnboardingButton(
                     action: .forwardOneCard,
@@ -187,7 +183,7 @@ struct NimbusOnboardingTestingConfigUtility {
                 secondary: NimbusOnboardingButton(
                     action: .forwardOneCard,
                     title: "\(CardElementNames.secondaryButtonTitle)"))
-        case .sync, .updateSync:
+        case .sync:
             return NimbusOnboardingButtons(
                 primary: NimbusOnboardingButton(
                     action: .syncSignIn,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/NimbusOnboardingKitFeatureLayerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/NimbusOnboardingKitFeatureLayerTests.swift
@@ -72,22 +72,10 @@ class NimbusOnboardingKitFeatureLayerTests: XCTestCase {
         XCTAssertTrue(subject.cards.allSatisfy { $0.name.contains("Japan") })
     }
 
-    func testGetOnboardingModel_withLegacyVariant_returnsOnlyLegacyCards() {
-        setupNimbusWithMixedVariants()
-        let layer = NimbusOnboardingKitFeatureLayer(
-            onboardingVariant: .legacy,
-            with: mockHelper)
-
-        let subject = layer.getOnboardingModel(for: .freshInstall)
-
-        XCTAssertEqual(subject.cards.count, 2)
-        XCTAssertTrue(subject.cards.allSatisfy { $0.name.contains("Legacy") })
-    }
-
     // MARK: - OnboardingType Filtering Tests
 
     func testGetOnboardingModel_freshInstall_returnsOnlyFreshInstallCards() {
-        setupNimbusWithMixedOnboardingTypes()
+        setupNimbusWithFreshInstallCards()
         let layer = NimbusOnboardingKitFeatureLayer(
             onboardingVariant: .modern,
             with: mockHelper)
@@ -96,18 +84,6 @@ class NimbusOnboardingKitFeatureLayerTests: XCTestCase {
 
         XCTAssertEqual(subject.cards.count, 2)
         XCTAssertTrue(subject.cards.allSatisfy { $0.onboardingType == .freshInstall })
-    }
-
-    func testGetOnboardingModel_upgrade_returnsOnlyUpgradeCards() {
-        setupNimbusWithMixedOnboardingTypes()
-        let layer = NimbusOnboardingKitFeatureLayer(
-            onboardingVariant: .modern,
-            with: mockHelper)
-
-        let subject = layer.getOnboardingModel(for: .upgrade)
-
-        XCTAssertEqual(subject.cards.count, 2)
-        XCTAssertTrue(subject.cards.allSatisfy { $0.onboardingType == .upgrade })
     }
 
     // MARK: - iPad-Specific Filtering Tests
@@ -304,21 +280,6 @@ class NimbusOnboardingKitFeatureLayerTests: XCTestCase {
             return
         }
         XCTAssertTrue(card.a11yIdRoot.hasPrefix("onboarding."))
-    }
-
-    func testGetOnboardingModel_upgrade_hasCorrectA11yIdRoot() {
-        setupNimbusWithVariousWelcomeCards(onboardingType: .upgrade)
-        let layer = NimbusOnboardingKitFeatureLayer(
-            onboardingVariant: .modern,
-            with: mockHelper)
-
-        let subject = layer.getOnboardingModel(for: .upgrade)
-
-        guard let card = subject.cards.first else {
-            XCTFail("Expected a card")
-            return
-        }
-        XCTAssertTrue(card.a11yIdRoot.hasPrefix("upgrade."))
     }
 
     func testGetOnboardingModel_a11yIdRoot_updatesWithIndexAfterFiltering() {
@@ -558,9 +519,9 @@ class NimbusOnboardingKitFeatureLayerTests: XCTestCase {
     }
 
     func testGetOnboardingCards_prerequisiteNever_excludesCard() {
-        configUtility.setupNimbusWith(prerequisites: ["NEVER"])
+        configUtility.setupNimbusWith(prerequisites: ["NEVER"], uiVariant: .modern)
         let layer = NimbusOnboardingKitFeatureLayer(
-            onboardingVariant: .legacy,
+            onboardingVariant: .modern,
             with: mockHelper)
 
         let subject = layer.getOnboardingModel(for: .freshInstall)
@@ -659,7 +620,7 @@ class NimbusOnboardingKitFeatureLayerTests: XCTestCase {
             uiVariant: .modern
         )
         let layer = NimbusOnboardingKitFeatureLayer(
-            onboardingVariant: .legacy,
+            onboardingVariant: .modern,
             with: mockHelper)
 
         let subject = layer.getOnboardingModel(for: .freshInstall)
@@ -694,7 +655,7 @@ class NimbusOnboardingKitFeatureLayerTests: XCTestCase {
     // MARK: - Edge Cases
 
     func testGetOnboardingModel_noMatchingCards_returnsEmptyArray() {
-        setupNimbusWithOnlyUpgradeCards()
+        setupNimbusWithNonMatchingVariantCards()
         let layer = NimbusOnboardingKitFeatureLayer(
             onboardingVariant: .modern,
             with: mockHelper)
@@ -722,19 +683,15 @@ class NimbusOnboardingKitFeatureLayerTests: XCTestCase {
             "Modern Card 1": createCard(variant: .modern, order: 1),
             "Modern Card 2": createCard(variant: .modern, order: 2),
             "Japan Card 1": createCard(variant: .japan, order: 3),
-            "Japan Card 2": createCard(variant: .japan, order: 4),
-            "Legacy Card 1": createCard(variant: .legacy, order: 5),
-            "Legacy Card 2": createCard(variant: .legacy, order: 6)
+            "Japan Card 2": createCard(variant: .japan, order: 4)
         ]
         setupNimbus(with: cards)
     }
 
-    private func setupNimbusWithMixedOnboardingTypes() {
+    private func setupNimbusWithFreshInstallCards() {
         let cards: [String: NimbusOnboardingCardData] = [
             "Fresh Install 1": createCard(variant: .modern, order: 1, onboardingType: .freshInstall),
-            "Fresh Install 2": createCard(variant: .modern, order: 2, onboardingType: .freshInstall),
-            "Upgrade 1": createCard(variant: .modern, order: 3, onboardingType: .upgrade),
-            "Upgrade 2": createCard(variant: .modern, order: 4, onboardingType: .upgrade)
+            "Fresh Install 2": createCard(variant: .modern, order: 2, onboardingType: .freshInstall)
         ]
         setupNimbus(with: cards)
     }
@@ -901,9 +858,9 @@ class NimbusOnboardingKitFeatureLayerTests: XCTestCase {
         setupNimbus(with: cards)
     }
 
-    private func setupNimbusWithOnlyUpgradeCards() {
+    private func setupNimbusWithNonMatchingVariantCards() {
         let cards: [String: NimbusOnboardingCardData] = [
-            "Upgrade Card": createCard(variant: .modern, order: 1, onboardingType: .upgrade)
+            "Japan Card": createCard(variant: .japan, order: 1)
         ]
         setupNimbus(with: cards)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingServiceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingServiceTests.swift
@@ -54,7 +54,7 @@ final class MockIntroScreenManager: IntroScreenManagerProtocol {
     init(
         shouldShowIntro: Bool = false,
         isModernEnabled: Bool = false,
-        onboardingVariant: Client.OnboardingVariant = .legacy
+        onboardingVariant: Client.OnboardingVariant = .modern
     ) {
         self.stubShouldShowIntroScreen = shouldShowIntro
         self.stubIsModernOnboardingEnabled = isModernEnabled

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingTelemetryUtilityTests.swift
@@ -376,14 +376,7 @@ final class OnboardingTelemetryUtilityTests: XCTestCase {
         line: UInt = #line
     ) -> OnboardingTelemetryUtility {
         let nimbusConfigUtility = NimbusOnboardingTestingConfigUtility()
-        let cardOrder: [NimbusOnboardingTestingConfigUtility.CardOrder] = {
-            switch onboardingType {
-            case .freshInstall:
-                return [.welcome, .notifications, .sync]
-            case .upgrade:
-                return [.updateWelcome, .updateSync]
-            }
-        }()
+        let cardOrder: [NimbusOnboardingTestingConfigUtility.CardOrder] = [.welcome, .notifications, .sync]
         nimbusConfigUtility.setupNimbus(withOrder: cardOrder, uiVariant: variant)
         let layer = NimbusOnboardingKitFeatureLayer(
             onboardingVariant: variant,

--- a/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
+++ b/firefox-ios/nimbus-features/onboardingFrameworkFeature.yaml
@@ -666,8 +666,6 @@ enums:
     description: >
       Which UI style this onboarding card is designed for.
     variants:
-      legacy:
-        description: Use the existing (legacy) onboarding UI.
       modern:
         description: Use the new (modern) onboarding UI.
       japan:
@@ -799,10 +797,6 @@ enums:
       fresh-install:
         description: >
           Corresponding to onboarding cards that are for new users
-      upgrade:
-        description: >
-          Corresponding to onboarding cards that are for users
-          who have updated
   OnboardingMultipleChoiceAction:
     description: >
       The identifiers for the different actions available for cards in onboarding


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16036)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Removes two dead onboarding enum cases left over from the legacy onboarding cleanup (FXIOS-15164):

- `OnboardingVariant.legacy`: no card uses `uiVariant: legacy` anymore, and the modern Kit layer only matches active variants.
- `OnboardingType.upgrade`: the "What's New" upgrade flow was retired earlier, so nothing produces or consumes upgrade-type cards.

Both are removed together because they originate from the same FML source (`onboardingFrameworkFeature.yaml` → generated `FxNimbus`) and touch the same test files. Splitting the work would only add churn.

Also removes the now-unreachable `upgrade` accessibility branch in `NimbusOnboardingKitFeatureLayer`, along with the corresponding legacy/upgrade scaffolding in onboarding tests.

No telemetry impact: `onboarding_variant` is recorded as a free-form string, and removing these unused enum values does not change any emitted values.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

