### PR TITLE
Bugfix FXIOS-166092 [AdsClient] Change RustAdsClient directory

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -86,6 +86,10 @@ public struct PrefsKeys {
         public static let Latest = "latestAppVersion"
     }
 
+    public struct AdsClient {
+        public static let documentsDirectoryMigrationCheck = "adsClientDocumentsDirectoryMigrationCheckUserPrefsKey"
+    }
+
     public struct Wallpapers {
         public static let MetadataLastCheckedDate = "WallpaperMetadataLastCheckedUserPrefsKey"
         public static let CurrentWallpaper = "CurrentWallpaperUserPrefsKey"

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/AdsClient/AdsClient.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/AdsClient/AdsClient.swift
@@ -30,8 +30,9 @@ public struct RustAdsClient {
 
     private static func getDatabaseURL(environment: MozAdsEnvironment) -> String {
         let fileManager = FileManager.default
-        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let applicationSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        try? fileManager.createDirectory(at: applicationSupportURL, withIntermediateDirectories: true)
         let dbName = environment == .prod ? "ads-client.db" : "ads-client-staging.db"
-        return documentsURL.appendingPathComponent(dbName).path
+        return applicationSupportURL.appendingPathComponent(dbName).path
     }
 }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -669,6 +669,7 @@
 		5A475E8F29DB89CE009C13FD /* MockTabDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A475E8C29DB888E009C13FD /* MockTabDataStore.swift */; };
 		5A475E9129DB8AA7009C13FD /* MockDiskImageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A475E9029DB8AA7009C13FD /* MockDiskImageStore.swift */; };
 		5A47CFF52860FB8900B2B7BF /* AppLaunchUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */; };
+		5A47D0002FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A47CFFF2FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigration.swift */; };
 		5A5AB980296CA03500485E06 /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = 5A5AB97F296CA03500485E06 /* SiteImageView */; };
 		5A64225129CB506500EEC3E5 /* TabManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A64225029CB506500EEC3E5 /* TabManagerDelegate.swift */; };
 		5A679E4B2B239FAE004F2B0D /* TabPeekViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A679E4A2B239FAE004F2B0D /* TabPeekViewController.swift */; };
@@ -910,6 +911,7 @@
 		8A1A935B2B757C7C0069C190 /* wave.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A1A93552B757C7B0069C190 /* wave.json */; };
 		8A1AB6BB2E7B8D5C00167FF5 /* NotificationManagerTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1AB6BA2E7B8D5C00167FF5 /* NotificationManagerTelemetry.swift */; };
 		8A1C0B8F2E723EDF0030DCC8 /* AppLaunchUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C0B8E2E723EDC0030DCC8 /* AppLaunchUtilTests.swift */; };
+		8A1C0B912FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1C0B902FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigrationTests.swift */; };
 		8A1CBB952BE017D3008BE4D4 /* MicrosurveyPromptAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1CBB942BE017D3008BE4D4 /* MicrosurveyPromptAction.swift */; };
 		8A1CBB972BE0182C008BE4D4 /* MicrosurveyPromptMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1CBB962BE0182C008BE4D4 /* MicrosurveyPromptMiddleware.swift */; };
 		8A1CBB992BE01839008BE4D4 /* MicrosurveyPromptState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1CBB982BE01839008BE4D4 /* MicrosurveyPromptState.swift */; };
@@ -8844,6 +8846,7 @@
 		5A475E8C29DB888E009C13FD /* MockTabDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabDataStore.swift; sourceTree = "<group>"; };
 		5A475E9029DB8AA7009C13FD /* MockDiskImageStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDiskImageStore.swift; sourceTree = "<group>"; };
 		5A47CFF42860FB8900B2B7BF /* AppLaunchUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchUtil.swift; sourceTree = "<group>"; };
+		5A47CFFF2FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdsClientDocumentsDirectoryMigration.swift; sourceTree = "<group>"; };
 		5A64225029CB506500EEC3E5 /* TabManagerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerDelegate.swift; sourceTree = "<group>"; };
 		5A679E4A2B239FAE004F2B0D /* TabPeekViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabPeekViewController.swift; sourceTree = "<group>"; };
 		5A70EF18295E2E1600790249 /* DependencyHelperMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyHelperMock.swift; sourceTree = "<group>"; };
@@ -9373,6 +9376,7 @@
 		8A1A93552B757C7B0069C190 /* wave.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = wave.json; sourceTree = "<group>"; };
 		8A1AB6BA2E7B8D5C00167FF5 /* NotificationManagerTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTelemetry.swift; sourceTree = "<group>"; };
 		8A1C0B8E2E723EDC0030DCC8 /* AppLaunchUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchUtilTests.swift; sourceTree = "<group>"; };
+		8A1C0B902FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdsClientDocumentsDirectoryMigrationTests.swift; sourceTree = "<group>"; };
 		8A1CBB942BE017D3008BE4D4 /* MicrosurveyPromptAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyPromptAction.swift; sourceTree = "<group>"; };
 		8A1CBB962BE0182C008BE4D4 /* MicrosurveyPromptMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyPromptMiddleware.swift; sourceTree = "<group>"; };
 		8A1CBB982BE01839008BE4D4 /* MicrosurveyPromptState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosurveyPromptState.swift; sourceTree = "<group>"; };
@@ -13740,6 +13744,7 @@
 			isa = PBXGroup;
 			children = (
 				617D8ABC2FC8D27300E1C7A5 /* ConversionTracking */,
+				8A1C0B902FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigrationTests.swift */,
 				0A80C4232F3CD3EB00DB85AE /* AppAuthenticatorTests.swift */,
 				8A1C0B8E2E723EDC0030DCC8 /* AppLaunchUtilTests.swift */,
 				BC0723512E33D7A2005BAC05 /* AppleIntelligenceUtilTests.swift */,
@@ -17132,6 +17137,7 @@
 			isa = PBXGroup;
 			children = (
 				619C60052FBFBA2F00FE5E9F /* ConversionTracking */,
+				5A47CFFF2FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigration.swift */,
 				5AD3B6732CF625A300AFA1FE /* DefaultBrowserUtility.swift */,
 				BC8E91DB2E32953C00434FD0 /* AppleIntelligenceUtil.swift */,
 				8A46F5AA2C9E4389005B6422 /* RemoteSettings */,
@@ -19196,6 +19202,7 @@
 				602A2B9827F6256200C3CB78 /* FxNimbus.swift in Sources */,
 				E1CD81C5290C6D5800124B27 /* HelpView.swift in Sources */,
 				5A47CFF52860FB8900B2B7BF /* AppLaunchUtil.swift in Sources */,
+				5A47D0002FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigration.swift in Sources */,
 				D04CD74A216CF86B004FF5B0 /* SiriShortcuts.swift in Sources */,
 				EB9A179F20E6C1A200B12184 /* ThemedTableViewController.swift in Sources */,
 				E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */,
@@ -20626,6 +20633,7 @@
 				8AF3B15C2AF99C77009BB262 /* ReadingListPanelTests.swift in Sources */,
 				AB9CBC082C53B7CD00102610 /* TrackingProtectionStateTests.swift in Sources */,
 				8A1C0B8F2E723EDF0030DCC8 /* AppLaunchUtilTests.swift in Sources */,
+				8A1C0B912FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigrationTests.swift in Sources */,
 				E1EAA5F12D49470900D3039C /* ToolbarStateTests.swift in Sources */,
 				5A9A09D428B01D8700B6F51E /* MockTelemetryWrapper.swift in Sources */,
 				C80C11F028B3C9150062922A /* MockUserDefaults.swift in Sources */,

--- a/firefox-ios/Client/Application/AdsClientDocumentsDirectoryMigration.swift
+++ b/firefox-ios/Client/Application/AdsClientDocumentsDirectoryMigration.swift
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Shared
+
+struct AdsClientDocumentsDirectoryMigration {
+    private static let databaseFileNames = ["ads-client.db", "ads-client-staging.db"]
+    private static let databaseFileSuffixes = ["", "-shm", "-wal", "-journal"]
+    private static var legacyDatabaseFileNames: [String] {
+        databaseFileNames.flatMap { databaseFileName in
+            databaseFileSuffixes.map { "\(databaseFileName)\($0)" }
+        }
+    }
+
+    private let fileManager: FileManagerProtocol
+    private let logger: Logger
+    private let userDefaults: UserDefaultsInterface
+
+    init(
+        fileManager: FileManagerProtocol = FileManager.default,
+        logger: Logger = DefaultLogger.shared,
+        userDefaults: UserDefaultsInterface = UserDefaults.standard
+    ) {
+        self.fileManager = fileManager
+        self.logger = logger
+        self.userDefaults = userDefaults
+    }
+
+    func removeLegacyDatabaseFiles() {
+        guard !userDefaults.bool(forKey: PrefsKeys.AdsClient.documentsDirectoryMigrationCheck) else { return }
+
+        guard let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            logger.log("Unable to resolve Documents directory for ads client cleanup",
+                       level: .warning,
+                       category: .storage)
+            return
+        }
+
+        let didFailToRemoveFile = Self.legacyDatabaseFileNames
+            .map { documentsURL.appendingPathComponent($0) }
+            .reduce(false) { didFail, databaseURL in
+                guard fileManager.fileExists(atPath: databaseURL.path) else { return didFail }
+
+                do {
+                    try fileManager.removeItem(at: databaseURL)
+                    return didFail
+                } catch {
+                    logger.log("Failed to remove legacy ads client database",
+                               level: .warning,
+                               category: .storage,
+                               extra: ["error": error.localizedDescription])
+                    return true
+                }
+            }
+
+        if !didFailToRemoveFile {
+            userDefaults.set(true, forKey: PrefsKeys.AdsClient.documentsDirectoryMigrationCheck)
+        }
+    }
+}

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -79,6 +79,8 @@ final class AppLaunchUtil: FeatureFlaggable, Sendable {
         // Initialize app services ( including NSS ). Must be called before any other calls to rust components.
         MozillaAppServices.initialize()
 
+        AdsClientDocumentsDirectoryMigration().removeLegacyDatabaseFiles()
+
         /// Migrate TermsOfService prefs to TermsOfUse prefs
         /// before Nimbus is initialized (should be available for experiments)
         /// and backfill accept date/version if needed - after telemetry set up

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AdsClientDocumentsDirectoryMigrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Application/AdsClientDocumentsDirectoryMigrationTests.swift
@@ -1,0 +1,159 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Shared
+import XCTest
+
+@testable import Client
+
+final class AdsClientDocumentsDirectoryMigrationTests: XCTestCase {
+    private var fileManager: MockAdsClientMigrationFileManager!
+    private var userDefaults: MockUserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        fileManager = MockAdsClientMigrationFileManager()
+        userDefaults = MockUserDefaults()
+    }
+
+    override func tearDown() {
+        fileManager = nil
+        userDefaults = nil
+        super.tearDown()
+    }
+
+    func testRemoveLegacyDatabaseFiles_whenFilesExist_removesDatabasesAndSidecarFilesAndMarksMigrationComplete() {
+        fileManager.existingPaths = [
+            "/Documents/ads-client.db",
+            "/Documents/ads-client.db-shm",
+            "/Documents/ads-client.db-wal",
+            "/Documents/ads-client.db-journal",
+            "/Documents/ads-client-staging.db",
+            "/Documents/ads-client-staging.db-shm",
+            "/Documents/ads-client-staging.db-wal",
+            "/Documents/ads-client-staging.db-journal"
+        ]
+        let subject = createSubject()
+
+        subject.removeLegacyDatabaseFiles()
+
+        XCTAssertEqual(
+            fileManager.removedURLs.map(\.path),
+            [
+                "/Documents/ads-client.db",
+                "/Documents/ads-client.db-shm",
+                "/Documents/ads-client.db-wal",
+                "/Documents/ads-client.db-journal",
+                "/Documents/ads-client-staging.db",
+                "/Documents/ads-client-staging.db-shm",
+                "/Documents/ads-client-staging.db-wal",
+                "/Documents/ads-client-staging.db-journal"
+            ]
+        )
+        XCTAssertTrue(userDefaults.bool(forKey: PrefsKeys.AdsClient.documentsDirectoryMigrationCheck))
+    }
+
+    func testRemoveLegacyDatabaseFiles_whenFilesDoNotExist_marksMigrationComplete() {
+        let subject = createSubject()
+
+        subject.removeLegacyDatabaseFiles()
+
+        XCTAssertTrue(fileManager.removedURLs.isEmpty)
+        XCTAssertTrue(userDefaults.bool(forKey: PrefsKeys.AdsClient.documentsDirectoryMigrationCheck))
+    }
+
+    func testRemoveLegacyDatabaseFiles_whenMigrationAlreadyComplete_doesNotCheckDocumentsDirectory() {
+        userDefaults.set(true, forKey: PrefsKeys.AdsClient.documentsDirectoryMigrationCheck)
+        let subject = createSubject()
+
+        subject.removeLegacyDatabaseFiles()
+
+        XCTAssertEqual(fileManager.urlsForDirectoryCalled, 0)
+        XCTAssertTrue(fileManager.removedURLs.isEmpty)
+    }
+
+    func testRemoveLegacyDatabaseFiles_whenRemoveFails_doesNotMarkMigrationComplete() {
+        fileManager.existingPaths = ["/Documents/ads-client.db"]
+        fileManager.removeError = CocoaError(.fileWriteUnknown)
+        let subject = createSubject()
+
+        subject.removeLegacyDatabaseFiles()
+
+        XCTAssertEqual(fileManager.removedURLs.map(\.path), ["/Documents/ads-client.db"])
+        XCTAssertFalse(userDefaults.bool(forKey: PrefsKeys.AdsClient.documentsDirectoryMigrationCheck))
+    }
+
+    private func createSubject() -> AdsClientDocumentsDirectoryMigration {
+        return AdsClientDocumentsDirectoryMigration(
+            fileManager: fileManager,
+            userDefaults: userDefaults
+        )
+    }
+}
+
+private final class MockAdsClientMigrationFileManager: FileManagerProtocol, @unchecked Sendable {
+    var existingPaths: Set<String> = []
+    var removeError: Error?
+    var removedURLs: [URL] = []
+    var urlsForDirectoryCalled = 0
+
+    func fileExists(atPath path: String) -> Bool {
+        return existingPaths.contains(path)
+    }
+
+    func urls(for directory: FileManager.SearchPathDirectory,
+              in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+        urlsForDirectoryCalled += 1
+        return [URL(fileURLWithPath: "/Documents")]
+    }
+
+    func contentsOfDirectory(atPath path: String) throws -> [String] {
+        return []
+    }
+
+    func moveItem(at: URL, to: URL) throws {}
+
+    func removeItem(atPath path: String) throws {}
+
+    func removeItem(at url: URL) throws {
+        removedURLs.append(url)
+
+        if let removeError {
+            throw removeError
+        }
+    }
+
+    func copyItem(at srcURL: URL, to dstURL: URL) throws {}
+
+    func createDirectory(
+        atPath path: String,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]?
+    ) throws {}
+
+    func contentsOfDirectoryAtPath(_ path: String, withFilenamePrefix prefix: String) throws -> [String] {
+        return []
+    }
+
+    func contents(atPath path: String) -> Data? {
+        return nil
+    }
+
+    func contentsOfDirectory(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions
+    ) throws -> [URL] {
+        return []
+    }
+
+    func createFile(
+        atPath path: String,
+        contents data: Data?,
+        attributes attr: [FileAttributeKey: Any]?
+    ) -> Bool {
+        return true
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16092)

## :bulb: Description
RustAdsClient now stores the ads DB under Application Support and creates that directory if needed. For existing users, I added a one-shot startup migration wired from AppLaunchUtil. It deletes the exact legacy Documents files for both prod and staging:

  - ads-client.db
  - ads-client.db-shm
  - ads-client.db-wal
  - ads-client.db-journal
  - staging equivalents

If deletion fails, it does not mark complete, so it can retry later.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

