### PR TITLE
Refactor - Fix cache issue making test to fail

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -152,7 +152,11 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - restore-spm-cache@3:
         is_always_run: true
-    - activate-build-cache-for-xcode@0: {}
+    # DIAGNOSTIC: Xcelerate build cache disabled to test if its remote
+    # content-addressed cache is causing the recurring
+    # testLongPressLinkOptionsPrivateMode failures. Restore this line if the
+    # experiment shows no improvement.
+    # - activate-build-cache-for-xcode@0: {}
     - xcode-build-for-test@3:
         inputs:
         - scheme: Fennec
@@ -180,13 +184,16 @@ workflows:
                 echo "Failure, the number of warnings increased"
                 exit 1
             fi
-    - script@1:
-        title: Remove cache
-        is_always_run: true
-        inputs:
-        - content: |
-            export PATH="${PATH#"$HOME/.bitrise-xcelerate/bin:"}"
-            envman add --key PATH --value "$PATH"
+    # DIAGNOSTIC: paired with the Xcelerate disable above. With Xcelerate off,
+    # the xcelerate bin is never in PATH so this strip becomes a no-op. Kept
+    # commented so it can be restored together with the activate step.
+    # - script@1:
+    #     title: Remove cache
+    #     is_always_run: true
+    #     inputs:
+    #     - content: |
+    #         export PATH="${PATH#"$HOME/.bitrise-xcelerate/bin:"}"
+    #         envman add --key PATH --value "$PATH"
     - script@1:
         title: Override xctestrun file to UnitTests
         inputs:
@@ -223,7 +230,7 @@ workflows:
         outputs:
         - BITRISE_TEST_SHARDS_PATH: BITRISE_TEST_SHARDS_PATH_FIREFOX
         is_always_run: true
-    - save-spm-cache@3:
+    - save-spm-cache@1:
         is_always_run: true
     - script@1:
         title: Clean before deploying

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -152,11 +152,7 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - restore-spm-cache@3:
         is_always_run: true
-    # DIAGNOSTIC: Xcelerate build cache disabled to test if its remote
-    # content-addressed cache is causing the recurring
-    # testLongPressLinkOptionsPrivateMode failures. Restore this line if the
-    # experiment shows no improvement.
-    # - activate-build-cache-for-xcode@0: {}
+    - activate-build-cache-for-xcode@0: {}
     - xcode-build-for-test@3:
         inputs:
         - scheme: Fennec
@@ -184,16 +180,13 @@ workflows:
                 echo "Failure, the number of warnings increased"
                 exit 1
             fi
-    # DIAGNOSTIC: paired with the Xcelerate disable above. With Xcelerate off,
-    # the xcelerate bin is never in PATH so this strip becomes a no-op. Kept
-    # commented so it can be restored together with the activate step.
-    # - script@1:
-    #     title: Remove cache
-    #     is_always_run: true
-    #     inputs:
-    #     - content: |
-    #         export PATH="${PATH#"$HOME/.bitrise-xcelerate/bin:"}"
-    #         envman add --key PATH --value "$PATH"
+    - script@1:
+        title: Remove cache
+        is_always_run: true
+        inputs:
+        - content: |
+            export PATH="${PATH#"$HOME/.bitrise-xcelerate/bin:"}"
+            envman add --key PATH --value "$PATH"
     - script@1:
         title: Override xctestrun file to UnitTests
         inputs:
@@ -230,8 +223,12 @@ workflows:
         outputs:
         - BITRISE_TEST_SHARDS_PATH: BITRISE_TEST_SHARDS_PATH_FIREFOX
         is_always_run: true
+    # Only push/release/epic builds save SPM cache. PRs read from the cache
+    # (via restore-spm-cache@3 above) but never write back, so they can't
+    # poison the cache for subsequent builds. main keeps the cache fresh.
     - save-spm-cache@1:
         is_always_run: true
+        run_if: '{{not .IsPR}}'
     - script@1:
         title: Clean before deploying
         timeout: 360

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -223,7 +223,7 @@ workflows:
         outputs:
         - BITRISE_TEST_SHARDS_PATH: BITRISE_TEST_SHARDS_PATH_FIREFOX
         is_always_run: true
-    - save-spm-cache@1:
+    - save-spm-cache@3:
         is_always_run: true
     - script@1:
         title: Clean before deploying


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Bumping the save step to @3 makes the pair consistent just in case there are issues with that for cache saved and restored making the test to fail. We have verified that after cleaning cache the test works for some builds

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

