### PR TITLE
Bugfix FXIOS-16133 [Tab manager deeplink] Fix for favicon / screenshot transition

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -357,6 +357,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
         let selectedTab = tabManager.selectedTab
         let tabManagerTabs = isPrivateMode ? tabManager.privateTabs : tabManager.normalTabs
         tabManagerTabs.forEach { tab in
+            print("LM ### screenshotUUID is not nil `\(tab.screenshotUUID != nil)` for \(tab.tabUUID)")
             let tabModel = TabModel(tabUUID: tab.tabUUID,
                                     isSelected: tab.tabUUID == selectedTab?.tabUUID,
                                     isPrivate: tab.isPrivate,
@@ -364,7 +365,8 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
                                     tabTitle: tab.displayTitle,
                                     url: tab.url,
                                     screenshot: tab.screenshot,
-                                    hasHomeScreenshot: tab.hasHomeScreenshot)
+                                    hasHomeScreenshot: tab.hasHomeScreenshot,
+                                    hasScreenshotOnDisk: tab.screenshotUUID != nil)
             tabs.append(tabModel)
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -357,7 +357,6 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
         let selectedTab = tabManager.selectedTab
         let tabManagerTabs = isPrivateMode ? tabManager.privateTabs : tabManager.normalTabs
         tabManagerTabs.forEach { tab in
-            print("LM ### screenshotUUID is not nil `\(tab.screenshotUUID != nil)` for \(tab.tabUUID)")
             let tabModel = TabModel(tabUUID: tab.tabUUID,
                                     isSelected: tab.tabUUID == selectedTab?.tabUUID,
                                     isPrivate: tab.isPrivate,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Models/TabModel.swift
@@ -15,6 +15,7 @@ struct TabModel: Equatable, Identifiable, Hashable {
 
     let screenshot: UIImage?
     let hasHomeScreenshot: Bool
+    let hasScreenshotOnDisk: Bool
 
     static func emptyState(
         tabUUID: TabUUID,
@@ -30,7 +31,8 @@ struct TabModel: Equatable, Identifiable, Hashable {
             tabTitle: title,
             url: nil,
             screenshot: nil,
-            hasHomeScreenshot: false
+            hasHomeScreenshot: false,
+            hasScreenshotOnDisk: false
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -242,6 +242,10 @@ final class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCe
         } else if let tabScreenshot = tabModel.screenshot {
             // Use Tab screenshot when available
             screenshotView.image = tabScreenshot
+        } else if tabModel.hasScreenshotOnDisk {
+            // A screenshot exists on disk and is being loaded asynchronously. Keep the cell blank
+            // until it arrives to avoid a brief favicon-to-screenshot flash after tab restoration.
+            screenshotView.image = nil
         } else {
             // Favicon or letter image when tab screenshot isn't available
             smallFaviconView.isHidden = false

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -203,6 +203,10 @@ final class TabCell: UICollectionViewCell,
         } else if let tabScreenshot = tabModel.screenshot {
             // Use Tab screenshot when available
             screenshotView.image = tabScreenshot
+        } else if tabModel.hasScreenshotOnDisk {
+            // A screenshot exists on disk and is being loaded asynchronously. Keep the cell blank
+            // until it arrives to avoid a brief favicon-to-screenshot flash after tab restoration.
+            screenshotView.image = nil
         } else {
             // Favicon or letter image when tab screenshot isn't available
             faviconBG.isHidden = false

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabCellTests.swift
@@ -61,7 +61,8 @@ class TabCellTests: XCTestCase {
                         tabTitle: "Firefox Browser",
                         url: URL(string: "https://www.mozilla.org/en-US/firefox/")!,
                         screenshot: nil,
-                        hasHomeScreenshot: false)
+                        hasHomeScreenshot: false,
+                        hasScreenshotOnDisk: false)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16133)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Using the existing `tab.screenshotUUID` to avoid showing the favicon for a split second in the UI before we're able to load the screenshot from disk.

## :movie_camera: Demos iPad

| Before | After |
| - | - |
|  https://github.com/user-attachments/assets/43a3ef43-9abe-446d-b171-b7b7da751294 | https://github.com/user-attachments/assets/3f303818-5a39-40c0-9db1-f1a761814cbe |

## :movie_camera: Demos iPhone

| Before | After |
| - | - |
| https://github.com/user-attachments/assets/e80ceb1c-c07c-495e-9acc-6ed5b850717b | https://github.com/user-attachments/assets/9ae1dd78-3f4a-4415-a328-21adf9c93569 |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

