### PR TITLE
Bugfix FXIOS-16156 [WC] Add dispatch queue for merino wc fetcher

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
@@ -47,8 +47,7 @@ struct WorldCupNormalFetchStrategy: WorldCupFetchStrategyProtocol {
     /// so `/matches`, `/live` and `/teams` don't serialize behind one another.
     private static let fetchQueue = DispatchQueue(
         label: "org.mozilla.ios.worldcup.fetch",
-        qos: .userInitiated,
-        attributes: .concurrent
+        qos: .userInitiated
     )
 
     static func singleAttempt<Response: Sendable>(

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
@@ -41,16 +41,29 @@ struct WorldCupNormalFetchStrategy: WorldCupFetchStrategyProtocol {
         }
     }
 
+    /// Dedicated queue for the blocking synchronous FFI. It is deliberately NOT the Swift
+    /// Concurrency cooperative pool: a stuck merino request blocks a thread here instead of
+    /// starving the cooperative pool (which would stall all async work app-wide). Concurrent
+    /// so `/matches`, `/live` and `/teams` don't serialize behind one another.
+    private static let fetchQueue = DispatchQueue(
+        label: "org.mozilla.ios.worldcup.fetch",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+
     static func singleAttempt<Response: Sendable>(
         _ fetch: @escaping @Sendable () throws -> Response?
     ) async -> Result<Response?, WorldCupLoadError> {
-        await Task.detached(priority: .userInitiated) {
-            () -> Result<Response?, WorldCupLoadError> in
-            do {
-                return .success(try fetch())
-            } catch {
-                return .failure(WorldCupLoadError.from(error))
+        await withCheckedContinuation { continuation in
+            fetchQueue.async {
+                let result: Result<Response?, WorldCupLoadError>
+                do {
+                    result = .success(try fetch())
+                } catch {
+                    result = .failure(WorldCupLoadError.from(error))
+                }
+                continuation.resume(returning: result)
             }
-        }.value
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16156)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Adds dispatch queue for merino wc fetcher. This our best theory as to why we see the freeze.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

