### PR TITLE
Add  FXIOS-16094 [Danger] Add checkForNimbusFeatureChange

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -19,6 +19,7 @@ if releaseCheck.isReleaseBranch {
     checkAlphabeticalOrder(inFile: standardImageIdentifiersPath)
     checkForSpecificFileChange()
     checkForGleanFileChange()
+    checkForNimbusFeatureChange()
     CodeUsageDetector().checkForCodeUsage()
     let coverageGate = CodeCoverageGate()
     coverageGate.failOnFiles(type: .newFiles)
@@ -470,6 +471,43 @@ func checkForGleanFileChange() {
         and tag @adudenamedruby for data review.
         """)
     }
+}
+
+// Detect added/removed Nimbus features and request a spreadsheet update
+func checkForNimbusFeatureChange() {
+    let nimbusFeaturesPath = "firefox-ios/nimbus-features/"
+    let nimbusManifestPath = "firefox-ios/nimbus.fml.yaml"
+    let spreadsheetURL = "https://docs.google.com/spreadsheets/d/1j5Eo0kY3LDgfKdeVu44PxYmkWMRJ1QaU07NTCl2c0Kg/edit?gid=842661143#gid=842661143"
+
+    let isFeatureFile: (String) -> Bool = { file in
+        file.contains(nimbusFeaturesPath) && file.hasSuffix(".yaml")
+    }
+    let createdFeatures = danger.git.createdFiles.filter(isFeatureFile)
+    let deletedFeatures = danger.git.deletedFiles.filter(isFeatureFile)
+    let manifestModified = danger.git.modifiedFiles.contains(nimbusManifestPath)
+
+    guard !createdFeatures.isEmpty || !deletedFeatures.isEmpty || manifestModified else { return }
+
+    var sections: [String] = []
+    if !createdFeatures.isEmpty {
+        let bullets = createdFeatures.map { "• `\($0)`" }.joined(separator: "\n")
+        sections.append("**Added feature file(s):**\n\(bullets)")
+    }
+    if !deletedFeatures.isEmpty {
+        let bullets = deletedFeatures.map { "• `\($0)`" }.joined(separator: "\n")
+        sections.append("**Removed feature file(s):**\n\(bullets)")
+    }
+    if manifestModified {
+        sections.append("**Manifest modified:** `\(nimbusManifestPath)`")
+    }
+
+    markdown("""
+    ### 🧪 **Nimbus feature changes detected**
+    \(sections.joined(separator: "\n\n"))
+
+    If a feature was added or removed, please update the \
+    [Nimbus features tracking spreadsheet](\(spreadsheetURL)) to reflect the change.
+    """)
 }
 
 private func saferFileDiff(for file: String) -> Result<FileDiff, Error> {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16094)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
I ran the Danger check on https://github.com/mozilla-mobile/firefox-ios/pull/34304, this is what the message will looked like when merged:

<img width="877" height="170" alt="Screenshot 2026-06-17 at 2 29 56 PM" src="https://github.com/user-attachments/assets/0584a5e0-a095-4588-b861-a62be34d3c71" />

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

