### PR TITLE
Add FXIOS-16066 [Google Lens] Gate address bar entry point behind google as default search engine

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -41,7 +41,8 @@ class BrowserViewController: UIViewController,
                              FeatureFlaggable,
                              CanRemoveQuickActionBookmark,
                              BrowserStatusBarScrollDelegate,
-                             LegacyTabScrollController.Delegate {
+                             LegacyTabScrollController.Delegate,
+                             SearchEngineDelegate {
     enum UX {
         static let showHeaderTapAreaHeight: CGFloat = 32
         static let downloadToastDelay = DispatchTimeInterval.milliseconds(500)
@@ -513,6 +514,7 @@ class BrowserViewController: UIViewController,
         tabManager.addDelegate(self)
         tabManager.setNavigationDelegate(self)
         downloadQueue.addDelegate(self)
+        self.searchEnginesManager.delegate = self
         let tabWindowUUID = tabManager.windowUUID
         AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(tabWindowUUID)]) { [weak self] in
             ensureMainThread { [weak self] in
@@ -4666,6 +4668,10 @@ extension BrowserViewController: SearchViewControllerDelegate {
         store.dispatch(action)
         searchController?.reloadSearchEngines()
         searchController?.reloadData()
+    }
+
+    func searchEnginesDidUpdate() {
+        updateForDefaultSearchEngineDidChange()
     }
 
     func setLocationView(text: String, search: Bool) {

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -36,12 +36,10 @@ final class OpenSearchEngine: NSObject, NSSecureCoding, Sendable, TrendingSearch
     private let trendingTemplate: String?
     private let searchTermComponent = "{searchTerms}"
     private let searchQueryComponentKey: String?
-    private let googleEngineID = {
-        return "google"
-    }()
+    static let googleEngineID = "google"
 
     var headerSearchTitle: String {
-        guard engineID != googleEngineID else {
+        guard engineID != Self.googleEngineID else {
             return .Search.GoogleEngineSectionTitle
         }
 

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/SearchEnginesManager.swift
@@ -19,6 +19,7 @@ protocol SearchEnginesManagerProvider: AnyObject, Sendable {
 }
 
 protocol SearchEngineDelegate: AnyObject {
+    @MainActor
     func searchEnginesDidUpdate()
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -231,6 +231,9 @@ struct AddressBarState: StateType, Sendable, Equatable {
         case SearchEngineSelectionMiddlewareActionType.didClearAlternativeSearchEngine:
             return handleDidClearAlternativeSearchEngine(state: state, action: action)
 
+        case ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine:
+            return handleSearchEngineDidChange(state: state, action: action)
+
         default:
             return defaultState(from: state)
         }
@@ -248,7 +251,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
             leadingPageActions: [ToolbarActionConfiguration](),
             trailingPageActions: [ToolbarActionConfiguration](),
             browserActions: [ToolbarActionConfiguration](),
-            editingAccessoryAction: editingAccessoryAction(isGoogleLensEnabled: toolbarAction.isGoogleLensEnabled == true),
+            editingAccessoryAction: nil,
             borderPosition: borderPosition,
             url: nil,
             searchTerm: nil,
@@ -1118,6 +1121,39 @@ struct AddressBarState: StateType, Sendable, Equatable {
             didStartTyping: state.didStartTyping,
             isEmptySearch: state.isEmptySearch,
             alternativeSearchEngine: nil
+        )
+    }
+
+    private static func handleSearchEngineDidChange(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarMiddlewareAction,
+              let isGoogleLensEnabled = toolbarAction.isGoogleLensEnabled else {
+            return defaultState(from: state)
+        }
+
+        return AddressBarState(
+            windowUUID: state.windowUUID,
+            navigationActions: state.navigationActions,
+            leadingPageActions: state.leadingPageActions,
+            trailingPageActions: state.trailingPageActions,
+            browserActions: state.browserActions,
+            editingAccessoryAction: editingAccessoryAction(isGoogleLensEnabled: isGoogleLensEnabled),
+            borderPosition: state.borderPosition,
+            url: state.url,
+            searchTerm: state.searchTerm,
+            lockIconButtonA11yId: state.lockIconButtonA11yId,
+            lockIconImageName: state.lockIconImageName,
+            lockIconNeedsTheming: state.lockIconNeedsTheming,
+            safeListedURLImageName: state.safeListedURLImageName,
+            isEditing: state.isEditing,
+            shouldShowKeyboard: state.shouldShowKeyboard,
+            shouldSelectSearchTerm: state.shouldSelectSearchTerm,
+            isLoading: state.isLoading,
+            readerModeState: state.readerModeState,
+            canSummarize: state.canSummarize,
+            translationConfiguration: state.translationConfiguration,
+            didStartTyping: state.didStartTyping,
+            isEmptySearch: state.isEmptySearch,
+            alternativeSearchEngine: state.alternativeSearchEngine
         )
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -154,12 +154,14 @@ struct ToolbarMiddlewareAction: Action {
     let gestureType: ToolbarButtonGesture?
     let scrollOffset: CGPoint?
     let readerModeState: ReaderModeState?
+    let isGoogleLensEnabled: Bool?
 
     init(buttonType: ToolbarActionConfiguration.ActionType? = nil,
          buttonTapped: UIButton? = nil,
          gestureType: ToolbarButtonGesture? = nil,
          scrollOffset: CGPoint? = nil,
          readerModeState: ReaderModeState? = nil,
+         isGoogleLensEnabled: Bool? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.windowUUID = windowUUID
@@ -169,6 +171,7 @@ struct ToolbarMiddlewareAction: Action {
         self.readerModeState = readerModeState
         self.gestureType = gestureType
         self.scrollOffset = scrollOffset
+        self.isGoogleLensEnabled = isGoogleLensEnabled
     }
 }
 
@@ -176,6 +179,7 @@ enum ToolbarMiddlewareActionType: ActionType {
     case didTapButton
     case customA11yAction
     case urlDidChange
+    case didUpdateDefaultSearchEngine
     case didClearSearch
     case didStartDragInteraction
     case didSwipeToOpenTabTray

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -20,6 +20,7 @@ final class ToolbarMiddleware {
     private let summarizerNimbusUtils: SummarizerNimbusUtils
     private let summarizerConfigFactory: SummarizerConfigFactory
     private let featureFlagsProvider: FeatureFlagProviding
+    private let searchEnginesManager: SearchEnginesManagerProvider
     private var isSummarizerOn: Bool {
         return summarizerNimbusUtils.isSummarizeFeatureToggledOn
     }
@@ -38,11 +39,13 @@ final class ToolbarMiddleware {
          summarizerConfigFactory: SummarizerConfigFactory = SummarizerMiddleware(),
          recentSearchProvider: RecentSearchProvider? = nil,
          featureFlagsProvider: FeatureFlagProviding = AppContainer.shared.resolve(),
+         searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(SearchEnginesManager.self),
          windowManager: WindowManager = AppContainer.shared.resolve(),
          logger: Logger = DefaultLogger.shared) {
         self.summarizerNimbusUtils = summarizerNimbusUtils
         self.summarizerConfigFactory = summarizerConfigFactory
         self.featureFlagsProvider = featureFlagsProvider
+        self.searchEnginesManager = searchEnginesManager
         self.manager = manager
         self.toolbarHelper = toolbarHelper
         self.toolbarTelemetry = toolbarTelemetry
@@ -100,7 +103,6 @@ final class ToolbarMiddleware {
                 displayNavBorder: displayBorder,
                 middleButton: middleButton,
                 isTranslationsEnabled: prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true,
-                isGoogleLensEnabled: featureFlagsProvider.isEnabled(.googleLens),
                 windowUUID: uuid,
                 actionType: ToolbarActionType.didLoadToolbars)
             store.dispatch(action)
@@ -174,6 +176,14 @@ final class ToolbarMiddleware {
             let action = SearchEngineSelectionAction(
                 windowUUID: action.windowUUID,
                 actionType: SearchEngineSelectionMiddlewareActionType.didClearAlternativeSearchEngine
+            )
+            store.dispatch(action)
+
+        case ToolbarActionType.searchEngineDidChange:
+            let action = ToolbarMiddlewareAction(
+                isGoogleLensEnabled: isGoogleLensToolbarEntryPointAvailable(),
+                windowUUID: action.windowUUID,
+                actionType: ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine
             )
             store.dispatch(action)
 
@@ -545,5 +555,19 @@ final class ToolbarMiddleware {
 
     private func tabManager(for uuid: WindowUUID) -> TabManager? {
         return windowManager.tabManager(for: uuid)
+    }
+
+    private func isGoogleLensToolbarEntryPointAvailable() -> Bool {
+        guard featureFlagsProvider.isEnabled(.googleLens),
+              let defaultEngine = searchEnginesManager.defaultEngine,
+              !defaultEngine.isCustomEngine
+        else { return false }
+
+        let engineID = defaultEngine.engineID
+        let googleEngineID = OpenSearchEngine.googleEngineID
+
+        // App Services can return regional Google engine IDs such as "google-b-1-m".
+        let isGoogleDefaultEngine = engineID == googleEngineID || engineID.hasPrefix("\(googleEngineID)-")
+        return isGoogleDefaultEngine
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -156,7 +156,7 @@ struct ToolbarState: ScreenState, Sendable {
             ToolbarActionType.didStartEditingUrl, ToolbarActionType.cancelEdit,
             ToolbarActionType.cancelEditOnHomepage,
             ToolbarActionType.keyboardStateDidChange, ToolbarActionType.websiteLoadingStateDidChange,
-            ToolbarActionType.searchEngineDidChange, ToolbarActionType.clearSearch,
+            ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine, ToolbarActionType.clearSearch,
             ToolbarActionType.didDeleteSearchTerm, ToolbarActionType.didEnterSearchTerm,
             ToolbarActionType.didSetSearchTerm, ToolbarActionType.didStartTyping,
             ToolbarActionType.animationStateChanged, ToolbarActionType.translucencyDidChange,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
@@ -157,6 +157,16 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         let action = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(action.readerModeState, .active)
     }
+
+    func testSearchEnginesDidUpdate_dispatchesSearchEngineDidChangeAction() throws {
+        let subject = createSubject()
+
+        subject.searchEnginesDidUpdate()
+
+        let action = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
+        XCTAssertEqual(action.actionType as? ToolbarActionType, ToolbarActionType.searchEngineDidChange)
+    }
+
     // TODO(FXIOS-13126): Fix and uncomment this test
 //    func testUpdateReaderModeState_whenSummarizeFeatureOff_dispatchesToolbarAction() throws {
 //        let expectation = XCTestExpectation(description: "expect mock store to dispatch an action")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -92,18 +92,42 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertNil(newState.editingAccessoryAction)
     }
 
-    func test_didLoadToolbarsAction_withGoogleLensEnabled_setsEditingAccessoryAction() {
+    func test_didUpdateDefaultSearchEngineAction_withGoogleLensDisabled_removesEditingAccessoryAction() {
+        setupStore()
+        let initialState = createSubject()
+        let reducer = addressBarReducer()
+
+        let stateWithGoogleLens = reducer(
+            initialState,
+            ToolbarMiddlewareAction(
+                isGoogleLensEnabled: true,
+                windowUUID: windowUUID,
+                actionType: ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine
+            )
+        )
+        let newState = reducer(
+            stateWithGoogleLens,
+            ToolbarMiddlewareAction(
+                isGoogleLensEnabled: false,
+                windowUUID: windowUUID,
+                actionType: ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine
+            )
+        )
+
+        XCTAssertNil(newState.editingAccessoryAction)
+    }
+
+    func test_didUpdateDefaultSearchEngineAction_withGoogleLensEnabled_setsEditingAccessoryAction() {
         setupStore()
         let initialState = createSubject()
         let reducer = addressBarReducer()
 
         let newState = reducer(
             initialState,
-            ToolbarAction(
-                addressBorderPosition: .top,
+            ToolbarMiddlewareAction(
                 isGoogleLensEnabled: true,
                 windowUUID: windowUUID,
-                actionType: ToolbarActionType.didLoadToolbars
+                actionType: ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine
             )
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -72,7 +72,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionCalled.addressBorderPosition, borderPosition)
         XCTAssertEqual(actionCalled.displayNavBorder, displayBorder)
         XCTAssertEqual(actionCalled.middleButton, .newTab)
-        XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
+        XCTAssertNil(actionCalled.isGoogleLensEnabled)
 
         let savedValue = try XCTUnwrap(
             mockGleanWrapper.savedValues.first as? String
@@ -80,10 +80,16 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(savedValue, "newTab")
     }
 
-    func testBrowserDidLoad_withGoogleLensEnabled_dispatchesDidLoadToolbarsWithGoogleLensEnabled() throws {
+    func testBrowserDidLoad_withGoogleLensEnabledAndGoogleDefault_dispatchesWithoutGoogleLensPayload() throws {
         let featureFlagsProvider = MockNimbusFeatureFlags()
         featureFlagsProvider.enabledFlags = [.googleLens]
-        let subject = createSubject(manager: toolbarManager, featureFlagsProvider: featureFlagsProvider)
+        let subject = createSubject(
+            manager: toolbarManager,
+            featureFlagsProvider: featureFlagsProvider,
+            searchEnginesManager: MockSearchEnginesManager(
+                searchEngines: [makeSearchEngine(engineID: OpenSearchEngine.googleEngineID)]
+            )
+        )
         let action = GeneralBrowserMiddlewareAction(
             toolbarPosition: .top,
             windowUUID: windowUUID,
@@ -92,7 +98,117 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.toolbarProvider(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
+        XCTAssertNil(actionCalled.isGoogleLensEnabled)
+    }
+
+    func testDefaultSearchEngineDidChange_withGoogleDefault_dispatchesGoogleLensEnabled() throws {
+        let featureFlagsProvider = MockNimbusFeatureFlags()
+        featureFlagsProvider.enabledFlags = [.googleLens]
+        let subject = createSubject(
+            manager: toolbarManager,
+            featureFlagsProvider: featureFlagsProvider,
+            searchEnginesManager: MockSearchEnginesManager(
+                searchEngines: [makeSearchEngine(engineID: OpenSearchEngine.googleEngineID)]
+            )
+        )
+        let action = ToolbarAction(
+            windowUUID: windowUUID,
+            actionType: ToolbarActionType.searchEngineDidChange
+        )
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
         XCTAssertEqual(actionCalled.isGoogleLensEnabled, true)
+    }
+
+    func testDefaultSearchEngineDidChange_withRegionalGoogleDefault_dispatchesGoogleLensEnabled() throws {
+        let featureFlagsProvider = MockNimbusFeatureFlags()
+        featureFlagsProvider.enabledFlags = [.googleLens]
+        let subject = createSubject(
+            manager: toolbarManager,
+            featureFlagsProvider: featureFlagsProvider,
+            searchEnginesManager: MockSearchEnginesManager(
+                searchEngines: [makeSearchEngine(engineID: "\(OpenSearchEngine.googleEngineID)-b-1-m")]
+            )
+        )
+        let action = ToolbarAction(
+            windowUUID: windowUUID,
+            actionType: ToolbarActionType.searchEngineDidChange
+        )
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+        XCTAssertEqual(actionCalled.isGoogleLensEnabled, true)
+    }
+
+    func testDefaultSearchEngineDidChange_withNonGoogleDefault_dispatchesGoogleLensDisabled() throws {
+        let featureFlagsProvider = MockNimbusFeatureFlags()
+        featureFlagsProvider.enabledFlags = [.googleLens]
+        let subject = createSubject(
+            manager: toolbarManager,
+            featureFlagsProvider: featureFlagsProvider,
+            searchEnginesManager: MockSearchEnginesManager(searchEngines: [makeSearchEngine(engineID: "bing")])
+        )
+        let action = ToolbarAction(
+            windowUUID: windowUUID,
+            actionType: ToolbarActionType.searchEngineDidChange
+        )
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+        XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
+    }
+
+    func testDefaultSearchEngineDidChange_withCustomGoogleDefault_dispatchesGoogleLensDisabled() throws {
+        let featureFlagsProvider = MockNimbusFeatureFlags()
+        featureFlagsProvider.enabledFlags = [.googleLens]
+        let subject = createSubject(
+            manager: toolbarManager,
+            featureFlagsProvider: featureFlagsProvider,
+            searchEnginesManager: MockSearchEnginesManager(
+                searchEngines: [makeSearchEngine(engineID: OpenSearchEngine.googleEngineID, isCustomEngine: true)]
+            )
+        )
+        let action = ToolbarAction(
+            windowUUID: windowUUID,
+            actionType: ToolbarActionType.searchEngineDidChange
+        )
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+        XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
+    }
+
+    func testDefaultSearchEngineDidChange_withGoogleLensDisabled_dispatchesGoogleLensDisabled() throws {
+        let subject = createSubject(
+            manager: toolbarManager,
+            searchEnginesManager: MockSearchEnginesManager(
+                searchEngines: [makeSearchEngine(engineID: OpenSearchEngine.googleEngineID)]
+            )
+        )
+        let action = ToolbarAction(
+            windowUUID: windowUUID,
+            actionType: ToolbarActionType.searchEngineDidChange
+        )
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+        XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
     }
 
     func testBrowserDidLoad_withHomeCustomMiddleButton_dispatchesDidLoadToolbars() throws {
@@ -910,7 +1026,8 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
     // MARK: - Helpers
     private func createSubject(
         manager: ToolbarManager,
-        featureFlagsProvider: FeatureFlagProviding = MockNimbusFeatureFlags()
+        featureFlagsProvider: FeatureFlagProviding = MockNimbusFeatureFlags(),
+        searchEnginesManager: SearchEnginesManagerProvider = MockSearchEnginesManager()
     ) -> ToolbarMiddleware {
         return ToolbarMiddleware(
             manager: manager,
@@ -919,7 +1036,20 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             summarizerConfigFactory: summarizerConfigFactory,
             recentSearchProvider: mockRecentSearchProvider,
             featureFlagsProvider: featureFlagsProvider,
+            searchEnginesManager: searchEnginesManager,
             windowManager: windowManager,
+        )
+    }
+
+    private func makeSearchEngine(engineID: String, isCustomEngine: Bool = false) -> OpenSearchEngine {
+        return OpenSearchEngine(
+            engineID: engineID,
+            shortName: engineID.capitalized,
+            telemetrySuffix: nil,
+            image: UIImage(),
+            searchTemplate: "https://example.com/search?q={searchTerms}",
+            suggestTemplate: nil,
+            isCustomEngine: isCustomEngine
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
@@ -249,6 +249,22 @@ final class ToolbarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.navigationToolbar, initialState.navigationToolbar)
     }
 
+    func test_didUpdateDefaultSearchEngineAction_updatesAddressToolbarGoogleLensAvailability() {
+        let initialState = createSubject()
+        let reducer = toolbarReducer()
+
+        let newState = reducer(
+            initialState,
+            ToolbarMiddlewareAction(
+                isGoogleLensEnabled: true,
+                windowUUID: windowUUID,
+                actionType: ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+        )
+
+        XCTAssertEqual(newState.addressToolbar.editingAccessoryAction?.actionType, .googleLens)
+        XCTAssertEqual(newState.navigationToolbar, initialState.navigationToolbar)
+    }
+
     func test_clearSearchAction_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = toolbarReducer()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16066)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34329)

## :bulb: Description
- Display Google Lens address toolbar entry point only when Google is the default search engine 

### 📝 Technical Notes
- Google Lens availability is checked only after the default search engine is initialized or updated; toolbar starts with Lens hidden on initial load
  - Google lens availability is not currently updated on changes to Unified Search / Address Toolbar search engine picker (see [FXIOS-16142](https://mozilla-hub.atlassian.net/browse/FXIOS-16142))

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code



[FXIOS-16142]: https://mozilla-hub.atlassian.net/browse/FXIOS-16142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ