### PR TITLE
Bugfix MTE-4339 L10n screenshots improvement without Mappa Mundi

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite1SnapshotTests.swift
@@ -237,8 +237,46 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         // snapshot("HomeDefaultBrowserLearnMore")
     }
 
+    // Maps screen graph node names to the Settings cell identifier MappaMundi will tap.
+    // For multi-hop paths (e.g. MailAppSettings via BrowsingSettings), use the first-hop cell.
+    private static let settingsCellId: [String: String] = [
+        SearchSettings: AccessibilityIdentifiers.Settings.Search.searchNavigationBar,
+        NewTabSettings: "NewTab",
+        MailAppSettings: AccessibilityIdentifiers.Settings.Browsing.title,
+        DisplaySettings: "DisplayThemeOption",
+        ClearPrivateDataSettings: AccessibilityIdentifiers.Settings.ClearData.title,
+        TrackingProtectionSettings: AccessibilityIdentifiers.Settings.ContentBlocker.title,
+        NotificationsSettings: AccessibilityIdentifiers.Settings.Notifications.title,
+        BrowsingSettings: AccessibilityIdentifiers.Settings.Browsing.title,
+        SummarizeSettings: AccessibilityIdentifiers.Settings.Summarize.title,
+        SiriSettings: "SiriSettings",
+        AutofillPasswordSettings: AccessibilityIdentifiers.Settings.AutofillsPasswords.title,
+        AppIconSettings: AccessibilityIdentifiers.Settings.AppIconSelection.settingsRowTitle,
+        ToolbarSettings: AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting,
+        HomeSettings: AccessibilityIdentifiers.Settings.Homepage.homeSettings,
+        AddCustomSearchSettings: AccessibilityIdentifiers.Settings.Search.searchNavigationBar,
+    ]
+
+    private func scrollCellIntoView(_ cell: XCUIElement, in scrollView: XCUIElement) {
+        if cell.isHittable { return }
+        for _ in 0..<8 {
+            scrollView.swipeUp()
+            if cell.isHittable { return }
+        }
+        for _ in 0..<16 {
+            scrollView.swipeDown()
+            if cell.isHittable { return }
+        }
+    }
+
     @MainActor
     func testSettings() {
+        // Allow failures on individual settings nodes without aborting the entire test.
+        // A single unreachable node previously wiped all remaining screenshots.
+        let savedContinueAfterFailure = continueAfterFailure
+        continueAfterFailure = true
+        defer { continueAfterFailure = savedContinueAfterFailure }
+
         let table = app.tables.element(boundBy: 0)
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
         navigator.nowAt(NewTabScreen)
@@ -248,7 +286,12 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
         }
 
         allSettingsScreens.forEach { nodeName in
+            // Scroll to top before each node so the target cell is reachable
             self.navigator.goto(SettingsScreen)
+            scrollToTop(table)
+            if let cellId = Self.settingsCellId[nodeName] {
+                scrollCellIntoView(table.cells[cellId], in: table)
+            }
             self.navigator.goto(nodeName)
             if nodeName == "DisplaySettings" {
                 snapshot("Settings-\(nodeName)")
@@ -262,6 +305,18 @@ class L10nSuite1SnapshotTests: L10nBaseSnapshotTests {
                     snapshot("Settings-\(nodeName)-\(i)")
                 }
             }
+        }
+    }
+
+    private func scrollToTop(_ table: XCUIElement) {
+        // Swipe down repeatedly to scroll back to the top of the settings list
+        for _ in 0..<10 {
+            guard table.exists else { return }
+            let firstCell = table.cells.element(boundBy: 0)
+            if firstCell.exists && firstCell.isHittable {
+                return
+            }
+            table.swipeDown()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -376,6 +376,7 @@ extension XCUIElement {
         }
 
         var cellNum: UInt = 0
+        var previousCellNum = UInt.max
         var screenNum = 0
 
         while true {
@@ -386,7 +387,20 @@ extension XCUIElement {
             if cellNum == UInt.min {
                 return
             }
-            firstCell.swipeUp()
+
+            // No-progress guard: if cellNum hasn't advanced, the list can't scroll further
+            if cellNum == previousCellNum {
+                return
+            }
+            previousCellNum = cellNum
+
+            // Swipe on the cell if it's hittable; fall back to swiping the table itself
+            // (cell.swipeUp() throws "visible frame is empty" when the cell is offscreen)
+            if firstCell.isHittable {
+                firstCell.swipeUp()
+            } else {
+                self.swipeUp()
+            }
             screenNum += 1
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5449)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Follow up to https://github.com/mozilla-mobile/firefox-ios/pull/34217, I have a solution without the changes in Mappa Mundi. We still need to scroll to the menu item from the Settings menu before tapping, but the scrolling now relies on L10nScreenshotTests and the FxScreenGraph.

Most (if not all) non-Latin now have complete set of screenshots for the settings menu (about 3 more per locale). The locales includes ab, bg, bo, cs, km, kn, my, ru, te, ur, anp, bn, gu-IN, hi-IN, lo, mr, ne-NP, pa-IN, th.

I have tested locally with anp, bo, cs, gd, lo, my, sat and tg so far and have good results.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

Example screenshots:
`my`: Home Settings
<img width="300" alt="iPhone 17-Settings-HomeSettings-0" src="https://github.com/user-attachments/assets/48d2796b-85b7-4290-80ee-1281ede447f1" /> <img width="300" alt="iPhone 17-Settings-HomeSettings-1" src="https://github.com/user-attachments/assets/b339b1f0-5c19-4041-adf4-d7b689e6ac1e" />
`cs`: Add Custom Search Settings
<img width="300" alt="iPhone 17-Settings-AddCustomSearchSettings-0" src="https://github.com/user-attachments/assets/52e855a9-e1a7-4941-977c-9314734f5568" />



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

