### PR TITLE
Enable explicit modules for Firefox CI build

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -158,7 +158,7 @@ workflows:
         - scheme: Fennec
         - configuration: Fennec_Testing
         - project_path: /Users/vagrant/git/firefox-ios/Client.xcodeproj
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates -skipMacroValidation -enableExplicitModules DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates -skipMacroValidation DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
     - script@1:
         title: Detect number of warnings

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -158,7 +158,7 @@ workflows:
         - scheme: Fennec
         - configuration: Fennec_Testing
         - project_path: /Users/vagrant/git/firefox-ios/Client.xcodeproj
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates -skipMacroValidation DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates -skipMacroValidation -enableExplicitModules DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
     - script@1:
         title: Detect number of warnings

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -158,7 +158,7 @@ workflows:
         - scheme: Fennec
         - configuration: Fennec_Testing
         - project_path: /Users/vagrant/git/firefox-ios/Client.xcodeproj
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates -skipMacroValidation DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "SWIFT_ENABLE_EXPLICIT_MODULES=YES" -allowProvisioningUpdates -skipMacroValidation DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
     - script@1:
         title: Detect number of warnings


### PR DESCRIPTION
## Summary
- Add `-enableExplicitModules` to `firefox_configure_build` xcodebuild options
- Improves build parallelism by allowing the compiler to build modules explicitly rather than implicitly, which can speed up compilation

## Test plan
- [ ] Trigger a CI build and verify it completes successfully with explicit modules enabled
- [ ] Compare build times with previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)