### PR TITLE
BugFix [WC] FXIOS-16189 widget flashing when backgrounding and reopening the app

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupFeed.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupFeed.swift
@@ -79,7 +79,6 @@ final class WorldCupFeed: WorldCupFeedProtocol {
     /// from.
     func start() {
         stop()
-        cachedLiveIDs = []
         lastMatchesResponse = nil
         cachedTeamsResponse = nil
         let stream = apiClient.matchesStream(team: nil)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16189)

## :bulb: Description
Bug fix flashing of the WC widget when backgrounding and reopening the app when there is a live match.

## :movie_camera: Demos



https://github.com/user-attachments/assets/8d9a1d70-1a61-42af-b43c-a8500a97fd71


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

