### PR TITLE
Add NO_TICKET Add SharedTests. Add UDeviceDetailsTests.

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2224,6 +2224,7 @@
 		ED28DAC92C45A95F00D2641C /* TabScrollBehaviorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED28DAC82C45A95F00D2641C /* TabScrollBehaviorModel.swift */; };
 		ED33E3572D0A4CE9002265A7 /* URLActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED33E3562D0A4CE9002265A7 /* URLActivityItemProviderTests.swift */; };
 		ED371A682CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */; };
+		ED3908E73000061F00342639 /* UIDeviceDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3908E63000061F00342639 /* UIDeviceDetailsTests.swift */; };
 		ED390D202CF4DE2E00A775F9 /* URLActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED390D1F2CF4DE2E00A775F9 /* URLActivityItemProvider.swift */; };
 		ED390D222CF4DEDB00A775F9 /* TitleSubtitleActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED390D212CF4DEDB00A775F9 /* TitleSubtitleActivityItemProvider.swift */; };
 		ED4294852CF1286E0077D7CB /* ShareManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4294842CF1286E0077D7CB /* ShareManagerTests.swift */; };
@@ -11739,6 +11740,7 @@
 		ED33E3562D0A4CE9002265A7 /* URLActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		ED364EECB95B96AB639A82DE /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/Localizable.strings; sourceTree = "<group>"; };
 		ED371A672CB881EF0099F3C8 /* SearchEngineSelectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionCoordinator.swift; sourceTree = "<group>"; };
+		ED3908E63000061F00342639 /* UIDeviceDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceDetailsTests.swift; sourceTree = "<group>"; };
 		ED390D1F2CF4DE2E00A775F9 /* URLActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLActivityItemProvider.swift; sourceTree = "<group>"; };
 		ED390D212CF4DEDB00A775F9 /* TitleSubtitleActivityItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleSubtitleActivityItemProvider.swift; sourceTree = "<group>"; };
 		ED4294842CF1286E0077D7CB /* ShareManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareManagerTests.swift; sourceTree = "<group>"; };
@@ -16938,6 +16940,7 @@
 				E4E25CCA1CA99E7400D0F088 /* HexExtensionsTests.swift */,
 				E6F9653B1B2F1D5D0034B023 /* NSURLExtensionsTests.swift */,
 				2FEBABAE1AB3659000DB5728 /* ResultTests.swift */,
+				ED3908E63000061F00342639 /* UIDeviceDetailsTests.swift */,
 				E6F9650E1B2F1CF20034B023 /* Supporting Files */,
 				E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */,
 				28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */,
@@ -19393,6 +19396,7 @@
 				8A456B6D2DC4FD8300056533 /* MockThemeManager.swift in Sources */,
 				8A456B6B2DC4F91000056533 /* ThemeableTests.swift in Sources */,
 				28532BE91C471FFB000072D9 /* ResultTests.swift in Sources */,
+				ED3908E73000061F00342639 /* UIDeviceDetailsTests.swift in Sources */,
 				E6F9653C1B2F1D5D0034B023 /* NSURLExtensionsTests.swift in Sources */,
 				5A29212A295CAA1700242235 /* XCTestCaseRootViewController.swift in Sources */,
 				0BA152502CE78DAD0090B869 /* UserAgentBuilderTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UIDeviceDetailsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UIDeviceDetailsTests.swift
@@ -5,6 +5,9 @@
 import XCTest
 @testable import Shared
 
+/// These tests attempt to call the `UIDeviceDetails` helper from multiple different threading contexts. The purpose is to
+/// ensure that calling this helper can't result in a deadlock or hang.
+/// See FXIOS-16307 for more context on app hangs that called into `UIDeviceDetails` code from our uniFFI rust layer.
 final class UIDeviceDetailsTests: XCTestCase {
     static func getSystemInfo() -> String {
         let device = UIDeviceDetails.model
@@ -12,7 +15,8 @@ final class UIDeviceDetailsTests: XCTestCase {
         return "(\(device); \(system) OS 18_7 like Mac OS X)"
     }
 
-    // MARK: Test calling a function that uses UIDeviceDetails from the main thread
+    // MARK: The following tests check if calling UIDeviceDetails from multiple threading contexts causes any problems.
+
     func testUIDeviceDetails_onMainThreadGCDAsync_callsUIDeviceDetails_getMainThreadDataSynchronously() {
         let exp = expectation(description: "Main thread work completed")
 

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UIDeviceDetailsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UIDeviceDetailsTests.swift
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Shared
+
+final class UIDeviceDetailsTests: XCTestCase {
+    static func getSystemInfo() -> String {
+        let device = UIDeviceDetails.model
+        let system = device == "iPad" ? "CPU" : "CPU iPhone"
+        return "(\(device); \(system) OS 18_7 like Mac OS X)"
+    }
+
+    // MARK: Test calling a function that uses UIDeviceDetails from the main thread
+    func testUIDeviceDetails_onMainThreadGCDAsync_callsUIDeviceDetails_getMainThreadDataSynchronously() {
+        let exp = expectation(description: "Main thread work completed")
+
+        // Test dispatch to main thread with GCD
+        DispatchQueue.main.async {
+            _ = Self.getSystemInfo()
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 3)
+    }
+
+    func testUIDeviceDetails_onMainThreadSyncGCD_callsUIDeviceDetails_getMainThreadDataSynchronously() {
+        let exp = expectation(description: "Main thread work completed")
+
+        // This test may run on the MT. It is an error to dispatch .sync when already on the MT.
+        // So offload this to a background thread first.
+        DispatchQueue.global().async {
+            // Test dispatch to main thread with GCD
+            DispatchQueue.main.sync {
+                _ = Self.getSystemInfo()
+                exp.fulfill()
+            }
+        }
+
+        wait(for: [exp], timeout: 3)
+    }
+
+    @MainActor
+    func testUIDeviceDetails_onMainActor_callsUIDeviceDetails_getMainThreadDataSynchronously() {
+        let exp = expectation(description: "Main thread work completed")
+
+        // Test dispatch to main thread with GCD
+        DispatchQueue.main.async {
+            _ = Self.getSystemInfo()
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 3)
+    }
+
+    func testUIDeviceDetails_onMainThreadTask_callsUIDeviceDetails_getMainThreadDataSynchronously() {
+        let exp = expectation(description: "Main thread work completed")
+
+        // Test dispatch to main thread with GCD
+        Task { @MainActor in
+            _ = Self.getSystemInfo()
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 3)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
No ticket.

## :bulb: Description
Investigating into a hang, added some unit tests around the UIDeviceDetails which uses a .sync call on the MT _only if_ the thread is not already the MT. This was a Swift 6 migration / strict concurrency workaround for the UIDevice main-actor isolated class.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

