### PR TITLE
Refactor FXIOS-16155 [Documentation] Update backport link in danger file

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -923,7 +923,7 @@ struct ReleaseBranchCheck {
         markdown("""
         # ‼️ ATTENTION ‼️
         ### 🎯 This PR targets a **release branch**.
-        Please ensure you've followed the [uplift request process](https://github.com/mozilla-mobile/firefox-ios/wiki/Requesting-an-uplift-to-a-release-branch).
+        Please ensure you've followed the [uplift request process](https://mozilla-hub.atlassian.net/wiki/x/OgAbog).
         """)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16155)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Old link was out of date on the bot comment when a PR targeted the release branch. It's now updated to the confluence link.
<img width="933" height="300" alt="Screenshot 2026-06-24 at 3 48 48 PM" src="https://github.com/user-attachments/assets/cd23a4cb-5e6e-478d-84a6-a238421abfe4" />



