### PR TITLE
Expand popup test cases

### DIFF
--- a/SampleBrowser/SampleBrowser/testPopUp.html
+++ b/SampleBrowser/SampleBrowser/testPopUp.html
@@ -8,26 +8,54 @@
 <body>
     <h2>Test WKWebView Window Open and Close</h2>
 
-    <!-- link to open in a new window -->
-    <a href="https://www.mozilla.org/" target="_blank">Open in New Window</a>
-    <button onclick="window.open('https://www.mozilla.org/')">Open new pop up Window</button>
+    <!-- Issue #17911: about:blank popup redirect -->
+    <button id="blankRedirectBtn">Open blank popup → redirect</button>
     <br><br>
 
-    <!-- tests for link with target -->
-    <a href="https://example.com" target="_blank">
-      Popup test case: link target
-    </a>
-    <br/>
+    <!-- Issue #25031: popup with window features -->
+    <button id="featurePopupBtn">Open popup with window features</button>
+    <br><br>
 
-    <!-- tests for scripted popup -->
+    <!-- Issue #30098: popup from cross-origin iframe -->
+    <iframe
+      src="https://example.org"
+      style="width:0;height:0;border:0;"
+      id="xframe">
+    </iframe>
+    <button id="iframePopupBtn">Trigger popup from cross-origin iframe</button>
+
     <script>
-      function openPopup2() {
-        window.open('https://example.com/test', 'popup2');
-      }
+      // Issue #17911: about:blank → redirect
+      document.getElementById("blankRedirectBtn").onclick = () => {
+        const w = window.open('about:blank', 'blankRedirectTest');
+        setTimeout(() => {
+          w.location.replace('https://example.org/redirect-test');
+        }, 1000);
+      };
+
+      // Issue #25031: popup with window features
+      document.getElementById("featurePopupBtn").onclick = () => {
+        window.open(
+          'https://example.org/feature-test',
+          'featurePopup',
+          'width=400,height=400,left=100,top=100'
+        );
+      };
+
+      // Issue #30098: popup triggered from cross-origin iframe
+      window.addEventListener("message", (e) => {
+        if (e.data === "openPopupFromIframe") {
+          const w = window.open('about:blank', 'iframePopupTest');
+          setTimeout(() => {
+            w.location.replace('https://example.org/iframe-redirect');
+          }, 1000);
+        }
+      });
+
+      document.getElementById("iframePopupBtn").onclick = () => {
+        document.getElementById('xframe').contentWindow.postMessage('openPopupFromIframe', '*');
+      };
     </script>
-
-    <button onclick="openPopup2()">Scripted popup test</button>
-    <br/>
-
+    
 </body>
 </html>

--- a/SampleBrowser/SampleBrowser/testPopUp.html
+++ b/SampleBrowser/SampleBrowser/testPopUp.html
@@ -8,12 +8,26 @@
 <body>
     <h2>Test WKWebView Window Open and Close</h2>
 
-    <!-- Link to open in a new window -->
+    <!-- link to open in a new window -->
     <a href="https://www.mozilla.org/" target="_blank">Open in New Window</a>
-
     <button onclick="window.open('https://www.mozilla.org/')">Open new pop up Window</button>
-
     <br><br>
+
+    <!-- tests for link with target -->
+    <a href="https://example.com" target="_blank">
+      Popup test case: link target
+    </a>
+    <br/>
+
+    <!-- tests for scripted popup -->
+    <script>
+      function openPopup2() {
+        window.open('https://example.com/test', 'popup2');
+      }
+    </script>
+
+    <button onclick="openPopup2()">Scripted popup test</button>
+    <br/>
 
 </body>
 </html>


### PR DESCRIPTION
sorry for the redundancy mistake in my previous PR!

for this update, each new test corresponds directly to one of the issues referenced in https://github.com/mozilla-mobile/firefox-ios/issues/26869, and none of these behaviors are covered by the existing tests in testPopUp.html:

- https://github.com/mozilla-mobile/firefox-ios/issues/17911 — reproduces the about:blank → redirect popup flow used by many embedded checkout and authentication flows

- https://github.com/mozilla-mobile/firefox-ios/issues/25031 — opens a popup with window features (the focus‑loss scenario)

- https://github.com/mozilla-mobile/firefox-ios/issues/30098 — triggers a popup from a cross‑origin iframe via postMessage (common in third‑party SDKs running inside iframes)

happy to adjust anything if needed!