### PR TITLE
Refactor [NO_TiCKET] minimal address bar state using isAddressBarMinimized instead of check for alpha

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
@@ -17,6 +17,10 @@ public struct AddressToolbarUXConfiguration {
     /// Changes between 0 (hidden) and 1 (visible) based on scroll direction.
     let scrollAlpha: CGFloat
 
+    var isAddressBarMinimized: Bool {
+        return scrollAlpha.isZero
+    }
+
     public static func experiment(backgroundAlpha: CGFloat = 1.0,
                                   scrollAlpha: CGFloat = 1.0,
                                   shouldBlur: Bool = false,
@@ -58,7 +62,7 @@ public struct AddressToolbarUXConfiguration {
     }
 
     func locationContainerBackgroundColor(theme: some Theme) -> UIColor {
-        guard !scrollAlpha.isZero else { return .clear }
+        guard !isAddressBarMinimized else { return .clear }
 
         if hasAlternativeLocationColor {
             return isLocationTextCentered ? theme.colors.layerSurfaceMediumAlt : theme.colors.layerEmphasis

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -140,10 +140,10 @@ public class BrowserAddressToolbar: UIView,
                           isUnifiedSearchEnabled: Bool,
                           animated: Bool) {
         [navigationActionStack, leadingPageActionStack, trailingPageActionStack, browserActionStack].forEach {
-            $0.isHidden = config.uxConfiguration.scrollAlpha.isZero
+            $0.isHidden = config.uxConfiguration.isAddressBarMinimized
         }
         if #available(iOS 26.0, *) {
-            toolbarTopBorderView.isHidden = config.uxConfiguration.scrollAlpha.isZero
+            toolbarTopBorderView.isHidden = config.uxConfiguration.isAddressBarMinimized
         }
         self.toolbarDelegate = toolbarDelegate
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
@@ -180,7 +180,7 @@ public class BrowserAddressToolbar: UIView,
     private func configureUX(config: AddressToolbarUXConfiguration,
                              toolbarPosition: AddressToolbarPosition) {
         locationContainer.layer.cornerRadius = config.toolbarCornerRadius
-        locationContainer.updateShadowOpacityBasedOn(scrollAlpha: config.scrollAlpha)
+        locationContainer.updateShadowOpacityBasedOn(isAddressBarMinimized: config.isAddressBarMinimized)
         dividerWidthConstraint?.constant = config.browserActionsAddressBarDividerWidth
         let locationViewPaddings = config.locationViewVerticalPaddings(addressBarPosition: toolbarPosition)
         toolbarBottomConstraint?.constant = -locationViewPaddings.bottom

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationContainer.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationContainer.swift
@@ -33,8 +33,8 @@ final class LocationContainer: UIView, ThemeApplicable {
         layer.masksToBounds = false
     }
 
-    func updateShadowOpacityBasedOn(scrollAlpha: CGFloat) {
-        let targetOpacity = scrollAlpha.isZero ? 0 : UX.shadowOpacity
+    func updateShadowOpacityBasedOn(isAddressBarMinimized: Bool) {
+        let targetOpacity = isAddressBarMinimized ? 0 : UX.shadowOpacity
         guard layer.shadowOpacity != targetOpacity else { return }
         layer.shadowOpacity = targetOpacity
     }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -40,9 +40,9 @@ final class LocationView: UIView,
     private var lockIconImageName: String?
     private var lockIconNeedsTheming = false
     private var safeListedURLImageName: String?
-    private var scrollAlpha: CGFloat = 1
     private var hasAlternativeLocationColor = false
     private var config: LocationViewConfiguration?
+    private(set) var isAddressBarMinimized = false
 
     private var isEditing = false
     private var isURLTextFieldEmpty: Bool {
@@ -52,10 +52,6 @@ final class LocationView: UIView,
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let window = windowScene.windows.first else { return false }
         return window.safeAreaInsets.bottom > 0
-    }
-
-    var isAddressBarMinimized: Bool {
-        return scrollAlpha.isZero
     }
 
     private var tapGestureRecognizer: UITapGestureRecognizer?
@@ -194,7 +190,7 @@ final class LocationView: UIView,
         )
 
         applyToolbarAlphaIfNeeded(
-            alpha: uxConfig.scrollAlpha,
+            isAddressBarMinimized: uxConfig.isAddressBarMinimized,
             barPosition: addressBarPosition
         )
         configureLockIconButton(config)
@@ -484,9 +480,8 @@ final class LocationView: UIView,
         effectView.effect = nil
     }
 
-    private func applyToolbarAlphaIfNeeded(alpha: CGFloat, barPosition: AddressToolbarPosition) {
-        guard scrollAlpha != alpha else { return }
-        scrollAlpha = alpha
+    private func applyToolbarAlphaIfNeeded(isAddressBarMinimized: Bool, barPosition: AddressToolbarPosition) {
+        self.isAddressBarMinimized = isAddressBarMinimized
         if isAddressBarMinimized {
             shrinkLocationView(barPosition: barPosition)
             if #available(iOS 26.0, *), barPosition == .bottom {

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -55,7 +55,7 @@ final class LocationView: UIView,
     }
 
     var isAddressBarMinimized: Bool {
-        return scrollAlpha == 0
+        return scrollAlpha.isZero
     }
 
     private var tapGestureRecognizer: UITapGestureRecognizer?
@@ -65,7 +65,7 @@ final class LocationView: UIView,
     /// An additional offset (default is 0) used when reader mode is available,
     /// to ensure the text does not overlap the icon when the view is constrained to its superview.
     private func isNormalizedHostWiderThanVisibleArea(safeOffset offset: CGFloat = 0) -> Bool {
-        guard let text = urlTextField.text, let font = urlTextField.font, !scrollAlpha.isZero else {
+        guard let text = urlTextField.text, let font = urlTextField.font, !isAddressBarMinimized else {
             return false
         }
         let (_, normalizedHost) = URL.getSubdomainAndHost(from: text)
@@ -487,7 +487,7 @@ final class LocationView: UIView,
     private func applyToolbarAlphaIfNeeded(alpha: CGFloat, barPosition: AddressToolbarPosition) {
         guard scrollAlpha != alpha else { return }
         scrollAlpha = alpha
-        if scrollAlpha.isZero {
+        if isAddressBarMinimized {
             shrinkLocationView(barPosition: barPosition)
             if #available(iOS 26.0, *), barPosition == .bottom {
                 effectView.effect = glassEffect
@@ -765,7 +765,7 @@ final class LocationView: UIView,
         ).cgColors
         searchEngineContentView.applyTheme(theme: theme)
         lockIconButton.tintColor = secondaryColor
-        lockIconButton.backgroundColor = scrollAlpha.isZero ? nil : mainBackgroundColor
+        lockIconButton.backgroundColor = isAddressBarMinimized ? nil : mainBackgroundColor
         urlTextField.applyTheme(theme: theme)
         urlTextField.textColor = primaryColor
         setTextFieldPlaceholder(color: colors.textPrimary)
@@ -777,7 +777,7 @@ final class LocationView: UIView,
     }
 
     private func getPrimaryAndSecondaryColors() -> (primary: UIColor, secondary: UIColor) {
-        if #available(iOS 26.0, *), scrollAlpha.isZero {
+        if #available(iOS 26.0, *), isAddressBarMinimized {
             // We want to use system colors when the location view is fully transparent
             // To make sure it blends well with the background when using glass effect.
             return (.label, .label)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -625,7 +625,7 @@ class BrowserViewController: UIViewController,
             ToolbarState.self,
             for: .toolbar,
             window: windowUUID
-        )?.scrollAlpha == 0
+        )?.isAddressBarMinimized == true
         let isScrollAlphaZero = if #available(iOS 26.0, *) { isToolbarCollapsed } else { false }
 
         // Prevent homepage from showing behind the keyboard when content isn't scrollable.

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -244,6 +244,7 @@ final class AddressToolbarContainer: UIView,
             let height = frame.height + UX.accessoryViewGradientOffset
             accessoryViewGradient.frame = CGRect(width: bounds.width, height: height)
             accessoryViewGradient.opacity = 1
+            // Dispatch action to change address bar to minimized state
             store.dispatch(
                 ToolbarAction(
                     scrollAlpha: 0,
@@ -372,7 +373,7 @@ final class AddressToolbarContainer: UIView,
         guard self.model != newModel else { return }
 
         updateSkeletonAddressBarsAlpha(to: CGFloat(newModel.scrollAlpha))
-        if #available(iOS 26.0, *), !newModel.shouldShowKeyboard, !newModel.scrollAlpha.isZero {
+        if #available(iOS 26.0, *), !newModel.shouldShowKeyboard, !newModel.isAddressBarMinimized {
             accessoryViewGradient.opacity = 0
         }
         // in case we are in edit mode but overlay is not active yet we have to activate it

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -37,6 +37,10 @@ final class AddressToolbarContainerModel: Equatable {
     let scrollAlpha: Float
     let hasAlternativeLocationColor: Bool
 
+    var isAddressBarMinimized: Bool {
+        return scrollAlpha.isZero
+    }
+
     let windowUUID: UUID
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -28,6 +28,10 @@ struct ToolbarState: ScreenState, Sendable {
     var previousTabScreenshot: UIImage?
     var nextTabScreenshot: UIImage?
 
+    var isAddressBarMinimized: Bool {
+        return scrollAlpha.isZero
+    }
+
     init(appState: AppState, uuid: WindowUUID) {
         guard let toolbarState = appState.componentState(
             ToolbarState.self,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Small quality-of-life PR. During all fixes for toolbar, I've always struggled without having a dedicated var to know if the minimal address bar is showing or not, and I have to keep reminding myself that `scrollAlpha == 0 `means true, so no more
- Remove all scrollAlpha = 0 checks and use an explicit `isAddressBarMinimized` computed var. 

Ideally should be a single source of truth but we have multiples scrollAlphas related to the toolbar and addressBarState related

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

