### PR TITLE
Refactor [Summarizer] FXIOS-16148 move summarizer config remote settings to separate task

### DIFF
--- a/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
@@ -179,7 +179,7 @@ final class SummarizerMiddleware: SummarizerConfigFactory {
         let summarizerModel: SummarizerModel =
             summarizerNimbusUtils.isAppleSummarizerEnabled() ? .appleSummarizer : .liteLLMSummarizer
 
-        return summarizerConfigProvider.getConfig(
+        return await summarizerConfigProvider.getConfig(
             summarizerModel: summarizerModel,
             contentType: contentType,
             locale: summarizerLocale

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerConfigProvider.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerConfigProvider.swift
@@ -5,12 +5,12 @@
 import SummarizeKit
 import WebKit
 
-protocol SummarizerConfigProvider {
+protocol SummarizerConfigProvider: Sendable {
     func getConfig(
         summarizerModel: SummarizerModel,
         contentType: SummarizationContentType,
         locale: Locale
-    ) -> SummarizerConfig
+    ) async -> SummarizerConfig
 }
 
 struct DefaultSummarizerConfigProvider: SummarizerConfigProvider {
@@ -36,7 +36,7 @@ struct DefaultSummarizerConfigProvider: SummarizerConfigProvider {
         summarizerModel: SummarizerModel,
         contentType: SummarizationContentType,
         locale: Locale
-    ) -> SummarizerConfig {
+    ) async -> SummarizerConfig {
         let initialConfig = SummarizerConfig(instructions: "", options: [:])
         // Merge configs in reverse order (so higher priority overrides lower)
         // $0.merging(with: $1) means "merge $0 into $1" so the result will prioritize $0's values.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSummarizerConfigProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSummarizerConfigProvider.swift
@@ -6,14 +6,14 @@ import Foundation
 import SummarizeKit
 @testable import Client
 
-final class MockSummarizerConfigProvider: SummarizerConfigProvider {
+final class MockSummarizerConfigProvider: SummarizerConfigProvider, @unchecked Sendable {
     private(set) var getConfigCalledCount = 0
 
     func getConfig(
         summarizerModel: SummarizerModel,
         contentType: SummarizationContentType,
         locale: Locale
-    ) -> SummarizerConfig {
+    ) async -> SummarizerConfig {
         getConfigCalledCount += 1
         return SummarizerConfig.defaultConfig
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Summarizer/SummarizerConfigProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Summarizer/SummarizerConfigProviderTests.swift
@@ -12,7 +12,7 @@ final class SummarizerConfigProviderTests: XCTestCase {
 
     func testReturnsEmptyConfigWhenNoSourcesProvided() async {
         let subject = createSubject(sources: [])
-        let config = subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, locale: locale)
+        let config = await subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, locale: locale)
         XCTAssertEqual(config.instructions, "")
         XCTAssertTrue(config.options.isEmpty)
     }
@@ -30,7 +30,7 @@ final class SummarizerConfigProviderTests: XCTestCase {
         ]
 
         let subject = createSubject(sources: mockSources)
-        let config = subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, locale: locale)
+        let config = await subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, locale: locale)
         XCTAssertEqual(config.instructions, "")
         XCTAssertTrue(config.options.isEmpty)
     }
@@ -48,7 +48,7 @@ final class SummarizerConfigProviderTests: XCTestCase {
         ]
 
         let subject = createSubject(sources: mockSources)
-        let config = subject.getConfig(summarizerModel: .liteLLMSummarizer, contentType: .recipe, locale: locale)
+        let config = await subject.getConfig(summarizerModel: .liteLLMSummarizer, contentType: .recipe, locale: locale)
         XCTAssertEqual(config.instructions, "Instructions")
         XCTAssertTrue(config.options.isEmpty)
     }
@@ -70,7 +70,7 @@ final class SummarizerConfigProviderTests: XCTestCase {
         ]
 
         let subject = createSubject(sources: mockSources)
-        let config = subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, locale: locale)
+        let config = await subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, locale: locale)
 
         // Highest priority instructions
         XCTAssertEqual(config.instructions, "Instructions 1")
@@ -95,7 +95,7 @@ final class SummarizerConfigProviderTests: XCTestCase {
         ]
 
         let subject = createSubject(sources: mockSources)
-        let config = subject.getConfig(summarizerModel: .liteLLMSummarizer, contentType: .recipe, locale: locale)
+        let config = await subject.getConfig(summarizerModel: .liteLLMSummarizer, contentType: .recipe, locale: locale)
 
         XCTAssertEqual(config.instructions, "Instructions 2")
         XCTAssertEqual(config.options["topP"] as? Int, 2)
@@ -104,7 +104,7 @@ final class SummarizerConfigProviderTests: XCTestCase {
         XCTAssertEqual(config.options["model"] as? String, "foo")
     }
 
-    func testAppliesLocaleToInstructions() {
+    func testAppliesLocaleToInstructions() async {
         let mockSources = [
             MockSummarizerConfigSource(configToReturn: SummarizerConfig(
                 instructions: "Instructions with **{lang}**",
@@ -114,7 +114,7 @@ final class SummarizerConfigProviderTests: XCTestCase {
         let enLocale = Locale(identifier: "en")
 
         let subject = createSubject(sources: mockSources)
-        let config = subject.getConfig(
+        let config = await subject.getConfig(
             summarizerModel: .appleSummarizer,
             contentType: .recipe,
             locale: locale


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16148)

## :bulb: Description
Move Remote settings summarizer config fetch to a separate task so we can unblock the calling thread.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

