### PR TITLE
Refactor FXIOS-16147 [Places] Move to async places call for bookmarks

### DIFF
--- a/BrowserKit/Sources/Shared/Deferred/Deferred.swift
+++ b/BrowserKit/Sources/Shared/Deferred/Deferred.swift
@@ -138,8 +138,7 @@ open class Deferred<T: Sendable>: @unchecked Sendable {
 
 // FIXME: FXIOS-13242 We want to remove this function for the sake of proper Swift Concurrency
 public func all<T>(_ deferreds: [Deferred<T>]) -> Deferred<[T]> {
-    //swiftlint:disable:next empty_count
-    if deferreds.count == 0 {
+    if deferreds.isEmpty {
         return Deferred(value: [])
     }
 

--- a/BrowserKit/Sources/Shared/Deferred/Deferred.swift
+++ b/BrowserKit/Sources/Shared/Deferred/Deferred.swift
@@ -87,6 +87,24 @@ open class Deferred<T: Sendable>: @unchecked Sendable {
         return result
     }
 
+    /// Blocks the calling thread until the receiver is filled or `timeout` elapses,
+    /// returning the value if it became available in time and `nil` otherwise.
+    ///
+    /// Prefer the non-blocking `upon`/`uponQueue` for accessing a `Deferred`. Use this
+    /// only when a synchronous read is unavoidable and an indefinite block on the calling
+    /// thread (e.g. the main thread, where it can trip the watchdog) must be prevented.
+    public func value(timeout: DispatchTimeInterval) -> T? {
+        // If already filled, return early to prevent delay.
+        if let v = peek() { return v }
+
+        let group = DispatchGroup()
+        group.enter()
+        self.upon { _ in group.leave() }
+        _ = group.wait(timeout: .now() + timeout)
+        // `peek()` reads under the lock, so this is safe even if the timeout races the fill.
+        return peek()
+    }
+
     public func bindQueue<U>(_ queue: DispatchQueue, f: @escaping @Sendable (T) -> Deferred<U>) -> Deferred<U> {
         let d = Deferred<U>()
         self.uponQueue(queue) {
@@ -120,6 +138,7 @@ open class Deferred<T: Sendable>: @unchecked Sendable {
 
 // FIXME: FXIOS-13242 We want to remove this function for the sake of proper Swift Concurrency
 public func all<T>(_ deferreds: [Deferred<T>]) -> Deferred<[T]> {
+    //swiftlint:disable:next empty_count
     if deferreds.count == 0 {
         return Deferred(value: [])
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/ContextMenu/ContextMenuState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/ContextMenu/ContextMenuState.swift
@@ -301,7 +301,11 @@ struct ContextMenuState {
 
     private func getBookmarkAction(site: Site) -> PhotonRowActions {
         let bookmarkAction: SingleActionViewModel
-        let isBookmarked = profile.places.isBookmarked(url: site.url).value.successValue ?? false
+        // The context menu is built synchronously on the main thread, so we cap the bookmark
+        // lookup with a short timeout instead of blocking indefinitely on a contended Places
+        // DB (which could trip the watchdog). On timeout we default to "not bookmarked".
+        let isBookmarked = profile.places.isBookmarked(url: site.url)
+            .value(timeout: .milliseconds(100))?.successValue ?? false
         if isBookmarked {
             bookmarkAction = getRemoveBookmarkAction(site: site)
         } else {

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
@@ -290,8 +290,13 @@ final class TopSitesMiddleware {
     }
 
     private func sendBookmarkOpenTelemetry(with urlString: String) {
-        let isBookmarked = profile.places.isBookmarked(url: urlString).value.successValue ?? false
-        guard isBookmarked else { return }
-        bookmarksTelemetry.openBookmarksSite(eventLabel: .topSites)
+        // Resolve the bookmark lookup off the main thread to avoid blocking it on a contended
+        // Places DB query (this runs on the homepage tap path).
+        profile.places.isBookmarked(url: urlString) { [weak self] result in
+            guard case .success(true) = result else { return }
+            Task { @MainActor in
+                self?.bookmarksTelemetry.openBookmarksSite(eventLabel: .topSites)
+            }
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/DeferredTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/DeferredTests.swift
@@ -76,6 +76,26 @@ class DeferredTests: XCTestCase {
         XCTAssertTrue(deferMaybe("foo").value.isSuccess)
     }
 
+    // MARK: Test `value(timeout:)`
+
+    func testValueWithTimeout_returnsValue_whenAlreadyFilled() {
+        let d = Deferred<Int>(value: 5)
+        XCTAssertEqual(d.value(timeout: .milliseconds(100)), 5)
+    }
+
+    func testValueWithTimeout_returnsValue_whenFilledBeforeTimeout() {
+        let d = Deferred<Int>()
+        DispatchQueue.global().async {
+            d.fill(7)
+        }
+        XCTAssertEqual(d.value(timeout: .seconds(5)), 7)
+    }
+
+    func testValueWithTimeout_returnsNil_whenTimeoutElapses() {
+        let d = Deferred<Int>()
+        XCTAssertNil(d.value(timeout: .milliseconds(50)))
+    }
+
     // MARK: Test `all`
 
     @MainActor // Test explicitly calling `all` on the main thread


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16147)


## :bulb: Description
Address and improve places async issue for bookmarks.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

