### PR TITLE
Refactor FXIOS-16160 [Automation Test PR] BVC ensureMainThread migration

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1164,20 +1164,6 @@ class BrowserViewController: UIViewController,
 
     // MARK: - Notifiable
 
-    nonisolated private func shouldHandleNotificationSynchronously(_ notification: Notification.Name) -> Bool {
-        // Whether to respond to the notification synchronously. Main thread notifications will (by default)
-        // be handled in a Task which allows the concurrency engine to schedule the work asynchronously.
-        // If a notification returns `true` here, then it will instead be wrapped in an `ensureMainThread`
-        // which (if the notification arrives on the MT) will perform the notification handler immediately.
-        switch notification {
-        case UIApplication.willResignActiveNotification:
-            // Handle immediately since this is where we display the PBM privacy screen
-            return true
-        default:
-            return false
-        }
-    }
-
     func handleNotifications(_ notification: Notification) {
         let notificationName = notification.name
         let windowScene = notification.object as? UIWindowScene
@@ -1186,27 +1172,13 @@ class BrowserViewController: UIViewController,
         let searchBarPosition = dictionary?[PrefsKeys.FeatureFlags.SearchBarPosition] as? SearchBarPosition
         let windowUUID = notification.windowUUID
         let zoomSetting = notification.userInfo?["zoom"] as? DomainZoomLevel
-
-        if shouldHandleNotificationSynchronously(notificationName) {
-            ensureMainThread {
-                self.performNotificationHandler(notificationName,
-                                                windowScene: windowScene,
-                                                announcementText: announcementText,
-                                                zoomSetting: zoomSetting,
-                                                windowUUID: windowUUID,
-                                                searchBarPosition: searchBarPosition)
-            }
-        } else {
-            // TODO: [FXIOS-16160] We should migrate all of our handlers to ensureMainThread. 
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                performNotificationHandler(notificationName,
-                                           windowScene: windowScene,
-                                           announcementText: announcementText,
-                                           zoomSetting: zoomSetting,
-                                           windowUUID: windowUUID,
-                                           searchBarPosition: searchBarPosition)
-            }
+        ensureMainThread {
+            self.performNotificationHandler(notificationName,
+                                            windowScene: windowScene,
+                                            announcementText: announcementText,
+                                            zoomSetting: zoomSetting,
+                                            windowUUID: windowUUID,
+                                            searchBarPosition: searchBarPosition)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16160)

## :bulb: Description

Automation test PR. No review required at this time. 

This PR is checking the Bitrise test results of a change to our async vs synchronous handling of notifications in BVC. For more context see the discussion in [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/34261). 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

