### PR TITLE
Refactor [Native Error Page] FXIOS-16001 ErrorType

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -130,46 +130,21 @@ class NativeErrorPageHelper {
     // MARK: - Instance Methods
 
     func parseErrorDetails() -> ErrorPageModel {
-        let model: ErrorPageModel = if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
+        if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
             switch error.code {
             case Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue):
-                ErrorPageModel(
-                    errorTitle: .NativeErrorPage.NoInternetConnection.TitleLabel,
-                    errorDescription: .NativeErrorPage.NoInternetConnection.Description,
-                    foxImageName: ImageIdentifiers.NativeErrorPage.noInternetConnection,
-                    url: nil,
-                    advancedSection: nil,
-                    showGoBackButton: false,
-                    type: .internetConnection
-                )
+                return .internetConnection
             case NSURLErrorServerCertificateUntrusted,
                  NSURLErrorServerCertificateHasBadDate,
                  NSURLErrorServerCertificateHasUnknownRoot,
                  NSURLErrorServerCertificateNotYetValid:
-                Self.buildCertificateErrorModel(for: error, url: url)
+                return Self.buildCertificateErrorModel(for: error, url: url)
             default:
-                ErrorPageModel(
-                    errorTitle: .NativeErrorPage.GenericError.TitleLabel,
-                    errorDescription: .NativeErrorPage.GenericError.Description,
-                    foxImageName: ImageIdentifiers.NativeErrorPage.securityError,
-                    url: url,
-                    advancedSection: nil,
-                    showGoBackButton: false,
-                    type: .generic
-                )
+                return .generic(GenericErrorModel(url: url))
             }
         } else {
-            ErrorPageModel(
-                errorTitle: .NativeErrorPage.NoInternetConnection.TitleLabel,
-                errorDescription: .NativeErrorPage.NoInternetConnection.Description,
-                foxImageName: ImageIdentifiers.NativeErrorPage.noInternetConnection,
-                url: nil,
-                advancedSection: nil,
-                showGoBackButton: false,
-                type: .internetConnection
-            )
+            return .internetConnection
         }
-        return model
     }
 
     /// Parses certificate details from the stored error.
@@ -225,15 +200,7 @@ class NativeErrorPageHelper {
         url: URL
     ) -> ErrorPageModel {
         guard error.domain == NSURLErrorDomain else {
-            return ErrorPageModel(
-                errorTitle: .NativeErrorPage.GenericError.TitleLabel,
-                errorDescription: .NativeErrorPage.GenericError.Description,
-                foxImageName: ImageIdentifiers.NativeErrorPage.securityError,
-                url: url,
-                advancedSection: nil,
-                showGoBackButton: false,
-                type: .generic
-            )
+            return .generic(GenericErrorModel(url: url))
         }
 
         // TODO: FXIOS-14569 — Investigate using SecTrustEvaluateWithError to evaluate TLS trust
@@ -260,25 +227,12 @@ class NativeErrorPageHelper {
                 showProceedButton: true
             )
 
-            return ErrorPageModel(
-                errorTitle: String.NativeErrorPage.BadCertDomain.TitleLabel,
-                errorDescription: String.NativeErrorPage.BadCertDomain.Description,
-                foxImageName: ImageIdentifiers.NativeErrorPage.securityError,
+            return .badCertDomain(BadCertDomainModel(
                 url: url,
-                advancedSection: advancedSection,
-                showGoBackButton: true,
-                type: .badCertDomain
-            )
+                advancedSection: advancedSection
+            ))
         } else {
-            return ErrorPageModel(
-                errorTitle: .NativeErrorPage.GenericError.TitleLabel,
-                errorDescription: .NativeErrorPage.GenericError.Description,
-                foxImageName: ImageIdentifiers.NativeErrorPage.securityError,
-                url: url,
-                advancedSection: nil,
-                showGoBackButton: false,
-                type: .generic
-            )
+            return .generic(GenericErrorModel(url: url))
         }
     }
 }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
@@ -3,11 +3,56 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Shared
 
 enum ErrorPageType: Equatable {
     case internetConnection
     case badCertDomain
     case generic
+}
+
+enum ErrorPageModel: Equatable {
+    case internetConnection
+    case badCertDomain(BadCertDomainModel)
+    case generic(GenericErrorModel)
+
+    var title: String {
+        switch self {
+        case .internetConnection: return .NativeErrorPage.NoInternetConnection.TitleLabel
+        case .badCertDomain: return String.NativeErrorPage.BadCertDomain.TitleLabel
+        case .generic: return .NativeErrorPage.GenericError.TitleLabel
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .internetConnection: return .NativeErrorPage.NoInternetConnection.Description
+        case .badCertDomain: return String.NativeErrorPage.BadCertDomain.Description
+        case .generic: return .NativeErrorPage.GenericError.Description
+        }
+    }
+
+    var foxImageName: String {
+        switch self {
+        case .internetConnection: return ImageIdentifiers.NativeErrorPage.noInternetConnection
+        case .badCertDomain, .generic: return ImageIdentifiers.NativeErrorPage.securityError
+        }
+    }
+
+    var url: URL? {
+        switch self {
+        case .internetConnection: return nil
+        case .badCertDomain(let model): return model.url
+        case .generic(let model): return model.url
+        }
+    }
+
+    var advancedSection: AdvancedSectionConfig? {
+        switch self {
+        case .badCertDomain(let model): return model.advancedSection
+        default: return nil
+        }
+    }
 
     var isRegularUI: Bool {
         switch self {
@@ -15,19 +60,14 @@ enum ErrorPageType: Equatable {
         case .badCertDomain: return false
         }
     }
-}
 
-struct ErrorPageModel: Equatable {
-    let errorTitle: String
-    let errorDescription: String
-    let foxImageName: String
-    let url: URL?
-    let advancedSection: AdvancedSectionConfig?
-    let showGoBackButton: Bool
-    // TODO - FXIOS-16001 - Refactoring the error page model 
-    // so that the error page type determines the model structure 
-    // rather than storing type within the error page model itself.
-    let type: ErrorPageType
+    var type: ErrorPageType {
+        switch self {
+        case .internetConnection: return .internetConnection
+        case .badCertDomain: return .badCertDomain
+        case .generic: return .generic
+        }
+    }
 
     struct AdvancedSectionConfig: Equatable {
         let buttonText: String
@@ -36,4 +76,13 @@ struct ErrorPageModel: Equatable {
         let certificateErrorCode: String?
         let showProceedButton: Bool
     }
+}
+
+struct BadCertDomainModel: Equatable {
+    let url: URL
+    let advancedSection: ErrorPageModel.AdvancedSectionConfig
+}
+
+struct GenericErrorModel: Equatable {
+    let url: URL?
 }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
@@ -5,12 +5,6 @@
 import Foundation
 import Shared
 
-enum ErrorPageType: Equatable {
-    case internetConnection
-    case badCertDomain
-    case generic
-}
-
 enum ErrorPageModel: Equatable {
     case internetConnection
     case badCertDomain(BadCertDomainModel)
@@ -58,14 +52,6 @@ enum ErrorPageModel: Equatable {
         switch self {
         case .internetConnection, .generic: return true
         case .badCertDomain: return false
-        }
-    }
-
-    var type: ErrorPageType {
-        switch self {
-        case .internetConnection: return .internetConnection
-        case .badCertDomain: return .badCertDomain
-        case .generic: return .generic
         }
     }
 

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
@@ -7,12 +7,14 @@ import Common
 
 struct NativeErrorPageState: ScreenState {
     var windowUUID: WindowUUID
-    var title: String
-    var description: String
-    var foxImage: String
-    var url: URL?
-    var advancedSection: ErrorPageModel.AdvancedSectionConfig?
-    var type: ErrorPageType
+    var model: ErrorPageModel?
+
+    var title: String { model?.title ?? "" }
+    var description: String { model?.description ?? "" }
+    var foxImage: String { model?.foxImageName ?? "" }
+    var url: URL? { model?.url }
+    var advancedSection: ErrorPageModel.AdvancedSectionConfig? { model?.advancedSection }
+    var isRegularUI: Bool { model?.isRegularUI ?? false }
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let nativeErrorPageState = appState.componentState(
@@ -26,31 +28,16 @@ struct NativeErrorPageState: ScreenState {
 
         self.init(
             windowUUID: nativeErrorPageState.windowUUID,
-            title: nativeErrorPageState.title,
-            description: nativeErrorPageState.description,
-            foxImage: nativeErrorPageState.foxImage,
-            url: nativeErrorPageState.url,
-            advancedSection: nativeErrorPageState.advancedSection,
-            type: nativeErrorPageState.type
+            model: nativeErrorPageState.model
         )
     }
 
     init(
         windowUUID: WindowUUID,
-        title: String = "",
-        description: String = "",
-        foxImage: String = "",
-        url: URL? = nil,
-        advancedSection: ErrorPageModel.AdvancedSectionConfig? = nil,
-        type: ErrorPageType = .generic
+        model: ErrorPageModel? = nil
     ) {
         self.windowUUID = windowUUID
-        self.title = title
-        self.description = description
-        self.foxImage = foxImage
-        self.url = url
-        self.advancedSection = advancedSection
-        self.type = type
+        self.model = model
     }
 
     static let reducer: Reducer<Self> = { state, action in
@@ -65,12 +52,7 @@ struct NativeErrorPageState: ScreenState {
             }
             return NativeErrorPageState(
                 windowUUID: state.windowUUID,
-                title: model.errorTitle,
-                description: model.errorDescription,
-                foxImage: model.foxImageName,
-                url: model.url,
-                advancedSection: model.advancedSection,
-                type: model.type
+                model: model
             )
         default:
             return defaultState(from: state)
@@ -80,12 +62,7 @@ struct NativeErrorPageState: ScreenState {
     static func defaultState(from state: NativeErrorPageState) -> NativeErrorPageState {
         return NativeErrorPageState(
             windowUUID: state.windowUUID,
-            title: state.title,
-            description: state.description,
-            foxImage: state.foxImage,
-            url: state.url,
-            advancedSection: state.advancedSection,
-            type: state.type
+            model: state.model
         )
     }
 }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
@@ -9,13 +9,6 @@ struct NativeErrorPageState: ScreenState {
     var windowUUID: WindowUUID
     var model: ErrorPageModel?
 
-    var title: String { model?.title ?? "" }
-    var description: String { model?.description ?? "" }
-    var foxImage: String { model?.foxImageName ?? "" }
-    var url: URL? { model?.url }
-    var advancedSection: ErrorPageModel.AdvancedSectionConfig? { model?.advancedSection }
-    var isRegularUI: Bool { model?.isRegularUI ?? false }
-
     init(appState: AppState, uuid: WindowUUID) {
         guard let nativeErrorPageState = appState.componentState(
             NativeErrorPageState.self,

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -30,6 +30,7 @@ final class NativeErrorPageViewController: UIViewController,
     private let logger: Logger
     var contentType: ContentType = .nativeErrorPage
     private var nativeErrorPageState: NativeErrorPageState
+    private var model: ErrorPageModel?
 
     // MARK: UI Elements
     private struct UX {
@@ -180,9 +181,10 @@ final class NativeErrorPageViewController: UIViewController,
 
     func newState(state: NativeErrorPageState) {
         nativeErrorPageState = state
-        guard state.model != nil else { return }
+        guard let model = state.model else { return }
+        self.model = model
 
-        if state.isRegularUI {
+        if model.isRegularUI {
             showRegularUI()
         } else {
             showBadCertUI()
@@ -190,6 +192,7 @@ final class NativeErrorPageViewController: UIViewController,
     }
 
     private func showRegularUI() {
+        guard let model else { return }
         setActionView(regularContentView)
         scrollContainer.spacing = UX.mainStackSpacing
         contentStack.spacing = UX.textStackSpacing
@@ -197,20 +200,21 @@ final class NativeErrorPageViewController: UIViewController,
         foxImageWidthConstraint?.constant = UX.logoSizeWidth
         foxImageHeightConstraint?.isActive = false
 
-        titleLabel.text = nativeErrorPageState.title
-        foxImage.image = UIImage(named: nativeErrorPageState.foxImage)
-        if let validURL = nativeErrorPageState.url {
+        titleLabel.text = model.title
+        foxImage.image = UIImage(named: model.foxImageName)
+        if let validURL = model.url {
             errorDescriptionLabel.attributedText = getDescriptionWithHostName(
                 errorURL: validURL,
-                description: nativeErrorPageState.description
+                description: model.description
             )
         } else {
-            errorDescriptionLabel.text = nativeErrorPageState.description
+            errorDescriptionLabel.text = model.description
         }
         applyTheme()
     }
 
     private func showBadCertUI() {
+        guard let model else { return }
         setActionView(badCertContentView)
         scrollContainer.spacing = UX.badCertGapBetweenImageAndContent
         contentStack.spacing = UX.badCertContentGap
@@ -220,21 +224,19 @@ final class NativeErrorPageViewController: UIViewController,
         foxImageWidthConstraint?.constant = UX.badCertImageSize
         foxImageHeightConstraint?.isActive = true
 
-        foxImage.image = !nativeErrorPageState.foxImage.isEmpty
-            ? UIImage(named: nativeErrorPageState.foxImage)
-            : UIImage(named: ImageIdentifiers.NativeErrorPage.securityError)
+        foxImage.image = UIImage(named: model.foxImageName)
 
-        titleLabel.text = nativeErrorPageState.title
+        titleLabel.text = model.title
         titleLabel.font = FXFontStyles.Bold.title2.scaledFont()
-        errorDescriptionLabel.text = nativeErrorPageState.description
+        errorDescriptionLabel.text = model.description
         errorDescriptionLabel.font = FXFontStyles.Regular.body.scaledFont()
 
         applyTheme()
 
-        if let advancedSection = nativeErrorPageState.advancedSection {
+        if let advancedSection = model.advancedSection {
             badCertContentView.configure(
                 advancedSection: advancedSection,
-                url: nativeErrorPageState.url,
+                url: model.url,
                 goBackTitle: String.NativeErrorPage.GoBackButton
             )
         }
@@ -436,14 +438,14 @@ final class NativeErrorPageViewController: UIViewController,
               let errorURL = selectedTab.webView?.url,
               let internalURL = InternalURL(errorURL),
               internalURL.isErrorPage else { return }
-        let originalURL = nativeErrorPageState.url ?? internalURL.originalURLFromErrorPage ?? errorURL
+        let originalURL = model?.url ?? internalURL.originalURLFromErrorPage ?? errorURL
         guard !CertificateHelper.certificatesFromErrorURL(errorURL, logger: logger).isEmpty else { return }
 
         let destination = NavigationDestination(
             .certificatesFromErrorPage,
             url: originalURL,
             errorPageURL: errorURL,
-            certificateTitle: nativeErrorPageState.title
+            certificateTitle: model?.title ?? ""
         )
         store.dispatch(
             NavigationBrowserAction(

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -180,9 +180,9 @@ final class NativeErrorPageViewController: UIViewController,
 
     func newState(state: NativeErrorPageState) {
         nativeErrorPageState = state
-        guard !state.title.isEmpty else { return }
+        guard state.model != nil else { return }
 
-        if state.type.isRegularUI {
+        if state.isRegularUI {
             showRegularUI()
         } else {
             showBadCertUI()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
@@ -161,7 +161,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.noInternetConnection)
         XCTAssertNil(model.url)
-        XCTAssertEqual(model.type, .internetConnection)
         XCTAssertTrue(model.isRegularUI)
     }
 
@@ -174,7 +173,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.noInternetConnection)
         XCTAssertNil(model.url)
-        XCTAssertEqual(model.type, .internetConnection)
     }
 
     func testParseErrorDetails_certError_withURL_returnsSecurityModel() {
@@ -189,7 +187,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
         let model = helper.parseErrorDetails()
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
-        XCTAssertEqual(model.type, .generic)
         XCTAssertTrue(model.isRegularUI)
     }
 
@@ -212,7 +209,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
         let model = helper.parseErrorDetails()
 
         XCTAssertNotNil(model.advancedSection)
-        XCTAssertEqual(model.type, .badCertDomain)
         XCTAssertFalse(model.isRegularUI)
     }
 
@@ -227,7 +223,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
         XCTAssertNil(model.advancedSection)
-        XCTAssertEqual(model.type, .generic)
         XCTAssertTrue(model.isRegularUI)
     }
 
@@ -265,7 +260,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
         XCTAssertNil(model.advancedSection)
-        XCTAssertEqual(model.type, .generic)
     }
 
     // MARK: - ErrorPageModel computed properties
@@ -279,7 +273,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
         XCTAssertNil(model.url)
         XCTAssertNil(model.advancedSection)
         XCTAssertTrue(model.isRegularUI)
-        XCTAssertEqual(model.type, .internetConnection)
     }
 
     func testBadCertDomainModel_hasCorrectComputedProperties() {
@@ -307,7 +300,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
         XCTAssertEqual(model.advancedSection?.certificateErrorCode, "SSL_ERROR_BAD_CERT_DOMAIN")
         XCTAssertTrue(model.advancedSection?.showProceedButton ?? false)
         XCTAssertFalse(model.isRegularUI)
-        XCTAssertEqual(model.type, .badCertDomain)
     }
 
     func testGenericErrorModel_withURL_hasCorrectComputedProperties() {
@@ -320,7 +312,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
         XCTAssertEqual(model.url, testURL)
         XCTAssertNil(model.advancedSection)
         XCTAssertTrue(model.isRegularUI)
-        XCTAssertEqual(model.type, .generic)
     }
 
     func testGenericErrorModel_withoutURL_hasNilURL() {
@@ -332,7 +323,6 @@ final class NativeErrorPageHelperTests: XCTestCase {
         XCTAssertNil(model.url)
         XCTAssertNil(model.advancedSection)
         XCTAssertTrue(model.isRegularUI)
-        XCTAssertEqual(model.type, .generic)
     }
 
     func testBadCertDomainModel_requiresNonOptionalURL() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
@@ -162,7 +162,7 @@ final class NativeErrorPageHelperTests: XCTestCase {
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.noInternetConnection)
         XCTAssertNil(model.url)
         XCTAssertEqual(model.type, .internetConnection)
-        XCTAssertTrue(model.type.isRegularUI)
+        XCTAssertTrue(model.isRegularUI)
     }
 
     func testParseErrorDetails_noFailingURL_returnsNoInternetModel() {
@@ -190,7 +190,7 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
         XCTAssertEqual(model.type, .generic)
-        XCTAssertTrue(model.type.isRegularUI)
+        XCTAssertTrue(model.isRegularUI)
     }
 
     func testParseErrorDetails_certErrorBadCertDomain_returnsAdvancedSection() {
@@ -212,9 +212,8 @@ final class NativeErrorPageHelperTests: XCTestCase {
         let model = helper.parseErrorDetails()
 
         XCTAssertNotNil(model.advancedSection)
-        XCTAssertTrue(model.showGoBackButton)
         XCTAssertEqual(model.type, .badCertDomain)
-        XCTAssertFalse(model.type.isRegularUI)
+        XCTAssertFalse(model.isRegularUI)
     }
 
     func testParseErrorDetails_genericError_withURL_returnsGenericModel() {
@@ -229,7 +228,7 @@ final class NativeErrorPageHelperTests: XCTestCase {
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
         XCTAssertNil(model.advancedSection)
         XCTAssertEqual(model.type, .generic)
-        XCTAssertTrue(model.type.isRegularUI)
+        XCTAssertTrue(model.isRegularUI)
     }
 
     // MARK: - getCertDetails
@@ -267,5 +266,119 @@ final class NativeErrorPageHelperTests: XCTestCase {
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
         XCTAssertNil(model.advancedSection)
         XCTAssertEqual(model.type, .generic)
+    }
+
+    // MARK: - ErrorPageModel computed properties
+
+    func testInternetConnectionModel_hasCorrectComputedProperties() {
+        let model = ErrorPageModel.internetConnection
+
+        XCTAssertEqual(model.title, .NativeErrorPage.NoInternetConnection.TitleLabel)
+        XCTAssertEqual(model.description, .NativeErrorPage.NoInternetConnection.Description)
+        XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.noInternetConnection)
+        XCTAssertNil(model.url)
+        XCTAssertNil(model.advancedSection)
+        XCTAssertTrue(model.isRegularUI)
+        XCTAssertEqual(model.type, .internetConnection)
+    }
+
+    func testBadCertDomainModel_hasCorrectComputedProperties() {
+        let testURL = URL(string: "https://example.com")!
+        let advancedSection = ErrorPageModel.AdvancedSectionConfig(
+            buttonText: "Advanced",
+            infoText: "Info",
+            warningText: "Warning",
+            certificateErrorCode: "SSL_ERROR_BAD_CERT_DOMAIN",
+            showProceedButton: true
+        )
+        let model = ErrorPageModel.badCertDomain(BadCertDomainModel(
+            url: testURL,
+            advancedSection: advancedSection
+        ))
+
+        XCTAssertEqual(model.title, String.NativeErrorPage.BadCertDomain.TitleLabel)
+        XCTAssertEqual(model.description, String.NativeErrorPage.BadCertDomain.Description)
+        XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
+        XCTAssertEqual(model.url, testURL)
+        XCTAssertNotNil(model.advancedSection)
+        XCTAssertEqual(model.advancedSection?.buttonText, "Advanced")
+        XCTAssertEqual(model.advancedSection?.infoText, "Info")
+        XCTAssertEqual(model.advancedSection?.warningText, "Warning")
+        XCTAssertEqual(model.advancedSection?.certificateErrorCode, "SSL_ERROR_BAD_CERT_DOMAIN")
+        XCTAssertTrue(model.advancedSection?.showProceedButton ?? false)
+        XCTAssertFalse(model.isRegularUI)
+        XCTAssertEqual(model.type, .badCertDomain)
+    }
+
+    func testGenericErrorModel_withURL_hasCorrectComputedProperties() {
+        let testURL = URL(string: "https://example.com")!
+        let model = ErrorPageModel.generic(GenericErrorModel(url: testURL))
+
+        XCTAssertEqual(model.title, .NativeErrorPage.GenericError.TitleLabel)
+        XCTAssertEqual(model.description, .NativeErrorPage.GenericError.Description)
+        XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
+        XCTAssertEqual(model.url, testURL)
+        XCTAssertNil(model.advancedSection)
+        XCTAssertTrue(model.isRegularUI)
+        XCTAssertEqual(model.type, .generic)
+    }
+
+    func testGenericErrorModel_withoutURL_hasNilURL() {
+        let model = ErrorPageModel.generic(GenericErrorModel(url: nil))
+
+        XCTAssertEqual(model.title, .NativeErrorPage.GenericError.TitleLabel)
+        XCTAssertEqual(model.description, .NativeErrorPage.GenericError.Description)
+        XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
+        XCTAssertNil(model.url)
+        XCTAssertNil(model.advancedSection)
+        XCTAssertTrue(model.isRegularUI)
+        XCTAssertEqual(model.type, .generic)
+    }
+
+    func testBadCertDomainModel_requiresNonOptionalURL() {
+        let advancedSection = ErrorPageModel.AdvancedSectionConfig(
+            buttonText: "Advanced",
+            infoText: "Info",
+            warningText: "Warning",
+            certificateErrorCode: nil,
+            showProceedButton: false
+        )
+        let domainModel = BadCertDomainModel(
+            url: URL(string: "https://example.com")!,
+            advancedSection: advancedSection
+        )
+
+        XCTAssertEqual(domainModel.url.absoluteString, "https://example.com")
+        XCTAssertEqual(domainModel.advancedSection.buttonText, "Advanced")
+    }
+
+    func testGenericErrorModel_acceptsOptionalURL() {
+        let withURL = GenericErrorModel(url: URL(string: "https://example.com")!)
+        let withoutURL = GenericErrorModel(url: nil)
+
+        XCTAssertEqual(withURL.url?.absoluteString, "https://example.com")
+        XCTAssertNil(withoutURL.url)
+    }
+
+    func testErrorPageModel_equatable() {
+        let url = URL(string: "https://example.com")!
+        let section = ErrorPageModel.AdvancedSectionConfig(
+            buttonText: "B",
+            infoText: "I",
+            warningText: "W",
+            certificateErrorCode: nil,
+            showProceedButton: false
+        )
+
+        XCTAssertEqual(ErrorPageModel.internetConnection, ErrorPageModel.internetConnection)
+        XCTAssertNotEqual(ErrorPageModel.internetConnection, ErrorPageModel.generic(GenericErrorModel(url: nil)))
+
+        let badCert1 = ErrorPageModel.badCertDomain(BadCertDomainModel(url: url, advancedSection: section))
+        let badCert2 = ErrorPageModel.badCertDomain(BadCertDomainModel(url: url, advancedSection: section))
+        XCTAssertEqual(badCert1, badCert2)
+
+        let generic1 = ErrorPageModel.generic(GenericErrorModel(url: url))
+        let generic2 = ErrorPageModel.generic(GenericErrorModel(url: url))
+        XCTAssertEqual(generic1, generic2)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageStateTests.swift
@@ -12,12 +12,6 @@ final class NativeErrorPageStateTests: XCTestCase {
         let initialState = createSubject()
 
         XCTAssertNil(initialState.model)
-        XCTAssertEqual(initialState.title, "")
-        XCTAssertEqual(initialState.description, "")
-        XCTAssertEqual(initialState.foxImage, "")
-        XCTAssertNil(initialState.url)
-        XCTAssertNil(initialState.advancedSection)
-        XCTAssertFalse(initialState.isRegularUI)
     }
 
     @MainActor
@@ -30,12 +24,7 @@ final class NativeErrorPageStateTests: XCTestCase {
         let action = getAction(model: model, for: .initialize)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.title, model.title)
-        XCTAssertEqual(newState.description, model.description)
-        XCTAssertEqual(newState.foxImage, model.foxImageName)
-        XCTAssertNil(newState.url)
-        XCTAssertNil(newState.advancedSection)
-        XCTAssertTrue(newState.isRegularUI)
+        XCTAssertEqual(newState.model, model)
     }
 
     @MainActor
@@ -55,28 +44,18 @@ If you’re on a corporate network, your support team might have more info.
         )
 
         let model = ErrorPageModel.badCertDomain(BadCertDomainModel(
-            url: URL(string: "https://example.com"),
+            url: URL(string: "https://example.com")!,
             advancedSection: advancedSection
         ))
 
         let action = getAction(model: model, for: .initialize)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.title, model.title)
-        XCTAssertEqual(newState.description, model.description)
-        XCTAssertEqual(newState.foxImage, model.foxImageName)
-        XCTAssertEqual(newState.url, model.url)
-        XCTAssertFalse(newState.isRegularUI)
-        XCTAssertNotNil(newState.advancedSection)
-        XCTAssertEqual(newState.advancedSection?.buttonText, advancedSection.buttonText)
-        XCTAssertEqual(newState.advancedSection?.infoText, advancedSection.infoText)
-        XCTAssertEqual(newState.advancedSection?.warningText, advancedSection.warningText)
-        XCTAssertEqual(newState.advancedSection?.certificateErrorCode, advancedSection.certificateErrorCode)
-        XCTAssertEqual(newState.advancedSection?.showProceedButton, advancedSection.showProceedButton)
+        XCTAssertEqual(newState.model, model)
     }
 
     @MainActor
-    func testStateComputedProperties_withGenericModelWithURL() {
+    func testStateModel_withGenericModelWithURL() {
         let initialState = createSubject()
         let reducer = nativeErrorPageReducer()
 
@@ -86,16 +65,11 @@ If you’re on a corporate network, your support team might have more info.
         let action = getAction(model: model, for: .initialize)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.title, .NativeErrorPage.GenericError.TitleLabel)
-        XCTAssertEqual(newState.description, .NativeErrorPage.GenericError.Description)
-        XCTAssertEqual(newState.foxImage, ImageIdentifiers.NativeErrorPage.securityError)
-        XCTAssertEqual(newState.url, testURL)
-        XCTAssertNil(newState.advancedSection)
-        XCTAssertTrue(newState.isRegularUI)
+        XCTAssertEqual(newState.model, model)
     }
 
     @MainActor
-    func testStateComputedProperties_withGenericModelWithoutURL() {
+    func testStateModel_withGenericModelWithoutURL() {
         let initialState = createSubject()
         let reducer = nativeErrorPageReducer()
 
@@ -104,10 +78,7 @@ If you’re on a corporate network, your support team might have more info.
         let action = getAction(model: model, for: .initialize)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.title, .NativeErrorPage.GenericError.TitleLabel)
-        XCTAssertNil(newState.url)
-        XCTAssertNil(newState.advancedSection)
-        XCTAssertTrue(newState.isRegularUI)
+        XCTAssertEqual(newState.model, model)
     }
 
     @MainActor
@@ -122,8 +93,6 @@ If you’re on a corporate network, your support team might have more info.
         let defaultState = NativeErrorPageState.defaultState(from: state)
 
         XCTAssertEqual(defaultState.model, state.model)
-        XCTAssertEqual(defaultState.title, state.title)
-        XCTAssertEqual(defaultState.url, state.url)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageStateTests.swift
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import Redux
 import XCTest
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageStateTests.swift
@@ -1,7 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-
 import Redux
 import XCTest
 
@@ -11,12 +7,13 @@ final class NativeErrorPageStateTests: XCTestCase {
     func testInitialState() {
         let initialState = createSubject()
 
+        XCTAssertNil(initialState.model)
         XCTAssertEqual(initialState.title, "")
         XCTAssertEqual(initialState.description, "")
         XCTAssertEqual(initialState.foxImage, "")
         XCTAssertNil(initialState.url)
         XCTAssertNil(initialState.advancedSection)
-        XCTAssertEqual(initialState.type, .generic)
+        XCTAssertFalse(initialState.isRegularUI)
     }
 
     @MainActor
@@ -24,28 +21,17 @@ final class NativeErrorPageStateTests: XCTestCase {
         let initialState = createSubject()
         let reducer = nativeErrorPageReducer()
 
-        let mockModel = ErrorPageModel(
-            errorTitle: "NoInternetConnection",
-            errorDescription: "There’s a problem with your internet connection.",
-            foxImageName: "foxLogo",
-            url: URL(
-                string: "url.com"
-            ),
-            advancedSection: nil,
-            showGoBackButton: false,
-            type: .internetConnection
-        )
+        let model = ErrorPageModel.internetConnection
 
-        let action = getAction(model: mockModel, for: .initialize)
+        let action = getAction(model: model, for: .initialize)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.title, mockModel.errorTitle)
-        XCTAssertEqual(newState.description, mockModel.errorDescription)
-        XCTAssertEqual(newState.foxImage, mockModel.foxImageName)
-        XCTAssertEqual(newState.url, mockModel.url)
+        XCTAssertEqual(newState.title, model.title)
+        XCTAssertEqual(newState.description, model.description)
+        XCTAssertEqual(newState.foxImage, model.foxImageName)
+        XCTAssertNil(newState.url)
         XCTAssertNil(newState.advancedSection)
-        XCTAssertEqual(newState.type, .internetConnection)
-        XCTAssertTrue(newState.type.isRegularUI)
+        XCTAssertTrue(newState.isRegularUI)
     }
 
     @MainActor
@@ -64,31 +50,76 @@ If you’re on a corporate network, your support team might have more info.
             showProceedButton: true
         )
 
-        let mockModel = ErrorPageModel(
-            errorTitle: "Be careful. Something doesn’t look right.",
-            errorDescription: "Someone pretending to be the site could try to steal your personal info.",
-            foxImageName: "securityError",
+        let model = ErrorPageModel.badCertDomain(BadCertDomainModel(
             url: URL(string: "https://example.com"),
-            advancedSection: advancedSection,
-            showGoBackButton: true,
-            type: .badCertDomain
-        )
+            advancedSection: advancedSection
+        ))
 
-        let action = getAction(model: mockModel, for: .initialize)
+        let action = getAction(model: model, for: .initialize)
         let newState = reducer(initialState, action)
 
-        XCTAssertEqual(newState.title, mockModel.errorTitle)
-        XCTAssertEqual(newState.description, mockModel.errorDescription)
-        XCTAssertEqual(newState.foxImage, mockModel.foxImageName)
-        XCTAssertEqual(newState.url, mockModel.url)
-        XCTAssertEqual(newState.type, .badCertDomain)
-        XCTAssertFalse(newState.type.isRegularUI)
+        XCTAssertEqual(newState.title, model.title)
+        XCTAssertEqual(newState.description, model.description)
+        XCTAssertEqual(newState.foxImage, model.foxImageName)
+        XCTAssertEqual(newState.url, model.url)
+        XCTAssertFalse(newState.isRegularUI)
         XCTAssertNotNil(newState.advancedSection)
         XCTAssertEqual(newState.advancedSection?.buttonText, advancedSection.buttonText)
         XCTAssertEqual(newState.advancedSection?.infoText, advancedSection.infoText)
         XCTAssertEqual(newState.advancedSection?.warningText, advancedSection.warningText)
         XCTAssertEqual(newState.advancedSection?.certificateErrorCode, advancedSection.certificateErrorCode)
         XCTAssertEqual(newState.advancedSection?.showProceedButton, advancedSection.showProceedButton)
+    }
+
+    @MainActor
+    func testStateComputedProperties_withGenericModelWithURL() {
+        let initialState = createSubject()
+        let reducer = nativeErrorPageReducer()
+
+        let testURL = URL(string: "https://example.com/page")!
+        let model = ErrorPageModel.generic(GenericErrorModel(url: testURL))
+
+        let action = getAction(model: model, for: .initialize)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.title, .NativeErrorPage.GenericError.TitleLabel)
+        XCTAssertEqual(newState.description, .NativeErrorPage.GenericError.Description)
+        XCTAssertEqual(newState.foxImage, ImageIdentifiers.NativeErrorPage.securityError)
+        XCTAssertEqual(newState.url, testURL)
+        XCTAssertNil(newState.advancedSection)
+        XCTAssertTrue(newState.isRegularUI)
+    }
+
+    @MainActor
+    func testStateComputedProperties_withGenericModelWithoutURL() {
+        let initialState = createSubject()
+        let reducer = nativeErrorPageReducer()
+
+        let model = ErrorPageModel.generic(GenericErrorModel(url: nil))
+
+        let action = getAction(model: model, for: .initialize)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.title, .NativeErrorPage.GenericError.TitleLabel)
+        XCTAssertNil(newState.url)
+        XCTAssertNil(newState.advancedSection)
+        XCTAssertTrue(newState.isRegularUI)
+    }
+
+    @MainActor
+    func testStateDefaultStatePreservesModel() {
+        let initialState = createSubject()
+        let reducer = nativeErrorPageReducer()
+
+        let model = ErrorPageModel.generic(GenericErrorModel(url: URL(string: "https://example.com")!))
+        let action = getAction(model: model, for: .initialize)
+        let state = reducer(initialState, action)
+
+        let defaultState = NativeErrorPageState.defaultState(from: state)
+
+        XCTAssertEqual(defaultState.model, state.model)
+        XCTAssertEqual(defaultState.title, state.title)
+        XCTAssertEqual(defaultState.url, state.url)
     }
 
     // MARK: - Private


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16001)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34148)

## :bulb: Description
Refactoring the error page model so that the error page type determines the model structure rather than storing type within a generic model.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

