### PR TITLE
Update MTE-5565 Align testSSL test with the manual test definition

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -42,6 +42,13 @@ class NavigationTest: FeatureFlaggedTestSuite {
         launchApp()
     }
 
+    private func restartTheApp() {
+        app.terminate()
+        _ = app.wait(for: .notRunning, timeout: TIMEOUT)
+        launchApp()
+        setUpScreenGraph()
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2441488
     func testNavigation() {
         let urlPlaceholder = "Search or enter address"
@@ -435,6 +442,14 @@ class NavigationTest: FeatureFlaggedTestSuite {
         sslScreen.waitForWarning()
         sslScreen.assertWarningVisible()
 
+        sslScreen.tapAdvanced()
+        sslScreen.tapVisitSiteAnyway()
+        sslScreen.waitForPageToLoadAfterBypass()
+
+        restartTheApp()
+        browserScreen.navigateToURL("https://expired.badssl.com/")
+        sslScreen.waitForWarning()
+        sslScreen.assertWarningVisible()
         sslScreen.tapAdvanced()
         sslScreen.tapVisitSiteAnyway()
         sslScreen.waitForPageToLoadAfterBypass()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -47,6 +47,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
         _ = app.wait(for: .notRunning, timeout: TIMEOUT)
         launchApp()
         setUpScreenGraph()
+        waitForTabsButton()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441488


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5565)

## :bulb: Description
Completes the `testSSL` XCUITest in `NavigationTest` by implementing step 6
of the test case: restarting Firefox and verifying that the untrusted
connection warning is shown again and the site can be visited.

This PR introduces a private method `restartTheApp()` in `NavigationTest` that performs the following sequence:

1. `app.terminate()`
2. wait for the app to reach `.notRunning` 
3. `launchApp()` 
4. `setUpScreenGraph()` to re-bind the `navigator` to the freshly
   launched app instance

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

