### PR TITLE
Refactor FXIOS-16110 Workaround for redirection bug for iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
@@ -133,7 +133,7 @@ class DomainAutocompleteTests: BaseTestCase {
     // Non-matches.
     // https://mozilla.testrail.io/index.php?/cases/view/2334650
     func test5NoMatches() {
-        navigator.openURL("twitter.com/login")
+        navigator.openURL("https://mozilla.github.io/form-fill-examples/basic.html")
         waitUntilPageLoad()
         navigator.nowAt(BrowserTab)
         navigator.goto(URLBarOpen)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16110)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34322)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The URL www.twitter.com would result in unintended multiple redirect. Let's use a site that's within our control for the time being. The test isn't specific to twitter.

See https://github.com/mozilla-mobile/firefox-ios/issues/34322 for details on the bug.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

