### PR TITLE
Refactor FXIOS-16104 [FeatureFlags] Add debug to user prefs

### DIFF
--- a/firefox-ios/Client/FeatureFlags/FeatureFlagsProvider.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagsProvider.swift
@@ -27,13 +27,7 @@ final class FeatureFlagsProvider: FeatureFlagProviding, @unchecked Sendable {
 
     /// Used for checking the status of a feature flag from the feature flag backend
     func isEnabled(_ flag: FeatureFlagID) -> Bool {
-        #if MOZ_CHANNEL_beta || MOZ_CHANNEL_developer
-        if let debugKey = flag.debugKey,
-           let override = prefs.boolForKey(debugKey) {
-            return override
-        }
-        #endif
-        return backendLayer.checkNimbusConfigFor(flag)
+        return backendLayer.checkNimbusConfigFor(flag, with: prefs)
     }
 
     /// Used specifically for overriding the status of a feature flag from the backend.

--- a/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
+++ b/firefox-ios/Client/FeatureFlags/UserFeaturePreferenceManager.swift
@@ -52,7 +52,7 @@ final class UserFeaturePreferenceManager: UserFeaturePreferring, @unchecked Send
         if flag == .aiKillSwitch {
             return false
         } else {
-            return backendLayer.checkNimbusConfigFor(flag)
+            return backendLayer.checkNimbusConfigFor(flag, with: prefs)
         }
     }
 

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -3,9 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Shared
 
 protocol NimbusFeatureFlagLayerProviding: Sendable {
-    func checkNimbusConfigFor(_ featureID: FeatureFlagID) -> Bool
+    func checkNimbusConfigFor(_ featureID: FeatureFlagID, with prefs: Prefs) -> Bool
     func checkStartAtHomeConfiguration() -> StartAtHome
 }
 
@@ -18,7 +19,15 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
 
     // MARK: - Public methods
     // swiftlint:disable:next function_body_length
-    public func checkNimbusConfigFor(_ featureID: FeatureFlagID) -> Bool {
+    public func checkNimbusConfigFor(_ featureID: FeatureFlagID, with prefs: Prefs) -> Bool {
+        // Always override Nimbus defaults if we're toggling things in the debug menu
+        #if MOZ_CHANNEL_beta || MOZ_CHANNEL_developer
+        if let debugKey = featureID.debugKey,
+           let override = prefs.boolForKey(debugKey) {
+            return override
+        }
+        #endif
+
         // For better code readability, please keep in alphabetical order by FeatureFlagID
         switch featureID {
         case .adBlocker:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FeatureFlagsProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FeatureFlagsProviderTests.swift
@@ -41,6 +41,17 @@ final class FeatureFlagsProviderTests: XCTestCase {
         XCTAssertFalse(subject.isEnabled(.translation))
     }
 
+    func testIsEnabled_passesPrefsToLayer() {
+        _ = subject.isEnabled(.translation)
+
+        XCTAssertEqual(mockLayer.checkedFlags, [.translation])
+        guard let receivedPrefs = mockLayer.checkedPrefs.first as? MockProfilePrefs else {
+            XCTFail("Expected layer to receive MockProfilePrefs")
+            return
+        }
+        XCTAssertTrue(receivedPrefs === prefs)
+    }
+
     // MARK: - Debug override behavior
 
     func testIsEnabled_debugOverrideTrue_overridesLayerFalse() {
@@ -137,9 +148,21 @@ final class FeatureFlagsProviderTests: XCTestCase {
 
 final class MockNimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, @unchecked Sendable {
     var enabledFlags: Set<FeatureFlagID> = []
+    private(set) var checkedFlags: [FeatureFlagID] = []
+    private(set) var checkedPrefs: [Prefs] = []
 
-    func checkNimbusConfigFor(_ featureID: FeatureFlagID) -> Bool {
-        enabledFlags.contains(featureID)
+    func checkNimbusConfigFor(_ featureID: FeatureFlagID, with prefs: Prefs) -> Bool {
+        checkedFlags.append(featureID)
+        checkedPrefs.append(prefs)
+
+        #if MOZ_CHANNEL_beta || MOZ_CHANNEL_developer
+        if let debugKey = featureID.debugKey,
+           let override = prefs.boolForKey(debugKey) {
+            return override
+        }
+        #endif
+
+        return enabledFlags.contains(featureID)
     }
 
     func checkStartAtHomeConfiguration() -> StartAtHome {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/UserFeaturePreferenceManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/UserFeaturePreferenceManagerTests.swift
@@ -301,6 +301,20 @@ final class UserFeaturePreferenceManagerTests: XCTestCase {
     }
 
     @MainActor
+    func testGetPreference_flagWithNoUserPrefsKey_passesPrefsToNimbusLayer() {
+        let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
+
+        _ = subject.getPreferenceFor(.microsurvey)
+
+        XCTAssertEqual(mockLayer.checkedFlags, [.microsurvey])
+        guard let receivedPrefs = mockLayer.checkedPrefs.first as? MockProfilePrefs else {
+            XCTFail("Expected layer to receive MockProfilePrefs")
+            return
+        }
+        XCTAssertTrue(receivedPrefs === prefs)
+    }
+
+    @MainActor
     func testSetPreference_flagWithNoUserPrefsKey_isNoOp() {
         let subject = createSubject(prefs: prefs, backendLayer: mockLayer, userInterfaceIdiom: .phone)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16104)


## :bulb: Description
UserPrefs defaults were always from Nimbus, even if we were overriding debugs in Nimbus.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

