### PR TITLE
Refactor FXIOS-16111 [Danger] Combine tests coverage gates

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -20,9 +20,7 @@ if releaseCheck.isReleaseBranch {
     checkForSpecificFileChange()
     checkForGleanFileChange()
     CodeUsageDetector().checkForCodeUsage()
-    let coverageGate = CodeCoverageGate()
-    coverageGate.failOnFiles(type: .newFiles)
-    coverageGate.failOnFiles(type: .modifiedFiles)
+    CodeCoverageGate().run()
     BrowserViewControllerChecker().failsOnAddedExtension()
     checkCodeCoverage()
 }
@@ -121,34 +119,6 @@ class CodeCoverageGate {
             }
         }
 
-        var label: String {
-            switch self {
-            case .newFiles: return "New file"
-            case .modifiedFiles: return "Existing file"
-            }
-        }
-
-        var emptyMessage: String {
-            switch self {
-            case .newFiles: return "No new file detected so code coverage gate wasn't ran."
-            case .modifiedFiles: return "No modified file detected so code coverage gate wasn't ran."
-            }
-        }
-
-        var insufficientChangesMessage: String {
-            switch self {
-            case .newFiles: return "No new file had significant enough changes for the coverage gate to run."
-            case .modifiedFiles: return "No modified file had significant enough changes for the coverage gate to run."
-            }
-        }
-
-        var allPassMessage: String {
-            switch self {
-            case .newFiles: return "All new files meet their thresholds**."
-            case .modifiedFiles: return "All modified files meet their thresholds."
-            }
-        }
-
         var thresholdRange: (min: Double, max: Double) {
             switch self {
             case .newFiles: return (min: 0.4, max: 0.7)
@@ -157,34 +127,39 @@ class CodeCoverageGate {
         }
     }
 
-    func failOnFiles(type: CoverageType) {
+    enum GateOutcome {
+        case noCandidates
+        case noSignificantChanges
+        case allPass
+        case failures([String]) // pre-formatted markdown table rows
+    }
+
+    func run() {
         guard let coverageFiles = parseCoverageFiles() else { return }
+        let newOutcome = evaluate(type: .newFiles, coverageFiles: coverageFiles)
+        let modifiedOutcome = evaluate(type: .modifiedFiles, coverageFiles: coverageFiles)
 
-        let candidates = swiftSourceCandidates(from: type.sourceFiles)
+        var failureRows: [String] = []
+        if case .failures(let rows) = newOutcome { failureRows += rows }
+        if case .failures(let rows) = modifiedOutcome { failureRows += rows }
 
-        guard !candidates.isEmpty else {
-            markdown("""
-            ### ✅ \(type.label) code coverage
-            \(type.emptyMessage)
-            """)
-            return
+        if !failureRows.isEmpty {
+            reportCoverageFailure(rows: failureRows)
+        } else {
+            reportCoverageSuccess(newOutcome: newOutcome, modifiedOutcome: modifiedOutcome)
         }
+    }
+
+    private func evaluate(type: CoverageType, coverageFiles: [[String: Any]]) -> GateOutcome {
+        let candidates = swiftSourceCandidates(from: type.sourceFiles)
+        guard !candidates.isEmpty else { return .noCandidates }
 
         // Ignore tiny edits: only gate files with at least `type.minimumLines`
         let gated = candidates.filter { addedLines(in: $0) >= type.minimumLines }
+        guard !gated.isEmpty else { return .noSignificantChanges }
 
-        guard !gated.isEmpty else {
-            markdown("""
-            ### ✅ \(type.label) code coverage
-            \(type.insufficientChangesMessage)
-            """)
-            return
-        }
-
-        // Collect failures
         var rows: [String] = []
         for file in gated {
-            // Find matching coverage entry
             let entry = coverageMatch(repoPath: file, coverageFiles: coverageFiles)
 
             // Extract percentage (supports 0..1 or 0..100 in lineCoverage)
@@ -193,7 +168,6 @@ class CodeCoverageGate {
                 return raw <= 1.000001 ? raw * 100.0 : raw
             }()
 
-            // Calculate threshold based on file length
             let lineCount = countLines(in: file)
             let threshold = scaledPercentage(for: Double(lineCount), in: type.thresholdRange) * 100.0
 
@@ -202,15 +176,40 @@ class CodeCoverageGate {
             }
         }
 
-        guard !rows.isEmpty else {
-            markdown("""
-            ### ✅ \(type.label) code coverage
-            \(type.allPassMessage)
-            """)
-            return
-        }
+        return rows.isEmpty ? .allPass : .failures(rows)
+    }
 
-        reportCoverageFailure(rows: rows, label: type.label)
+    private func reportCoverageSuccess(newOutcome: GateOutcome, modifiedOutcome: GateOutcome) {
+        let body: String
+        switch (newOutcome, modifiedOutcome) {
+        case (.noCandidates, .noCandidates):
+            body = "No new or modified files detected so the code coverage gate wasn't run."
+        case (.allPass, .allPass):
+            body = "All new and modified files meet their coverage thresholds."
+        default:
+            body = """
+            - \(successLine(for: newOutcome, type: .newFiles))
+            - \(successLine(for: modifiedOutcome, type: .modifiedFiles))
+            """
+        }
+        markdown("""
+        ### ✅ Code coverage
+        \(body)
+        """)
+    }
+
+    private func successLine(for outcome: GateOutcome, type: CoverageType) -> String {
+        let noun = (type == .newFiles) ? "new" : "modified"
+        switch outcome {
+        case .noCandidates:
+            return "No \(noun) files detected so the coverage gate wasn't run."
+        case .noSignificantChanges:
+            return "No \(noun) files had significant enough changes for the coverage gate to run."
+        case .allPass:
+            return "All \(noun) files meet their coverage thresholds."
+        case .failures:
+            return ""
+        }
     }
 
     private func swiftSourceCandidates(from files: [String]) -> [String] {
@@ -257,9 +256,9 @@ class CodeCoverageGate {
         }
     }
 
-    private func reportCoverageFailure(rows: [String], label: String) {
+    private func reportCoverageFailure(rows: [String]) {
         let header = """
-        ### ❌ \(label) code coverage
+        ### ❌ Code coverage
         The following file(s) are below their scaled coverage:
 
         | File | Coverage | Required |


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16111)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Since code coverage for new files has been going smoothly lately, I wanted to combine them so it's not as noisy in the message. An example of the current message is:

<img width="977" height="502" alt="Screenshot 2026-06-18 at 10 45 25 AM" src="https://github.com/user-attachments/assets/73fde3f3-a207-4b3a-94d4-0e4ed9d2cc04" />

So this will be combined with one header now! Short and sweet. Code coverage gates stay the same (different for old and new files), and the bypass label stays the same.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

