### PR TITLE
Refactor FXIOS-16149 [WorldCup] Feature flag gate and stop background poll

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 		3933D4F42EF3358300C0C4E3 /* DefaultBrowserUtilityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3933D4F32EF3357D00C0C4E3 /* DefaultBrowserUtilityTelemetry.swift */; };
 		3943A81D1E9807C700D4F6DC /* FxAPushMessageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */; };
 		39455F771FC83F430088A22C /* TabEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39455F761FC83F430088A22C /* TabEventHandler.swift */; };
+		394614102FEC2928003321D8 /* MockWorldCupFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3946140F2FEC2928003321D8 /* MockWorldCupFeed.swift */; };
 		394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */; };
 		3954D0F12F74288E00CDC338 /* MerinoStoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3954D0F02F74286800CDC338 /* MerinoStoryResponse.swift */; };
 		39673BC12B6D82F400653F4A /* FxNimbusMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39673BC02B6D82F400653F4A /* FxNimbusMessaging.swift */; };
@@ -3482,6 +3483,7 @@
 		3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAPushMessageTest.swift; sourceTree = "<group>"; };
 		39444D13AAEACA4C6EF83703 /* my */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = my; path = my.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		39455F761FC83F430088A22C /* TabEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabEventHandler.swift; sourceTree = "<group>"; };
+		3946140F2FEC2928003321D8 /* MockWorldCupFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWorldCupFeed.swift; sourceTree = "<group>"; };
 		394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultSuggestedSites.swift; sourceTree = "<group>"; };
 		3954D0F02F74286800CDC338 /* MerinoStoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerinoStoryResponse.swift; sourceTree = "<group>"; };
 		3964F5FB2656D2B500065278 /* initial_experiments.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = initial_experiments.json; path = Client/Experiments/initial_experiments.json; sourceTree = SOURCE_ROOT; };
@@ -15699,6 +15701,7 @@
 				8A6CDB462DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift */,
 				8A01FE3F2DF0CE49002C483B /* MockDateProvider.swift */,
 				FF0005AA2F000001000BBBBB /* MockWorldCupStore.swift */,
+				3946140F2FEC2928003321D8 /* MockWorldCupFeed.swift */,
 				8A9F4F042DC8F4ED004644B9 /* MockRemoteTabs.swift */,
 				8A9F4F022DC8F4E6004644B9 /* MockPlaces.swift */,
 				2199A1D32DB8389000DC84BD /* MockZoomStore.swift */,
@@ -20556,6 +20559,7 @@
 				8A09A9E32D77552C0069B005 /* HomepageMiddlewareTests.swift in Sources */,
 				0AB76B562F3F67E3009458EB /* BlockedTrackersFooterViewTests.swift in Sources */,
 				033A5FCC2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift in Sources */,
+				394614102FEC2928003321D8 /* MockWorldCupFeed.swift in Sources */,
 				C2446B312A856D13000C527D /* MockLibraryCoordinatorDelegate.swift in Sources */,
 				C869915728917809007ACC5C /* NetworkingMock.swift in Sources */,
 				ED575BD32D00F9D00056BCDA /* MockTemporaryDocument.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageAction.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageAction.swift
@@ -71,6 +71,7 @@ enum HomepageMiddlewareActionType: ActionType {
     case jumpBackInRemoteTabsUpdated
     case bookmarksUpdated
     case didBecomeActive
+    case didEnterBackground
     case configuredPrivacyNotice
     case configuredSearchBar
     case configuredSpacer

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
@@ -116,6 +116,7 @@ final class HomepageMiddleware: FeatureFlaggable, Notifiable {
     private func observeNotifications() {
         let notifications: [Notification.Name] = [
             UIApplication.didBecomeActiveNotification,
+            UIApplication.didEnterBackgroundNotification,
             .FirefoxAccountChanged,
             .PrivateDataClearedHistory,
             .ProfileDidFinishSyncing,
@@ -149,6 +150,13 @@ final class HomepageMiddleware: FeatureFlaggable, Notifiable {
                         actionType: HomepageMiddlewareActionType.didBecomeActive
                     )
                     store.dispatch(storiesAction)
+
+                case UIApplication.didEnterBackgroundNotification:
+                    let backgroundAction = HomepageAction(
+                        windowUUID: windowUUID,
+                        actionType: HomepageMiddlewareActionType.didEnterBackground
+                    )
+                    store.dispatch(backgroundAction)
 
                 case .PrivateDataClearedHistory,
                         .TopSitesUpdated,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupFeed.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupFeed.swift
@@ -5,6 +5,16 @@
 import Foundation
 import Common
 
+/// The subset of `WorldCupFeed` the middleware drives. Extracted so the
+/// middleware can be unit-tested against a mock feed.
+@MainActor
+protocol WorldCupFeedProtocol: AnyObject {
+    var onUpdate: ((WorldCupFeed.Snapshot) -> Void)? { get set }
+    var latestSnapshot: WorldCupFeed.Snapshot { get }
+    func start()
+    func stop()
+}
+
 /// Owns the World Cup data lifecycle: consumes the `/matches` and `/live`
 /// streams from `WorldCupAPIClientProtocol`, merges live IDs into the
 /// matches view-model, and emits a fresh `Snapshot` to its listener every
@@ -16,7 +26,7 @@ import Common
 /// (see `WorldCupPollingFetchStrategy.shouldPollLive`), so we don't hit
 /// merino outside the tournament window.
 @MainActor
-final class WorldCupFeed {
+final class WorldCupFeed: WorldCupFeedProtocol {
     struct Snapshot: Equatable {
         let matches: [WorldCupMatches]
         let defaultMatchIndex: Int

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
@@ -14,7 +14,7 @@ import Shared
 @MainActor
 final class WorldCupMiddleware {
     private let worldCupStore: WorldCupStoreProtocol
-    private let feed: WorldCupFeed?
+    private let feed: WorldCupFeedProtocol?
     private var lastWindowUUID: WindowUUID?
     /// Wether the homepage is currently displayed on screen
     private var homepageIsOnScreen = false
@@ -25,7 +25,7 @@ final class WorldCupMiddleware {
         self.init(worldCupStore: store, feed: feed)
     }
 
-    init(worldCupStore: WorldCupStoreProtocol, feed: WorldCupFeed?) {
+    init(worldCupStore: WorldCupStoreProtocol, feed: WorldCupFeedProtocol?) {
         self.worldCupStore = worldCupStore
         self.feed = feed
         feed?.onUpdate = { [weak self] snapshot in
@@ -40,6 +40,11 @@ final class WorldCupMiddleware {
              HomepageMiddlewareActionType.didBecomeActive,
              WorldCupActionType.retryMatchesFetch:
             self.startFeed(windowUUID: action.windowUUID)
+        case HomepageMiddlewareActionType.didEnterBackground:
+            // Stop polling when the app is backgrounded so the feed calling
+            // the network (and contending for shared resources) off-screen.
+            // It is restarted on the next `didBecomeActive`.
+            self.feed?.stop()
         case HomepageActionType.viewDidAppear:
             self.homepageIsOnScreen = true
         case HomepageActionType.viewWillDisappear:
@@ -66,6 +71,7 @@ final class WorldCupMiddleware {
             dispatch(snapshot: .empty)
             return
         }
+        guard worldCupStore.isFeatureEnabledAndSectionEnabled else { return }
         feed.start()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
@@ -33,8 +33,9 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
     func test_init_setsUpNotifications() {
         _ = createSubject()
 
-        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 8)
+        XCTAssertEqual(mockNotificationCenter?.addObserverCallCount, 9)
         XCTAssertEqual(mockNotificationCenter?.observers, [UIApplication.didBecomeActiveNotification,
+                                                           UIApplication.didEnterBackgroundNotification,
                                                            .FirefoxAccountChanged,
                                                            .PrivateDataClearedHistory,
                                                            .ProfileDidFinishSyncing,
@@ -64,6 +65,28 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionTypes = actionsCalled.compactMap { $0.actionType as? HomepageMiddlewareActionType }
 
         XCTAssertEqual(actionTypes, [.didBecomeActive])
+        XCTAssertEqual(actionsCalled.map(\.windowUUID), [.XCTestDefaultUUID])
+    }
+
+    func test_didEnterBackgroundNotification_dispatchesBackgroundAction() throws {
+        let mockWindowManager = MockWindowManager(wrappedManager: WindowManagerImplementation())
+        mockWindowManager.overrideWindows = true
+        let subject = createSubject(windowManager: mockWindowManager)
+        mockNotificationCenter.notifiableListener = subject
+        let dispatchExpectation = XCTestExpectation(description: "Homepage background action dispatched")
+
+        mockStore.dispatchCalled = {
+            dispatchExpectation.fulfill()
+        }
+
+        mockNotificationCenter.post(name: UIApplication.didEnterBackgroundNotification)
+
+        wait(for: [dispatchExpectation], timeout: 1)
+
+        let actionsCalled = try XCTUnwrap(mockStore.dispatchedActions as? [HomepageAction])
+        let actionTypes = actionsCalled.compactMap { $0.actionType as? HomepageMiddlewareActionType }
+
+        XCTAssertEqual(actionTypes, [.didEnterBackground])
         XCTAssertEqual(actionsCalled.map(\.windowUUID), [.XCTestDefaultUUID])
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -148,6 +148,39 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.worldCupProvider = { _, _ in }
     }
 
+    // MARK: - HomepageMiddlewareActionType.didEnterBackground
+
+    func test_didEnterBackground_stopsFeed() throws {
+        let feed = MockWorldCupFeed()
+        let subject = WorldCupMiddleware(worldCupStore: mockWorldCupStore, feed: feed)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageMiddlewareActionType.didEnterBackground
+        )
+
+        subject.worldCupProvider(appState, action)
+
+        XCTAssertEqual(feed.stopCalled, 1)
+        XCTAssertEqual(feed.startCalled, 0)
+        XCTAssertTrue(mockStore.dispatchedActions.isEmpty)
+        subject.worldCupProvider = { _, _ in }
+    }
+
+    func test_didBecomeActive_whenMilestone2_startsFeed() throws {
+        mockWorldCupStore.isMilestone2 = true
+        let feed = MockWorldCupFeed()
+        let subject = WorldCupMiddleware(worldCupStore: mockWorldCupStore, feed: feed)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageMiddlewareActionType.didBecomeActive
+        )
+
+        subject.worldCupProvider(appState, action)
+
+        XCTAssertEqual(feed.startCalled, 1)
+        subject.worldCupProvider = { _, _ in }
+    }
+
     // MARK: - WorldCupActionType.selectTeam
 
     func test_selectTeam_persistsTeamAndKicksOffFetch() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupFeed.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupFeed.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import Foundation
+
+@MainActor
+final class MockWorldCupFeed: WorldCupFeedProtocol {
+    var onUpdate: ((WorldCupFeed.Snapshot) -> Void)?
+    var latestSnapshot: WorldCupFeed.Snapshot = .empty
+
+    private(set) var startCalled = 0
+    private(set) var stopCalled = 0
+
+    func start() {
+        startCalled += 1
+    }
+
+    func stop() {
+        stopCalled += 1
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16149)

## :bulb: Description
HomepageMiddleware now observes UIApplication.didEnterBackgroundNotification and dispatches the new didEnterBackground action sot hat WorldCupMiddleware handles didEnterBackground by calling feed?.stop(). Also changed the stored feed from the concrete WorldCupFeed? to a new WorldCupFeedProtocol? so it's mockable for testing.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

