### PR TITLE
Add FXIOS-16056 [Google Lens] Update strings

### DIFF
--- a/.github/l10n/linter_config_ios.json
+++ b/.github/l10n/linter_config_ios.json
@@ -20,6 +20,7 @@
             "Pocket"
         ],
         "exclusions": [
+            "firefox-ios.xliff:CameraAccess.DisabledAlertMessage.v153",
             "firefox-ios.xliff:CFBundleDisplayName",
             "firefox-ios.xliff:ctDNmu",
             "firefox-ios.xliff:DefaultBrowserCard.BetterInternet.Description.v108",

--- a/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
@@ -9,22 +9,6 @@ typealias UIAlertActionCallback = (UIAlertAction) -> Void
 
 // MARK: - Extension methods for building specific UIAlertController instances used across the app
 extension UIAlertController {
-    class func cameraAccessDisabledAlert(okayCallback: UIAlertActionCallback? = nil) -> UIAlertController {
-        let featureFlagsProvider: FeatureFlagProviding = AppContainer.shared.resolve()
-        let alertMessage: String = featureFlagsProvider.isEnabled(.googleLens) ?
-            .CameraAccess.DisabledAlertMessage :
-            .ScanQRCodePermissionErrorMessage
-
-        let alert = UIAlertController(
-            title: "",
-            message: alertMessage,
-            preferredStyle: .alert
-        )
-
-        alert.addAction(UIAlertAction(title: .OKString, style: .default, handler: okayCallback))
-        return alert
-    }
-
     class func clearSelectedWebsiteDataAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
         let alert = UIAlertController(
             title: "",
@@ -152,6 +136,22 @@ extension UIAlertController {
         alert.addAction(cancelAction)
         alert.addAction(saveAction)
 
+        return alert
+    }
+
+    class func cameraAccessDisabledAlert(okayCallback: UIAlertActionCallback? = nil) -> UIAlertController {
+        let featureFlagsProvider: FeatureFlagProviding = AppContainer.shared.resolve()
+        let alertMessage: String = featureFlagsProvider.isEnabled(.googleLens) ?
+            .CameraAccess.DisabledAlertMessage :
+            .ScanQRCodePermissionErrorMessage
+
+        let alert = UIAlertController(
+            title: "",
+            message: alertMessage,
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: .OKString, style: .default, handler: okayCallback))
         return alert
     }
 }

--- a/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
@@ -2,12 +2,29 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import UIKit
 
 typealias UIAlertActionCallback = (UIAlertAction) -> Void
 
 // MARK: - Extension methods for building specific UIAlertController instances used across the app
 extension UIAlertController {
+    class func cameraAccessDisabledAlert(okayCallback: UIAlertActionCallback? = nil) -> UIAlertController {
+        let featureFlagsProvider: FeatureFlagProviding = AppContainer.shared.resolve()
+        let alertMessage: String = featureFlagsProvider.isEnabled(.googleLens) ?
+            .CameraAccess.DisabledAlertMessage :
+            .ScanQRCodePermissionErrorMessage
+
+        let alert = UIAlertController(
+            title: "",
+            message: alertMessage,
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: .OKString, style: .default, handler: okayCallback))
+        return alert
+    }
+
     class func clearSelectedWebsiteDataAlert(okayCallback: @escaping (UIAlertAction) -> Void) -> UIAlertController {
         let alert = UIAlertController(
             title: "",

--- a/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Shared
 import UIKit
 
 typealias UIAlertActionCallback = (UIAlertAction) -> Void
@@ -142,8 +143,8 @@ extension UIAlertController {
     class func cameraAccessDisabledAlert(okayCallback: UIAlertActionCallback? = nil) -> UIAlertController {
         let featureFlagsProvider: FeatureFlagProviding = AppContainer.shared.resolve()
         let alertMessage: String = featureFlagsProvider.isEnabled(.googleLens) ?
-            .CameraAccess.DisabledAlertMessage :
-            .ScanQRCodePermissionErrorMessage
+            String(format: .CameraAccess.DisabledAlertMessage, AppName.shortName.rawValue)
+            : .ScanQRCodePermissionErrorMessage
 
         let alert = UIAlertController(
             title: "",

--- a/firefox-ios/Client/Frontend/Browser/QRCodeViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/QRCodeViewController.swift
@@ -172,12 +172,9 @@ class QRCodeViewController: UIViewController {
     }
 
     private func presentAlert() {
-        let alert = UIAlertController(title: "", message: .ScanQRCodePermissionErrorMessage, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: .ScanQRCodeErrorOKButton,
-                                      style: .default,
-                                      handler: { _ in
+        let alert = UIAlertController.cameraAccessDisabledAlert { _ in
             self.dismissController()
-        }))
+        }
         present(alert, animated: true)
     }
 

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -132,7 +132,7 @@
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Firefox uses speech recognition to convert your voice to text for voice search.</string>
 	<key>NSCameraUsageDescription</key>
-	<string>Firefox uses your camera to scan QR codes and take photos and video.</string>
+	<string>Firefox can use your camera to scan QR codes or take photos and video.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Firefox requires Face ID to access your saved passwords and payment methods.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/firefox-ios/Client/en-US.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/en-US.lproj/InfoPlist.strings
@@ -8,7 +8,7 @@
 "New Tab" = "New Tab";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox uses your camera to scan QR codes and take photos and video.";
+"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox requires Face ID to access your saved passwords and payment methods.";

--- a/firefox-ios/Client/en.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/en.lproj/InfoPlist.strings
@@ -1,7 +1,7 @@
 
 NSLocationWhenInUseUsageDescription = "Websites you visit may request your location.";
 NSPhotoLibraryAddUsageDescription = "This lets you save photos.";
-NSCameraUsageDescription = "Firefox uses your camera to scan QR codes and take photos and video.";
+NSCameraUsageDescription = "Firefox can use your camera to scan QR codes or take photos and video.";
 NSMicrophoneUsageDescription = "Firefox uses your microphone to record and upload audio.";
 "New Tab" = "New Tab";
 "New Private Tab" = "New Private Tab";

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4211,7 +4211,7 @@ extension String {
                 public static let Description = MZLocalizedString(
                     key: "Settings.Search.GoogleLens.Description.v153",
                     tableName: "Settings",
-                    value: "Sends images and photos to Google for visual search.",
+                    value: "Send images to Google to search.",
                     comment: "In the Search settings, this is the description that describes the Google Lens feature"
                 )
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -3437,22 +3437,6 @@ extension String {
                     )
                 }
 
-                public struct GoogleLensSection {
-                    public static let Title = MZLocalizedString(
-                        key: "Settings.AIControls.AIPoweredFeaturesSection.GoogleLensSection.Title.v153",
-                        tableName: "Settings",
-                        value: "Google Lens",
-                        comment: "In the AI Controls settings, in the AI powered features section, this is the title that describes the Google Lens feature"
-                    )
-
-                    public static let Message = MZLocalizedString(
-                        key: "Settings.AIControls.AIPoweredFeaturesSection.GoogleLensSection.Message.v153",
-                        tableName: "Settings",
-                        value: "Sends images and photos to Google for visual search.",
-                        comment: "In the AI Controls settings, in the AI powered features section, this is the message that describes the Google Lens feature"
-                    )
-                }
-
                 public struct QuickAnswersSection {
                     public static let Title = MZLocalizedString(
                         key: "Settings.AIControls.AIPoweredFeaturesSection.QuickAnswersSection.Title.v154",
@@ -4214,6 +4198,29 @@ extension String {
                     tableName: "Settings",
                     value: "Learn more about Firefox Suggest",
                     comment: "Accessibility label for Learn more about Firefox Suggest.")
+            }
+
+            public struct GoogleLens {
+                public static let Title = MZLocalizedString(
+                    key: "Settings.Search.GoogleLens.Title.v153",
+                    tableName: "Settings",
+                    value: "Google Lens",
+                    comment: "In the Search settings, this is the title that describes the Google Lens feature"
+                )
+
+                public static let Description = MZLocalizedString(
+                    key: "Settings.Search.GoogleLens.Description.v153",
+                    tableName: "Settings",
+                    value: "Sends images and photos to Google for visual search.",
+                    comment: "In the Search settings, this is the description that describes the Google Lens feature"
+                )
+
+                public static let Footnote = MZLocalizedString(
+                    key: "Settings.Search.GoogleLens.Footnote.v153",
+                    tableName: "Settings",
+                    value: "Available only when Google is enabled above and is your active search engine while browsing.",
+                    comment: "In the Search settings, this is the disclaimer underneath the Google Lens settings toggle that explains the conditions required for Google Lens to be available."
+                )
             }
 
             public struct SearchZero {
@@ -5673,6 +5680,17 @@ extension String {
         tableName: "WebContextMenu",
         value: "Search Image with Google Lens",
         comment: "Context menu item to search for an image using Google Lens")
+}
+
+// MARK: - Camera access
+extension String {
+    public struct CameraAccess {
+        public static let DisabledAlertMessage = MZLocalizedString(
+            key: "CameraAccess.DisabledAlertMessage.v153",
+            tableName: "Camera",
+            value: "Go to Settings > Firefox on your device to allow Firefox to use your camera.",
+            comment: "Message shown in an alert when camera access is disabled in iOS Settings. This is used by features that require camera access, such as QR code scanning and Google Lens.")
+    }
 }
 
 // MARK: - Photo Library access
@@ -7929,9 +7947,9 @@ extension String {
 
         public struct GoogleLens {
             public static let A11yLabel = MZLocalizedString(
-                key: "AddressToolbar.GoogleLens.A11yLabel.v153",
+                key: "AddressToolbar.GoogleLens.A11yLabel.v153.v2",
                 tableName: "AddressToolbar",
-                value: "Search with Google Lens",
+                value: "Search image with Google Lens",
                 comment: "Accessibility label describing the Google Lens button on the address toolbar that prompts a menu to allow the user to take a new photo or select an existing photo from their photo library to search with Google Lens.")
 
             public struct ContextMenu {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -5688,8 +5688,8 @@ extension String {
         public static let DisabledAlertMessage = MZLocalizedString(
             key: "CameraAccess.DisabledAlertMessage.v153",
             tableName: "Camera",
-            value: "Go to Settings > Firefox on your device to allow Firefox to use your camera.",
-            comment: "Message shown in an alert when camera access is disabled in iOS Settings. This is used by features that require camera access, such as QR code scanning and Google Lens.")
+            value: "Go to Settings > %@ on your device to allow Firefox to use your camera.",
+            comment: "Message shown in an alert when camera access is disabled in iOS Settings. The %@ is replaced with the app name. This is used by features that require camera access, such as QR code scanning and Google Lens.")
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16056)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34227)

## :bulb: Description
- Update a couple of the Google Lens strings
  - Update `NSCameraUsageDescription` in info.plist 
  - Update "Camera permission denied" alert description string and made the alert generic so that it can be reused for Google Lens
  - Moved setting from AI Controls -> Search
  - Update address toolbar entry point a11y label

Left all string keys labelled as v153 as we still intend to release this feature then, regardless of whether translations are ready (potentially to English-users only)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

