### PR TITLE
Add FXIOS-16019 [Bookmarks] Add delete bookmark button in edit form

### DIFF
--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -183,6 +183,9 @@ class BookmarksCoordinator: BaseCoordinator,
         viewModel.onBookmarkSaved = { [weak self] in
             self?.reloadLastBookmarksController()
         }
+        viewModel.onBookmarkDeleted = { [weak self] in
+            self?.reloadLastBookmarksController()
+        }
         viewModel.bookmarkCoordinatorDelegate = self
         setBackBarButtonItemTitle(viewModel.getBackNavigationButtonTitle)
         let controller = EditBookmarkViewController(viewModel: viewModel,

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -10,6 +10,10 @@ class EditBookmarkViewController: UIViewController,
                                   UITableViewDelegate,
                                   Themeable {
     private struct UX {
+        static let viewHorizontalMargin: CGFloat = 16
+        static let deleteImageHorizontalMargin: CGFloat = 12
+        static let viewVerticalMargin: CGFloat = 8
+        static let deleteBookmarkButtonViewTopMargin: CGFloat = 32
         static let bookmarkCellTopPadding: CGFloat = 25.0
         static let folderHeaderIdentifier = "folderHeaderIdentifier"
         static let folderHeaderHorizontalPadding: CGFloat = 16.0
@@ -58,6 +62,32 @@ class EditBookmarkViewController: UIViewController,
     var onViewWillAppear: VoidReturnCallback?
 
     private let viewModel: EditBookmarkViewModel
+
+    private lazy var deleteBookmarkButton: UIButton = .build { button in
+        let deleteImage = UIImage(named: StandardImageIdentifiers.Large.delete)?.withRenderingMode(.alwaysTemplate)
+
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = .RemoveBookmarkContextMenuTitle
+        configuration.image = deleteImage
+        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = FXFontStyles.Regular.body.scaledFont()
+            return outgoing
+        }
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+            top: UX.viewVerticalMargin,
+            leading: UX.viewHorizontalMargin,
+            bottom: UX.viewVerticalMargin,
+            trailing: UX.viewHorizontalMargin
+        )
+        configuration.imagePadding = UX.deleteImageHorizontalMargin
+        configuration.titleAlignment = .leading
+
+        button.configuration = configuration
+        button.contentHorizontalAlignment = .leading
+        button.addTarget(self, action: #selector(self.deleteBookmarkAction), for: .touchUpInside)
+    }
+
     private lazy var dataSource: EditBookmarkDiffableDataSource = {
         return EditBookmarkDiffableDataSource(tableView: tableView,
                                               cellProvider: { [weak self] _, indexPath, item in
@@ -132,12 +162,17 @@ class EditBookmarkViewController: UIViewController,
 
     // MARK: - Setup
     private func setupSubviews() {
-        view.addSubview(tableView)
+        view.addSubviews(tableView, deleteBookmarkButton)
         NSLayoutConstraint.activate([
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            deleteBookmarkButton.topAnchor.constraint(equalTo: tableView.bottomAnchor,
+                                                      constant: UX.deleteBookmarkButtonViewTopMargin),
+
+            deleteBookmarkButton.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            deleteBookmarkButton.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            deleteBookmarkButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
     }
 
@@ -160,6 +195,19 @@ class EditBookmarkViewController: UIViewController,
         }
     }
 
+    @objc
+    private func deleteBookmarkAction() {
+        viewModel.onBookmarkDeleted = { [weak self] in
+            guard let self else { return }
+            if navigationController?.viewControllers.first == self {
+                viewModel.didFinish()
+            } else {
+                navigationController?.popViewController(animated: true)
+            }
+        }
+        viewModel.deleteBookmark()
+    }
+
     // MARK: - Themeable
 
     func applyTheme() {
@@ -180,6 +228,9 @@ class EditBookmarkViewController: UIViewController,
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
         view.backgroundColor = theme.colors.layer1
         tableView.backgroundColor = theme.colors.layer1
+        deleteBookmarkButton.tintColor = theme.colors.textPrimary
+        deleteBookmarkButton.setTitleColor(theme.colors.textPrimary, for: .normal)
+        deleteBookmarkButton.backgroundColor = theme.colors.layer5
         if #available(iOS 26.0, *) {
             saveBarButton.tintColor = theme.colors.textAccent
         }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewModel.swift
@@ -40,6 +40,7 @@ class EditBookmarkViewModel: ParentFolderSelector, @unchecked Sendable {
 
     var onFolderStatusUpdate: VoidReturnCallback?
     var onBookmarkSaved: VoidReturnCallback?
+    var onBookmarkDeleted: VoidReturnCallback?
 
     var getBackNavigationButtonTitle: String {
         if parentFolder.guid == BookmarkRoots.MobileFolderGUID {
@@ -136,6 +137,18 @@ class EditBookmarkViewModel: ParentFolderSelector, @unchecked Sendable {
             }
 
             self?.onBookmarkSaved?()
+        }
+    }
+
+    func deleteBookmark() {
+        guard let node else { return }
+        profile.places.deleteBookmarkNode(guid: node.guid).uponQueue(.main) { [weak self] _ in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                let bookmarksTelemetry = BookmarksTelemetry()
+                bookmarksTelemetry.deleteBookmark(eventLabel: .bookmarksPanel)
+                self.onBookmarkDeleted?()
+            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16019)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34173)

## :bulb: Description
I added a delete bookmark button to the bookmark editing form. This feature is available in all popular browsers, and many would find it useful here as well.
I've seen users request this feature.

## :movie_camera: Demos


| Before | After |
| - | - |
| <img width="300" src="https://github.com/user-attachments/assets/5b54422a-3a65-4d7f-9dbc-9751e3f7b5e7" /> | <img width="300" src="https://github.com/user-attachments/assets/8d5a16ff-3b3c-4952-8bdf-708f348c4a27" /> |

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

