### PR TITLE
Telemetry FXIOS-16079 [Toolbar] Add telemetry for address bar swipe gestures

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressBarPanGestureHandler.swift
@@ -243,9 +243,8 @@ final class AddressBarPanGestureHandler: NSObject, StoreSubscriber {
             return
         }
 
-        let action = GeneralBrowserAction(windowUUID: windowUUID,
-                                          actionType: GeneralBrowserActionType.showTabTray)
-        store.dispatch(action)
+        store.dispatch(ToolbarMiddlewareAction(windowUUID: windowUUID,
+                                               actionType: ToolbarMiddlewareActionType.didSwipeToOpenTabTray))
     }
 
     private func handleGestureChangedState(translation: CGPoint, nextTab: Tab?) {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -175,5 +175,6 @@ enum ToolbarMiddlewareActionType: ActionType {
     case urlDidChange
     case didClearSearch
     case didStartDragInteraction
+    case didSwipeToOpenTabTray
     case loadSummaryState
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -147,6 +147,14 @@ final class ToolbarMiddleware {
         case ToolbarMiddlewareActionType.didStartDragInteraction:
             toolbarTelemetry.dragInteractionStarted()
 
+        case ToolbarMiddlewareActionType.didSwipeToOpenTabTray:
+            guard let toolbarState = state.componentState(ToolbarState.self, for: .toolbar, window: action.windowUUID)
+            else { return }
+            toolbarTelemetry.tabTrayOpenedViaSwipe(isAtBottom: toolbarState.toolbarPosition == .bottom)
+            let action = GeneralBrowserAction(windowUUID: action.windowUUID,
+                                              actionType: GeneralBrowserActionType.showTabTray)
+            store.dispatch(action)
+
         case ToolbarMiddlewareActionType.loadSummaryState:
             checkPageCanSummarize(action: action)
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarTelemetry.swift
@@ -99,6 +99,11 @@ struct ToolbarTelemetry {
         let isPrivateExtra = GleanMetrics.Toolbar.TabTrayLongPressExtra(isPrivate: isPrivate)
         gleanWrapper.recordEvent(for: GleanMetrics.Toolbar.tabTrayLongPress, extras: isPrivateExtra)
     }
+    
+    func tabTrayOpenedViaSwipe(isAtBottom: Bool) {
+        let isAtBottomExtra = GleanMetrics.Toolbar.TabTrayOpenedViaSwipeExtra(isAtBottom: isAtBottom)
+        gleanWrapper.recordEvent(for: GleanMetrics.Toolbar.tabTrayOpenedViaSwipe, extras: isAtBottomExtra)
+    }
 
     // Other
     func dragInteractionStarted() {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarTelemetry.swift
@@ -99,7 +99,7 @@ struct ToolbarTelemetry {
         let isPrivateExtra = GleanMetrics.Toolbar.TabTrayLongPressExtra(isPrivate: isPrivate)
         gleanWrapper.recordEvent(for: GleanMetrics.Toolbar.tabTrayLongPress, extras: isPrivateExtra)
     }
-    
+
     func tabTrayOpenedViaSwipe(isAtBottom: Bool) {
         let isAtBottomExtra = GleanMetrics.Toolbar.TabTrayOpenedViaSwipeExtra(isAtBottom: isAtBottom)
         gleanWrapper.recordEvent(for: GleanMetrics.Toolbar.tabTrayOpenedViaSwipe, extras: isAtBottomExtra)

--- a/firefox-ios/Client/Glean/probes/toolbar.yaml
+++ b/firefox-ios/Client/Glean/probes/toolbar.yaml
@@ -283,7 +283,7 @@ toolbar:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16079
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34299
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/toolbar.yaml
+++ b/firefox-ios/Client/Glean/probes/toolbar.yaml
@@ -286,7 +286,7 @@ toolbar:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34299
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: never
+    expires: 2026-12-01
   app_menu_button_tapped:
     type: event
     description: |

--- a/firefox-ios/Client/Glean/probes/toolbar.yaml
+++ b/firefox-ios/Client/Glean/probes/toolbar.yaml
@@ -272,6 +272,21 @@ toolbar:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+  tab_tray_opened_via_swipe:
+    type: event
+    description: |
+        Counts the number of times a user opened the tab tray using a swipe gesture
+    extra_keys:
+      is_at_bottom:
+        description: Whether the address bar is at the bottom
+        type: boolean
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16079
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
   app_menu_button_tapped:
     type: event
     description: |

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -753,6 +753,47 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
     }
 
+    func testDidSwipeToOpenTabTray_withTopToolbar_recordsIsAtBottomFalse() throws {
+        let subject = createSubject(manager: toolbarManager)
+        let action = ToolbarMiddlewareAction(
+            windowUUID: windowUUID,
+            actionType: ToolbarMiddlewareActionType.didSwipeToOpenTabTray)
+        subject.toolbarProvider(mockStore.state, action)
+
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.TabTrayOpenedViaSwipeExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.TabTrayOpenedViaSwipeExtra
+        )
+        let expectedMetricType = type(of: GleanMetrics.Toolbar.tabTrayOpenedViaSwipe)
+        let resultMetricType = type(of: savedMetric)
+        let debugMessage = TelemetryDebugMessage(expectedMetric: expectedMetricType, resultMetric: resultMetricType)
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssert(resultMetricType == expectedMetricType, debugMessage.text)
+        XCTAssertEqual(savedExtras.isAtBottom, false)
+    }
+
+    func testDidSwipeToOpenTabTray_withBottomToolbar_recordsIsAtBottomTrue() throws {
+        mockStore = MockStoreForMiddleware(state: setupToolbarBottomPositionAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+
+        let subject = createSubject(manager: toolbarManager)
+        let action = ToolbarMiddlewareAction(
+            windowUUID: windowUUID,
+            actionType: ToolbarMiddlewareActionType.didSwipeToOpenTabTray)
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.TabTrayOpenedViaSwipeExtra
+        )
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.isAtBottom, true)
+    }
+
     // MARK: - ToolbarAction
     func testCancelEdit_dispatchesDidClearAlternativeSearchEngine() throws {
         let subject = createSubject(manager: toolbarManager)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16079)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added telemetry for the swipe up/down gestures on the address bar. These gestures open the tab tray.

This PR also has a slight refactor to follow how telemetry is typically recorded (from ToolbarMiddleware.swift).

PR That implemented the gestures: https://github.com/mozilla-mobile/firefox-ios/pull/34252

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

