### PR TITLE
Refactor FXIOS-16140 [Technical Debt] [Redux] Action migration part 2: Add `ModernAction` `Middleware` providers

### DIFF
--- a/BrowserKit/Sources/Redux/Middleware.swift
+++ b/BrowserKit/Sources/Redux/Middleware.swift
@@ -3,9 +3,16 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 
-/// Redux `Middleware` provides a third-party extension point between dispatching an `Action`,
-/// and the moment it reaches the `Reducer` Middleware produces side effects or uses dependencies and
-/// is the best place to put logger, API calls or access storage.
-public typealias DispatchFunction = (Action) -> Void
-public typealias Middleware<State> = (State, Action) -> Void
+/// Redux middlewares consume `Action`s and are designed to perform logic with side effects (e.g. API calls, logging, or
+/// accessing storage).
+/// Currently our middleware providers must implement a legacy provider and a modern provider as we migrate from consuming
+/// `Action`s to consuming `ModernAction`s.
+public typealias Middleware<State> = (
+    legacyMiddleware: LegacyMiddlewareMethod<State>,
+    modernMiddleware: MiddlewareMethod<State>
+)
+
+public typealias MiddlewareMethod<State> = @MainActor (State, ModernAction, WindowUUID) -> Void
+public typealias LegacyMiddlewareMethod<State> = @MainActor (State, Action) -> Void

--- a/BrowserKit/Sources/Redux/Middleware.swift
+++ b/BrowserKit/Sources/Redux/Middleware.swift
@@ -5,14 +5,14 @@
 import Foundation
 import Common
 
-/// Redux middlewares consume `Action`s and are designed to perform logic with side effects (e.g. API calls, logging, or
-/// accessing storage).
-/// Currently our middleware providers must implement a legacy provider and a modern provider as we migrate from consuming
-/// `Action`s to consuming `ModernAction`s.
+/// Redux middleware providers consume `Action`s and are designed to perform logic with side effects (e.g. API calls,
+/// logging, or accessing storage).
+/// Currently, our middleware providers must implement a legacy provider and a modern provider as we migrate from consuming
+/// legacy `Action`s to the new `ModernAction`s.
 public typealias Middleware<State> = (
-    legacyMiddleware: LegacyMiddlewareMethod<State>,
-    modernMiddleware: MiddlewareMethod<State>
+    legacyMiddleware: LegacyMiddlewareClosure<State>,
+    modernMiddleware: MiddlewareClosure<State>
 )
 
-public typealias MiddlewareMethod<State> = @MainActor (State, ModernAction, WindowUUID) -> Void
-public typealias LegacyMiddlewareMethod<State> = @MainActor (State, Action) -> Void
+public typealias MiddlewareClosure<State> = @MainActor (State, ModernAction, WindowUUID) -> Void
+public typealias LegacyMiddlewareClosure<State> = @MainActor (State, Action) -> Void

--- a/BrowserKit/Sources/Redux/Store.swift
+++ b/BrowserKit/Sources/Redux/Store.swift
@@ -126,11 +126,9 @@ public final class Store<State: StateType & Sendable>: DefaultDispatchStore {
         middlewares.forEach { middleware in
             switch action {
             case .legacy(let legacyAction):
-                middleware(newState, legacyAction)
-            case .modern:
-                // TODO: FXIOS-16140 Part 3 - Middleware migration
-                //  middleware.modernMiddleware(newState, modernAction, windowUUID)
-                break
+                middleware.legacyMiddleware(newState, legacyAction)
+            case .modern(let modernAction):
+                middleware.modernMiddleware(newState, modernAction, windowUUID)
             }
         }
 

--- a/BrowserKit/Sources/TestKit/EmptyMiddlewareProviderFactory.swift
+++ b/BrowserKit/Sources/TestKit/EmptyMiddlewareProviderFactory.swift
@@ -4,15 +4,28 @@
 
 import Redux
 
-// TODO: FIXME: FXIOS-16140 will expand on these provider factory methods.
-
 /// Because our current paradigm for middlewares is to strong retain `self` inside our providers, our middleware unit tests
 /// will never successfully pass the `trackForMemoryLeaks` check. We can get around this by setting an empty provider on
 /// the middleware before the end of each test. A better longterm solution would be to rewrite our providers to avoid strong
 /// retain cycles, like by injecting a whole type into the `DefaultDispatchStore` rather than just provider closures.
 /// - Returns: Returns an empty provider implementation which does not retain `self`.
-public func emptyLegacyMiddlewareMethodFactory<T>() -> Middleware<T> {
-    let emptyProvider: Middleware<T> = { _, _ in }
+public func emptyMiddlewareProviderFactory<T>() -> Middleware<T> {
+    let emptyProvider: Middleware<T> = (
+        legacyMiddleware: emptyLegacyMiddlewareMethodFactory(),
+        modernMiddleware: emptyMiddlewareMethodFactory()
+    )
+
+    return emptyProvider
+}
+
+public func emptyMiddlewareMethodFactory<T>() -> MiddlewareMethod<T> {
+    let emptyProvider: MiddlewareMethod<T> = { _, _, _ in }
+
+    return emptyProvider
+}
+
+public func emptyLegacyMiddlewareMethodFactory<T>() -> LegacyMiddlewareMethod<T> {
+    let emptyProvider: LegacyMiddlewareMethod<T> = { _, _ in }
 
     return emptyProvider
 }

--- a/BrowserKit/Sources/TestKit/EmptyMiddlewareProviderFactory.swift
+++ b/BrowserKit/Sources/TestKit/EmptyMiddlewareProviderFactory.swift
@@ -4,28 +4,15 @@
 
 import Redux
 
+// TODO: FIXME: FXIOS-16140 will expand on these provider factory methods.
+
 /// Because our current paradigm for middlewares is to strong retain `self` inside our providers, our middleware unit tests
 /// will never successfully pass the `trackForMemoryLeaks` check. We can get around this by setting an empty provider on
 /// the middleware before the end of each test. A better longterm solution would be to rewrite our providers to avoid strong
 /// retain cycles, like by injecting a whole type into the `DefaultDispatchStore` rather than just provider closures.
 /// - Returns: Returns an empty provider implementation which does not retain `self`.
-public func emptyMiddlewareProviderFactory<T>() -> Middleware<T> {
-    let emptyProvider: Middleware<T> = (
-        legacyMiddleware: emptyLegacyMiddlewareMethodFactory(),
-        modernMiddleware: emptyMiddlewareMethodFactory()
-    )
-
-    return emptyProvider
-}
-
-public func emptyMiddlewareMethodFactory<T>() -> MiddlewareMethod<T> {
-    let emptyProvider: MiddlewareMethod<T> = { _, _, _ in }
-
-    return emptyProvider
-}
-
-public func emptyLegacyMiddlewareMethodFactory<T>() -> LegacyMiddlewareMethod<T> {
-    let emptyProvider: LegacyMiddlewareMethod<T> = { _, _ in }
+public func emptyLegacyMiddlewareMethodFactory<T>() -> Middleware<T> {
+    let emptyProvider: Middleware<T> = { _, _ in }
 
     return emptyProvider
 }

--- a/BrowserKit/Sources/TestKit/EmptyMiddlewareProviderFactory.swift
+++ b/BrowserKit/Sources/TestKit/EmptyMiddlewareProviderFactory.swift
@@ -11,21 +11,21 @@ import Redux
 /// - Returns: Returns an empty provider implementation which does not retain `self`.
 public func emptyMiddlewareProviderFactory<T>() -> Middleware<T> {
     let emptyProvider: Middleware<T> = (
-        legacyMiddleware: emptyLegacyMiddlewareMethodFactory(),
-        modernMiddleware: emptyMiddlewareMethodFactory()
+        legacyMiddleware: emptyLegacyMiddlewareFactory(),
+        modernMiddleware: emptyMiddlewareFactory()
     )
 
     return emptyProvider
 }
 
-public func emptyMiddlewareMethodFactory<T>() -> MiddlewareMethod<T> {
-    let emptyProvider: MiddlewareMethod<T> = { _, _, _ in }
+public func emptyMiddlewareFactory<T>() -> MiddlewareClosure<T> {
+    let emptyProvider: MiddlewareClosure<T> = { _, _, _ in }
 
     return emptyProvider
 }
 
-public func emptyLegacyMiddlewareMethodFactory<T>() -> LegacyMiddlewareMethod<T> {
-    let emptyProvider: LegacyMiddlewareMethod<T> = { _, _ in }
+public func emptyLegacyMiddlewareFactory<T>() -> LegacyMiddlewareClosure<T> {
+    let emptyProvider: LegacyMiddlewareClosure<T> = { _, _ in }
 
     return emptyProvider
 }

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
@@ -10,16 +10,54 @@ import Foundation
 class FakeReduxMiddleware {
     var generateInitialCountValue: (() -> Int)?
 
-    lazy var fakeProvider: Middleware<FakeReduxState> = { state, action in
-        switch action.actionType {
-        case FakeReduxActionType.requestInitialValue:
+    lazy var fakeProvider: Middleware<FakeReduxState> = (legacyFakeProvider, modernFakeProvider)
+
+    lazy var modernFakeProvider: MiddlewareMethod<FakeReduxState> = { [self] state, action, windowUUID in
+        // Handles one type of action
+        guard let action = action as? FakeReduxModernAction else { return }
+
+        switch action {
+        case .requestInitialValue:
+            let initialValue = self.generateInitialCountValue?() ?? 0
+            store.dispatch(
+                FakeReduxModernAction.initialValueLoaded(initialValue: initialValue),
+                forWindowUUID: windowUUID
+            )
+
+        case .increaseCounter:
+            let existingValue = state.counter
+            let newValue = self.increaseCounter(currentValue: existingValue)
+            store.dispatch(
+                FakeReduxModernAction.counterIncreased(counterValue: newValue),
+                forWindowUUID: windowUUID
+            )
+
+        case .decreaseCounter:
+            let existingValue = state.counter
+            let newValue = self.decreaseCounter(currentValue: existingValue)
+            store.dispatch(
+                FakeReduxModernAction.counterDecreased(counterValue: newValue),
+                forWindowUUID: windowUUID
+            )
+
+        default:
+            break
+        }
+    }
+
+    lazy var legacyFakeProvider: LegacyMiddlewareMethod<FakeReduxState> = { [self] state, action in
+        // Handles one type of action
+        guard let actionType = action.actionType as? FakeReduxActionType else { return }
+
+        switch actionType {
+        case .requestInitialValue:
             let initialValue = self.generateInitialCountValue?() ?? 0
             let action = FakeReduxAction(counterValue: initialValue,
                                          windowUUID: windowUUID,
                                          actionType: FakeReduxActionType.initialValueLoaded)
             store.dispatch(action)
 
-        case FakeReduxActionType.increaseCounter:
+        case .increaseCounter:
             let existingValue = state.counter
             let newValue = self.increaseCounter(currentValue: existingValue)
             let action = FakeReduxAction(counterValue: newValue,
@@ -27,7 +65,7 @@ class FakeReduxMiddleware {
                                          actionType: FakeReduxActionType.counterIncreased)
             store.dispatch(action)
 
-        case FakeReduxActionType.decreaseCounter:
+        case .decreaseCounter:
             let existingValue = state.counter
             let newValue = self.decreaseCounter(currentValue: existingValue)
             let action = FakeReduxAction(counterValue: newValue,

--- a/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
+++ b/BrowserKit/Tests/ReduxTests/Utilities/FakeReduxMiddleware.swift
@@ -12,7 +12,7 @@ class FakeReduxMiddleware {
 
     lazy var fakeProvider: Middleware<FakeReduxState> = (legacyFakeProvider, modernFakeProvider)
 
-    lazy var modernFakeProvider: MiddlewareMethod<FakeReduxState> = { [self] state, action, windowUUID in
+    lazy var modernFakeProvider: MiddlewareClosure<FakeReduxState> = { [self] state, action, windowUUID in
         // Handles one type of action
         guard let action = action as? FakeReduxModernAction else { return }
 
@@ -45,7 +45,7 @@ class FakeReduxMiddleware {
         }
     }
 
-    lazy var legacyFakeProvider: LegacyMiddlewareMethod<FakeReduxState> = { [self] state, action in
+    lazy var legacyFakeProvider: LegacyMiddlewareClosure<FakeReduxState> = { [self] state, action in
         // Handles one type of action
         guard let actionType = action.actionType as? FakeReduxActionType else { return }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -44,7 +44,13 @@ final class MainMenuMiddleware {
         self.logger = logger
     }
 
-    lazy var mainMenuProvider: Middleware<AppState> = { state, action in
+    lazy var mainMenuProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         guard let action = action as? MainMenuAction else { return }
         let isHomepage = action.telemetryInfo?.isHomepage ?? false
         self.handleMainMenuActions(action: action, isHomepage: isHomepage)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -46,11 +46,11 @@ final class MainMenuMiddleware {
 
     lazy var mainMenuProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         guard let action = action as? MainMenuAction else { return }
         let isHomepage = action.telemetryInfo?.isHomepage ?? false
         self.handleMainMenuActions(action: action, isHomepage: isHomepage)

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -19,7 +19,13 @@ final class SearchEngineSelectionMiddleware {
         self.searchEnginesManager = searchEnginesManager
     }
 
-    lazy var searchEngineSelectionProvider: Middleware<AppState> = { [self] state, action in
+    lazy var searchEngineSelectionProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         guard let action = action as? SearchEngineSelectionAction else { return }
 
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -21,11 +21,11 @@ final class SearchEngineSelectionMiddleware {
 
     lazy var searchEngineSelectionProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         guard let action = action as? SearchEngineSelectionAction else { return }
 
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
@@ -23,7 +23,13 @@ final class StartAtHomeMiddleware {
         self.dateProvider = dateProvider
     }
 
-    lazy var startAtHomeProvider: Middleware<AppState> = { state, action in
+    lazy var startAtHomeProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         switch action.actionType {
         case StartAtHomeActionType.didBrowserBecomeActive:
             let shouldStartAtHome = self.startAtHomeCheck(windowUUID: action.windowUUID)

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeMiddleware.swift
@@ -25,11 +25,11 @@ final class StartAtHomeMiddleware {
 
     lazy var startAtHomeProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         switch action.actionType {
         case StartAtHomeActionType.didBrowserBecomeActive:
             let shouldStartAtHome = self.startAtHomeCheck(windowUUID: action.windowUUID)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -26,7 +26,13 @@ final class RemoteTabsPanelMiddleware: Notifiable {
         observeNotifications()
     }
 
-    lazy var remoteTabsPanelProvider: Middleware<AppState> = { [self] state, action in
+    lazy var remoteTabsPanelProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         let uuid = action.windowUUID
         if let action = action as? RemoteTabsPanelAction {
             self.resolveRemoteTabsPanelActions(action: action, state: state)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -28,11 +28,11 @@ final class RemoteTabsPanelMiddleware: Notifiable {
 
     lazy var remoteTabsPanelProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         let uuid = action.windowUUID
         if let action = action as? RemoteTabsPanelAction {
             self.resolveRemoteTabsPanelActions(action: action, state: state)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -55,7 +55,13 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
         self.tabsPanelTelemetry = TabsPanelTelemetry(gleanWrapper: gleanWrapper, logger: logger)
     }
 
-    lazy var tabsPanelProvider: Middleware<AppState> = { state, action in
+    lazy var tabsPanelProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         if let action = action as? TabPeekAction {
             self.resolveTabPeekActions(action: action, state: state)
         } else if let action = action as? RemoteTabsPanelAction {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -57,11 +57,11 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
 
     lazy var tabsPanelProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         if let action = action as? TabPeekAction {
             self.resolveTabPeekActions(action: action, state: state)
         } else if let action = action as? RemoteTabsPanelAction {

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
@@ -19,7 +19,13 @@ final class TermsOfUseMiddleware {
         self.telemetry = telemetry
     }
 
-    lazy var termsOfUseProvider: Middleware<AppState> = { _, action in
+    lazy var termsOfUseProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         if let action = action as? TermsOfUseAction {
             self.handleTermsOfUseAction(action)
         } else if let action = action as? HomepageAction {

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseMiddleware.swift
@@ -21,11 +21,11 @@ final class TermsOfUseMiddleware {
 
     lazy var termsOfUseProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         if let action = action as? TermsOfUseAction {
             self.handleTermsOfUseAction(action)
         } else if let action = action as? HomepageAction {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -58,7 +58,13 @@ final class ToolbarMiddleware {
         self.logger = logger
     }
 
-    lazy var toolbarProvider: Middleware<AppState> = { state, action in
+    lazy var toolbarProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         if let action = action as? GeneralBrowserMiddlewareAction {
             self.resolveGeneralBrowserMiddlewareActions(action: action, state: state)
         } else if let action = action as? MicrosurveyPromptMiddlewareAction {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -60,11 +60,11 @@ final class ToolbarMiddleware {
 
     lazy var toolbarProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         if let action = action as? GeneralBrowserMiddlewareAction {
             self.resolveGeneralBrowserMiddlewareActions(action: action, state: state)
         } else if let action = action as? MicrosurveyPromptMiddlewareAction {

--- a/firefox-ios/Client/Frontend/FeltPrivacy/FeltPrivacyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/FeltPrivacy/FeltPrivacyMiddleware.swift
@@ -14,7 +14,13 @@ final class FeltPrivacyMiddleware {
         self.privacyStateManager = privacyStateManager
     }
 
-    lazy var privacyManagerProvider: Middleware<AppState> = { state, action in
+    lazy var privacyManagerProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         guard let action = action as? PrivateModeAction else { return }
         switch action.actionType {
         case PrivateModeActionType.setPrivateModeTo:

--- a/firefox-ios/Client/Frontend/FeltPrivacy/FeltPrivacyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/FeltPrivacy/FeltPrivacyMiddleware.swift
@@ -16,11 +16,11 @@ final class FeltPrivacyMiddleware {
 
     lazy var privacyManagerProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         guard let action = action as? PrivateModeAction else { return }
         switch action.actionType {
         case PrivateModeActionType.setPrivateModeTo:

--- a/firefox-ios/Client/Frontend/Home/Homepage/Bookmark/BookmarksMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Bookmark/BookmarksMiddleware.swift
@@ -15,7 +15,13 @@ final class BookmarksMiddleware {
         self.bookmarksHandler = profile.places
     }
 
-    lazy var bookmarksProvider: Middleware<AppState> = { state, action in
+    lazy var bookmarksProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
 
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage/Bookmark/BookmarksMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Bookmark/BookmarksMiddleware.swift
@@ -17,11 +17,11 @@ final class BookmarksMiddleware {
 
     lazy var bookmarksProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
 
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoMiddleware.swift
@@ -23,7 +23,13 @@ final class MerinoMiddleware {
         self.logger = logger
     }
 
-    lazy var pocketSectionProvider: Middleware<AppState> = { state, action in
+    lazy var pocketSectionProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         switch action.actionType {
         case HomepageActionType.initialize,
             HomepageMiddlewareActionType.didBecomeActive,

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoMiddleware.swift
@@ -25,11 +25,11 @@ final class MerinoMiddleware {
 
     lazy var pocketSectionProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         switch action.actionType {
         case HomepageActionType.initialize,
             HomepageMiddlewareActionType.didBecomeActive,

--- a/firefox-ios/Client/Frontend/Home/Homepage/MessageCard/MessageCardMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/MessageCard/MessageCardMiddleware.swift
@@ -26,7 +26,13 @@ final class MessageCardMiddleware {
         self.logger = logger
     }
 
-    lazy var messageCardProvider: Middleware<AppState> = { state, action in
+    lazy var messageCardProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
 
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage/MessageCard/MessageCardMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/MessageCard/MessageCardMiddleware.swift
@@ -28,11 +28,11 @@ final class MessageCardMiddleware {
 
     lazy var messageCardProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
 
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
@@ -30,7 +30,13 @@ final class HomepageMiddleware: FeatureFlaggable, Notifiable {
         observeNotifications()
     }
 
-    lazy var homepageProvider: Middleware<AppState> = { state, action in
+    lazy var homepageProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         switch action.actionType {
         case HomepageActionType.viewDidAppear:
             self.homepageTelemetry.sendHomepageImpressionEvent()

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
@@ -32,11 +32,11 @@ final class HomepageMiddleware: FeatureFlaggable, Notifiable {
 
     lazy var homepageProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         switch action.actionType {
         case HomepageActionType.viewDidAppear:
             self.homepageTelemetry.sendHomepageImpressionEvent()

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
@@ -45,7 +45,13 @@ final class TopSitesMiddleware {
         self.profile = profile
     }
 
-    lazy var topSitesProvider: Middleware<AppState> = { state, action in
+    lazy var topSitesProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         switch action.actionType {
         case HomepageActionType.initialize,
             ShortcutsLibraryActionType.initialize,

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
@@ -47,11 +47,11 @@ final class TopSitesMiddleware {
 
     lazy var topSitesProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         switch action.actionType {
         case HomepageActionType.initialize,
             ShortcutsLibraryActionType.initialize,

--- a/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/Redux/WallpaperMiddleware.swift
@@ -16,7 +16,13 @@ final class WallpaperMiddleware {
         self.wallpaperManager = wallpaperManager
     }
 
-    lazy var wallpaperProvider: Middleware<AppState> = { state, action in
+    lazy var wallpaperProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         if let action = action as? HomepageAction {
             self.resolveHomepageAction(action: action, state: state)
         } else if let action = action as? WallpaperAction {

--- a/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/Redux/WallpaperMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/Redux/WallpaperMiddleware.swift
@@ -18,11 +18,11 @@ final class WallpaperMiddleware {
 
     lazy var wallpaperProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         if let action = action as? HomepageAction {
             self.resolveHomepageAction(action: action, state: state)
         } else if let action = action as? WallpaperAction {

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
@@ -33,7 +33,13 @@ final class WorldCupMiddleware {
         }
     }
 
-    lazy var worldCupProvider: Middleware<AppState> = { state, action in
+    lazy var worldCupProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         self.lastWindowUUID = action.windowUUID
         switch action.actionType {
         case HomepageActionType.initialize,

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
@@ -35,11 +35,11 @@ final class WorldCupMiddleware {
 
     lazy var worldCupProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         self.lastWindowUUID = action.windowUUID
         switch action.actionType {
         case HomepageActionType.initialize,

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -14,7 +14,13 @@ final class MicrosurveyPromptMiddleware {
         self.microsurveyManager = microsurveyManager
     }
 
-    lazy var microsurveyProvider: Middleware<AppState> = { state, action in
+    lazy var microsurveyProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
 
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptMiddleware.swift
@@ -16,11 +16,11 @@ final class MicrosurveyPromptMiddleware {
 
     lazy var microsurveyProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
 
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
@@ -14,7 +14,13 @@ final class MicrosurveyMiddleware {
         self.microsurveyTelemetry = microsurveyTelemetry
     }
 
-    lazy var microsurveyProvider: Middleware<AppState> = { state, action in
+    lazy var microsurveyProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
         guard let surveyId = (action as? MicrosurveyAction)?.surveyId else { return }
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyMiddleware.swift
@@ -16,11 +16,11 @@ final class MicrosurveyMiddleware {
 
     lazy var microsurveyProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
         guard let surveyId = (action as? MicrosurveyAction)?.surveyId else { return }
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageMiddleware.swift
@@ -21,7 +21,13 @@ final class NativeErrorPageMiddleware {
         self.logger = logger
     }
 
-    lazy var nativeErrorPageProvider: Middleware<AppState> = { [self] state, action in
+    lazy var nativeErrorPageProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
         switch action.actionType {
         case NativeErrorPageActionType.receivedError:

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageMiddleware.swift
@@ -23,11 +23,11 @@ final class NativeErrorPageMiddleware {
 
     lazy var nativeErrorPageProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
         switch action.actionType {
         case NativeErrorPageActionType.receivedError:

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
@@ -29,7 +29,13 @@ final class PasswordGeneratorMiddleware {
         PasswordGeneratorMiddleware.loadPasswordRules()
     }
 
-    lazy var passwordGeneratorProvider: Middleware<AppState> = { state, action in
+    lazy var passwordGeneratorProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
 
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorMiddleware.swift
@@ -31,11 +31,11 @@ final class PasswordGeneratorMiddleware {
 
     lazy var passwordGeneratorProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
 
         switch action.actionType {

--- a/firefox-ios/Client/Frontend/QuickAnswers/QuickAnswersMiddleware.swift
+++ b/firefox-ios/Client/Frontend/QuickAnswers/QuickAnswersMiddleware.swift
@@ -33,7 +33,15 @@ final class QuickAnswersMiddleware: QuickAnswersStore {
     }
 
     @MainActor
-    lazy var quickAnswersProvider: Middleware<AppState> = { state, action in
+    lazy var quickAnswersProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    @MainActor
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    @MainActor
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         switch action.actionType {
         case HomepageActionType.initialize, HomepageActionType.viewWillAppear:
             self.handleInitializeAction(action: action)

--- a/firefox-ios/Client/Frontend/QuickAnswers/QuickAnswersMiddleware.swift
+++ b/firefox-ios/Client/Frontend/QuickAnswers/QuickAnswersMiddleware.swift
@@ -36,12 +36,12 @@ final class QuickAnswersMiddleware: QuickAnswersStore {
     lazy var quickAnswersProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
     @MainActor
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
     @MainActor
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         switch action.actionType {
         case HomepageActionType.initialize, HomepageActionType.viewWillAppear:
             self.handleInitializeAction(action: action)

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -36,7 +36,13 @@ final class ThemeManagerMiddleware: ThemeManagerProvider {
         self.themeManager = themeManager
     }
 
-    lazy var themeManagerProvider: Middleware<AppState> = { _, action in
+    lazy var themeManagerProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         if let action = action as? ThemeSettingsViewAction {
             self.resolveThemeSettingsViewActionType(action: action)
         } else if let action = action as? PrivateModeAction {

--- a/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/ThemeSettings/ThemeMiddleware.swift
@@ -38,11 +38,11 @@ final class ThemeManagerMiddleware: ThemeManagerProvider {
 
     lazy var themeManagerProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         if let action = action as? ThemeSettingsViewAction {
             self.resolveThemeSettingsViewActionType(action: action)
         } else if let action = action as? PrivateModeAction {

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
@@ -34,7 +34,13 @@ final class TranslationSettingsMiddleware {
         loadSettingsTask?.cancel()
     }
 
-    lazy var translationSettingsProvider: Middleware<AppState> = { state, action in
+    lazy var translationSettingsProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         guard let action = action as? TranslationSettingsViewAction else { return }
         self.handleAction(action, state: state)
     }

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsMiddleware.swift
@@ -36,11 +36,11 @@ final class TranslationSettingsMiddleware {
 
     lazy var translationSettingsProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         guard let action = action as? TranslationSettingsViewAction else { return }
         self.handleAction(action, state: state)
     }

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryMiddleware.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryMiddleware.swift
@@ -16,7 +16,13 @@ final class ShortcutsLibraryMiddleware {
         self.shortcutsLibraryTelemetry = shortcutsLibraryTelemetry
     }
 
-    lazy var shortcutsLibraryProvider: Middleware<AppState> = { state, action in
+    lazy var shortcutsLibraryProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         switch action.actionType {
         case ShortcutsLibraryActionType.tapOnShortcutCell:
             self.shortcutsLibraryTelemetry.sendShortcutTappedEvent()

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryMiddleware.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryMiddleware.swift
@@ -18,11 +18,11 @@ final class ShortcutsLibraryMiddleware {
 
     lazy var shortcutsLibraryProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         switch action.actionType {
         case ShortcutsLibraryActionType.tapOnShortcutCell:
             self.shortcutsLibraryTelemetry.sendShortcutTappedEvent()

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
@@ -46,7 +46,13 @@ final class SummarizerMiddleware: SummarizerConfigFactory {
         self.summarizerConfigProvider = summarizerConfigProvider
     }
 
-    lazy var summarizerProvider: Middleware<AppState> = { state, action in
+    lazy var summarizerProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         if let action = action as? GeneralBrowserAction {
             self.handleGeneralBrowserAction(action: action)
         } else if let action = action as? ToolbarAction {

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
@@ -48,11 +48,11 @@ final class SummarizerMiddleware: SummarizerConfigFactory {
 
     lazy var summarizerProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         if let action = action as? GeneralBrowserAction {
             self.handleGeneralBrowserAction(action: action)
         } else if let action = action as? ToolbarAction {

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionMiddleware.swift
@@ -10,7 +10,13 @@ import Common
 final class TrackingProtectionMiddleware {
     private let telemetryWrapper = TrackingProtectionTelemetry()
 
-    lazy var trackingProtectionProvider: Middleware<AppState> = { state, action in
+    lazy var trackingProtectionProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
         switch action.actionType {
         case TrackingProtectionActionType.toggleTrackingProtectionStatus:

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionMiddleware.swift
@@ -12,11 +12,11 @@ final class TrackingProtectionMiddleware {
 
     lazy var trackingProtectionProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
         switch action.actionType {
         case TrackingProtectionActionType.toggleTrackingProtectionStatus:

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -82,7 +82,13 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
         }
     }
 
-    lazy var translationsProvider: Middleware<AppState> = { state, action in
+    lazy var translationsProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
         switch action.actionType {
         case ToolbarActionType.urlDidChange:

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -84,11 +84,11 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
 
     lazy var translationsProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
-    lazy var modernProvider: MiddlewareMethod<AppState> = { [self] state, action, windowUUID in
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         // Does not test any modern actions
     }
 
-    lazy var legacyProvider: LegacyMiddlewareMethod<AppState> = { [self] state, action in
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         let windowUUID = action.windowUUID
         switch action.actionType {
         case ToolbarActionType.urlDidChange:

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
@@ -7,7 +7,13 @@ import Redux
 
 @MainActor
 final class WebCompatReporterMiddleware {
-    lazy var webCompatReporterProvider: Middleware<AppState> = { state, action in
+    lazy var webCompatReporterProvider: Middleware<AppState> = (legacyProvider, modernProvider)
+
+    lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
+        // Does not test any modern actions
+    }
+
+    lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
         guard let action = action as? WebCompatReporterViewAction else { return }
         self.handleAction(action, state: state)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
@@ -40,7 +40,7 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = createSubject(mockSearchEnginesManager: mockSearchEnginesManager)
         let action = getAction(for: .viewDidLoad)
 
-        subject.searchEngineSelectionProvider(AppState(), action)
+        subject.searchEngineSelectionProvider.legacyMiddleware(AppState(), action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? SearchEngineSelectionAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? SearchEngineSelectionActionType)
@@ -54,7 +54,7 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = createSubject(mockSearchEnginesManager: mockSearchEnginesManager)
         let action = getAction(for: .didTapSearchEngine)
 
-        subject.searchEngineSelectionProvider(AppState(), action)
+        subject.searchEngineSelectionProvider.legacyMiddleware(AppState(), action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/BookmarksMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/BookmarksMiddlewareTests.swift
@@ -35,7 +35,7 @@ final class BookmarksMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.bookmarksProvider(AppState(), action)
+        subject.bookmarksProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation])
 
@@ -59,7 +59,7 @@ final class BookmarksMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.bookmarksProvider(AppState(), action)
+        subject.bookmarksProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation])
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
@@ -97,7 +97,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageActionType.viewWillAppear
         )
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 0)
         XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
@@ -111,7 +111,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageActionType.viewDidAppear
         )
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let event = GleanMetrics.Homepage.viewed
@@ -128,7 +128,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: NavigationBrowserActionType.tapOnBookmarksShowMoreButton
         )
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
@@ -152,7 +152,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: NavigationBrowserActionType.tapOnJumpBackInShowAllButton
         )
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
@@ -176,7 +176,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: NavigationBrowserActionType.tapOnJumpBackInShowAllButton
         )
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
@@ -200,7 +200,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageActionType.didSelectItem
         )
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Homepage.ItemTappedExtra>
@@ -224,7 +224,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageActionType.sectionSeen
         )
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? LabeledMetricType<CounterMetricType>)
         let metric = GleanMetrics.Homepage.sectionViewed
@@ -249,7 +249,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -278,7 +278,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -307,7 +307,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -336,7 +336,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -365,7 +365,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -393,7 +393,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -422,7 +422,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -450,7 +450,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -479,7 +479,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -507,7 +507,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -538,7 +538,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -564,7 +564,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageActionType.initialize
         )
 
-        subject.homepageProvider(AppState(), action)
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         let configuredPrivacyNoticeActions = mockStore.dispatchedActions.compactMap { $0 as? HomepageAction }
             .filter { ($0.actionType as? HomepageMiddlewareActionType) == .configuredPrivacyNotice }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoMiddlewareTests.swift
@@ -37,7 +37,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.pocketSectionProvider(AppState(), action)
+        subject.pocketSectionProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation])
 
@@ -62,7 +62,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.pocketSectionProvider(AppState(), action)
+        subject.pocketSectionProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation])
 
@@ -88,7 +88,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.pocketSectionProvider(AppState(), action)
+        subject.pocketSectionProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation])
 
@@ -110,7 +110,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: .XCTestDefaultUUID,
             actionType: MerinoActionType.tapOnHomepageMerinoCell
         )
-        subject.pocketSectionProvider(AppState(), action)
+        subject.pocketSectionProvider.legacyMiddleware(AppState(), action)
 
         let firstMetric = GleanMetrics.Pocket.openStoryOrigin
         let secondMetric = GleanMetrics.Pocket.openStoryPosition
@@ -133,7 +133,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: .XCTestDefaultUUID,
             actionType: MerinoActionType.tapOnHomepageMerinoCell
         )
-        subject.pocketSectionProvider(AppState(), action)
+        subject.pocketSectionProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordLabelCalled, 0)
@@ -143,7 +143,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = createSubject(merinoManager: merinoManager)
         let action = MerinoAction(windowUUID: .XCTestDefaultUUID, actionType: MerinoActionType.viewedSection)
 
-        subject.pocketSectionProvider(AppState(), action)
+        subject.pocketSectionProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? CounterMetricType)
         let metric = GleanMetrics.Pocket.sectionImpressions
@@ -164,7 +164,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ContextMenuActionType.tappedOnOpenNewPrivateTab
         )
 
-        subject.pocketSectionProvider(AppState(), action)
+        subject.pocketSectionProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let event = GleanMetrics.Pocket.openInPrivateTab
@@ -184,7 +184,7 @@ final class MerinoMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: .XCTestDefaultUUID,
             actionType: ContextMenuActionType.tappedOnOpenNewPrivateTab
         )
-        subject.pocketSectionProvider(AppState(), action)
+        subject.pocketSectionProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MessageCardMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MessageCardMiddlewareTests.swift
@@ -35,7 +35,7 @@ final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.messageCardProvider(AppState(), action)
+        subject.messageCardProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation])
 
@@ -64,7 +64,7 @@ final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.messageCardProvider(AppState(), action)
+        subject.messageCardProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -80,14 +80,14 @@ final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
 
-        subject.messageCardProvider(AppState(), action)
+        subject.messageCardProvider.legacyMiddleware(AppState(), action)
 
         let secondaryAction = MessageCardAction(
             windowUUID: .XCTestDefaultUUID,
             actionType: MessageCardActionType.tappedOnActionButton
         )
 
-        subject.messageCardProvider(AppState(), secondaryAction)
+        subject.messageCardProvider.legacyMiddleware(AppState(), secondaryAction)
 
         XCTAssertEqual(messagingManager.onMessagePressedCalled, 1)
     }
@@ -100,14 +100,14 @@ final class MessageCardMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
 
-        subject.messageCardProvider(AppState(), action)
+        subject.messageCardProvider.legacyMiddleware(AppState(), action)
 
         let secondaryAction = MessageCardAction(
             windowUUID: .XCTestDefaultUUID,
             actionType: MessageCardActionType.tappedOnCloseButton
         )
 
-        subject.messageCardProvider(AppState(), secondaryAction)
+        subject.messageCardProvider.legacyMiddleware(AppState(), secondaryAction)
 
         XCTAssertEqual(messagingManager.onMessageDismissedCalled, 1)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesMiddlewareTests.swift
@@ -43,7 +43,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -71,7 +71,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -98,7 +98,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TopSitesActionType.topSitesSeen
         )
 
-        subject.topSitesProvider(AppState(), action)
+        subject.topSitesProvider.legacyMiddleware(AppState(), action)
         XCTAssertEqual(unifiedAdsTelemetry.sendImpressionTelemetryCalled, 1)
     }
 
@@ -115,7 +115,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -142,7 +142,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -169,9 +169,9 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
-        subject.topSitesProvider(appState, action)
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -199,9 +199,9 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
-        subject.topSitesProvider(appState, action)
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -227,7 +227,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -254,7 +254,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TopSitesActionType.tapOnHomepageTopSitesCell
         )
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         try checkTopSitesPressedMetrics(label: "zero-search", position: "0", tileType: "sponsored")
 
@@ -283,7 +283,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TopSitesActionType.tapOnHomepageTopSitesCell
         )
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         try checkTopSitesPressedMetrics(label: "origin-other", position: "1", tileType: "suggested")
 
@@ -304,7 +304,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TopSitesActionType.tapOnHomepageTopSitesCell
         )
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordLabelCalled, 0)
@@ -323,7 +323,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ContextMenuActionType.tappedOnPinTopSite
         )
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         let contextMenuMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.TopSites.ContextualMenuExtra>
@@ -357,7 +357,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ContextMenuActionType.tappedOnPinTopSite
         )
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
@@ -374,7 +374,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ContextMenuActionType.tappedOnPinTopSite
         )
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         let pinnedExtras = try XCTUnwrap(
             mockGleanWrapper.savedExtras.last as? GleanMetrics.TopSites.ShortcutPinnedExtra
@@ -399,7 +399,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             unpinTopSiteExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         let contextMenuMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.TopSites.ContextualMenuExtra>
@@ -438,7 +438,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             unpinTopSiteExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
@@ -461,7 +461,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             unpinTopSiteExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         let unpinnedExtras = try XCTUnwrap(
             mockGleanWrapper.savedExtras.last as? GleanMetrics.TopSites.ShortcutUnpinnedExtra
@@ -488,7 +488,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             removeTopSiteExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         try checkContextMenuMetricsCalled(withExtra: "remove")
 
@@ -508,7 +508,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             removeTopSiteExpectation.fulfill()
         }
 
-        subject.topSitesProvider(appState, action)
+        subject.topSitesProvider.legacyMiddleware(appState, action)
 
         XCTAssertEqual(mockGleanWrapper.savedEvents.count, 0)
         XCTAssertEqual(mockGleanWrapper.recordEventCalled, 0)
@@ -531,7 +531,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ContextMenuActionType.tappedOnOpenNewPrivateTab
         )
 
-        subject.topSitesProvider(AppState(), action)
+        subject.topSitesProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let event = GleanMetrics.TopSites.openInPrivateTab
@@ -546,7 +546,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: .XCTestDefaultUUID,
             actionType: ContextMenuActionType.tappedOnSettingsAction
         )
-        subject.topSitesProvider(AppState(), action)
+        subject.topSitesProvider.legacyMiddleware(AppState(), action)
 
         try checkContextMenuMetricsCalled(withExtra: "settings")
     }
@@ -557,7 +557,7 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: .XCTestDefaultUUID,
             actionType: ContextMenuActionType.tappedOnSponsoredAction
         )
-        subject.topSitesProvider(AppState(), action)
+        subject.topSitesProvider.legacyMiddleware(AppState(), action)
 
         try checkContextMenuMetricsCalled(withExtra: "sponsoredSupport")
     }
@@ -580,9 +580,9 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TopSitesActionType.shortcutPinned
         )
 
-        subject.topSitesProvider(AppState(), homeScreenAction)
-        subject.topSitesProvider(AppState(), appMenuAction)
-        subject.topSitesProvider(AppState(), contextMenuAction)
+        subject.topSitesProvider.legacyMiddleware(AppState(), homeScreenAction)
+        subject.topSitesProvider.legacyMiddleware(AppState(), appMenuAction)
+        subject.topSitesProvider.legacyMiddleware(AppState(), contextMenuAction)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.TopSites.ShortcutPinnedExtra>
@@ -608,8 +608,8 @@ final class TopSitesMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TopSitesActionType.shortcutUnpinned
         )
 
-        subject.topSitesProvider(AppState(), contextMenuAction)
-        subject.topSitesProvider(AppState(), appMenuAction)
+        subject.topSitesProvider.legacyMiddleware(AppState(), contextMenuAction)
+        subject.topSitesProvider.legacyMiddleware(AppState(), appMenuAction)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.TopSites.ShortcutUnpinnedExtra>

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Wallpaper/WallpaperMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Wallpaper/WallpaperMiddlewareTests.swift
@@ -28,7 +28,7 @@ class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = WallpaperMiddleware(wallpaperManager: wallpaperManager)
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
 
-        subject.wallpaperProvider(appState, action)
+        subject.wallpaperProvider.legacyMiddleware(appState, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? WallpaperAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? WallpaperMiddlewareActionType)
@@ -47,7 +47,7 @@ class WallpaperMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: WallpaperActionType.wallpaperSelected
         )
 
-        subject.wallpaperProvider(appState, action)
+        subject.wallpaperProvider.legacyMiddleware(appState, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? WallpaperAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? WallpaperMiddlewareActionType)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -47,7 +47,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let expectation = XCTestExpectation(description: "didUpdate dispatched")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -78,7 +78,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -106,7 +106,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: WorldCupActionType.didChangeHomepageSettings
         )
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         XCTAssertEqual(feed.startCalled, 1)
         XCTAssertEqual(feed.stopCalled, 0)
@@ -125,7 +125,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: WorldCupActionType.didChangeHomepageSettings
         )
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         XCTAssertEqual(feed.stopCalled, 1)
         XCTAssertEqual(feed.startCalled, 0)
@@ -147,7 +147,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let expectation = XCTestExpectation(description: "didUpdate dispatched")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -172,7 +172,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageMiddlewareActionType.didEnterBackground
         )
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         XCTAssertEqual(feed.stopCalled, 1)
         XCTAssertEqual(feed.startCalled, 0)
@@ -190,7 +190,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageMiddlewareActionType.didBecomeActive
         )
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         XCTAssertEqual(feed.startCalled, 1)
 
@@ -241,7 +241,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -267,7 +267,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let expectation = XCTestExpectation(description: "didUpdate dispatched")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -292,7 +292,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -322,7 +322,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -364,7 +364,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -398,7 +398,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -433,7 +433,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -463,7 +463,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -490,7 +490,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         )
 
         let expectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
         wait(for: [expectation])
 
         XCTAssertEqual(apiClient.matchesFetchCount, 1)
@@ -527,7 +527,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -576,7 +576,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let teamsExpectation = expectation(description: "loadTeams called")
         apiClient.loadTeamsCalled = teamsExpectation
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [matchesExpectation, teamsExpectation])
 
@@ -628,7 +628,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchCardCount(2)
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -670,7 +670,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         // expect at least two dispatches with non-empty matches.
         let expectation = expectationForMatchCardCount(2)
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -709,7 +709,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -734,7 +734,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let expectation = XCTestExpectation(description: "didUpdate dispatched")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -756,7 +756,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageMiddlewareActionType.configuredPrivacyNotice
         )
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         XCTAssertEqual(mockWorldCupStore.setIsHomepageSectionEnabledCalled, 0)
@@ -792,7 +792,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -839,7 +839,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -879,7 +879,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -913,7 +913,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -948,7 +948,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let expectation = expectationForMatchesDispatch()
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -981,7 +981,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
 
         let expectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
         wait(for: [expectation])
 
         let dispatched = try XCTUnwrap(latestWorldCupAction())
@@ -1031,7 +1031,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
 
         let expectation = expectationForMatchCardCount(2)
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
         wait(for: [expectation])
 
         let dispatched = try XCTUnwrap(latestWorldCupAction())
@@ -1060,7 +1060,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         bringHomepageOnScreen(subject)
 
         let firstExpectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(
+        subject.worldCupProvider.legacyMiddleware(
             appState,
             HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
         )
@@ -1071,7 +1071,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         // persisted as seen, it must not celebrate again — this is the
         // cross-launch correlation behavior.
         let secondExpectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(
+        subject.worldCupProvider.legacyMiddleware(
             appState,
             WorldCupAction(windowUUID: .XCTestDefaultUUID, actionType: WorldCupActionType.retryMatchesFetch)
         )
@@ -1104,7 +1104,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
 
         let expectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
         wait(for: [expectation])
 
         let dispatched = try XCTUnwrap(latestWorldCupAction())
@@ -1141,7 +1141,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
 
         let expectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
         wait(for: [expectation])
 
         let dispatched = try XCTUnwrap(latestWorldCupAction())
@@ -1180,7 +1180,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
 
         let expectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
         wait(for: [expectation])
 
         let dispatched = try XCTUnwrap(latestWorldCupAction())
@@ -1218,7 +1218,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
 
         let expectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
         wait(for: [expectation])
 
         let dispatched = try XCTUnwrap(latestWorldCupAction())
@@ -1254,7 +1254,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         bringHomepageOnScreen(subject)
 
         let firstExpectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(
+        subject.worldCupProvider.legacyMiddleware(
             appState,
             HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
         )
@@ -1262,7 +1262,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(try XCTUnwrap(latestWorldCupAction()).shouldShowConfetti)
 
         let secondExpectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(
+        subject.worldCupProvider.legacyMiddleware(
             appState,
             WorldCupAction(windowUUID: .XCTestDefaultUUID, actionType: WorldCupActionType.retryMatchesFetch)
         )
@@ -1287,13 +1287,13 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let apiClient = MockWorldCupAPIClient(matchesResult: .success(response))
         let subject = createSubject(apiClient: apiClient, usesDevServerTimeline: true)
         bringHomepageOnScreen(subject)
-        subject.worldCupProvider(
+        subject.worldCupProvider.legacyMiddleware(
             appState,
             HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.viewWillDisappear)
         )
 
         let expectation = expectationForMatchesDispatch()
-        subject.worldCupProvider(
+        subject.worldCupProvider.legacyMiddleware(
             appState,
             HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.initialize)
         )
@@ -1352,7 +1352,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
     /// visible — the precondition for `resolveShouldShowConfetti` to run. Also
     /// re-dispatches the feed's latest snapshot, mirroring the real lifecycle.
     private func bringHomepageOnScreen(_ subject: WorldCupMiddleware) {
-        subject.worldCupProvider(
+        subject.worldCupProvider.legacyMiddleware(
             appState,
             HomepageAction(windowUUID: .XCTestDefaultUUID, actionType: HomepageActionType.viewDidAppear)
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -1337,7 +1337,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
     /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: WorldCupMiddleware) {
-        subject.worldCupProvider = emptyLegacyMiddlewareMethodFactory()
+        subject.worldCupProvider = emptyMiddlewareProviderFactory()
     }
 
     /// Hands the middleware a `MockWorldCupFeed` so tests can assert on the

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -1338,8 +1338,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: WorldCupMiddleware) {
         subject.worldCupProvider = emptyMiddlewareProviderFactory()
-        subject.legacyProvider = emptyLegacyMiddlewareMethodFactory()
-        subject.modernProvider = emptyMiddlewareMethodFactory()
+        subject.legacyProvider = emptyLegacyMiddlewareFactory()
+        subject.modernProvider = emptyMiddlewareFactory()
     }
 
     /// Hands the middleware a `MockWorldCupFeed` so tests can assert on the

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -1338,6 +1338,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: WorldCupMiddleware) {
         subject.worldCupProvider = emptyMiddlewareProviderFactory()
+        subject.legacyProvider = emptyLegacyMiddlewareMethodFactory()
+        subject.modernProvider = emptyMiddlewareMethodFactory()
     }
 
     /// Hands the middleware a `MockWorldCupFeed` so tests can assert on the

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -211,7 +211,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let expectation = XCTestExpectation(description: "didUpdate dispatched")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.worldCupProvider(appState, action)
+        subject.worldCupProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -222,7 +222,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(dispatched.shouldShowHomepageWorldCupSection)
         XCTAssertTrue(dispatched.matches.isEmpty)
         XCTAssertEqual(feed.startCalled, 0)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - WorldCupActionType.selectTeam

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ShortcutsLibrary/Redux/ShortcutsLibraryMiddlewareTests.swift
@@ -33,7 +33,7 @@ final class ShortcutsLibraryMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ShortcutsLibraryActionType.viewDidAppear
         )
 
-        subject.shortcutsLibraryProvider(initialState, action)
+        subject.shortcutsLibraryProvider.legacyMiddleware(initialState, action)
 
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let event = GleanMetrics.HomepageShortcutsLibrary.viewed
@@ -49,7 +49,7 @@ final class ShortcutsLibraryMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ShortcutsLibraryActionType.viewDidAppear
         )
 
-        subject.shortcutsLibraryProvider(AppState(), action)
+        subject.shortcutsLibraryProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 0)
     }
@@ -61,7 +61,7 @@ final class ShortcutsLibraryMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ShortcutsLibraryActionType.viewDidDisappear
         )
 
-        subject.shortcutsLibraryProvider(AppState(), action)
+        subject.shortcutsLibraryProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let event = GleanMetrics.HomepageShortcutsLibrary.closed
@@ -77,7 +77,7 @@ final class ShortcutsLibraryMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ShortcutsLibraryActionType.tapOnShortcutCell
         )
 
-        subject.shortcutsLibraryProvider(AppState(), action)
+        subject.shortcutsLibraryProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
         let event = GleanMetrics.HomepageShortcutsLibrary.shortcutTapped

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
@@ -464,7 +464,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
     /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: SummarizerMiddleware) {
-        subject.summarizerProvider = emptyLegacyMiddlewareMethodFactory()
+        subject.summarizerProvider = emptyMiddlewareProviderFactory()
     }
 
     private func setupWebViewForTabManager(isHomePage: Bool = false) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
@@ -68,7 +68,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.summarizerProvider(AppState(), action)
+        subject.summarizerProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1)
 
@@ -100,7 +100,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.summarizerProvider(AppState(), action)
+        subject.summarizerProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1)
 
@@ -131,7 +131,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.summarizerProvider(AppState(), action)
+        subject.summarizerProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -158,7 +158,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.summarizerProvider(AppState(), action)
+        subject.summarizerProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1)
 
@@ -180,7 +180,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.summarizerProvider(AppState(), action)
+        subject.summarizerProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1)
 
@@ -208,7 +208,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.summarizerProvider(AppState(), action)
+        subject.summarizerProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1)
 
@@ -239,7 +239,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.summarizerProvider(AppState(), action)
+        subject.summarizerProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1)
 
@@ -268,7 +268,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.summarizerProvider(AppState(), action)
+        subject.summarizerProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1)
 
@@ -298,7 +298,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.summarizerProvider(AppState(), action)
+        subject.summarizerProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1)
 
@@ -325,7 +325,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.summarizerProvider(AppState(), action)
+        subject.summarizerProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [expectation], timeout: 1)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
@@ -465,6 +465,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: SummarizerMiddleware) {
         subject.summarizerProvider = emptyMiddlewareProviderFactory()
+        subject.legacyProvider = emptyLegacyMiddlewareMethodFactory()
+        subject.modernProvider = emptyMiddlewareMethodFactory()
     }
 
     private func setupWebViewForTabManager(isHomePage: Bool = false) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
@@ -465,8 +465,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: SummarizerMiddleware) {
         subject.summarizerProvider = emptyMiddlewareProviderFactory()
-        subject.legacyProvider = emptyLegacyMiddlewareMethodFactory()
-        subject.modernProvider = emptyMiddlewareMethodFactory()
+        subject.legacyProvider = emptyLegacyMiddlewareFactory()
+        subject.modernProvider = emptyMiddlewareFactory()
     }
 
     private func setupWebViewForTabManager(isHomePage: Bool = false) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
@@ -30,7 +30,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .findInPage)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -49,7 +49,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .bookmarks)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -68,7 +68,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .history)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -87,7 +87,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .downloads)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -106,7 +106,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .passwords)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -125,7 +125,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .settings)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -144,7 +144,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .printSheet)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -163,7 +163,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .shareSheet)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -182,7 +182,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .saveAsPDF)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -201,7 +201,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .syncSignIn)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -220,7 +220,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .editBookmark)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -239,7 +239,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .readerView)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -258,7 +258,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .zoom)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -277,7 +277,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .siteProtections)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -296,7 +296,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = getNavigationDestinationAction(for: .defaultBrowser)
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -319,7 +319,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -341,7 +341,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.CloseButtonExtra>
@@ -369,7 +369,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -396,7 +396,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -423,7 +423,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -451,7 +451,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
             dispatchExpectation.fulfill()
         }
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         wait(for: [dispatchExpectation], timeout: 1)
 
@@ -473,7 +473,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MenuDismissedExtra>
@@ -496,7 +496,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -519,7 +519,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -542,7 +542,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -565,7 +565,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -588,7 +588,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -611,7 +611,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>
@@ -634,7 +634,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let subject = createSubject()
 
-        subject.mainMenuProvider(AppState(), action)
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.AppMenu.MainMenuOptionSelectedExtra>

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/MicrosurveyMiddlewareTests.swift
@@ -30,7 +30,7 @@ final class MicrosurveyMiddlewareIntegrationTests: XCTestCase, StoreTestUtility 
         let subject = createSubject()
         let action = getAction(for: .closeSurvey)
 
-        subject.microsurveyProvider(AppState(), action)
+        subject.microsurveyProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockMicrosurveyTelemetry.lastSurveyId, "microsurvey-id")
         XCTAssertEqual(mockMicrosurveyTelemetry.dismissButtonTappedCalledCount, 1)
@@ -46,7 +46,7 @@ final class MicrosurveyMiddlewareIntegrationTests: XCTestCase, StoreTestUtility 
         let subject = createSubject()
         let action = getAction(for: .tapPrivacyNotice)
 
-        subject.microsurveyProvider(AppState(), action)
+        subject.microsurveyProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockMicrosurveyTelemetry.lastSurveyId, "microsurvey-id")
         XCTAssertEqual(mockMicrosurveyTelemetry.privacyNoticeTappedCalledCount, 1)
@@ -62,7 +62,7 @@ final class MicrosurveyMiddlewareIntegrationTests: XCTestCase, StoreTestUtility 
             actionType: MicrosurveyActionType.submitSurvey
         )
 
-        subject.microsurveyProvider(AppState(), action)
+        subject.microsurveyProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockMicrosurveyTelemetry.lastSurveyId, "microsurvey-id")
         XCTAssertEqual(mockMicrosurveyTelemetry.lastUserSelection, "Neutral")
@@ -79,7 +79,7 @@ final class MicrosurveyMiddlewareIntegrationTests: XCTestCase, StoreTestUtility 
         let subject = createSubject()
         let action = getAction(for: .surveyDidAppear)
 
-        subject.microsurveyProvider(AppState(), action)
+        subject.microsurveyProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockMicrosurveyTelemetry.lastSurveyId, "microsurvey-id")
         XCTAssertEqual(mockMicrosurveyTelemetry.surveyViewedCalledCount, 1)
@@ -89,7 +89,7 @@ final class MicrosurveyMiddlewareIntegrationTests: XCTestCase, StoreTestUtility 
         let subject = createSubject()
         let action = getAction(for: .confirmationViewed)
 
-        subject.microsurveyProvider(AppState(), action)
+        subject.microsurveyProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockMicrosurveyTelemetry.lastSurveyId, "microsurvey-id")
         XCTAssertEqual(mockMicrosurveyTelemetry.confirmationShownCalledCount, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyPromptMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Microsurvey/Mock/MicrosurveyPromptMiddlewareTests.swift
@@ -46,7 +46,7 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
             actionType: MicrosurveyPromptActionType.showPrompt
         )
 
-        subject.microsurveyProvider(AppState(), action)
+        subject.microsurveyProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         XCTAssertEqual(mockMicrosurveyManager.handleMessageDisplayedCount, 0)
@@ -59,7 +59,7 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
             actionType: MicrosurveyPromptActionType.showPrompt
         )
 
-        subject.microsurveyProvider(AppState(), action)
+        subject.microsurveyProvider.legacyMiddleware(AppState(), action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? MicrosurveyPromptMiddlewareAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? MicrosurveyPromptMiddlewareActionType)
@@ -76,7 +76,7 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
             actionType: MicrosurveyPromptActionType.closePrompt
         )
 
-        subject.microsurveyProvider(AppState(), action)
+        subject.microsurveyProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         XCTAssertEqual(mockMicrosurveyManager.handleMessageDismissCount, 1)
@@ -89,7 +89,7 @@ final class MicrosurveyPromptMiddlewareTests: XCTestCase {
             actionType: MicrosurveyPromptActionType.continueToSurvey
         )
 
-        subject.microsurveyProvider(AppState(), action)
+        subject.microsurveyProvider.legacyMiddleware(AppState(), action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         XCTAssertEqual(mockMicrosurveyManager.handleMessagePressedCount, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageMiddlewareTests.swift
@@ -48,7 +48,7 @@ final class NativeErrorPageMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: NativeErrorPageActionType.bypassCertificateWarning
         )
 
-        subject.nativeErrorPageProvider(mockStore.state, action)
+        subject.nativeErrorPageProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockLogger.savedLevel, .warning)
         XCTAssertEqual(mockLogger.savedCategory, .certificate)
@@ -62,7 +62,7 @@ final class NativeErrorPageMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: NativeErrorPageActionType.bypassCertificateWarning
         )
 
-        subject.nativeErrorPageProvider(mockStore.state, action)
+        subject.nativeErrorPageProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockLogger.savedLevel, .warning)
         XCTAssertEqual(mockLogger.savedCategory, .certificate)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/QuickAnswers/QuickAnswersMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/QuickAnswers/QuickAnswersMiddlewareTests.swift
@@ -47,7 +47,7 @@ final class QuickAnswersMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: QuickAnswersActionType.didSettingsChange
         )
 
-        subject.quickAnswersProvider(mockStore.state, action)
+        subject.quickAnswersProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
@@ -67,7 +67,7 @@ final class QuickAnswersMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: QuickAnswersActionType.didSettingsChange
         )
 
-        subject.quickAnswersProvider(mockStore.state, action)
+        subject.quickAnswersProvider.legacyMiddleware(mockStore.state, action)
 
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
         XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, false)
@@ -83,7 +83,7 @@ final class QuickAnswersMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: QuickAnswersActionType.didSettingsChange
         )
 
-        subject.quickAnswersProvider(mockStore.state, action)
+        subject.quickAnswersProvider.legacyMiddleware(mockStore.state, action)
 
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
         XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, false)
@@ -99,7 +99,7 @@ final class QuickAnswersMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: QuickAnswersActionType.didSettingsChange
         )
 
-        subject.quickAnswersProvider(mockStore.state, action)
+        subject.quickAnswersProvider.legacyMiddleware(mockStore.state, action)
 
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
         XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, false)
@@ -116,7 +116,7 @@ final class QuickAnswersMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageActionType.initialize
         )
 
-        subject.quickAnswersProvider(mockStore.state, action)
+        subject.quickAnswersProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
@@ -136,7 +136,7 @@ final class QuickAnswersMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageActionType.initialize
         )
 
-        subject.quickAnswersProvider(mockStore.state, action)
+        subject.quickAnswersProvider.legacyMiddleware(mockStore.state, action)
 
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
         XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, false)
@@ -152,7 +152,7 @@ final class QuickAnswersMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: HomepageActionType.initialize
         )
 
-        subject.quickAnswersProvider(mockStore.state, action)
+        subject.quickAnswersProvider.legacyMiddleware(mockStore.state, action)
 
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? QuickAnswersMiddlewareAction)
         XCTAssertEqual(dispatchedAction.isQuickAnswersEnabled, false)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -50,7 +50,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -81,7 +81,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -111,7 +111,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -140,7 +140,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -161,7 +161,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.saveLanguages
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationSettingsMiddlewareAction)
         let preferredLanguages = try XCTUnwrap(dispatched.preferredLanguages)
@@ -185,7 +185,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -209,7 +209,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         let expectation = XCTestExpectation(description: "wait for action to dispatch")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -235,7 +235,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.toggleTranslationsEnabled
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
 
@@ -263,7 +263,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.toggleTranslationsEnabled
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation, resetExpectation], timeout: 1.0)
 
@@ -288,7 +288,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.toggleTranslationsEnabled
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation, resetExpectation], timeout: 2.0)
 
@@ -308,7 +308,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.toggleAutoTranslate
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 2)
         let firstAction = try XCTUnwrap(mockStore.dispatchedActions[0] as? TranslationSettingsMiddlewareAction)
@@ -332,7 +332,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.toggleAutoTranslate
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationSettingsMiddlewareAction)
@@ -354,7 +354,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.saveLanguages
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         let stored = mockProfile.prefs.stringForKey(PrefsKeys.Settings.translationPreferredLanguages)
         XCTAssertEqual(stored, "en,fr")
@@ -376,7 +376,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.enterEditMode
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
 
@@ -390,7 +390,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.cancelEditMode
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
 
@@ -405,7 +405,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.reorderLanguages
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
 
@@ -420,7 +420,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TranslationSettingsViewActionType.removeLanguage
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
 
@@ -436,7 +436,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: GeneralBrowserActionType.showToast
         )
 
-        subject.translationSettingsProvider(mockStore.state, action)
+        subject.translationSettingsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -508,6 +508,6 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
     /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: TranslationSettingsMiddleware) {
-        subject.translationSettingsProvider = emptyLegacyMiddlewareMethodFactory()
+        subject.translationSettingsProvider = emptyMiddlewareProviderFactory()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -509,7 +509,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: TranslationSettingsMiddleware) {
         subject.translationSettingsProvider = emptyMiddlewareProviderFactory()
-        subject.legacyProvider = emptyLegacyMiddlewareMethodFactory()
-        subject.modernProvider = emptyMiddlewareMethodFactory()
+        subject.legacyProvider = emptyLegacyMiddlewareFactory()
+        subject.modernProvider = emptyMiddlewareFactory()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -509,5 +509,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: TranslationSettingsMiddleware) {
         subject.translationSettingsProvider = emptyMiddlewareProviderFactory()
+        subject.legacyProvider = emptyLegacyMiddlewareMethodFactory()
+        subject.modernProvider = emptyMiddlewareMethodFactory()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHome/StartAtHomeMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHome/StartAtHomeMiddlewareTests.swift
@@ -58,7 +58,7 @@ final class StartAtHomeMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.startAtHomeProvider(appState, action)
+        subject.startAtHomeProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -84,7 +84,7 @@ final class StartAtHomeMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.startAtHomeProvider(appState, action)
+        subject.startAtHomeProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -110,7 +110,7 @@ final class StartAtHomeMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.startAtHomeProvider(appState, action)
+        subject.startAtHomeProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabsMiddlewareTests.swift
@@ -40,7 +40,7 @@ final class RemoteTabsMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.remoteTabsPanelProvider(appState, action)
+        subject.remoteTabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -67,7 +67,7 @@ final class RemoteTabsMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.remoteTabsPanelProvider(appState, action)
+        subject.remoteTabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -94,7 +94,7 @@ final class RemoteTabsMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.remoteTabsPanelProvider(appState, action)
+        subject.remoteTabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -121,7 +121,7 @@ final class RemoteTabsMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.remoteTabsPanelProvider(appState, action)
+        subject.remoteTabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -148,7 +148,7 @@ final class RemoteTabsMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.remoteTabsPanelProvider(appState, action)
+        subject.remoteTabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -61,7 +61,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         mockWindowManager.overrideWindows = true
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
         wait(for: [expectation])
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabPanelMiddlewareAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? TabPanelMiddlewareActionType)
@@ -85,7 +85,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
         wait(for: [expectation], timeout: 0.1)
         XCTAssertTrue(mockWindowManager.windowsWereAccessed)
     }
@@ -107,7 +107,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         mockWindowManager.overrideWindows = true
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
         wait(for: [expectation])
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabPanelMiddlewareAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? TabPanelMiddlewareActionType)
@@ -132,7 +132,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TabPanelViewActionType.prefetchScreenshots
         )
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         XCTAssertEqual(
             mockTabManager.restoreScreenshotCalls.map { $0.tabUUID },
@@ -151,7 +151,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: TabPanelViewActionType.prefetchScreenshots
         )
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         XCTAssertTrue(mockTabManager.restoreScreenshotCalls.isEmpty)
     }
@@ -170,7 +170,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -195,7 +195,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -220,7 +220,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -245,7 +245,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -270,7 +270,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -295,7 +295,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -320,7 +320,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -345,7 +345,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let mockTabManager = mockWindowManager.tabManager(for: .XCTestDefaultUUID) as? MockTabManager
         mockTabManager?.selectTabExpectation = expectation
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -370,7 +370,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             guard self?.mockStore.dispatchedActions.count == 2 else { return }
             expectation.fulfill()
         }
-        subject.tabsPanelProvider(
+        subject.tabsPanelProvider.legacyMiddleware(
             appState,
             MainMenuAction(
                 windowUUID: .XCTestDefaultUUID,
@@ -395,7 +395,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         mockStore.dispatchCalled = {
             expectation.fulfill()
         }
-        subject.tabsPanelProvider(
+        subject.tabsPanelProvider.legacyMiddleware(
             appState,
             MainMenuAction(
                 windowUUID: .XCTestDefaultUUID,
@@ -419,7 +419,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         mockStore.dispatchCalled = {
             expectation.fulfill()
         }
-        subject.tabsPanelProvider(
+        subject.tabsPanelProvider.legacyMiddleware(
             appState,
             MainMenuAction(
                 windowUUID: .XCTestDefaultUUID,
@@ -443,7 +443,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         mockStore.dispatchCalled = {
             expectation.fulfill()
         }
-        subject.tabsPanelProvider(
+        subject.tabsPanelProvider.legacyMiddleware(
             appState,
             MainMenuAction(
                 windowUUID: .XCTestDefaultUUID,
@@ -467,7 +467,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         mockStore.dispatchCalled = {
             expectation.fulfill()
         }
-        subject.tabsPanelProvider(
+        subject.tabsPanelProvider.legacyMiddleware(
             appState,
             MainMenuAction(
                 windowUUID: .XCTestDefaultUUID,
@@ -493,7 +493,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         mockStore.dispatchCalled = {
             expectation.fulfill()
         }
-        subject.tabsPanelProvider(
+        subject.tabsPanelProvider.legacyMiddleware(
             appState,
             MainMenuAction(
                 windowUUID: .XCTestDefaultUUID,
@@ -516,7 +516,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ShortcutsLibraryActionType.switchTabToastButtonTapped
         )
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
         let selectedTab = mockWindowManager.tabManager(for: .XCTestDefaultUUID)!.selectedTab
 
         XCTAssertEqual(selectedTab, tab)
@@ -531,7 +531,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ShortcutsLibraryActionType.initialize
         )
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
         let selectedTab = mockWindowManager.tabManager(for: .XCTestDefaultUUID)!.selectedTab
 
         XCTAssertNotEqual(selectedTab, tab)
@@ -547,7 +547,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             tabID: tab.tabUUID
         )
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? TopSitesAction)
         let actionType = try XCTUnwrap(dispatchedAction.actionType as? TopSitesActionType)
@@ -563,7 +563,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: MainMenuActionType.tapAddToShortcuts
         )
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         XCTAssertTrue(mockStore.dispatchedActions.isEmpty)
     }
@@ -578,7 +578,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             tabID: tab.tabUUID
         )
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? TopSitesAction)
         let actionType = try XCTUnwrap(dispatchedAction.actionType as? TopSitesActionType)
@@ -594,7 +594,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: MainMenuActionType.tapRemoveFromShortcuts
         )
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         XCTAssertTrue(mockStore.dispatchedActions.isEmpty)
     }
@@ -616,7 +616,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -641,7 +641,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -671,7 +671,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -696,7 +696,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -721,7 +721,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -746,7 +746,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -771,7 +771,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 
@@ -796,7 +796,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation.fulfill()
         }
 
-        subject.tabsPanelProvider(appState, action)
+        subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         wait(for: [expectation])
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseMiddlewareTests.swift
@@ -30,13 +30,13 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_termsAccepted_updatesAcceptedPref() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsAccepted)
-        middleware.termsOfUseProvider(AppState(), action)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), action)
         XCTAssertTrue(profile.prefs.boolForKey(PrefsKeys.TermsOfUseAccepted) == true)
     }
 
     func testMiddleware_gestureDismiss_updatesPrefsWithDate() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.gestureDismiss)
-        middleware.termsOfUseProvider(AppState(), action)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), action)
         let dismissedTimestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseDismissedDate)
         XCTAssertNotNil(dismissedTimestamp)
 
@@ -48,7 +48,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_remindMeLaterTapped_updatesPrefsWithDate() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.remindMeLaterTapped)
-        middleware.termsOfUseProvider(AppState(), action)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), action)
         let dismissedTimestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseDismissedDate)
         XCTAssertNotNil(dismissedTimestamp)
 
@@ -60,7 +60,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_termsShown_setsShownPref() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
-        middleware.termsOfUseProvider(AppState(), action)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), action)
 
         // Should set the first shown preference
         XCTAssertTrue(profile.prefs.boolForKey(PrefsKeys.TermsOfUseFirstShown) == true)
@@ -71,7 +71,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_termsAccepted_recordsDatePref() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsAccepted)
-        middleware.termsOfUseProvider(AppState(), action)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), action)
 
         let dateTimestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseAcceptedDate)
         XCTAssertNotNil(dateTimestamp)
@@ -83,7 +83,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_remindMeLaterTapped_tracksTapTimestamp() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.remindMeLaterTapped)
-        middleware.termsOfUseProvider(AppState(), action)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), action)
 
         let timestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseRemindMeLaterTapDate)
         XCTAssertNotNil(timestamp)
@@ -91,7 +91,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_learnMoreLinkTapped_tracksTapTimestamp() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.learnMoreLinkTapped)
-        middleware.termsOfUseProvider(AppState(), action)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), action)
 
         let timestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseLearnMoreTapDate)
         XCTAssertNotNil(timestamp)
@@ -99,7 +99,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_privacyLinkTapped_tracksTapTimestamp() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.privacyLinkTapped)
-        middleware.termsOfUseProvider(AppState(), action)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), action)
 
         let timestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUsePrivacyNoticeTapDate)
         XCTAssertNotNil(timestamp)
@@ -107,7 +107,7 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_termsLinkTapped_tracksTapTimestamp() {
         let action = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsLinkTapped)
-        middleware.termsOfUseProvider(AppState(), action)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), action)
 
         let timestamp = profile.prefs.timestampForKey(PrefsKeys.TermsOfUseTermsLinkTapDate)
         XCTAssertNotNil(timestamp)
@@ -115,10 +115,10 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_firstDismissal_doesNotIncrementRemindersCount() {
         let shownAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
-        middleware.termsOfUseProvider(AppState(), shownAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), shownAction)
 
         let dismissAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.gestureDismiss)
-        middleware.termsOfUseProvider(AppState(), dismissAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), dismissAction)
 
         let remindersCount = profile.prefs.intForKey(PrefsKeys.TermsOfUseRemindersCount) ?? 0
         XCTAssertEqual(remindersCount, 0, "First gesture dismissal should not increment reminders count")
@@ -127,15 +127,15 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_secondDismissal_incrementsRemindersCount() {
         let shownAction1 = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
-        middleware.termsOfUseProvider(AppState(), shownAction1)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), shownAction1)
 
         let dismissAction1 = TermsOfUseAction(windowUUID: .XCTestDefaultUUID,
                                               actionType: TermsOfUseActionType.gestureDismiss)
-        middleware.termsOfUseProvider(AppState(), dismissAction1)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), dismissAction1)
 
         let dismissAction2 = TermsOfUseAction(windowUUID: .XCTestDefaultUUID,
                                               actionType: TermsOfUseActionType.gestureDismiss)
-        middleware.termsOfUseProvider(AppState(), dismissAction2)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), dismissAction2)
 
         let remindersCount = profile.prefs.intForKey(PrefsKeys.TermsOfUseRemindersCount) ?? 0
         XCTAssertEqual(remindersCount, 1, "Second gesture dismissal should increment reminders count to 1")
@@ -143,11 +143,11 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_remindMeLaterTapped_firstDismissal_doesNotIncrementCount() {
         let shownAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
-        middleware.termsOfUseProvider(AppState(), shownAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), shownAction)
 
         let remindAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID,
                                             actionType: TermsOfUseActionType.remindMeLaterTapped)
-        middleware.termsOfUseProvider(AppState(), remindAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), remindAction)
 
         let remindersCount = profile.prefs.intForKey(PrefsKeys.TermsOfUseRemindersCount) ?? 0
         XCTAssertEqual(remindersCount, 0, "First 'Remind Me Later' should not increment reminders count")
@@ -155,15 +155,15 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_remindMeLaterTapped_secondDismissal_incrementsCount() {
         let shownAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
-        middleware.termsOfUseProvider(AppState(), shownAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), shownAction)
 
         let remindAction1 = TermsOfUseAction(windowUUID: .XCTestDefaultUUID,
                                              actionType: TermsOfUseActionType.remindMeLaterTapped)
-        middleware.termsOfUseProvider(AppState(), remindAction1)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), remindAction1)
 
         let remindAction2 = TermsOfUseAction(windowUUID: .XCTestDefaultUUID,
                                              actionType: TermsOfUseActionType.remindMeLaterTapped)
-        middleware.termsOfUseProvider(AppState(), remindAction2)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), remindAction2)
 
         let remindersCount = profile.prefs.intForKey(PrefsKeys.TermsOfUseRemindersCount) ?? 0
         XCTAssertEqual(remindersCount, 1, "Second 'Remind Me Later' should increment reminders count to 1")
@@ -171,45 +171,45 @@ final class TermsOfUseMiddlewareTests: XCTestCase {
 
     func testMiddleware_mixedDismissalTypes_incrementsCorrectly() {
         let shownAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
-        middleware.termsOfUseProvider(AppState(), shownAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), shownAction)
 
         let gestureAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.gestureDismiss)
-        middleware.termsOfUseProvider(AppState(), gestureAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), gestureAction)
         XCTAssertEqual(profile.prefs.intForKey(PrefsKeys.TermsOfUseRemindersCount) ?? 0, 0)
 
         let remindAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID,
                                             actionType: TermsOfUseActionType.remindMeLaterTapped)
-        middleware.termsOfUseProvider(AppState(), remindAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), remindAction)
         XCTAssertEqual(profile.prefs.intForKey(PrefsKeys.TermsOfUseRemindersCount) ?? 0, 1)
 
         let gestureAction2 = TermsOfUseAction(windowUUID: .XCTestDefaultUUID,
                                               actionType: TermsOfUseActionType.gestureDismiss)
-        middleware.termsOfUseProvider(AppState(), gestureAction2)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), gestureAction2)
         XCTAssertEqual(profile.prefs.intForKey(PrefsKeys.TermsOfUseRemindersCount) ?? 0, 2)
     }
 
     func testMiddleware_termsShown_firstAppearance_incrementsShownCountOnce() {
         let shownAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
-        middleware.termsOfUseProvider(AppState(), shownAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), shownAction)
 
         XCTAssertEqual(mockGleanWrapper.incrementCounterCalled, 1)
     }
 
     func testMiddleware_termsShown_whenReminderIsShown_incrementsShownCountAgain() {
         let dismissAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.gestureDismiss)
-        middleware.termsOfUseProvider(AppState(), dismissAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), dismissAction)
 
         let shownAction = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
-        middleware.termsOfUseProvider(AppState(), shownAction)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), shownAction)
         XCTAssertEqual(mockGleanWrapper.incrementCounterCalled, 2)
     }
 
     func testMiddleware_termsShown_onResumeFromBackgroundOrLinks_doesNotIncrementShownCount() {
         let shownAction1 = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
-        middleware.termsOfUseProvider(AppState(), shownAction1)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), shownAction1)
 
         let shownAction2 = TermsOfUseAction(windowUUID: .XCTestDefaultUUID, actionType: TermsOfUseActionType.termsShown)
-        middleware.termsOfUseProvider(AppState(), shownAction2)
+        middleware.termsOfUseProvider.legacyMiddleware(AppState(), shownAction2)
 
         XCTAssertEqual(mockGleanWrapper.incrementCounterCalled, 1)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -59,7 +59,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: GeneralBrowserMiddlewareActionType.browserDidLoad)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -99,7 +99,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: GeneralBrowserMiddlewareActionType.browserDidLoad)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.last as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
@@ -143,7 +143,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.searchEngineDidChange
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
@@ -166,7 +166,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.searchEngineDidChange
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
@@ -187,7 +187,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.searchEngineDidChange
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
@@ -210,7 +210,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.searchEngineDidChange
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
@@ -230,7 +230,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.searchEngineDidChange
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
@@ -406,7 +406,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: GeneralBrowserMiddlewareActionType.browserDidLoad)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -429,7 +429,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: GeneralBrowserMiddlewareActionType.websiteDidScroll)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -452,7 +452,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: GeneralBrowserMiddlewareActionType.toolbarPositionChanged)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -475,7 +475,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = ToolbarMiddlewareAction(readerModeState: .active,
                                              windowUUID: .XCTestDefaultUUID,
                                              actionType: ToolbarMiddlewareActionType.loadSummaryState)
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertNil(mockStore.dispatchedActions.first as? ToolbarAction)
     }
@@ -495,7 +495,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         mockStore.dispatchCalled = {
             expectation.fulfill()
         }
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
         wait(for: [expectation])
 
         let result = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
@@ -508,7 +508,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = MicrosurveyPromptMiddlewareAction(
             windowUUID: windowUUID,
             actionType: MicrosurveyPromptMiddlewareActionType.initialize)
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -526,7 +526,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = MicrosurveyPromptMiddlewareAction(
             windowUUID: windowUUID,
             actionType: MicrosurveyPromptMiddlewareActionType.initialize)
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -543,7 +543,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = MicrosurveyPromptAction(
             windowUUID: windowUUID,
             actionType: MicrosurveyPromptActionType.closePrompt)
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -561,7 +561,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = MicrosurveyPromptAction(
             windowUUID: windowUUID,
             actionType: MicrosurveyPromptActionType.closePrompt)
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -580,7 +580,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.customA11yAction)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
@@ -661,7 +661,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.didTapButton)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         try cancelEditMode(dispatchedActionsCount: 3)
 
@@ -710,7 +710,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.didTapButton)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         try cancelEditMode(dispatchedActionsCount: 3)
 
@@ -740,7 +740,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.didTapButton)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         try cancelEditMode(dispatchedActionsCount: 2)
     }
@@ -873,7 +873,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.didTapButton)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -972,7 +972,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.didTapButton)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
@@ -1028,7 +1028,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.urlDidChange)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -1046,7 +1046,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = ToolbarMiddlewareAction(
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.didClearSearch)
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? ToolbarActionType)
@@ -1072,7 +1072,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = ToolbarMiddlewareAction(
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.didStartDragInteraction)
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
 
@@ -1090,7 +1090,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = ToolbarMiddlewareAction(
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.didSwipeToOpenTabTray)
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.TabTrayOpenedViaSwipeExtra>
@@ -1114,7 +1114,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.didSwipeToOpenTabTray)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let savedExtras = try XCTUnwrap(
             mockGleanWrapper.savedExtras.first as? GleanMetrics.Toolbar.TabTrayOpenedViaSwipeExtra
@@ -1131,7 +1131,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: ToolbarActionType.cancelEdit)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? SearchEngineSelectionAction)
         let actionType = try XCTUnwrap(actionCalled.actionType as? SearchEngineSelectionMiddlewareActionType)
@@ -1149,7 +1149,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.didSubmitSearchTerm
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
         XCTAssertEqual(mockRecentSearchProvider.addRecentSearchCalledCount, 1)
     }
 
@@ -1161,7 +1161,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.didSubmitSearchTerm
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
         XCTAssertEqual(mockRecentSearchProvider.addRecentSearchCalledCount, 0)
     }
 
@@ -1172,7 +1172,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.didSubmitSearchTerm
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
         XCTAssertEqual(mockRecentSearchProvider.addRecentSearchCalledCount, 0)
     }
 
@@ -1188,7 +1188,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.didSubmitSearchTerm
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
         XCTAssertEqual(mockRecentSearchProvider.addRecentSearchCalledCount, 0)
     }
 
@@ -1203,7 +1203,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.didSubmitSearchTerm
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
         XCTAssertEqual(mockRecentSearchProvider.addRecentSearchCalledCount, 0)
     }
 
@@ -1217,7 +1217,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: ToolbarActionType.didSubmitSearchTerm
         )
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
         XCTAssertEqual(mockRecentSearchProvider.addRecentSearchCalledCount, 0)
     }
 
@@ -1273,7 +1273,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation?.fulfill()
         }
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         if let expectation {
             wait(for: [expectation], timeout: 1.0)
@@ -1301,7 +1301,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             expectation?.fulfill()
         }
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         if let expectation {
             wait(for: [expectation], timeout: 1.0)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -120,7 +120,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: GeneralBrowserMiddlewareActionType.browserDidLoad)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.last as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
@@ -251,7 +251,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.googleLensSettingDidChange)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
@@ -272,7 +272,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.googleLensSettingDidChange)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
@@ -296,7 +296,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: GeneralBrowserMiddlewareActionType.browserDidLoad)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.last as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
@@ -320,7 +320,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: GeneralBrowserMiddlewareActionType.browserDidLoad)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.last as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
@@ -342,7 +342,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.urlDidChange)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
@@ -367,7 +367,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.urlDidChange)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
@@ -392,7 +392,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.urlDidChange)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertTrue(mockStore.dispatchedActions.isEmpty)
     }
@@ -823,7 +823,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             windowUUID: windowUUID,
             actionType: ToolbarMiddlewareActionType.didTapButton)
 
-        subject.toolbarProvider(mockStore.state, action)
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -61,7 +61,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarActionType.urlDidChange
         )
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
@@ -75,7 +75,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarActionType.urlDidChange
         )
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
@@ -90,7 +90,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarActionType.urlDidChange
         )
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
@@ -115,7 +115,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             expectation.fulfill()
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -145,7 +145,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage action to be fired")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -178,7 +178,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             expectation.fulfill()
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -212,7 +212,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             expectation.fulfill()
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -235,7 +235,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage clear action to be fired")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -269,7 +269,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.isInverted = true
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
@@ -296,7 +296,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.isInverted = true
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
@@ -322,7 +322,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "receivedTranslationLanguage dispatched")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
@@ -351,7 +351,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "receivedTranslationLanguage dispatched")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(tab.translationConfiguration?.state, .inactive)
@@ -380,7 +380,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "receivedTranslationLanguage clear dispatched")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertNil(tab.translationConfiguration)
@@ -408,7 +408,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "receivedTranslationLanguage clear dispatched for PDF")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -440,7 +440,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "receivedTranslationLanguage clear dispatched for image")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -477,7 +477,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             }
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
         // Simulate a tab switch while the eligibility Task is in flight.
         mockTabManager.selectedTab = tabB
 
@@ -508,7 +508,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             }
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [completedExpectation], timeout: 3.0)
         XCTAssertEqual(tab.translationConfiguration?.state, .active)
@@ -539,7 +539,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             }
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
         // Simulate the user switching tabs while the translation Task is in flight.
         mockTabManager.selectedTab = tabB
 
@@ -574,7 +574,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             }
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [errorExpectation], timeout: 1.0)
         XCTAssertEqual(tab.translationConfiguration?.state, .inactive)
@@ -591,7 +591,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarMiddlewareActionType.didTapButton
         )
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         XCTAssertEqual(mockTranslationsTelemetry.translateButtonTappedCalledCount, 0)
@@ -612,7 +612,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.expectedFulfillmentCount = 1
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(setupAppStateWithTranslationConfig(for: .inactive), action)
+        subject.translationsProvider.legacyMiddleware(setupAppStateWithTranslationConfig(for: .inactive), action)
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
@@ -642,7 +642,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             default: break
             }
         }
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [didStartExpectation, completedExpectation], timeout: 3.0, enforceOrder: true)
 
@@ -672,7 +672,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarMiddlewareActionType.didTapButton
         )
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockTranslationsTelemetry.translateButtonTappedCalledCount, 0)
         XCTAssertEqual(mockTranslationsTelemetry.pageLanguageIdentifiedCalledCount, 0)
@@ -701,7 +701,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             expectation.fulfill()
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -751,7 +751,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             expectation.fulfill()
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -799,7 +799,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         mockStore.dispatchCalled = {
              expectation.fulfill()
         }
-        subject.translationsProvider(
+        subject.translationsProvider.legacyMiddleware(
             setupAppStateWithTranslationConfig(for: .active),
             action
         )
@@ -845,7 +845,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(setupAppStateWithTranslationConfig(for: .active), action)
+        subject.translationsProvider.legacyMiddleware(setupAppStateWithTranslationConfig(for: .active), action)
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(tab.translationConfiguration?.state, .inactive)
@@ -867,7 +867,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "receivedTranslationLanguage dispatched after feature enabled")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -893,7 +893,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.isInverted = true
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 0.5)
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
@@ -918,7 +918,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "reloadWebsite dispatched when disabling translations")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 0.5)
 
@@ -948,7 +948,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.isInverted = true
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 0.5)
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
@@ -966,7 +966,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             windowUUID: .XCTestDefaultUUID,
             actionType: TranslationsActionType.didTranslationSettingsChange
         )
-        subject.translationsProvider(mockStore.state, toggleAction)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, toggleAction)
         mockStore.dispatchedActions.removeAll()
 
         let retryAction = TranslationsAction(
@@ -978,7 +978,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.isInverted = true
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, retryAction)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, retryAction)
 
         wait(for: [expectation], timeout: 0.5)
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
@@ -1007,7 +1007,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1043,7 +1043,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.expectedFulfillmentCount = 1
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1075,7 +1075,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let restoreExpectation = XCTestExpectation(description: "restore dispatches completed")
         restoreExpectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { restoreExpectation.fulfill() }
-        subject.translationsProvider(setupAppStateWithTranslationConfig(for: .active), restoreAction)
+        subject.translationsProvider.legacyMiddleware(setupAppStateWithTranslationConfig(for: .active), restoreAction)
         wait(for: [restoreExpectation], timeout: 1.0)
         mockStore.dispatchedActions.removeAll()
 
@@ -1090,7 +1090,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.expectedFulfillmentCount = 1
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, urlAction)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, urlAction)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1125,7 +1125,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.expectedFulfillmentCount = 1
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1155,7 +1155,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         )
         expectation.expectedFulfillmentCount = 3
         mockStore.dispatchCalled = { expectation.fulfill() }
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1184,7 +1184,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         )
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1210,7 +1210,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         )
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1229,7 +1229,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarActionType.urlDidChange
         )
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
     }
@@ -1246,7 +1246,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.isInverted = true
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 0.5)
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
@@ -1272,7 +1272,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             expectation.fulfill()
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1318,7 +1318,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             expectation.fulfill()
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1369,7 +1369,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             expectation.fulfill()
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1441,7 +1441,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let seedExpectation = XCTestExpectation(description: "seed target language")
         seedExpectation.expectedFulfillmentCount = successDispatchCount
         mockStore.dispatchCalled = { seedExpectation.fulfill() }
-        subject.translationsProvider(mockStore.state, seedAction)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, seedAction)
         wait(for: [seedExpectation], timeout: 1.0)
         mockStore.dispatchedActions.removeAll()
         mockTranslationsTelemetry.reset()
@@ -1574,7 +1574,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "showTranslationLanguagePicker dispatched on long press")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(
+        subject.translationsProvider.legacyMiddleware(
             setupAppStateWithTranslationLanguage(translatedToLanguage: "da"),
             action
         )
@@ -1601,7 +1601,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "showTranslationLanguagePicker dispatched on long press inactive")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(setupAppStateWithTranslationConfig(for: .inactive), action)
+        subject.translationsProvider.legacyMiddleware(setupAppStateWithTranslationConfig(for: .inactive), action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1625,7 +1625,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         let expectation = XCTestExpectation(description: "picker dispatched with source and translated languages filtered")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(
+        subject.translationsProvider.legacyMiddleware(
             setupAppStateWithTranslationLanguage(translatedToLanguage: "da", sourceLanguage: "de"),
             action
         )
@@ -1653,7 +1653,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         expectation.expectedFulfillmentCount = 2
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -1693,7 +1693,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             }
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
         wait(for: [loadingExpectation], timeout: 1.0)
         mockStore.dispatchedActions.removeAll()
 
@@ -1774,7 +1774,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             }
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
         wait(for: [loadingExpectation], timeout: 1.0)
         mockStore.dispatchedActions.removeAll()
 
@@ -1819,7 +1819,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             }
         }
 
-        subject.translationsProvider(mockStore.state, action)
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
         wait(for: [loadingExpectation], timeout: 1.0)
         mockStore.dispatchedActions.removeAll()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -4,6 +4,7 @@
 
 import Common
 import Redux
+import TestKit
 import XCTest
 
 @testable import Client
@@ -34,14 +35,15 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: WebCompatReporterViewActionType.viewDidLoad
         )
 
-        subject.webCompatReporterProvider(mockStore.state, action)
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WebCompatReporterMiddlewareAction)
         let dispatchedType = try XCTUnwrap(dispatched.actionType as? WebCompatReporterMiddlewareActionType)
         XCTAssertEqual(dispatchedType, WebCompatReporterMiddlewareActionType.didLoadInitialDraft)
         XCTAssertEqual(dispatched.url, "https://example.com")
-        subject.webCompatReporterProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - submit
@@ -53,10 +55,11 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: WebCompatReporterViewActionType.submit
         )
 
-        subject.webCompatReporterProvider(mockStore.state, action)
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        subject.webCompatReporterProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Pure view actions are not handled by the middleware
@@ -69,10 +72,11 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: WebCompatReporterViewActionType.selectCategory
         )
 
-        subject.webCompatReporterProvider(mockStore.state, action)
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        subject.webCompatReporterProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Unrelated action
@@ -84,10 +88,11 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
             actionType: WebCompatReporterMiddlewareActionType.didLoadInitialDraft
         )
 
-        subject.webCompatReporterProvider(mockStore.state, action)
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        subject.webCompatReporterProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - StoreTestUtility
@@ -117,5 +122,18 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = WebCompatReporterMiddleware()
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    /// Our middleware providers always retain a strong reference to `self` for ease of use. Thus, `trackForMemoryLeaks` will
+    /// fail in our unit tests due to a strong circular reference to the middleware retained by its provider closures. In
+    /// practice, this is not a memory leak issue, as we permanently allocate and retain our middleware providers for the
+    /// entire app lifecycle.
+    ///
+    /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
+    /// empty closure, which does not strongly retain `self`.
+    private func releaseMiddlewareProvidersFromMemory(_ subject: WebCompatReporterMiddleware) {
+        subject.webCompatReporterProvider = emptyMiddlewareProviderFactory()
+        subject.legacyProvider = emptyLegacyMiddlewareFactory()
+        subject.modernProvider = emptyMiddlewareFactory()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16140)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34384)

## :bulb: Description
- The Redux Store can now dispatch `ModernAction`s to the Client `Middleware`s.
- Client `Middleware`s have been updated with modern providers, leaving the legacy provider untouched.
- All Client `Middleware`s have the exact same basic change, so it should be a quick review

The Client code should have no behavioural changes; this PR simply stubs in new providers but no actions have been migrated yet.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

