### PR TITLE
Bugfix FXIOS-15995 [Minimal address bar] Weird animation when long tapping minimal address

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -548,9 +548,7 @@ public class BrowserAddressToolbar: UIView,
         let dragPoint = session.location(in: self)
         guard let url = droppableUrl,
               let itemProvider = NSItemProvider(contentsOf: url),
-              // allow drag only on the location view frame in order to don't mess with long press gesture
-              // on the address bar buttons.
-              locationView.frame.contains(dragPoint) else { return [] }
+              locationViewCanBeDrag(dragPoint: dragPoint) else { return [] }
 
         toolbarDelegate?.addressToolbarDidProvideItemsForDragInteraction()
 
@@ -560,5 +558,13 @@ public class BrowserAddressToolbar: UIView,
 
     public func dragInteraction(_ interaction: UIDragInteraction, sessionWillBegin session: UIDragSession) {
         toolbarDelegate?.addressToolbarDidBeginDragInteraction()
+    }
+
+    // Allow drag only when the touch is within the location view frame.
+    // This avoids interfering with long-press gestures on address bar buttons
+    // and disables drag interactions while the location view is minimized.
+    private func locationViewCanBeDrag(dragPoint: CGPoint) -> Bool {
+        return locationView.frame.contains(dragPoint) &&
+            !locationView.isAddressBarMinimized
     }
 }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -54,6 +54,10 @@ final class LocationView: UIView,
         return window.safeAreaInsets.bottom > 0
     }
 
+    var isAddressBarMinimized: Bool {
+        return scrollAlpha == 0
+    }
+
     private var tapGestureRecognizer: UITapGestureRecognizer?
     private var longPressGestureRecognizer: UILongPressGestureRecognizer?
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15995)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- Add condition to avoid drag interaction if the address bar is in minimal adress bar state. When the LocationView is minimized we shrink using transform if the drag interaction is enabled the locationView real frame (not shrink) is visible causing this bug.
I tested and the drag action is still working if there is no minimal address bar as well as the drag gesture to show tab tray.


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

