### PR TITLE
Bugfix FXIOS-16041 [Toolbar] Navigation bar is missing after rotating from landscape to portrait and swiping up on a webpage

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5090,7 +5090,14 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        if #available(iOS 26.0, *), isBottomSearchBar {
+        // Only restore the address bar to fully shown if it wasn't collapsed by scrolling. When the
+        // keyboard is dismissed via scroll and the toolbars are already collapsed, so forcing scrollAlpha
+        // back to 1 here would leave the address bar full while the bottom containers stay collapsed
+        // (inconsistent state).
+        // This is a legacy-only patch (via the `LegacyTabScrollProvider` cast below); the scroll
+        // controller refactor (TabScrollHandler) will address the underlying issue differently
+        let isToolbarStateCollapsed = (scrollController as? LegacyTabScrollProvider)?.isToolbarStateCollapsed ?? false
+        if #available(iOS 26.0, *), isBottomSearchBar, !isToolbarStateCollapsed {
             store.dispatch(
                 ToolbarAction(
                     scrollAlpha: 1,
@@ -5141,9 +5148,9 @@ extension BrowserViewController: KeyboardHelperDelegate {
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillChangeWithState state: KeyboardState) {
         keyboardState = state
-        // keyboard frame changes that don't fire willShow/willHide like (find-in-page
-        // dismissal, accessory view toggle, interactive scroll-to-dismiss). Removing the calls to update layout
-        // leaves the keyboard spacer stale and combined with a stale scrollAlpha == 0 leaves the toolbar with extra space
+        // Keep the keyboard spacer and bottom constraints in sync as the keyboard frame changes
+        // (e.g. accessory-view height changes, interactive scroll-to-dismiss). Without this the
+        // spacer holds its previous height and leaves a gap below the address bar.
         if isSnapKitRemovalEnabled {
             updateConstraintsForKeyboard()
             updateBottomContentStackViewConstraints()

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -15,6 +15,11 @@ protocol LegacyTabScrollProvider: TabScrollHandlerProtocol {
     var overKeyboardContainerConstraint: ConstraintReference? { get set }
     var bottomContainerConstraint: ConstraintReference? { get set }
 
+    /// `true` when the toolbars are collapsed because the user scrolled the page (not when the
+    /// address bar was minimized for the keyboard accessory). Lets the keyboard-dismiss path keep
+    /// the collapsed/pill state instead of forcing the address bar back to fully shown.
+    var isToolbarStateCollapsed: Bool { get }
+
     func configureToolbarViews(overKeyboardContainer: BaseAlphaStackView?,
                                bottomContainer: BaseAlphaStackView?,
                                headerContainer: BaseAlphaStackView?)
@@ -91,7 +96,11 @@ final class LegacyTabScrollController: NSObject,
     private var lastPanTranslation: CGFloat = 0
     private var lastContentOffsetY: CGFloat = 0
     private var scrollDirection: ScrollDirection = .down
-    var toolbarState: ToolbarState = .visible
+    private var toolbarState: ToolbarState = .visible
+
+    var isToolbarStateCollapsed: Bool {
+        return toolbarState == .collapsed
+    }
 
     private let windowUUID: WindowUUID
     private let logger: Logger

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -44,7 +44,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         mockGesture.gestureTranslation = CGPoint(x: 0, y: 100)
         subject.handlePan(mockGesture)
 
-        XCTAssertEqual(subject.toolbarState, LegacyTabScrollController.ToolbarState.collapsed)
+        XCTAssertTrue(subject.isToolbarStateCollapsed)
     }
 
     func testHandlePan_ScrollingDown() {
@@ -54,7 +54,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         mockGesture.gestureTranslation = CGPoint(x: 0, y: -100)
         subject.handlePan(mockGesture)
 
-        XCTAssertEqual(subject.toolbarState, LegacyTabScrollController.ToolbarState.visible)
+        XCTAssertFalse(subject.isToolbarStateCollapsed)
     }
 
     func testShowToolbar_AfterHidingWithScroll() {
@@ -67,7 +67,20 @@ final class LegacyTabScrollControllerTests: XCTestCase {
 
         // Force call to showToolbars like clicking on top bar area
         subject.showToolbars(animated: true)
-        XCTAssertEqual(subject.toolbarState, LegacyTabScrollController.ToolbarState.visible)
+        XCTAssertFalse(subject.isToolbarStateCollapsed)
+    }
+
+    func testIsToolbarStateCollapsed_reflectsHideAndShowToolbars() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        XCTAssertFalse(subject.isToolbarStateCollapsed)
+
+        subject.hideToolbars(animated: false)
+        XCTAssertTrue(subject.isToolbarStateCollapsed)
+
+        subject.showToolbars(animated: false)
+        XCTAssertFalse(subject.isToolbarStateCollapsed)
     }
 
     func testScrollDidEndDragging_ScrollingUp() {
@@ -79,7 +92,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         subject.handlePan(mockGesture)
         subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
 
-        XCTAssertEqual(subject.toolbarState, LegacyTabScrollController.ToolbarState.visible)
+        XCTAssertFalse(subject.isToolbarStateCollapsed)
     }
 
     func testScrollDidEndDragging_ScrollingDown() {
@@ -91,7 +104,7 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         subject.handlePan(mockGesture)
         subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
 
-        XCTAssertEqual(subject.toolbarState, LegacyTabScrollController.ToolbarState.collapsed)
+        XCTAssertTrue(subject.isToolbarStateCollapsed)
     }
 
     func testDidSetTab_addsPullRefreshViewToScrollView() {
@@ -279,24 +292,23 @@ final class LegacyTabScrollControllerTests: XCTestCase {
     func testToolbarTapHandler_WhenMinimalAddressBarEnabledAndCollapsed_ShowsToolbar() {
         let subject = createSubject()
         setupTabScroll(with: subject)
-        subject.toolbarState = .collapsed
+        subject.hideToolbars(animated: false)
 
         let handler = subject.createToolbarTapHandler()
         handler()
 
-        XCTAssertEqual(subject.toolbarState, .visible)
+        XCTAssertFalse(subject.isToolbarStateCollapsed)
     }
 
     func testToolbarTapHandler_WhenToolbarVisible_DoesNothing() {
         let subject = createSubject()
         setupTabScroll(with: subject)
-
-        subject.toolbarState = .visible
+        subject.showToolbars(animated: false)
 
         let handler = subject.createToolbarTapHandler()
         handler()
 
-        XCTAssertEqual(subject.toolbarState, .visible)
+        XCTAssertFalse(subject.isToolbarStateCollapsed)
     }
 
     // MARK: - Setup


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16041)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- Attempts to fix a bug where minimal address bar state and bottom containers views constraints are not in sync so we end up with the views position and size as minimal_address_bar was showing but it's alpha value is the opposite due to an extra Redux event that reverts it's pill look. This is patch fix trying to tackle only the edge case without causing other side effects.

Thanks to this bug we now know more about the issues between our accessory views handling, keyboard handling and constraints but we can fix it the right way confidently without refactoring

## :movie_camera: Demos

https://github.com/user-attachments/assets/55d7d324-8a53-488f-8b08-742209b89b76


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

