### PR TITLE
Refactor FXIOS-16116 [Homepage] Merino stale while refresh

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoMiddleware.swift
@@ -26,7 +26,7 @@ final class MerinoMiddleware {
     lazy var pocketSectionProvider: Middleware<AppState> = { state, action in
         switch action.actionType {
         case HomepageActionType.initialize,
-            HomepageMiddlewareActionType.enteredForeground,
+            HomepageMiddlewareActionType.didBecomeActive,
             MerinoActionType.toggleShowSectionSetting:
             self.getHomepageStoriesAndUpdateState(for: action)
         case MerinoActionType.tapOnHomepageMerinoCell:

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageAction.swift
@@ -69,7 +69,7 @@ enum HomepageMiddlewareActionType: ActionType {
     case jumpBackInLocalTabsUpdated
     case jumpBackInRemoteTabsUpdated
     case bookmarksUpdated
-    case enteredForeground
+    case didBecomeActive
     case configuredPrivacyNotice
     case configuredSearchBar
     case configuredSpacer

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
@@ -143,12 +143,13 @@ final class HomepageMiddleware: FeatureFlaggable, Notifiable {
         ensureMainThread {
             self.windowManager.windows.forEach { windowUUID, _ in
                 switch notificationName {
-                case UIApplication.willEnterForegroundNotification:
+                case UIApplication.didBecomeActiveNotification:
                     let storiesAction = HomepageAction(
                         windowUUID: windowUUID,
-                        actionType: HomepageMiddlewareActionType.enteredForeground
+                        actionType: HomepageMiddlewareActionType.didBecomeActive
                     )
                     store.dispatch(storiesAction)
+                    self.dispatchActionToFetchTopSites(windowUUID: windowUUID)
 
                 case .PrivateDataClearedHistory,
                         .TopSitesUpdated,

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
@@ -149,7 +149,6 @@ final class HomepageMiddleware: FeatureFlaggable, Notifiable {
                         actionType: HomepageMiddlewareActionType.didBecomeActive
                     )
                     store.dispatch(storiesAction)
-                    self.dispatchActionToFetchTopSites(windowUUID: windowUUID)
 
                 case .PrivateDataClearedHistory,
                         .TopSitesUpdated,

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesManager.swift
@@ -52,9 +52,11 @@ final class TopSitesManager: TopSitesManagerInterface, UserFeaturePreferenceProv
     private let searchEnginesManager: SearchEnginesManagerProvider
     private let unifiedAdsProvider: UnifiedAdsProviderInterface
     private let notification: NotificationProtocol
+    private let sponsoredTilesFetchTimeoutNanoseconds: UInt64
 
     private let maxTopSites: Int
     private let maxNumberOfSponsoredTile = 2
+    private static let defaultSponsoredTilesFetchTimeoutNanoseconds: UInt64 = 3_000_000_000
 
     init(
         profile: Profile,
@@ -64,7 +66,8 @@ final class TopSitesManager: TopSitesManagerInterface, UserFeaturePreferenceProv
         searchEnginesManager: SearchEnginesManagerProvider,
         logger: Logger = DefaultLogger.shared,
         notification: NotificationProtocol = NotificationCenter.default,
-        maxTopSites: Int = 4 * 14 // Max rows * max tiles on the largest screen plus some padding
+        maxTopSites: Int = 4 * 14, // Max rows * max tiles on the largest screen plus some padding
+        sponsoredTilesFetchTimeoutNanoseconds: UInt64 = TopSitesManager.defaultSponsoredTilesFetchTimeoutNanoseconds
     ) {
         self.profile = profile
         self.unifiedAdsProvider = unifiedAdsProvider
@@ -74,6 +77,7 @@ final class TopSitesManager: TopSitesManagerInterface, UserFeaturePreferenceProv
         self.logger = logger
         self.notification = notification
         self.maxTopSites = maxTopSites
+        self.sponsoredTilesFetchTimeoutNanoseconds = sponsoredTilesFetchTimeoutNanoseconds
     }
 
     @MainActor
@@ -103,22 +107,76 @@ final class TopSitesManager: TopSitesManagerInterface, UserFeaturePreferenceProv
     // MARK: Sponsored tiles (Unified Tiles)
     func fetchSponsoredSites() async -> [Site] {
         guard shouldLoadSponsoredTiles else { return [] }
-        let unifiedTiles = await withCheckedContinuation { continuation in
-            unifiedAdsProvider.fetchTiles { [weak self] result in
-                if case .success(let unifiedTiles) = result {
-                    continuation.resume(returning: unifiedTiles)
-                } else {
-                    self?.logger.log(
-                        "Unified ads provider did not return any sponsored tiles when requested",
-                        level: .warning,
-                        category: .homepage
-                    )
-                    continuation.resume(returning: [])
-                }
-            }
-        }
+        let unifiedTiles = await fetchUnifiedTilesWithTimeout()
 
         return unifiedTiles.compactMap { Site.createSponsoredSite(fromUnifiedTile: $0) }
+    }
+
+    private func fetchUnifiedTilesWithTimeout() async -> [UnifiedTile] {
+        await withCheckedContinuation { continuation in
+            let fetchState = SponsoredTilesFetchState()
+            let timeoutTask = startSponsoredTilesTimeout(
+                fetchState: fetchState,
+                continuation: continuation
+            )
+
+            unifiedAdsProvider.fetchTiles { [weak self] result in
+                timeoutTask.cancel()
+                Self.resumeSponsoredTilesFetch(
+                    result,
+                    fetchState: fetchState,
+                    continuation: continuation,
+                    logger: self?.logger
+                )
+            }
+        }
+    }
+
+    private func startSponsoredTilesTimeout(
+        fetchState: SponsoredTilesFetchState,
+        continuation: CheckedContinuation<[UnifiedTile], Never>
+    ) -> Task<Void, Never> {
+        return Task { [logger, sponsoredTilesFetchTimeoutNanoseconds] in
+            do {
+                try await Task.sleep(nanoseconds: sponsoredTilesFetchTimeoutNanoseconds)
+            } catch {
+                return
+            }
+
+            guard !Task.isCancelled else { return }
+
+            logger.log(
+                "Unified ads provider timed out when requesting sponsored tiles",
+                level: .warning,
+                category: .homepage
+            )
+            fetchState.resumeOnce {
+                continuation.resume(returning: [])
+            }
+        }
+    }
+
+    private static func resumeSponsoredTilesFetch(
+        _ result: UnifiedTileResult,
+        fetchState: SponsoredTilesFetchState,
+        continuation: CheckedContinuation<[UnifiedTile], Never>,
+        logger: Logger?
+    ) {
+        switch result {
+        case .success(let unifiedTiles):
+            fetchState.resumeOnce {
+                continuation.resume(returning: unifiedTiles)
+            }
+        case .failure:
+            logger?.log(
+                "Unified ads provider did not return any sponsored tiles when requested",
+                level: .warning,
+                category: .homepage
+            )
+            fetchState.resumeOnce {
+                continuation.resume(returning: [])
+            }
+        }
     }
 
     private var shouldLoadSponsoredTiles: Bool {
@@ -241,5 +299,22 @@ final class TopSitesManager: TopSitesManagerInterface, UserFeaturePreferenceProv
         profile.places.deleteVisitsFor(url: site.url).uponQueue(.main) { [weak self] _ in
             self?.notification.post(name: .TopSitesUpdated, withObject: nil)
         }
+    }
+}
+
+private final class SponsoredTilesFetchState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var hasResumed = false
+
+    func resumeOnce(_ resume: () -> Void) {
+        lock.lock()
+        guard !hasResumed else {
+            lock.unlock()
+            return
+        }
+        hasResumed = true
+        lock.unlock()
+
+        resume()
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
@@ -48,11 +48,10 @@ final class TopSitesMiddleware {
         switch action.actionType {
         case HomepageActionType.initialize,
             ShortcutsLibraryActionType.initialize,
+            HomepageMiddlewareActionType.didBecomeActive,
             HomepageMiddlewareActionType.topSitesUpdated,
             TopSitesActionType.toggleShowSponsoredSettings:
-            Task { @MainActor in
-                await self.getTopSitesDataAndUpdateState(for: action)
-            }
+            self.fetchTopSitesDataAndUpdateState(for: action)
         case TopSitesActionType.topSitesSeen:
             self.handleSponsoredImpressionTracking(for: action)
 
@@ -87,6 +86,12 @@ final class TopSitesMiddleware {
             self.homepageTelemetry.sendContextMenuOpenedEventForTopSites(for: .sponsoredSupport)
         default:
             break
+        }
+    }
+
+    private func fetchTopSitesDataAndUpdateState(for action: Action) {
+        Task { @MainActor in
+            await self.getTopSitesDataAndUpdateState(for: action)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
@@ -35,7 +35,7 @@ final class WorldCupMiddleware {
         self.lastWindowUUID = action.windowUUID
         switch action.actionType {
         case HomepageActionType.initialize,
-             HomepageMiddlewareActionType.enteredForeground,
+             HomepageMiddlewareActionType.didBecomeActive,
              WorldCupActionType.retryMatchesFetch:
             self.startFeed(windowUUID: action.windowUUID)
         case WorldCupActionType.didChangeHomepageSettings:

--- a/firefox-ios/Providers/Merino/MerinoProvider.swift
+++ b/firefox-ios/Providers/Merino/MerinoProvider.swift
@@ -59,8 +59,10 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
         else { throw Error.failure }
 
         if let cachedResponse = cache.loadResponse(),
-           cacheUpdateThresholdHasNotPassed(),
            responseHasDisplayableContent(cachedResponse) {
+            if !cacheUpdateThresholdHasNotPassed() {
+                refreshCacheInBackground()
+            }
             return cachedResponse
         }
 
@@ -68,6 +70,10 @@ final class MerinoProvider: MerinoStoriesProviding, FeatureFlaggable, @unchecked
             throw Error.failure
         }
         return response
+    }
+
+    private func refreshCacheInBackground() {
+        _ = createTask()
     }
 
     static func isLocaleSupported(_ locale: String) -> Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
@@ -45,13 +45,12 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         ])
     }
 
-    func test_didBecomeActiveNotification_dispatchesForegroundAndTopSitesRefresh() throws {
+    func test_didBecomeActiveNotification_dispatchesForegroundRefresh() throws {
         let mockWindowManager = MockWindowManager(wrappedManager: WindowManagerImplementation())
         mockWindowManager.overrideWindows = true
         let subject = createSubject(windowManager: mockWindowManager)
         mockNotificationCenter.notifiableListener = subject
         let dispatchExpectation = XCTestExpectation(description: "Homepage active refresh actions dispatched")
-        dispatchExpectation.expectedFulfillmentCount = 2
 
         mockStore.dispatchCalled = {
             dispatchExpectation.fulfill()
@@ -64,8 +63,8 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
         let actionTypes = actionsCalled.compactMap { $0.actionType as? HomepageMiddlewareActionType }
 
-        XCTAssertEqual(actionTypes, [.didBecomeActive, .topSitesUpdated])
-        XCTAssertEqual(actionsCalled.map(\.windowUUID), [.XCTestDefaultUUID, .XCTestDefaultUUID])
+        XCTAssertEqual(actionTypes, [.didBecomeActive])
+        XCTAssertEqual(actionsCalled.map(\.windowUUID), [.XCTestDefaultUUID])
     }
 
     func test_viewWillAppearAction_doesNotSendTelemetryData() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Glean
 import Redux
 import XCTest
@@ -42,6 +43,29 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
                                                            .BookmarksUpdated,
                                                            .RustPlacesOpened
         ])
+    }
+
+    func test_didBecomeActiveNotification_dispatchesForegroundAndTopSitesRefresh() throws {
+        let mockWindowManager = MockWindowManager(wrappedManager: WindowManagerImplementation())
+        mockWindowManager.overrideWindows = true
+        let subject = createSubject(windowManager: mockWindowManager)
+        mockNotificationCenter.notifiableListener = subject
+        let dispatchExpectation = XCTestExpectation(description: "Homepage active refresh actions dispatched")
+        dispatchExpectation.expectedFulfillmentCount = 2
+
+        mockStore.dispatchCalled = {
+            dispatchExpectation.fulfill()
+        }
+
+        mockNotificationCenter.post(name: UIApplication.didBecomeActiveNotification)
+
+        wait(for: [dispatchExpectation], timeout: 1)
+
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
+        let actionTypes = actionsCalled.compactMap { $0.actionType as? HomepageMiddlewareActionType }
+
+        XCTAssertEqual(actionTypes, [.didBecomeActive, .topSitesUpdated])
+        XCTAssertEqual(actionsCalled.map(\.windowUUID), [.XCTestDefaultUUID, .XCTestDefaultUUID])
     }
 
     func test_viewWillAppearAction_doesNotSendTelemetryData() throws {
@@ -539,13 +563,17 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     // MARK: - Helpers
-    private func createSubject(privacyNoticeHelper: PrivacyNoticeHelperProtocol? = nil) -> HomepageMiddleware {
+    private func createSubject(
+        privacyNoticeHelper: PrivacyNoticeHelperProtocol? = nil,
+        windowManager: WindowManager = AppContainer.shared.resolve()
+    ) -> HomepageMiddleware {
         return HomepageMiddleware(
             homepageTelemetry: HomepageTelemetry(
                 gleanWrapper: mockGleanWrapper
             ),
             privacyNoticeHelper: privacyNoticeHelper,
-            notificationCenter: mockNotificationCenter
+            notificationCenter: mockNotificationCenter,
+            windowManager: windowManager
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoMiddlewareTests.swift
@@ -50,14 +50,14 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(merinoManager.getMerinoItemsCalled, 1)
     }
 
-    func test_enterForegroundAction_getPocketData() throws {
+    func test_didBecomeActiveAction_getPocketData() throws {
         let subject = createSubject(merinoManager: merinoManager)
         let action = HomepageAction(
             windowUUID: .XCTestDefaultUUID,
-            actionType: HomepageMiddlewareActionType.enteredForeground
+            actionType: HomepageMiddlewareActionType.didBecomeActive
         )
 
-        let expectation = XCTestExpectation(description: "Homepage action entered foreground dispatched")
+        let expectation = XCTestExpectation(description: "Homepage action did become active dispatched")
         mockStore.dispatchCalled = {
             expectation.fulfill()
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
@@ -129,6 +129,33 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 
+    func test_didBecomeActiveAction_returnsTopSitesSection() throws {
+        let subject = createSubject(topSitesManager: mockTopSitesManager)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageMiddlewareActionType.didBecomeActive
+        )
+
+        let dispatchExpectation = XCTestExpectation(description: "All relevant top sites middleware actions are dispatched")
+
+        mockStore.dispatchCalled = {
+            dispatchExpectation.fulfill()
+        }
+
+        subject.topSitesProvider(appState, action)
+
+        wait(for: [dispatchExpectation], timeout: 1)
+
+        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 1)
+
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
+        let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionsType, [.retrievedUpdatedSites])
+        XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
+    }
+
     func test_fetchTopSitesAction_withMultipleCalles_returnsTopSitesSection() throws {
         let subject = createSubject(topSitesManager: mockTopSitesManager)
         let action = HomepageAction(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
@@ -160,6 +160,31 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 
+    func test_homepageInitializeAction_withoutSponsoredSites_dispatchesOtherSites() throws {
+        let topSitesManager = FallbackTopSitesManager()
+        let subject = createSubject(topSitesManager: topSitesManager)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+        let dispatchExpectation = XCTestExpectation(description: "Top sites middleware dispatches fallback sites")
+
+        mockStore.dispatchCalled = {
+            dispatchExpectation.fulfill()
+        }
+
+        subject.topSitesProvider(appState, action)
+
+        wait(for: [dispatchExpectation], timeout: 1)
+
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
+        let topSites = try XCTUnwrap(actionsCalled.last?.topSites)
+
+        XCTAssertEqual(topSites.count, 1)
+        XCTAssertEqual(topSites.first?.title, "Fallback Site")
+        XCTAssertEqual(topSites.first?.isSponsored, false)
+    }
+
     func test_tappedOnHomepageTopSite_forSponsoredSites_withUnifiedAds_sendsTelemetry() throws {
         let unifiedAdsTelemetry = MockUnifiedAdsCallbackTelemetry()
         let subject = createSubject(
@@ -563,7 +588,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
     // MARK: - Helpers
     private func createSubject(
-        topSitesManager: MockTopSitesManager,
+        topSitesManager: TopSitesManagerInterface,
         unifiedAdsTelemetry: UnifiedAdsCallbackTelemetry? = nil,
         featureFlagsProvider: FeatureFlagProviding = MockNimbusFeatureFlags()
     ) -> TopSitesMiddleware {
@@ -639,4 +664,29 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
     func resetStore() {
         StoreTestUtilityHelper.resetStore()
     }
+}
+
+private final class FallbackTopSitesManager: TopSitesManagerInterface, @unchecked Sendable {
+    func getOtherSites() async -> [TopSiteConfiguration] {
+        return [
+            TopSiteConfiguration(
+                site: Site.createBasicSite(url: "www.example.com", title: "Fallback Site")
+            )
+        ]
+    }
+
+    func fetchSponsoredSites() async -> [Site] {
+        return []
+    }
+
+    @MainActor
+    func recalculateTopSites(otherSites: [TopSiteConfiguration], sponsoredSites: [Site]) -> [TopSiteConfiguration] {
+        return otherSites
+    }
+
+    func removeTopSite(_ site: Site) async {}
+
+    func pinTopSite(_ site: Site) {}
+
+    func unpinTopSite(_ site: Site) async {}
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TopSitesManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TopSitesManagerTests.swift
@@ -110,6 +110,16 @@ final class TopSitesManagerTests: XCTestCase {
         XCTAssertEqual(topSites.count, 0)
     }
 
+    func test_fetchSponsoredSites_forUnifiedAds_whenProviderDoesNotComplete_returnNoSponsoredSites() async throws {
+        let subject = try createSubject(
+            unifiedAdsProvider: MockUnifiedAdsProvider(result: nil),
+            sponsoredTilesFetchTimeoutNanoseconds: 1_000_000
+        )
+
+        let topSites = await subject.fetchSponsoredSites()
+        XCTAssertEqual(topSites.count, 0)
+    }
+
     func test_recalculateTopSites_shouldShowSponsoredSites_returnOnlyMaxSponsoredSites() throws {
         // Max tiles is currently at 2, so it should add 2 tiles only.
         let subject = try createSubject()
@@ -450,6 +460,7 @@ final class TopSitesManagerTests: XCTestCase {
         topSiteHistoryManager: TopSiteHistoryManagerProvider = MockTopSiteHistoryManager(sites: []),
         searchEngineManager: SearchEnginesManagerProvider = MockSearchEnginesManager(),
         maxCount: Int = 10,
+        sponsoredTilesFetchTimeoutNanoseconds: UInt64 = 3_000_000_000,
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> TopSitesManager {
@@ -462,7 +473,8 @@ final class TopSitesManagerTests: XCTestCase {
             topSiteHistoryManager: topSiteHistoryManager,
             searchEnginesManager: searchEngineManager,
             notification: mockNotificationCenter,
-            maxTopSites: maxCount
+            maxTopSites: maxCount,
+            sponsoredTilesFetchTimeoutNanoseconds: sponsoredTilesFetchTimeoutNanoseconds
         )
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Merino/MerinoProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Merino/MerinoProviderTests.swift
@@ -122,7 +122,7 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
         XCTAssertFalse(control.cache.didClear)
     }
 
-    func test_fetchContent_fetchesAndSaves_whenThresholdPassed() async throws {
+    func test_fetchContent_returnsStaleCacheAndRefreshes_whenThresholdPassed() async throws {
         let control = await createSubject(thresholdHours: 1/60)
         let cachedResponse = CuratedRecommendationsResponse.makeResponse(items: [.makeItem("old")])
         control.cache.seed(response: cachedResponse, lastUpdated: Date().addingTimeInterval(-3600))
@@ -132,10 +132,12 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
                 .makeItem("new2")
             ]
         )
+        control.fetcher.fetchDelay = 10_000_000
 
         let result = try await control.subject.fetchContent()
 
-        XCTAssertEqual(result.data.map(\.title), ["new1", "new2"])
+        XCTAssertEqual(result.data.map(\.title), ["old"])
+        await waitForBackgroundRefresh(control: control, expectedTitles: ["new1", "new2"])
         XCTAssertTrue(control.cache.didClear)
         XCTAssertEqual(control.cache.loadResponse()?.data.map(\.title), ["new1", "new2"])
         XCTAssertEqual(control.fetcher.callCount, 1)
@@ -169,7 +171,7 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
         }
     }
 
-    func test_fetchContent_fetches_whenNoLastUpdatedEvenIfItemsExist() async throws {
+    func test_fetchContent_returnsStaleCacheAndRefreshes_whenNoLastUpdatedEvenIfItemsExist() async throws {
         let control = await createSubject(prefsEnabled: true)
 
         let cachedResponse = CuratedRecommendationsResponse.makeResponse(
@@ -183,16 +185,18 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
                 .makeItem("net2")
             ]
         )
+        control.fetcher.fetchDelay = 10_000_000
 
         let result = try await control.subject.fetchContent()
 
-        XCTAssertEqual(result.data.count, 2)
-        XCTAssertEqual(result.data.map(\.title), ["net1", "net2"])
-        XCTAssertEqual(control.fetcher.callCount, 1)
+        XCTAssertEqual(result.data.count, 1)
+        XCTAssertEqual(result.data.map(\.title), ["staleButNoTimestamp"])
 
+        await waitForBackgroundRefresh(control: control, expectedTitles: ["net1", "net2"])
         XCTAssertTrue(control.cache.didClear)
         XCTAssertEqual(control.cache.loadResponse()?.data.count, 2)
         XCTAssertEqual(control.cache.loadResponse()?.data.map(\.title), ["net1", "net2"])
+        XCTAssertEqual(control.fetcher.callCount, 1)
     }
 
     func test_fetchContent_returnsCached_whenWithinOneHourThreshold() async throws {
@@ -321,7 +325,7 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(response2.data.map(\.title), ["a", "b"])
     }
 
-    func test_fetchContent_fetchesFromNetwork_whenOneHourThresholdPassed() async throws {
+    func test_fetchContent_returnsStaleCacheAndRefreshes_whenOneHourThresholdPassed() async throws {
         let control = await createSubject(thresholdHours: 1)
         let cachedResponse = CuratedRecommendationsResponse.makeResponse(
             items: [.makeItem("old")]
@@ -333,7 +337,8 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
 
         let result = try await control.subject.fetchContent()
 
-        XCTAssertEqual(result.data.map(\.title), ["fresh"])
+        XCTAssertEqual(result.data.map(\.title), ["old"])
+        await waitForBackgroundRefresh(control: control, expectedTitles: ["fresh"])
         XCTAssertEqual(control.fetcher.callCount, 1)
     }
 
@@ -371,6 +376,27 @@ final class MerinoProviderTests: XCTestCase, @unchecked Sendable {
 
         await trackForMemoryLeaks(subject)
         return TestableSubject(subject: subject, cache: cache, fetcher: fetcher)
+    }
+
+    private func waitForBackgroundRefresh(
+        control: TestableSubject,
+        expectedTitles: [String],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let didRefresh = await waitUntil {
+            control.cache.loadResponse()?.data.map(\.title) == expectedTitles
+        }
+
+        XCTAssertTrue(didRefresh, "Timed out waiting for Merino background refresh", file: file, line: line)
+    }
+
+    private func waitUntil(_ condition: () -> Bool) async -> Bool {
+        for _ in 0..<100 {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return condition()
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUnifiedAdsProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUnifiedAdsProvider.swift
@@ -7,13 +7,15 @@
 import Shared
 
 final class MockUnifiedAdsProvider: UnifiedAdsProviderInterface, @unchecked Sendable {
-    private var result: UnifiedTileResult
+    private var result: UnifiedTileResult?
 
-    init(result: UnifiedTileResult) {
+    init(result: UnifiedTileResult?) {
         self.result = result
     }
 
-    func fetchTiles(timestamp: Timestamp, completion: @escaping (UnifiedTileResult) -> Void) {
+    func fetchTiles(timestamp: Timestamp, completion: @escaping @Sendable (UnifiedTileResult) -> Void) {
+        guard let result else { return }
+
         switch result {
         case .success(let unifiedTiles):
             completion(.success(unifiedTiles))


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16116)
[GH ticket](https://github.com/mozilla-mobile/firefox-ios/issues/34343)

## :bulb: Description
If there is any displayable cached Merino response, return it immediately even if expired, then start createTask() in the background to refresh the cache. No UI/design change: users see normal story cells, just possibly stale for this session. Fresh data is ready next time.


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

