### PR TITLE
BugFix FXIOS-16157 [WorldCup] didChangeHomepageSettings not turning back on the feed

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
@@ -51,6 +51,11 @@ final class WorldCupMiddleware {
             self.homepageIsOnScreen = false
         case WorldCupActionType.didChangeHomepageSettings:
             self.dispatch(snapshot: self.feed?.latestSnapshot ?? .empty)
+            if self.worldCupStore.isFeatureEnabledAndSectionEnabled {
+                self.startFeed(windowUUID: action.windowUUID)
+            } else {
+                self.feed?.stop()
+            }
         case WorldCupActionType.removeHomepageCard:
             self.worldCupStore.setIsHomepageSectionEnabled(false)
             self.feed?.stop()

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
@@ -47,8 +47,7 @@ struct WorldCupNormalFetchStrategy: WorldCupFetchStrategyProtocol {
     /// so `/matches`, `/live` and `/teams` don't serialize behind one another.
     private static let fetchQueue = DispatchQueue(
         label: "org.mozilla.ios.worldcup.fetch",
-        qos: .userInitiated,
-        attributes: .concurrent
+        qos: .userInitiated
     )
 
     static func singleAttempt<Response: Sendable>(

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupNormalFetchStrategy.swift
@@ -41,16 +41,29 @@ struct WorldCupNormalFetchStrategy: WorldCupFetchStrategyProtocol {
         }
     }
 
+    /// Dedicated queue for the blocking synchronous FFI. It is deliberately NOT the Swift
+    /// Concurrency cooperative pool: a stuck merino request blocks a thread here instead of
+    /// starving the cooperative pool (which would stall all async work app-wide). Concurrent
+    /// so `/matches`, `/live` and `/teams` don't serialize behind one another.
+    private static let fetchQueue = DispatchQueue(
+        label: "org.mozilla.ios.worldcup.fetch",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+
     static func singleAttempt<Response: Sendable>(
         _ fetch: @escaping @Sendable () throws -> Response?
     ) async -> Result<Response?, WorldCupLoadError> {
-        await Task.detached(priority: .userInitiated) {
-            () -> Result<Response?, WorldCupLoadError> in
-            do {
-                return .success(try fetch())
-            } catch {
-                return .failure(WorldCupLoadError.from(error))
+        await withCheckedContinuation { continuation in
+            fetchQueue.async {
+                let result: Result<Response?, WorldCupLoadError>
+                do {
+                    result = .success(try fetch())
+                } catch {
+                    result = .failure(WorldCupLoadError.from(error))
+                }
+                continuation.resume(returning: result)
             }
-        }.value
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -92,31 +92,39 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     // MARK: - WorldCupActionType.didChangeHomepageSettings
-
-    func test_didChangeHomepageSettings_dispatchesDidUpdate() throws {
+    func test_didChangeHomepageSettings_whenFeatureAndSectionEnabled_startsFeed() throws {
         mockWorldCupStore.isFeatureEnabled = true
-        mockWorldCupStore.isHomepageSectionEnabled = false
-        let apiClient = MockWorldCupAPIClient(matchesResult: .success(makeResponse()))
-        let subject = createSubject(apiClient: apiClient)
+        mockWorldCupStore.isHomepageSectionEnabled = true
+        mockWorldCupStore.isMilestone2 = true
+        let feed = MockWorldCupFeed()
+        let subject = createSubject(feed: feed)
         let action = WorldCupAction(
             windowUUID: .XCTestDefaultUUID,
             actionType: WorldCupActionType.didChangeHomepageSettings
         )
 
-        let expectation = XCTestExpectation(description: "didUpdate dispatched")
-        mockStore.dispatchCalled = { expectation.fulfill() }
+        subject.worldCupProvider(appState, action)
+
+        XCTAssertEqual(feed.startCalled, 1)
+        XCTAssertEqual(feed.stopCalled, 0)
+        subject.worldCupProvider = { _, _ in }
+    }
+
+    func test_didChangeHomepageSettings_whenSectionDisabled_stopsFeed() throws {
+        mockWorldCupStore.isFeatureEnabled = true
+        mockWorldCupStore.isHomepageSectionEnabled = false
+        mockWorldCupStore.isMilestone2 = true
+        let feed = MockWorldCupFeed()
+        let subject = createSubject(feed: feed)
+        let action = WorldCupAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WorldCupActionType.didChangeHomepageSettings
+        )
 
         subject.worldCupProvider(appState, action)
 
-        wait(for: [expectation])
-
-        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WorldCupAction)
-        let actionType = try XCTUnwrap(dispatched.actionType as? WorldCupMiddlewareActionType)
-
-        XCTAssertEqual(actionType, .didUpdate)
-        XCTAssertFalse(dispatched.shouldShowHomepageWorldCupSection)
-        XCTAssertEqual(mockWorldCupStore.setIsHomepageSectionEnabledCalled, 0)
-        XCTAssertEqual(apiClient.matchesFetchCount, 0)
+        XCTAssertEqual(feed.stopCalled, 1)
+        XCTAssertEqual(feed.startCalled, 0)
         subject.worldCupProvider = { _, _ in }
     }
 
@@ -1251,6 +1259,14 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
             )
         }
         let subject = WorldCupMiddleware(worldCupStore: store, feed: feed)
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+
+    /// Hands the middleware a `MockWorldCupFeed` so tests can assert on the
+    /// feed lifecycle (start/stop) without driving the real network plumbing.
+    private func createSubject(feed: MockWorldCupFeed) -> WorldCupMiddleware {
+        let subject = WorldCupMiddleware(worldCupStore: mockWorldCupStore, feed: feed)
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16157)

## :bulb: Description
Fix `didChangeHomepageSettings` doesn't turn back on the feed.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

