### PR TITLE
Refator FXIOS-161446 [GCDWebServer] Move GCDWebServer lifecycle off main thread

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -464,6 +464,7 @@
 		367C100A7ABD4B4585D029D5 /* AutoTranslatePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137DDFADC6034016BE36E02B /* AutoTranslatePromptView.swift */; };
 		39012F281F8ED262002E3D31 /* ScreenGraphTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39012F271F8ED262002E3D31 /* ScreenGraphTest.swift */; };
 		391B4FFF1F9767F50094F841 /* FxScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */; };
+		39230FDC2FEC53BA00AD5FAB /* WebServerLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39230FDB2FEC53BA00AD5FAB /* WebServerLifecycleTests.swift */; };
 		39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */; };
 		392D791A2F8FCE1A00B10BDC /* FeatureFlagID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392D79192F8FCE0E00B10BDC /* FeatureFlagID.swift */; };
 		392D80542F901D2600B10BDC /* UserFeaturePreferenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392D80532F901D1500B10BDC /* UserFeaturePreferenceManager.swift */; };
@@ -473,6 +474,9 @@
 		3943A81D1E9807C700D4F6DC /* FxAPushMessageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */; };
 		39455F771FC83F430088A22C /* TabEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39455F761FC83F430088A22C /* TabEventHandler.swift */; };
 		394614102FEC2928003321D8 /* MockWorldCupFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3946140F2FEC2928003321D8 /* MockWorldCupFeed.swift */; };
+		394615602FEC37E3003321D8 /* WebServerUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3946155F2FEC37E1003321D8 /* WebServerUtilTests.swift */; };
+		394615622FEC37FC003321D8 /* MockWebServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394615612FEC37FA003321D8 /* MockWebServer.swift */; };
+		394615642FEC381D003321D8 /* MockReaderModeHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394615632FEC381A003321D8 /* MockReaderModeHandlers.swift */; };
 		394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */; };
 		3954D0F12F74288E00CDC338 /* MerinoStoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3954D0F02F74286800CDC338 /* MerinoStoryResponse.swift */; };
 		39673BC12B6D82F400653F4A /* FxNimbusMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39673BC02B6D82F400653F4A /* FxNimbusMessaging.swift */; };
@@ -3473,6 +3477,7 @@
 		3905274B1C874D35007E0BB7 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
 		3905B4D41E8E7A6B0027D953 /* FxAPushMessageHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAPushMessageHandler.swift; sourceTree = "<group>"; };
 		39104C4F9A5CFDE66911D82B /* hy-AM */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hy-AM"; path = "hy-AM.lproj/Search.strings"; sourceTree = "<group>"; };
+		39230FDB2FEC53BA00AD5FAB /* WebServerLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServerLifecycleTests.swift; sourceTree = "<group>"; };
 		39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabEventHandlerTests.swift; sourceTree = "<group>"; };
 		392D79192F8FCE0E00B10BDC /* FeatureFlagID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagID.swift; sourceTree = "<group>"; };
 		392D80532F901D1500B10BDC /* UserFeaturePreferenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeaturePreferenceManager.swift; sourceTree = "<group>"; };
@@ -3484,6 +3489,9 @@
 		39444D13AAEACA4C6EF83703 /* my */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = my; path = my.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		39455F761FC83F430088A22C /* TabEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabEventHandler.swift; sourceTree = "<group>"; };
 		3946140F2FEC2928003321D8 /* MockWorldCupFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWorldCupFeed.swift; sourceTree = "<group>"; };
+		3946155F2FEC37E1003321D8 /* WebServerUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServerUtilTests.swift; sourceTree = "<group>"; };
+		394615612FEC37FA003321D8 /* MockWebServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebServer.swift; sourceTree = "<group>"; };
+		394615632FEC381A003321D8 /* MockReaderModeHandlers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockReaderModeHandlers.swift; sourceTree = "<group>"; };
 		394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultSuggestedSites.swift; sourceTree = "<group>"; };
 		3954D0F02F74286800CDC338 /* MerinoStoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerinoStoryResponse.swift; sourceTree = "<group>"; };
 		3964F5FB2656D2B500065278 /* initial_experiments.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = initial_experiments.json; path = Client/Experiments/initial_experiments.json; sourceTree = SOURCE_ROOT; };
@@ -15767,6 +15775,8 @@
 				C283EED32E4E0F25008EB540 /* MockSummarizerConfigSource.swift */,
 				C27484DD2F558BD000920313 /* MockSummarizerNimbusUtils.swift */,
 				C27484DF2F558C2800920313 /* MockSummarizerLanguageProvider.swift */,
+				394615632FEC381A003321D8 /* MockReaderModeHandlers.swift */,
+				394615612FEC37FA003321D8 /* MockWebServer.swift */,
 				C27484E12F558DDD00920313 /* MockSummarizerConfigProvider.swift */,
 				C27484E32F55C4B600920313 /* MockSummarizerConfigFactory.swift */,
 			);
@@ -17172,6 +17182,8 @@
 				8A1E3BE028CBAC1F003388C4 /* Utils */,
 				C84655ED28873C4800861B4A /* Wallpaper */,
 				E4CD9F1C1A6D9C2800318571 /* WebServerTests.swift */,
+				3946155F2FEC37E1003321D8 /* WebServerUtilTests.swift */,
+				39230FDB2FEC53BA00AD5FAB /* WebServerLifecycleTests.swift */,
 				8A0727472B4898750071BB9F /* WebviewTelemetryTests.swift */,
 				1D74FF4D2B27962200FF01D0 /* WindowManagerTests.swift */,
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
@@ -20350,6 +20362,7 @@
 			files = (
 				2151EF572F2AB94A007B67A6 /* BrowserViewControllerConstraintTests.swift in Sources */,
 				8C50DD752F56E1D00020E5C4 /* PreferredTranslationLanguagesManagerTests.swift in Sources */,
+				394615622FEC37FC003321D8 /* MockWebServer.swift in Sources */,
 				E4CD9F1D1A6D9C2800318571 /* WebServerTests.swift in Sources */,
 				961577942A39008100391E8D /* SponsoredTileDataUtilityTests.swift in Sources */,
 				1D2A1B592F3BAB5200157ACB /* RelayMaskSettingsViewControllerTests.swift in Sources */,
@@ -20525,6 +20538,7 @@
 				ED6D46E02D3573F80045E4ED /* TitleActivityItemProviderTests.swift in Sources */,
 				C8501F5128510DA1003B09AB /* WallpaperMigrationUtilityTests.swift in Sources */,
 				39E186E22F7DAA7F00FD3FFA /* MerinoCategoryConfigurationTests.swift in Sources */,
+				394615642FEC381D003321D8 /* MockReaderModeHandlers.swift in Sources */,
 				39E186E32F7DAA7F00FD3FFA /* MerinoCategoryTests.swift in Sources */,
 				E1442FDA294782F7003680B0 /* UIPasteboard+Extension.swift in Sources */,
 				CB5541872F51E1B100256DA1 /* CertificateHelperTests.swift in Sources */,
@@ -20571,6 +20585,7 @@
 				F00CA4022F00000000000009 /* WorldCupAPIClientTests.swift in Sources */,
 				C2886BB22EC4AB58007AE6C3 /* TinyRouterTests.swift in Sources */,
 				8A4190D22A6B0848001E8401 /* StatusBarOverlayTests.swift in Sources */,
+				394615602FEC37E3003321D8 /* WebServerUtilTests.swift in Sources */,
 				C2500D7C2ECB4A600071506F /* MockTranslationModelsFetcher.swift in Sources */,
 				8AD8FF172EBB022A00FDFD78 /* MockGleanPlumbMessageManagerProtocol.swift in Sources */,
 				C8EDDBF029DD83FC003A4C07 /* RouteTests.swift in Sources */,
@@ -20874,6 +20889,7 @@
 				8AA0A6682CAC747500AC7EB3 /* HomepageDiffableDataSourceTests.swift in Sources */,
 				C8E1BC0A28085AA700C62964 /* NimbusFeatureFlagLayerTests.swift in Sources */,
 				213046B92F202F27007ECEDA /* UIFontExtensionsTests.swift in Sources */,
+				39230FDC2FEC53BA00AD5FAB /* WebServerLifecycleTests.swift in Sources */,
 				032CE5F62EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift in Sources */,
 				AAB5AF382EDDCF600051EF6E /* MockLocaleProvider.swift in Sources */,
 				F80D53CF2A09A3350047ED14 /* RustSyncManagerTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b169e7338b86b61952dc9bbb31c6069f8c5059c3efa9fdacd774945ef995fe35",
+  "originHash" : "86bd697a1a392b72e648b2bd9af514fbcaac7c4077351b276556d0690e757411",
   "pins" : [
     {
       "identity" : "a-star",

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -54,6 +54,8 @@ class AppDelegate: UIResponder,
     private var suggestBackgroundUtility: BackgroundFirefoxSuggestIngestUtility?
     private var suggestBackgroundTaskID: UIBackgroundTaskIdentifier = .invalid
     private static let suggestBackgroundTaskName = "SuggestIngest"
+    private var webServerShutdownTaskID: UIBackgroundTaskIdentifier = .invalid
+    private static let webServerShutdownTaskName = "WebServerShutdown"
     private var widgetManager: TopSitesWidgetManager?
     private var menuBuilderHelper: MenuBuilderHelper?
     private lazy var metricKitWrapper = MetricKitWrapper()
@@ -223,15 +225,32 @@ class AppDelegate: UIResponder,
         // 2 seconds is ample for a localhost request to be completed by GCDWebServer.
         // <500ms is expected on newer devices.
         singleShotTimer.schedule(deadline: .now() + 2.0, repeating: .never)
-        singleShotTimer.setEventHandler {
-            WebServer.sharedInstance.server.stop()
+        singleShotTimer.setEventHandler { [weak self] in
+            guard let self else { return }
             self.shutdownWebServer = nil
+            // Stop the server off the main thread so a slow shutdown can't trip the watchdog.
+            // Hold a background task so iOS lets the stop finish while we're backgrounded, and
+            // end it both when the stop completes and if the OS deadline expires first.
+            self.webServerShutdownTaskID = application.beginBackgroundTask(
+                withName: Self.webServerShutdownTaskName) { [weak self] in
+                self?.endWebServerShutdownTask()
+            }
+            WebServer.sharedInstance.stop { [weak self] in
+                Task { @MainActor in self?.endWebServerShutdownTask() }
+            }
         }
         singleShotTimer.resume()
         shutdownWebServer = singleShotTimer
         backgroundWorkUtility?.scheduleOnAppBackground()
 
         logger.log("applicationDidEnterBackground end", level: .info, category: .lifecycle)
+    }
+
+    @MainActor
+    private func endWebServerShutdownTask() {
+        guard webServerShutdownTaskID != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(webServerShutdownTaskID)
+        webServerShutdownTaskID = .invalid
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -231,6 +231,9 @@ class AppDelegate: UIResponder,
             // Stop the server off the main thread so a slow shutdown can't trip the watchdog.
             // Hold a background task so iOS lets the stop finish while we're backgrounded, and
             // end it both when the stop completes and if the OS deadline expires first.
+            // End any task still outstanding from a previous, slow shutdown so we don't clobber
+            // and leak its identifier.
+            self.endWebServerShutdownTask()
             self.webServerShutdownTaskID = application.beginBackgroundTask(
                 withName: Self.webServerShutdownTaskName) { [weak self] in
                 self?.endWebServerShutdownTask()

--- a/firefox-ios/Client/Application/WebServer.swift
+++ b/firefox-ios/Client/Application/WebServer.swift
@@ -11,6 +11,11 @@ protocol WebServerProtocol {
     var server: GCDWebServer { get }
     @discardableResult
     func start() throws -> Bool
+    /// Starts the server on the serial lifecycle queue if it isn't already running.
+    func startIfNeeded()
+    /// Stops the server on the serial lifecycle queue, off the main thread. `completion`,
+    /// if provided, runs on the main queue once the server has stopped.
+    func stop(completion: (@Sendable () -> Void)?)
 }
 
 /// FIXME: FXIOS-13989 Make truly thread safe
@@ -34,6 +39,12 @@ final class WebServer: WebServerProtocol, @unchecked Sendable {
     /// so this prevents them from accessing any resources.
     fileprivate let sessionToken = UUID().uuidString
 
+    /// Serializes all GCDWebServer start/stop calls. GCDWebServer is not thread-safe,
+    /// so funneling lifecycle operations through one serial queue (off the main thread)
+    /// guarantees a start and a stop can never run concurrently, which would otherwise
+    /// race during a background-to-foreground transition.
+    private let lifecycleQueue = DispatchQueue(label: "org.mozilla.ios.WebServer.lifecycle")
+
     init(logger: Logger = DefaultLogger.shared) {
         credentials = URLCredential(user: sessionToken, password: "", persistence: .forSession)
         self.logger = logger
@@ -51,6 +62,27 @@ final class WebServer: WebServerProtocol, @unchecked Sendable {
             ])
         }
         return server.isRunning
+    }
+
+    func startIfNeeded() {
+        lifecycleQueue.async { [weak self] in
+            guard let self, !self.server.isRunning else { return }
+            do {
+                try self.start()
+            } catch {
+                self.logger.log("Failed to start web server: \(error)",
+                                level: .warning,
+                                category: .webview)
+            }
+        }
+    }
+
+    func stop(completion: (@Sendable () -> Void)? = nil) {
+        lifecycleQueue.async { [server] in
+            server.stop()
+            guard let completion else { return }
+            DispatchQueue.main.async(execute: completion)
+        }
     }
 
     /// Convenience method to register a dynamic handler. Will be mounted at $base/$module/$resource

--- a/firefox-ios/Client/Application/WebServerUtil.swift
+++ b/firefox-ios/Client/Application/WebServerUtil.swift
@@ -12,8 +12,13 @@ final class WebServerUtil {
     private let webServer: WebServerProtocol
     private let profile: Profile
 
+    /// Handlers persist on the GCDWebServer instance across stop/start, so they only
+    /// need to be registered once. Re-registering on every foreground would risk
+    /// touching the server concurrently with a backgrounded shutdown.
+    private var hasRegisteredHandlers = false
+
     init(readerModeHandler: some ReaderModeHandlersProtocol,
-         webServer: WebServer = WebServer.sharedInstance,
+         webServer: WebServerProtocol = WebServer.sharedInstance,
          profile: Profile) {
         self.readerModeHander = readerModeHandler
         self.webServer = webServer
@@ -22,13 +27,20 @@ final class WebServerUtil {
 
     @MainActor
     func setUpWebServer() {
-        guard !webServer.server.isRunning else { return }
+        registerHandlersIfNeeded()
+        webServer.startIfNeeded()
+    }
+
+    @MainActor
+    private func registerHandlersIfNeeded() {
+        guard !hasRegisteredHandlers else { return }
 
         readerModeHander.register(webServer, profile: profile)
-        let responders: [(String, InternalSchemeResponse)] =
-             [(AboutHomeHandler.path, AboutHomeHandler()),
-              (AboutLicenseHandler.path, AboutLicenseHandler()),
-              (ErrorPageHandler.path, ErrorPageHandler())]
+        let responders: [(String, InternalSchemeResponse)] = [
+            (AboutHomeHandler.path, AboutHomeHandler()),
+            (AboutLicenseHandler.path, AboutLicenseHandler()),
+            (ErrorPageHandler.path, ErrorPageHandler())
+        ]
         responders.forEach { (path, responder) in
             InternalSchemeHandler.responders[path] = responder
         }
@@ -37,13 +49,7 @@ final class WebServerUtil {
             registerHandlersForTestMethods(server: webServer.server)
         }
 
-        // Bug 1223009 was an issue whereby CGDWebserver crashed when moving to a background task
-        // catching and handling the error seemed to fix things, but we're not sure why.
-        // Either way, not implicitly unwrapping a try is not a great way of doing things
-        // so this is better anyway.
-        do {
-            try webServer.start()
-        } catch {}
+        hasRegisteredHandlers = true
     }
 
     private func registerHandlersForTestMethods(server: GCDWebServer) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockReaderModeHandlers.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockReaderModeHandlers.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+@MainActor
+final class MockReaderModeHandlers: ReaderModeHandlersProtocol {
+    private(set) var registerCalled = 0
+
+    func register(_ webServer: WebServerProtocol, profile: Profile) {
+        registerCalled += 1
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWebServer.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWebServer.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import GCDWebServers
+@testable import Client
+
+final class MockWebServer: WebServerProtocol, @unchecked Sendable {
+    let server = GCDWebServer()
+
+    private(set) var startCalled = 0
+    private(set) var startIfNeededCalled = 0
+    private(set) var stopCalled = 0
+
+    @discardableResult
+    func start() throws -> Bool {
+        startCalled += 1
+        return true
+    }
+
+    func startIfNeeded() {
+        startIfNeededCalled += 1
+    }
+
+    func stop(completion: (@Sendable () -> Void)?) {
+        stopCalled += 1
+        completion?()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebServerLifecycleTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebServerLifecycleTests.swift
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class WebServerLifecycleTests: XCTestCase {
+    /// `stop` does its blocking work off the main thread but must hand control back on the
+    /// main thread, since callers (AppDelegate) end a `UIBackgroundTask`/touch UIKit there.
+    func test_stop_invokesCompletionOnTheMainThread() {
+        let subject = WebServer()
+        let completionRun = expectation(description: "stop completion runs")
+
+        subject.stop {
+            XCTAssertTrue(Thread.isMainThread)
+            completionRun.fulfill()
+        }
+
+        wait(for: [completionRun], timeout: 5)
+    }
+
+    /// Stopping a server that was never started is a no-op and must not crash.
+    func test_stop_withoutCompletion_doesNotCrash() {
+        let subject = WebServer()
+        subject.stop(completion: nil)
+
+        // Enqueue a second stop with a completion: because the lifecycle queue is serial,
+        // this only runs once the first stop has finished, proving it completed cleanly.
+        let drained = expectation(description: "lifecycle queue drains")
+        subject.stop { drained.fulfill() }
+        wait(for: [drained], timeout: 5)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebServerUtilTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebServerUtilTests.swift
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+@MainActor
+final class WebServerUtilTests: XCTestCase {
+    private var mockReaderMode: MockReaderModeHandlers!
+    private var mockWebServer: MockWebServer!
+    private var profile: MockProfile!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockReaderMode = MockReaderModeHandlers()
+        mockWebServer = MockWebServer()
+        profile = MockProfile()
+    }
+
+    override func tearDown() async throws {
+        mockReaderMode = nil
+        mockWebServer = nil
+        profile = nil
+        try await super.tearDown()
+    }
+
+    func test_setUpWebServer_startsTheServer() {
+        let subject = createSubject()
+
+        subject.setUpWebServer()
+
+        XCTAssertEqual(mockWebServer.startIfNeededCalled, 1)
+        XCTAssertEqual(mockReaderMode.registerCalled, 1)
+    }
+
+    func test_setUpWebServer_registersHandlersOnce_butStartsEachTime() {
+        let subject = createSubject()
+
+        subject.setUpWebServer()
+        subject.setUpWebServer()
+        subject.setUpWebServer()
+
+        // Handlers persist on the server across stop/start, so they're only registered once,
+        // but the server is (re)started on every foreground.
+        XCTAssertEqual(mockReaderMode.registerCalled, 1)
+        XCTAssertEqual(mockWebServer.startIfNeededCalled, 3)
+    }
+
+    private func createSubject() -> WebServerUtil {
+        return WebServerUtil(
+            readerModeHandler: mockReaderMode,
+            webServer: mockWebServer,
+            profile: profile
+        )
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16146)

## :bulb: Description
One of the causes  of the watchdog killing the app on hang is GCDWebServer.stop(), which runs on the main thread during the background transition and blocks while it waits for in-flight localhost requests to drain. This PR moves the server's start/stop onto a dedicated serial queue so the blocking shutdown no longer runs on the main thread. The queue also serializes the two operations, because GCDWebServer isn't thread-safe and a backgrounded stop could otherwise race a foreground start. The background shutdown is wrapped in a UIBackgroundTask so iOS lets it finish, and handler registration now happens once (handlers persisting across stop/start cycles) so it can't overlap a shutdown either.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

