### PR TITLE
FXIOS-15236 [Feature flag] Unblock debug menu with `isNimbusConfigured` 

### DIFF
--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -87,7 +87,7 @@ enum FeatureFlagID: String, CaseIterable {
     }
 
     /// Returns `false` for flags that have no Nimbus configuration and are driven solely by a user preference.
-    var isNimbusBacked: Bool {
+    var isNimbusConfigured: Bool {
         switch self {
         case .hntSponsoredShortcuts: return false
         default: return true

--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -86,6 +86,14 @@ enum FeatureFlagID: String, CaseIterable {
         }
     }
 
+    /// Returns `false` for flags that have no Nimbus configuration and are driven solely by a user preference.
+    var isNimbusBacked: Bool {
+        switch self {
+        case .hntSponsoredShortcuts: return false
+        default: return true
+        }
+    }
+
     // Add flags here if you want to toggle them in the `FeatureFlagsDebugViewController`.
     // Add in alphabetical order.
     var debugKey: String? {

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -337,7 +337,7 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
     }
 
     private func generateFeatureFlagList() -> SettingSection {
-        let flags = FeatureFlagID.allCases
+        let flags = FeatureFlagID.allCases.filter { $0.isNimbusBacked }
         let settingsList = flags.compactMap { flagID in
             return Setting(title: format(string: "\(flagID): \(featureFlagsProvider.isEnabled(flagID))"))
         }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -337,7 +337,7 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
     }
 
     private func generateFeatureFlagList() -> SettingSection {
-        let flags = FeatureFlagID.allCases.filter { $0.isNimbusBacked }
+        let flags = FeatureFlagID.allCases.filter { $0.isNimbusConfigured }
         let settingsList = flags.compactMap { flagID in
             return Setting(title: format(string: "\(flagID): \(featureFlagsProvider.isEnabled(flagID))"))
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15236)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32756)

## :bulb: Description
Fixes debug menu under settings, explanation [here](https://mozilla-hub.atlassian.net/browse/FXIOS-15236?focusedCommentId=1506472)

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

