### PR TITLE
Refactor - Reenable testLongPressLinkOptionsPrivateMode

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -743,7 +743,6 @@ workflows:
                 envman add --key NEW_RC_VERSION --value New_RC_Version
             fi
         title: Save Branch Name
-    - cache-pull@2: {}
   2_certificate_and_profile:
     steps:
     - certificate-and-profile-installer@1: {}
@@ -932,7 +931,6 @@ workflows:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@6: {}
-    - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
         run_if: '{{getenv "NEW_XCODE_VERSION" | eq "New_Version_Found" | or (getenv "RUN_ALL_STEPS" | eq "Run_All_Steps")}}'
@@ -1003,7 +1001,6 @@ workflows:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@6: {}
-    - cache-pull@2: {}
     - certificate-and-profile-installer@1: {}
     - script@1:
         inputs:
@@ -1617,8 +1614,6 @@ workflows:
 
   Bitrise_Performance_Test:
     steps:
-    - cache-pull@2:
-        is_always_run: true
     - xcode-test@6:
         inputs:
         - project_path: firefox-ios/Client.xcodeproj
@@ -2110,7 +2105,6 @@ workflows:
     before_run:
     - focus-clone-and-build-dependencies
     steps:
-    - cache-pull@2: {}
     #- swiftlint-extended@1:
     #    inputs:
     #    - linting_path: "$BITRISE_SOURCE_DIR"
@@ -2167,7 +2161,6 @@ workflows:
     before_run:
     - focus-clone-and-build-dependencies
     steps:
-    - cache-pull@2: {}
     #- swiftlint-extended@1:
     #    inputs:
     #    - linting_path: "$BITRISE_SOURCE_DIR"

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -486,7 +486,6 @@
         "PrivateBrowsingTest\/testClosePrivateTabsOptionClosesPrivateTabs_tabTrayExperimentOff()",
         "PrivateBrowsingTest\/testHamburgerMenuNewPrivateTab_tabTrayExperimentOff()",
         "PrivateBrowsingTest\/testHamburgerMenuNewPrivateTab_tabTrayExperimentOn()",
-        "PrivateBrowsingTest\/testLongPressLinkOptionsPrivateMode()",
         "PrivateBrowsingTest\/testLongPressLinkOptionsPrivateMode_TAE()",
         "PrivateBrowsingTest\/testPrivateBrowserPanelView()",
         "PrivateBrowsingTest\/testPrivateBrowserPanelView_tabTrayExperimentOff()",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Let's try to reenable the tests once the cache for PRs is taken from main

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

