### PR TITLE
Refactor FXIOS-16078 Remove `getTotalTabCount` assert

### DIFF
--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -127,7 +127,6 @@ final class TabErrorTelemetryHelper {
     private func getTotalTabCount(window: WindowUUID) -> Int? {
         guard windowManager.windows.keys.contains(window),
               let tabManager = windowManager.tabManager(for: window) else {
-            assertionFailure("getTabCount() should not be called prior to TabManager config.")
             return nil
         }
         return tabManager.normalTabs.count

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WindowManagerTests.swift
@@ -397,6 +397,20 @@ class WindowManagerTests: XCTestCase {
         XCTAssertNil(tabManager)
     }
 
+    func test_isWindowConfigured_returnsTrueForConfiguredWindow() {
+        let subject = createSubject()
+        let uuid = WindowUUID.XCTestDefaultUUID
+        subject.newBrowserWindowConfigured(AppWindowInfo(tabManager: tabManager), uuid: uuid)
+
+        XCTAssertTrue(subject.windows.keys.contains(uuid))
+    }
+
+    func test_isWindowConfigured_returnsFalseForUnconfiguredWindow() {
+        let subject = createSubject()
+
+        XCTAssertFalse(subject.windows.keys.contains(.unavailable))
+    }
+
     // MARK: - Test Subject
 
     private func createSubject() -> WindowManager {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16078)

## :bulb: Description

Removes localized assert for `getTotalTabCount()`. See also: https://github.com/mozilla-mobile/firefox-ios/pull/34267

@razvanlitianu Per our async discussion I think this is probably fine. I'm reluctant to add a dedicated API for this because I still feel it's not something that we should encourage (it feels like a code smell to have an `isWindowConfigured()`). I'm open to any further changes here however, just LMK if you have other thoughts. Sorry for the back-and-forth on this and thanks for sync'ing. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

