### PR TITLE
Add FXIOS-16177 [WebCompat] broken-site-report Glean ping and metrics

### DIFF
--- a/firefox-ios/Client/Glean/glean_index.yaml
+++ b/firefox-ios/Client/Glean/glean_index.yaml
@@ -15,6 +15,7 @@ metrics_files:
   - firefox-ios/Client/Glean/probes/autofill.email_mask.yaml
   - firefox-ios/Client/Glean/probes/autofill.password_generator.yaml
   - firefox-ios/Client/Glean/probes/autofill.passwords.yaml
+  - firefox-ios/Client/Glean/probes/broken_site_report.yaml
   - firefox-ios/Client/Glean/probes/history.yaml
   - firefox-ios/Client/Glean/probes/homepage.shortcuts_library.yaml
   - firefox-ios/Client/Glean/probes/library.bookmarks_panel.yaml

--- a/firefox-ios/Client/Glean/pings.yaml
+++ b/firefox-ios/Client/Glean/pings.yaml
@@ -190,3 +190,20 @@ onboarding:
     - https://github.com/mozilla-mobile/firefox-ios/pull/32275
   notification_emails:
     - fx-ios-data-stewards@mozilla.com
+broken-site-report:
+  description: |
+    A ping submitted when a user files an in-app "Report Broken Site"
+    (WebCompat) report. Carries the reported URL, the chosen breakage
+    category, an optional free-text description, and a small set of
+    device/app environment fields. Does not include a client id — each
+    report is self-contained. iOS counterpart of the cross-platform
+    desktop/Android `broken-site-report` ping, with a reduced payload
+    (no Gecko engine-internals; WebKit has no equivalent).
+  include_client_id: false
+  send_if_empty: false
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/FXMO-860
+  data_reviews:
+    - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+  notification_emails:
+    - fx-ios-data-stewards@mozilla.com

--- a/firefox-ios/Client/Glean/pings.yaml
+++ b/firefox-ios/Client/Glean/pings.yaml
@@ -202,7 +202,7 @@ broken-site-report:
   include_client_id: false
   send_if_empty: false
   bugs:
-    - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
   data_reviews:
     - https://github.com/mozilla-mobile/firefox-ios/pull/34309
   notification_emails:

--- a/firefox-ios/Client/Glean/pings.yaml
+++ b/firefox-ios/Client/Glean/pings.yaml
@@ -204,6 +204,6 @@ broken-site-report:
   bugs:
     - https://mozilla-hub.atlassian.net/browse/FXMO-860
   data_reviews:
-    - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+    - https://github.com/mozilla-mobile/firefox-ios/pull/34309
   notification_emails:
     - fx-ios-data-stewards@mozilla.com

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -184,7 +184,7 @@ broken_site_report.tab_info.antitracking:
   is_private_browsing:
     type: boolean
     description: |
-      Whether the reported tab is in private browsing.
+      Whether the reported tab is in private browsing mode.
     data_sensitivity:
       - technical
     lifetime: ping

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -221,7 +221,8 @@ broken_site_report.tab_info.frameworks:
   marfeel:
     type: boolean
     description: |
-      Whether the Marfeel framework was detected on the reported page.
+      Whether the Marfeel framework was detected on the reported page
+      (detected via injected JS at report time).
     data_sensitivity:
       - technical
     lifetime: ping
@@ -237,7 +238,8 @@ broken_site_report.tab_info.frameworks:
   mobify:
     type: boolean
     description: |
-      Whether the Mobify framework was detected on the reported page.
+      Whether the Mobify framework was detected on the reported page
+      (detected via injected JS at report time).
     data_sensitivity:
       - technical
     lifetime: ping

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -36,7 +36,7 @@ $tags:
 # capture/storage is a separate open decision (see the data-review doc); no
 # screenshot field is defined here.
 #
-# `bugs` is the impl ticket (placeholder FXMO-860); `data_reviews` is the
+# `bugs` is the impl ticket (FXIOS-16177); `data_reviews` is the
 # data-review PR. `url` and `description` carry user-entered data.
 ###############################################################################
 
@@ -52,7 +52,7 @@ broken_site_report:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -70,7 +70,7 @@ broken_site_report:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -87,7 +87,7 @@ broken_site_report:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -106,7 +106,7 @@ broken_site_report.tab_info:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -123,7 +123,7 @@ broken_site_report.tab_info:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -141,7 +141,7 @@ broken_site_report.tab_info.antitracking:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -159,7 +159,7 @@ broken_site_report.tab_info.antitracking:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -175,7 +175,7 @@ broken_site_report.tab_info.antitracking:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -191,7 +191,7 @@ broken_site_report.tab_info.antitracking:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -210,7 +210,7 @@ broken_site_report.tab_info.frameworks:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -226,7 +226,7 @@ broken_site_report.tab_info.frameworks:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -242,7 +242,7 @@ broken_site_report.tab_info.frameworks:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -260,7 +260,7 @@ broken_site_report.browser_info.app:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -279,7 +279,7 @@ broken_site_report.browser_info.app:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -299,7 +299,7 @@ broken_site_report.browser_info.system:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -316,7 +316,7 @@ broken_site_report.browser_info.system:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -334,7 +334,7 @@ broken_site_report.browser_info.graphics:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
@@ -350,7 +350,7 @@ broken_site_report.browser_info.graphics:
     send_in_pings:
       - broken-site-report
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -134,7 +134,9 @@ broken_site_report.tab_info.antitracking:
   block_list:
     type: string
     description: |
-      The active content-blocker list for the tab ("basic" or "strict").
+      Which content-blocking rule set is active for the tab: a single value,
+      one of "basic" or "strict" (not a list of blocked items; those are in
+      blocked_origins). Named block_list to match the cross-platform schema.
     data_sensitivity:
       - technical
     lifetime: ping

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -47,7 +47,7 @@ broken_site_report:
       The URL of the site the user is reporting. The user may edit this before
       submitting. May contain PII.
     data_sensitivity:
-      - web_activity
+      - stored_content
     lifetime: ping
     send_in_pings:
       - broken-site-report
@@ -118,7 +118,7 @@ broken_site_report.tab_info:
       The user agent string the reported page actually saw
       (navigator.userAgent), read from the page context at report time.
     data_sensitivity:
-      - web_activity
+      - stored_content
     lifetime: ping
     send_in_pings:
       - broken-site-report
@@ -154,7 +154,7 @@ broken_site_report.tab_info.antitracking:
       included when the user keeps the "list of items blocked by tracking
       protection" option on.
     data_sensitivity:
-      - web_activity
+      - stored_content
     lifetime: ping
     send_in_pings:
       - broken-site-report
@@ -274,7 +274,7 @@ broken_site_report.browser_info.app:
       The app's default user agent string (the app-level UA, distinct from the
       per-page `tab_info.useragent_string`).
     data_sensitivity:
-      - web_activity
+      - stored_content
     lifetime: ping
     send_in_pings:
       - broken-site-report

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -13,32 +13,39 @@ $tags:
   - WebCompat
 
 ###############################################################################
-# WebCompat — Report Broken Site
+# WebCompat — Report a Website Issue
 #
 # Structured metrics submitted in the `broken-site-report` ping when a user
-# files an in-app "Report Broken Site" report. The metric shape mirrors the
+# files an in-app "Report a Website Issue" report. Metric names mirror the
 # cross-platform desktop/Android `broken_site_report.*` schema so iOS data
-# lands in the same family, but it is restricted to the subset of fields a
-# WebKit-based browser (Firefox iOS) can actually populate.
+# lands in the same family. The set matches the iOS design's "Report Preview"
+# sections: basic / tabInfo / graphics / antiTracking / frameworks /
+# browserInfo / app — restricted to fields a WebKit browser (Firefox iOS) can
+# populate (page-context values via on-demand JS; tracking-protection state
+# from the content blocker; device/app values natively).
 #
-# Gecko engine-internals collected on desktop/Android (anti-tracking state,
-# JS framework detection, graphics/driver info, Gecko prefs, security software)
-# are intentionally omitted — iOS has no equivalent of GeckoView's
-# getWebCompatInfo API. Likewise the page-context values (the languages / UA
-# the site actually saw) are omitted for v1; iOS reports the app-configured
-# user agent and the app's preferred locale list instead.
+# OMITTED (Gecko-only, no WebKit equivalent): browser_info.prefs.*,
+# graphics.{devices,drivers,features,monitors}_json, browser_info.security.*,
+# browser_info.addons, app.fission_enabled, and the Gecko-specific antitracking
+# mixed-content / bounce-tracking flags. browser_info.experiments (Nimbus,
+# object) is deferred — add later if the data team wants it.
 #
-# NOTE: `bugs` points at the implementation ticket and `data_reviews` must be
-# updated with the data-review PR URL before this ships. The free-text
-# `description` and `url` fields carry user-entered data — see the data review.
+# SCREENSHOT: the iOS design includes a default-on "Include screenshot" option.
+# The image is intentionally NOT carried by this Glean ping — Glean has no
+# image metric type and desktop/Android do not transport it via Glean. Its
+# capture/storage is a separate open decision (see the data-review doc); no
+# screenshot field is defined here.
+#
+# `bugs` is the impl ticket (placeholder FXMO-860); `data_reviews` is the
+# data-review PR. `url` and `description` carry user-entered data.
 ###############################################################################
 
 broken_site_report:
   url:
     type: url
     description: |
-      The URL of the site the user is reporting as broken. The user may edit
-      this before submitting. May contain PII.
+      The URL of the site the user is reporting. The user may edit this before
+      submitting. May contain PII.
     data_sensitivity:
       - web_activity
     lifetime: ping
@@ -54,10 +61,9 @@ broken_site_report:
   breakage_category:
     type: string
     description: |
-      The user-selected reason the site is broken. One of: load, content,
-      media, account, checkout, slow, adblocker, notsupported, deceptive,
-      other. Stored as a free string; the option set is UI-driven and may
-      change over time.
+      The user-selected reason the site is broken (e.g. "media", "load",
+      "content"). Serialized as a single value even though the UI presents a
+      two-level picker. The option set is UI-driven and may change over time.
     data_sensitivity:
       - interaction
     lifetime: ping
@@ -73,8 +79,8 @@ broken_site_report:
   description:
     type: text
     description: |
-      Optional free-text description of the problem, entered by the user.
-      May contain PII (free-form text).
+      Optional free-text "Additional Details" entered by the user. May contain
+      PII (free-form text).
     data_sensitivity:
       - highly_sensitive
     lifetime: ping
@@ -88,21 +94,14 @@ broken_site_report:
       - fx-ios-data-stewards@mozilla.com
     expires: never
 
-broken_site_report.browser_info.app:
-  default_useragent_string:
-    type: text
+broken_site_report.tab_info:
+  languages:
+    type: string_list
     description: |
-      The default user agent string the app is configured to send. Note: this
-      is the app-level UA, not necessarily the exact UA the reported page saw
-      (per-site overrides and JS are not captured on iOS in v1).
-    # `text` metrics must declare a high sensitivity category; the UA is sent
-    # to every site as part of web requests.
+      The languages the reported page actually saw (navigator.languages),
+      read from the page context at report time.
     data_sensitivity:
-      - web_activity
-    # Names mirror the cross-platform desktop/Android `browser_info.app.*`
-    # schema for data parity; suppress the shared-prefix nit.
-    no_lint:
-      - COMMON_PREFIX
+      - technical
     lifetime: ping
     send_in_pings:
       - broken-site-report
@@ -113,14 +112,150 @@ broken_site_report.browser_info.app:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+  useragent_string:
+    type: text
+    description: |
+      The user agent string the reported page actually saw
+      (navigator.userAgent), read from the page context at report time.
+    data_sensitivity:
+      - web_activity
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+
+broken_site_report.tab_info.antitracking:
+  block_list:
+    type: string
+    description: |
+      The active content-blocker list for the tab ("basic" or "strict").
+    data_sensitivity:
+      - technical
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  blocked_origins:
+    type: string_list
+    description: |
+      Origins blocked by tracking protection on the reported page. Only
+      included when the user keeps the "list of items blocked by tracking
+      protection" option on.
+    data_sensitivity:
+      - web_activity
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  etp_category:
+    type: string
+    description: |
+      The user's tracking-protection strength setting ("basic" or "strict").
+    data_sensitivity:
+      - technical
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  is_private_browsing:
+    type: boolean
+    description: |
+      Whether the reported tab is in private browsing.
+    data_sensitivity:
+      - technical
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+
+broken_site_report.tab_info.frameworks:
+  fastclick:
+    type: boolean
+    description: |
+      Whether the FastClick library was detected on the reported page
+      (detected via injected JS at report time).
+    data_sensitivity:
+      - technical
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  marfeel:
+    type: boolean
+    description: |
+      Whether the Marfeel framework was detected on the reported page.
+    data_sensitivity:
+      - technical
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  mobify:
+    type: boolean
+    description: |
+      Whether the Mobify framework was detected on the reported page.
+    data_sensitivity:
+      - technical
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+
+broken_site_report.browser_info.app:
   default_locales:
     type: string_list
     description: |
       The app's preferred locale list (e.g. ["en-US", "en"]).
     data_sensitivity:
       - technical
-    no_lint:
-      - COMMON_PREFIX
     lifetime: ping
     send_in_pings:
       - broken-site-report
@@ -131,6 +266,27 @@ broken_site_report.browser_info.app:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+    no_lint:
+      - COMMON_PREFIX
+  default_useragent_string:
+    type: text
+    description: |
+      The app's default user agent string (the app-level UA, distinct from the
+      per-page `tab_info.useragent_string`).
+    data_sensitivity:
+      - web_activity
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+    no_lint:
+      - COMMON_PREFIX
 
 broken_site_report.browser_info.system:
   is_tablet:
@@ -172,6 +328,22 @@ broken_site_report.browser_info.graphics:
     type: string
     description: |
       The device pixel ratio (screen scale) as a decimal string, e.g. "3.0".
+    data_sensitivity:
+      - technical
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  has_touch_screen:
+    type: boolean
+    description: |
+      Whether the device reports a touch screen (navigator.maxTouchPoints > 0).
     data_sensitivity:
       - technical
     lifetime: ping

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -47,7 +47,7 @@ broken_site_report:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXMO-860
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -66,7 +66,7 @@ broken_site_report:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXMO-860
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -83,7 +83,7 @@ broken_site_report:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXMO-860
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -109,7 +109,7 @@ broken_site_report.browser_info.app:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXMO-860
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -127,7 +127,7 @@ broken_site_report.browser_info.app:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXMO-860
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -145,7 +145,7 @@ broken_site_report.browser_info.system:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXMO-860
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -162,7 +162,7 @@ broken_site_report.browser_info.system:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXMO-860
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -180,7 +180,7 @@ broken_site_report.browser_info.graphics:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXMO-860
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34309
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -1,0 +1,186 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the metrics that are recorded by the Glean SDK. They are
+# automatically converted to Swift code at build time using the `glean_parser`
+# PyPI package.
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+$tags:
+  - WebCompat
+
+###############################################################################
+# WebCompat — Report Broken Site
+#
+# Structured metrics submitted in the `broken-site-report` ping when a user
+# files an in-app "Report Broken Site" report. The metric shape mirrors the
+# cross-platform desktop/Android `broken_site_report.*` schema so iOS data
+# lands in the same family, but it is restricted to the subset of fields a
+# WebKit-based browser (Firefox iOS) can actually populate.
+#
+# Gecko engine-internals collected on desktop/Android (anti-tracking state,
+# JS framework detection, graphics/driver info, Gecko prefs, security software)
+# are intentionally omitted — iOS has no equivalent of GeckoView's
+# getWebCompatInfo API. Likewise the page-context values (the languages / UA
+# the site actually saw) are omitted for v1; iOS reports the app-configured
+# user agent and the app's preferred locale list instead.
+#
+# NOTE: `bugs` points at the implementation ticket and `data_reviews` must be
+# updated with the data-review PR URL before this ships. The free-text
+# `description` and `url` fields carry user-entered data — see the data review.
+###############################################################################
+
+broken_site_report:
+  url:
+    type: url
+    description: |
+      The URL of the site the user is reporting as broken. The user may edit
+      this before submitting. May contain PII.
+    data_sensitivity:
+      - web_activity
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  breakage_category:
+    type: string
+    description: |
+      The user-selected reason the site is broken. One of: load, content,
+      media, account, checkout, slow, adblocker, notsupported, deceptive,
+      other. Stored as a free string; the option set is UI-driven and may
+      change over time.
+    data_sensitivity:
+      - interaction
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  description:
+    type: text
+    description: |
+      Optional free-text description of the problem, entered by the user.
+      May contain PII (free-form text).
+    data_sensitivity:
+      - highly_sensitive
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+
+broken_site_report.browser_info.app:
+  default_useragent_string:
+    type: text
+    description: |
+      The default user agent string the app is configured to send. Note: this
+      is the app-level UA, not necessarily the exact UA the reported page saw
+      (per-site overrides and JS are not captured on iOS in v1).
+    # `text` metrics must declare a high sensitivity category; the UA is sent
+    # to every site as part of web requests.
+    data_sensitivity:
+      - web_activity
+    # Names mirror the cross-platform desktop/Android `browser_info.app.*`
+    # schema for data parity; suppress the shared-prefix nit.
+    no_lint:
+      - COMMON_PREFIX
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  default_locales:
+    type: string_list
+    description: |
+      The app's preferred locale list (e.g. ["en-US", "en"]).
+    data_sensitivity:
+      - technical
+    no_lint:
+      - COMMON_PREFIX
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+
+broken_site_report.browser_info.system:
+  is_tablet:
+    type: boolean
+    description: |
+      Whether the reporting device is a tablet (iPad).
+    data_sensitivity:
+      - technical
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  memory:
+    type: quantity
+    unit: mb
+    description: |
+      Total physical memory of the device, in megabytes.
+    data_sensitivity:
+      - technical
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+
+broken_site_report.browser_info.graphics:
+  device_pixel_ratio:
+    type: string
+    description: |
+      The device pixel ratio (screen scale) as a decimal string, e.g. "3.0".
+    data_sensitivity:
+      - technical
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXMO-860
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO-DATA-REVIEW
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never

--- a/firefox-ios/Client/Glean/tags.yaml
+++ b/firefox-ios/Client/Glean/tags.yaml
@@ -137,6 +137,9 @@ TrendingSearches:
 User:
   description: Corresponds to user properties and settings.
 
+WebCompat:
+  description: Corresponds to the in-app "Report Broken Site" (WebCompat) reporting tool.
+
 WorldCupWidget:
   description: Corresponds to the World Cup widget shown on the homepage.
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16177)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Define the iOS broken-site-report custom ping and its structured metrics for the in-app Report Broken Site feature. The metric names mirror the cross-platform desktop/Android broken_site_report.* schema so iOS data lands in the same family, restricted to the reduced payload a WebKit browser can populate (URL, breakage category, description, and basic app/device environment fields). No engine-internal diagnostics.

Adds the WebCompat Glean tag and registers the new probe file. Validated with glean_parser glinter and Swift translate.

Data-review URLs and the bugs ticket are placeholders pending the data-review PR and iOS implementation ticket.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

