### PR TITLE
Refactor FXIOS-16117 [Homepage] Top sites local first fallback

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
@@ -51,7 +51,7 @@ final class TopSitesMiddleware {
             HomepageMiddlewareActionType.didBecomeActive,
             HomepageMiddlewareActionType.topSitesUpdated,
             TopSitesActionType.toggleShowSponsoredSettings:
-            self.fetchTopSitesDataAndUpdateState(for: action)
+            self.fetchTopSitesDataAndUpdateState(for: action, state: state)
         case TopSitesActionType.topSitesSeen:
             self.handleSponsoredImpressionTracking(for: action)
 
@@ -89,9 +89,26 @@ final class TopSitesMiddleware {
         }
     }
 
-    private func fetchTopSitesDataAndUpdateState(for action: Action) {
+    private func fetchTopSitesDataAndUpdateState(for action: Action, state: AppState) {
+        let shouldDispatchLocalSitesFirst = shouldDispatchLocalSitesFirst(for: action, state: state)
         Task { @MainActor in
-            await self.getTopSitesDataAndUpdateState(for: action)
+            await self.getTopSitesDataAndUpdateState(
+                for: action,
+                shouldDispatchLocalSitesFirst: shouldDispatchLocalSitesFirst
+            )
+        }
+    }
+
+    private func shouldDispatchLocalSitesFirst(for action: Action, state: AppState) -> Bool {
+        switch action.actionType {
+        case HomepageActionType.initialize,
+            HomepageMiddlewareActionType.didBecomeActive,
+            HomepageMiddlewareActionType.topSitesUpdated,
+            TopSitesActionType.toggleShowSponsoredSettings:
+            let homepageState = HomepageState(appState: state, uuid: action.windowUUID)
+            return homepageState.topSitesState.topSitesData.isEmpty
+        default:
+            return false
         }
     }
 
@@ -125,11 +142,36 @@ final class TopSitesMiddleware {
     }
 
     @MainActor
-    private func getTopSitesDataAndUpdateState(for action: Action) async {
+    private func getTopSitesDataAndUpdateState(
+        for action: Action,
+        shouldDispatchLocalSitesFirst: Bool
+    ) async {
+        if shouldDispatchLocalSitesFirst {
+            let sponsoredSitesTask = fetchSponsoredSitesInBackground()
+            let otherSites = await self.topSitesManager.getOtherSites()
+            let localTopSites = self.topSitesManager.recalculateTopSites(otherSites: otherSites, sponsoredSites: [])
+
+            if !localTopSites.isEmpty {
+                dispatchTopSitesRetrievedAction(for: action.windowUUID, topSites: localTopSites)
+                return
+            }
+
+            let sponsoredSites = await sponsoredSitesTask.value
+            let topSites = self.topSitesManager.recalculateTopSites(otherSites: otherSites, sponsoredSites: sponsoredSites)
+            dispatchTopSitesRetrievedAction(for: action.windowUUID, topSites: topSites)
+            return
+        }
+
         async let sponsoredSites = await self.topSitesManager.fetchSponsoredSites()
         async let otherSites = await self.topSitesManager.getOtherSites()
         let topSites = await self.topSitesManager.recalculateTopSites(otherSites: otherSites, sponsoredSites: sponsoredSites)
         dispatchTopSitesRetrievedAction(for: action.windowUUID, topSites: topSites)
+    }
+
+    private func fetchSponsoredSitesInBackground() -> Task<[Site], Never> {
+        return Task { [topSitesManager] in
+            await topSitesManager.fetchSponsoredSites()
+        }
     }
 
     private func dispatchTopSitesRetrievedAction(for windowUUID: WindowUUID, topSites: [TopSiteConfiguration]) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
@@ -212,6 +212,86 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(topSites.first?.isSponsored, false)
     }
 
+    func test_homepageInitializeAction_whenHomepageTopSitesEmpty_dispatchesLocalSitesFirst() throws {
+        let topSitesManager = SponsoredFallbackTopSitesManager()
+        let subject = createSubject(topSitesManager: topSitesManager)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+        let dispatchExpectation = XCTestExpectation(description: "Top sites middleware dispatches local sites")
+        let sponsoredFetchExpectation = XCTestExpectation(description: "Sponsored sites refresh starts")
+        topSitesManager.fetchSponsoredSitesCalled = {
+            sponsoredFetchExpectation.fulfill()
+        }
+
+        mockStore.dispatchCalled = {
+            dispatchExpectation.fulfill()
+        }
+
+        subject.topSitesProvider(appState, action)
+
+        wait(for: [dispatchExpectation, sponsoredFetchExpectation], timeout: 1)
+
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
+        let topSites = try XCTUnwrap(actionsCalled.last?.topSites)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(topSites.map(\.title), ["Local Site"])
+        XCTAssertEqual(topSitesManager.sponsoredSitesUsedForRecalculation, [0])
+    }
+
+    func test_homepageInitializeAction_whenHomepageTopSitesEmptyAndLocalSitesEmpty_dispatchesSponsoredSites() throws {
+        let topSitesManager = SponsoredFallbackTopSitesManager()
+        topSitesManager.otherSites = []
+        let subject = createSubject(topSitesManager: topSitesManager)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+        let dispatchExpectation = XCTestExpectation(description: "Top sites middleware dispatches sponsored sites")
+
+        mockStore.dispatchCalled = {
+            dispatchExpectation.fulfill()
+        }
+
+        subject.topSitesProvider(appState, action)
+
+        wait(for: [dispatchExpectation], timeout: 1)
+
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
+        let topSites = try XCTUnwrap(actionsCalled.last?.topSites)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(topSites.map(\.title), ["Sponsored Site"])
+        XCTAssertEqual(topSitesManager.sponsoredSitesUsedForRecalculation, [0, 1])
+    }
+
+    func test_homepageInitializeAction_whenHomepageTopSitesLoaded_dispatchesSponsoredSites() throws {
+        let topSitesManager = SponsoredFallbackTopSitesManager()
+        let subject = createSubject(topSitesManager: topSitesManager)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.initialize
+        )
+        let dispatchExpectation = XCTestExpectation(description: "Top sites middleware dispatches full sites")
+
+        mockStore.dispatchCalled = {
+            dispatchExpectation.fulfill()
+        }
+
+        subject.topSitesProvider(appStateWithHomepageTopSites(), action)
+
+        wait(for: [dispatchExpectation], timeout: 1)
+
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
+        let topSites = try XCTUnwrap(actionsCalled.last?.topSites)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(topSites.map(\.title), ["Sponsored Site", "Local Site"])
+        XCTAssertEqual(topSitesManager.sponsoredSitesUsedForRecalculation, [1])
+    }
+
     func test_tappedOnHomepageTopSite_forSponsoredSites_withUnifiedAds_sendsTelemetry() throws {
         let unifiedAdsTelemetry = MockUnifiedAdsCallbackTelemetry()
         let subject = createSubject(
@@ -691,6 +771,29 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
     func resetStore() {
         StoreTestUtilityHelper.resetStore()
     }
+
+    private func appStateWithHomepageTopSites() -> AppState {
+        let topSitesAction = TopSitesAction(
+            topSites: [
+                TopSiteConfiguration(
+                    site: Site.createBasicSite(url: "www.existing.com", title: "Existing Site")
+                )
+            ],
+            shouldShowAddShortcutTile: false,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: TopSitesMiddlewareActionType.retrievedUpdatedSites
+        )
+        let homepageState = HomepageState.reducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            topSitesAction
+        )
+
+        return AppState(
+            presentedComponents: PresentedComponentsState(
+                components: [.homepage(homepageState)]
+            )
+        )
+    }
 }
 
 private final class FallbackTopSitesManager: TopSitesManagerInterface, @unchecked Sendable {
@@ -709,6 +812,47 @@ private final class FallbackTopSitesManager: TopSitesManagerInterface, @unchecke
     @MainActor
     func recalculateTopSites(otherSites: [TopSiteConfiguration], sponsoredSites: [Site]) -> [TopSiteConfiguration] {
         return otherSites
+    }
+
+    func removeTopSite(_ site: Site) async {}
+
+    func pinTopSite(_ site: Site) {}
+
+    func unpinTopSite(_ site: Site) async {}
+}
+
+private final class SponsoredFallbackTopSitesManager: TopSitesManagerInterface, @unchecked Sendable {
+    var fetchSponsoredSitesCalled: () -> Void = {}
+    var sponsoredSitesUsedForRecalculation = [Int]()
+    var otherSites = [
+        TopSiteConfiguration(
+            site: Site.createBasicSite(url: "www.example.com", title: "Local Site")
+        )
+    ]
+
+    func getOtherSites() async -> [TopSiteConfiguration] {
+        return otherSites
+    }
+
+    func fetchSponsoredSites() async -> [Site] {
+        fetchSponsoredSitesCalled()
+        return [
+            Site.createSponsoredSite(
+                url: "www.sponsored.com",
+                title: "Sponsored Site",
+                siteInfo: SponsoredSiteInfo(
+                    impressionURL: "https://example.com/impression",
+                    clickURL: "https://example.com/click",
+                    imageURL: "https://example.com/image"
+                )
+            )
+        ]
+    }
+
+    @MainActor
+    func recalculateTopSites(otherSites: [TopSiteConfiguration], sponsoredSites: [Site]) -> [TopSiteConfiguration] {
+        sponsoredSitesUsedForRecalculation.append(sponsoredSites.count)
+        return sponsoredSites.map { TopSiteConfiguration(site: $0) } + otherSites
     }
 
     func removeTopSite(_ site: Site) async {}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16117)
[GH ticket](https://github.com/mozilla-mobile/firefox-ios/issues/34344)

## :bulb: Description
When the top-sites section is currently empty, dispatch local/history/default shortcuts immediately using sponsoredSites: []. Let sponsored fetch continue in the background, but do not insert sponsored tiles into the already-visible section unless they were available for the first snapshot. That avoids content shifting while removing the shortcut delay.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

