### PR TITLE
Refactor FXIOS-16118 [Homepage] Coalesce duplicate homepage refreshes

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
@@ -17,6 +17,7 @@ final class TopSitesMiddleware {
     private let featureFlagsProvider: FeatureFlagProviding
     private let logger: Logger
     private let profile: Profile
+    private var inFlightHomepageTopSitesFetchWindowIDs = Set<WindowUUID>()
 
     init(
         profile: Profile = AppContainer.shared.resolve(),
@@ -90,12 +91,38 @@ final class TopSitesMiddleware {
     }
 
     private func fetchTopSitesDataAndUpdateState(for action: Action, state: AppState) {
+        // We add an in-flight guard per window in TopSitesMiddleware so `initialize`,
+        // `didBecomeActive`, and top-site notifications do not fire parallel sponsored
+        // requests on launch/foreground. This is to address issues on slow-networks
+        // and not create unnecessary additional pressure.
+        let shouldCoalesceRefresh = shouldCoalesceHomepageRefresh(for: action)
+        if shouldCoalesceRefresh {
+            guard inFlightHomepageTopSitesFetchWindowIDs.insert(action.windowUUID).inserted else { return }
+        }
+
         let shouldDispatchLocalSitesFirst = shouldDispatchLocalSitesFirst(for: action, state: state)
         Task { @MainActor in
+            defer {
+                if shouldCoalesceRefresh {
+                    self.inFlightHomepageTopSitesFetchWindowIDs.remove(action.windowUUID)
+                }
+            }
+
             await self.getTopSitesDataAndUpdateState(
                 for: action,
                 shouldDispatchLocalSitesFirst: shouldDispatchLocalSitesFirst
             )
+        }
+    }
+
+    private func shouldCoalesceHomepageRefresh(for action: Action) -> Bool {
+        switch action.actionType {
+        case HomepageActionType.initialize,
+            HomepageMiddlewareActionType.didBecomeActive,
+            HomepageMiddlewareActionType.topSitesUpdated:
+            return true
+        default:
+            return false
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
@@ -156,7 +156,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 
-    func test_fetchTopSitesAction_withMultipleCalles_returnsTopSitesSection() throws {
+    func test_fetchTopSitesAction_withMultipleCalls_coalescesTopSitesRefresh() throws {
         let subject = createSubject(topSitesManager: mockTopSitesManager)
         let action = HomepageAction(
             windowUUID: .XCTestDefaultUUID,
@@ -165,6 +165,34 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let dispatchExpectation = XCTestExpectation(description: "All relevant top sites middleware actions are dispatched")
 
+        mockStore.dispatchCalled = {
+            dispatchExpectation.fulfill()
+        }
+
+        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider(appState, action)
+
+        wait(for: [dispatchExpectation], timeout: 1)
+
+        XCTAssertEqual(mockTopSitesManager.recalculateTopSitesCalledCount, 1)
+
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [TopSitesAction])
+        let actionsType = try XCTUnwrap(actionsCalled.compactMap { $0.actionType } as? [TopSitesMiddlewareActionType])
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionsType, [.retrievedUpdatedSites])
+        XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
+    }
+
+    func test_shortcutsLibraryInitializeAction_withMultipleCalls_doesNotCoalesceTopSitesRefresh() throws {
+        let subject = createSubject(topSitesManager: mockTopSitesManager)
+        let action = ShortcutsLibraryAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ShortcutsLibraryActionType.initialize
+        )
+
+        let dispatchExpectation = XCTestExpectation(description: "Top sites middleware dispatches each shortcut update")
         dispatchExpectation.expectedFulfillmentCount = 3
 
         mockStore.dispatchCalled = {
@@ -184,7 +212,6 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 3)
         XCTAssertEqual(actionsType, [.retrievedUpdatedSites, .retrievedUpdatedSites, .retrievedUpdatedSites])
-        XCTAssertEqual(actionsCalled.last?.topSites?.count, 30)
     }
 
     func test_homepageInitializeAction_withoutSponsoredSites_dispatchesOtherSites() throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16118)
[GH ticket](https://github.com/mozilla-mobile/firefox-ios/issues/34345)

## :bulb: Description
Add an in-flight guard per window in TopSitesMiddleware so initialize, didBecomeActive, and top-site notifications do not fire parallel sponsored requests on launch/foreground. This is behavior-preserving and reduces slow-network pressure.
- TopSitesMiddleware now tracks in-flight homepage top-sites refreshes by windowUUID.
- Duplicate homepage refresh triggers are dropped while one is already running: initialize, didBecomeActive, topSitesUpdated.
- Shortcuts library initialization and sponsored-settings refreshes are intentionally not touched here

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

