### PR TITLE
Add FXIOS-15945 [SKAN] Add ad-click conversion event

### DIFF
--- a/firefox-ios/Client/Application/ConversionTracking/ConversionEventTracker.swift
+++ b/firefox-ios/Client/Application/ConversionTracking/ConversionEventTracker.swift
@@ -74,7 +74,6 @@ enum ConversionEvent {
     case setAsDefault
     case appOpenDay2Plus
     case uriLoadDay2Plus
-    // TODO: FXIOS-15945 implement this conversion value for SERP ad click
     case firstAdClick
     case thirdActivityFirstWeek
     case activeLastThreeWeek1

--- a/firefox-ios/Client/Telemetry/AdsTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/AdsTelemetryHelper.swift
@@ -146,5 +146,6 @@ final class AdsTelemetryHelper: TabContentScript {
 
     static func trackAdsClickedOnPage(providerName: String) {
         GleanMetrics.BrowserSearch.adClicks["provider-\(providerName)"].add()
+        ConversionEventTracker().record(.firstAdClick)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15945)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Add conversion event for Search engine provider ad click. This event can fire in any of the 3 conversion windows and sets the fine conversion value to 35 and the coarse conversion value to medium.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

