### PR TITLE
Add FXIOS-16178 [WebCompat] Add WebCompatReporter Redux layer

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -24,6 +24,12 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		8C2FB1E22FF3D65C00C9A803 /* WebCompatIssueCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1E12FF3D65C00C9A803 /* WebCompatIssueCategory.swift */; };
+		8C2FB1E42FF3D66500C9A803 /* WebCompatReporterAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1E32FF3D66500C9A803 /* WebCompatReporterAction.swift */; };
+		8C2FB1E62FF3D67900C9A803 /* WebCompatReporterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1E52FF3D67900C9A803 /* WebCompatReporterState.swift */; };
+		8C2FB1E82FF3D68100C9A803 /* WebCompatReporterMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1E72FF3D68100C9A803 /* WebCompatReporterMiddleware.swift */; };
+		8C2FB1EB2FF3D6BB00C9A803 /* WebCompatReporterStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1EA2FF3D6BB00C9A803 /* WebCompatReporterStateTests.swift */; };
+		8C2FB1ED2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1EC2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift */; };
 		032CE5F62EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032CE5F52EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift */; };
 		033A5FCC2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A5FCB2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift */; };
 		033A62002E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A61FF2E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift */; };
@@ -2686,6 +2692,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		8C2FB1E12FF3D65C00C9A803 /* WebCompatIssueCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatIssueCategory.swift; sourceTree = "<group>"; };
+		8C2FB1E32FF3D66500C9A803 /* WebCompatReporterAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReporterAction.swift; sourceTree = "<group>"; };
+		8C2FB1E52FF3D67900C9A803 /* WebCompatReporterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReporterState.swift; sourceTree = "<group>"; };
+		8C2FB1E72FF3D68100C9A803 /* WebCompatReporterMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReporterMiddleware.swift; sourceTree = "<group>"; };
+		8C2FB1EA2FF3D6BB00C9A803 /* WebCompatReporterStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReporterStateTests.swift; sourceTree = "<group>"; };
+		8C2FB1EC2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReporterMiddlewareTests.swift; sourceTree = "<group>"; };
 		001348F79CA80B94DCD3E535 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		00218A431FC749D7BC8EC05D /* homepageStoryCategoriesOn.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = homepageStoryCategoriesOn.json; sourceTree = "<group>"; };
 		003141C6B19507C79B6C399C /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Menu.strings; sourceTree = "<group>"; };
@@ -12146,6 +12158,34 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8C2FB1DF2FF3D64B00C9A803 /* WebCompatReporter */ = {
+			isa = PBXGroup;
+			children = (
+				8C2FB1E02FF3D64F00C9A803 /* Redux */,
+			);
+			path = WebCompatReporter;
+			sourceTree = "<group>";
+		};
+		8C2FB1E02FF3D64F00C9A803 /* Redux */ = {
+			isa = PBXGroup;
+			children = (
+				8C2FB1E12FF3D65C00C9A803 /* WebCompatIssueCategory.swift */,
+				8C2FB1E32FF3D66500C9A803 /* WebCompatReporterAction.swift */,
+				8C2FB1E52FF3D67900C9A803 /* WebCompatReporterState.swift */,
+				8C2FB1E72FF3D68100C9A803 /* WebCompatReporterMiddleware.swift */,
+			);
+			path = Redux;
+			sourceTree = "<group>";
+		};
+		8C2FB1E92FF3D69C00C9A803 /* WebCompatReporter */ = {
+			isa = PBXGroup;
+			children = (
+				8C2FB1EA2FF3D6BB00C9A803 /* WebCompatReporterStateTests.swift */,
+				8C2FB1EC2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift */,
+			);
+			path = WebCompatReporter;
+			sourceTree = "<group>";
+		};
 		033C94F32E2F839900C2382F /* TermsOfUse */ = {
 			isa = PBXGroup;
 			children = (
@@ -17120,6 +17160,7 @@
 				D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */,
 				8A96C4BA28F9E7B300B75884 /* XCTestCaseRootViewController.swift */,
 				2199A1D12DB80B6C00DC84BD /* ZoomPageManagerTests.swift */,
+				8C2FB1E92FF3D69C00C9A803 /* WebCompatReporter */,
 			);
 			path = ClientTests;
 			sourceTree = "<group>";
@@ -17240,6 +17281,7 @@
 				D0FCF7EE1FE44E15004A7995 /* UserContent */,
 				8AB8572D27D94A1A0075C173 /* UXSizeClass.swift */,
 				D38A1BEB1A9FA2CA00F6A386 /* Widgets */,
+				8C2FB1DF2FF3D64B00C9A803 /* WebCompatReporter */,
 			);
 			path = Frontend;
 			sourceTree = "<group>";
@@ -19208,6 +19250,7 @@
 				5A47D0002FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigration.swift in Sources */,
 				D04CD74A216CF86B004FF5B0 /* SiriShortcuts.swift in Sources */,
 				EB9A179F20E6C1A200B12184 /* ThemedTableViewController.swift in Sources */,
+				8C2FB1E22FF3D65C00C9A803 /* WebCompatIssueCategory.swift in Sources */,
 				E68E39BE1C46F42000B85F42 /* AppSettingsTableViewController.swift in Sources */,
 				21EEAA192D3852B300595119 /* BookmarksTelemetry.swift in Sources */,
 				8A9F4F072DC8F5CA004644B9 /* MockRemoteTabs.swift in Sources */,
@@ -19373,6 +19416,7 @@
 				AA25A7512FB4C9CE00A55859 /* QuickAnswersSettingsViewController.swift in Sources */,
 				C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */,
 				8A0727462B4890B50071BB9F /* WebviewTelemetry.swift in Sources */,
+				8C2FB1E42FF3D66500C9A803 /* WebCompatReporterAction.swift in Sources */,
 				8ADC2A212A3399DC00543DAA /* YourRightsSetting.swift in Sources */,
 				214099652DD295F5004881E1 /* ZoomLevelPickerView.swift in Sources */,
 				8C3B1A1B2F73C8D100E2C370 /* TranslationToggleCell.swift in Sources */,
@@ -19716,6 +19760,7 @@
 				F84B22041A0910F600AAB793 /* AppDelegate.swift in Sources */,
 				21EA337F2EC65CC300D20D90 /* ToolbarViewProtocol.swift in Sources */,
 				81E9B6E82E2AB73400CE6FF6 /* MerinoStory.swift in Sources */,
+				8C2FB1E82FF3D68100C9A803 /* WebCompatReporterMiddleware.swift in Sources */,
 				E1442FD2294782D9003680B0 /* UIViewController+Extension.swift in Sources */,
 				E653422D1C5944F90039DD9E /* BrowserPrompts.swift in Sources */,
 				E127313C28B6AD99006F39D2 /* WallpaperSettingsViewController.swift in Sources */,
@@ -19960,6 +20005,7 @@
 				1DCEC3F62D600C4400129966 /* ASSearchEngineIconRecord.swift in Sources */,
 				D5D0532E2645B3A700759F85 /* ExperimentsTableView.swift in Sources */,
 				8A832A9029DC96C50025D5DD /* LaunchScreenView.swift in Sources */,
+				8C2FB1E62FF3D67900C9A803 /* WebCompatReporterState.swift in Sources */,
 				8AAAB05B2C1B7268008830B3 /* ClientTabsSearchWrapper.swift in Sources */,
 				214EF4152AC5D5D0005BCCDA /* TabDisplayView.swift in Sources */,
 				8A2D593E27DC0AA100713EC9 /* TopSite.swift in Sources */,
@@ -20538,6 +20584,7 @@
 				C2B808B12A77FA3F00A65487 /* DownloadsCoordinatorTests.swift in Sources */,
 				C2DFB1452ECE62EE004E20AB /* MockTranslationsService.swift in Sources */,
 				354F8FAB2E0985B9007DFFEB /* SearchBarStateTests.swift in Sources */,
+				8C2FB1EB2FF3D6BB00C9A803 /* WebCompatReporterStateTests.swift in Sources */,
 				399BA8002F901D9200CCC502 /* UserFeaturePreferenceManagerTests.swift in Sources */,
 				5A475E9129DB8AA7009C13FD /* MockDiskImageStore.swift in Sources */,
 				AAD9D64B2EB25B3500BFECAF /* TranslationsMiddlewareTests.swift in Sources */,
@@ -20579,6 +20626,7 @@
 				ED55DC8C2CC2D7DA00E3FE3A /* SearchEngineSelectionCoordinatorTests.swift in Sources */,
 				0A80C4262F3CD45900DB85AE /* MockLAContext.swift in Sources */,
 				C8C3FEA129F973C40038E3BA /* MockBrowserViewController.swift in Sources */,
+				8C2FB1ED2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift in Sources */,
 				8A93F86B29D39BDA004159D9 /* BaseCoordinatorTests.swift in Sources */,
 				8AF3B15A2AF99B86009BB262 /* HistoryPanelTests.swift in Sources */,
 				814A62462B587A3E00608195 /* DefaultThemeManagerTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatIssueCategory.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatIssueCategory.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Issue categories for the "Report a Website Issue" form. Raw values and
+/// `subOptionIDs` are Glean `broken-site-report` reason keys, not display copy.
+enum WebCompatIssueCategory: String, CaseIterable, Identifiable {
+    case siteNotUsable
+    case designBroken
+    case videoOrAudio
+    case other
+
+    var id: String { rawValue }
+
+    var subOptionIDs: [String] {
+        switch self {
+        case .siteNotUsable:
+            return ["browser_blocked", "page_not_loading", "missing_items", "buttons_not_working"]
+        case .designBroken:
+            return ["images_not_loaded", "items_overlapped", "items_misaligned", "items_not_visible"]
+        case .videoOrAudio:
+            return ["no_video", "no_audio", "media_controls_broken", "playback_fails", "captions_missing"]
+        case .other:
+            return []
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterAction.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterAction.swift
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+
+struct WebCompatReporterViewAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+    let url: String?
+    let category: WebCompatIssueCategory?
+    let subOptionID: String?
+    let additionalDetails: String?
+    let includeScreenshot: Bool?
+    let includeBlockedList: Bool?
+
+    init(url: String? = nil,
+         category: WebCompatIssueCategory? = nil,
+         subOptionID: String? = nil,
+         additionalDetails: String? = nil,
+         includeScreenshot: Bool? = nil,
+         includeBlockedList: Bool? = nil,
+         windowUUID: WindowUUID,
+         actionType: ActionType) {
+        self.url = url
+        self.category = category
+        self.subOptionID = subOptionID
+        self.additionalDetails = additionalDetails
+        self.includeScreenshot = includeScreenshot
+        self.includeBlockedList = includeBlockedList
+        self.windowUUID = windowUUID
+        self.actionType = actionType
+    }
+}
+
+struct WebCompatReporterMiddlewareAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+    let url: String?
+
+    init(url: String? = nil,
+         windowUUID: WindowUUID,
+         actionType: ActionType) {
+        self.url = url
+        self.windowUUID = windowUUID
+        self.actionType = actionType
+    }
+}
+
+enum WebCompatReporterViewActionType: ActionType {
+    case viewDidLoad
+    case editURL
+    case selectCategory
+    case selectSubOption
+    case setAdditionalDetails
+    case toggleScreenshot
+    case toggleBlockedList
+    case preview
+    case submit
+    case cancel
+}
+
+enum WebCompatReporterMiddlewareActionType: ActionType {
+    case didLoadInitialDraft
+}

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+
+@MainActor
+final class WebCompatReporterMiddleware {
+    lazy var webCompatReporterProvider: Middleware<AppState> = { state, action in
+        guard let action = action as? WebCompatReporterViewAction else { return }
+        self.handleAction(action, state: state)
+    }
+
+    private func handleAction(_ action: WebCompatReporterViewAction, state: AppState) {
+        switch action.actionType {
+        case WebCompatReporterViewActionType.viewDidLoad:
+            // The presenting layer passes the current tab URL. Payload collection
+            // for the Glean ping is FXIOS-16177.
+            store.dispatch(WebCompatReporterMiddlewareAction(
+                url: action.url,
+                windowUUID: action.windowUUID,
+                actionType: WebCompatReporterMiddlewareActionType.didLoadInitialDraft
+            ))
+
+        case WebCompatReporterViewActionType.submit:
+            // TODO: FXIOS-16177 collect the payload and send the broken-site-report ping.
+            break
+
+        default:
+            break
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
@@ -1,0 +1,155 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ModifiedCopy
+import Redux
+
+/// The in-progress "Report a Website Issue" report, held as Redux screen state.
+@Copyable
+struct WebCompatReporterState: ScreenState, Equatable {
+    var windowUUID: WindowUUID
+    var url: String
+    var selectedCategory: WebCompatIssueCategory?
+    var selectedSubOptionID: String?
+    var additionalDetails: String
+    var includeScreenshot: Bool
+    var includeBlockedList: Bool
+
+    /// Preview and Send stay disabled until the user picks a category.
+    var canSubmit: Bool { selectedCategory != nil }
+    var canPreview: Bool { selectedCategory != nil }
+
+    init(appState: AppState, uuid: WindowUUID) {
+        guard let state = appState.componentState(
+            WebCompatReporterState.self,
+            for: .webCompatReporter,
+            window: uuid
+        ) else {
+            self.init(windowUUID: uuid)
+            return
+        }
+        self.init(
+            windowUUID: state.windowUUID,
+            url: state.url,
+            selectedCategory: state.selectedCategory,
+            selectedSubOptionID: state.selectedSubOptionID,
+            additionalDetails: state.additionalDetails,
+            includeScreenshot: state.includeScreenshot,
+            includeBlockedList: state.includeBlockedList
+        )
+    }
+
+    init(windowUUID: WindowUUID) {
+        self.init(
+            windowUUID: windowUUID,
+            url: "",
+            selectedCategory: nil,
+            selectedSubOptionID: nil,
+            additionalDetails: "",
+            includeScreenshot: true,
+            includeBlockedList: false
+        )
+    }
+
+    init(windowUUID: WindowUUID,
+         url: String,
+         selectedCategory: WebCompatIssueCategory? = nil,
+         selectedSubOptionID: String? = nil,
+         additionalDetails: String = "",
+         includeScreenshot: Bool = true,
+         includeBlockedList: Bool = false) {
+        self.windowUUID = windowUUID
+        self.url = url
+        self.selectedCategory = selectedCategory
+        self.selectedSubOptionID = selectedSubOptionID
+        self.additionalDetails = additionalDetails
+        self.includeScreenshot = includeScreenshot
+        self.includeBlockedList = includeBlockedList
+    }
+
+    static let reducer: Reducer<Self> = { state, action in
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else {
+            return defaultState(from: state)
+        }
+
+        switch action {
+        case let action as WebCompatReporterMiddlewareAction:
+            return reduceMiddlewareAction(state: state, action: action)
+
+        case let action as WebCompatReporterViewAction:
+            return reduceViewAction(state: state, action: action)
+
+        default:
+            return defaultState(from: state)
+        }
+    }
+
+    private static func reduceMiddlewareAction(
+        state: WebCompatReporterState,
+        action: WebCompatReporterMiddlewareAction
+    ) -> WebCompatReporterState {
+        switch action.actionType {
+        case WebCompatReporterMiddlewareActionType.didLoadInitialDraft:
+            return state.copy(url: action.url ?? state.url)
+        default:
+            return defaultState(from: state)
+        }
+    }
+
+    private static func reduceViewAction(
+        state: WebCompatReporterState,
+        action: WebCompatReporterViewAction
+    ) -> WebCompatReporterState {
+        switch action.actionType {
+        case WebCompatReporterViewActionType.editURL:
+            return state.copy(url: action.url ?? state.url)
+
+        case WebCompatReporterViewActionType.selectCategory:
+            guard let category = action.category, category != state.selectedCategory else {
+                return defaultState(from: state)
+            }
+            // A new category clears the previous sub-option.
+            return state
+                .copy(selectedCategory: category)
+                .copy(selectedSubOptionID: nil)
+
+        case WebCompatReporterViewActionType.selectSubOption:
+            return state.copy(selectedSubOptionID: action.subOptionID)
+
+        case WebCompatReporterViewActionType.setAdditionalDetails:
+            return state.copy(additionalDetails: action.additionalDetails ?? state.additionalDetails)
+
+        case WebCompatReporterViewActionType.toggleScreenshot:
+            return state.copy(includeScreenshot: action.includeScreenshot ?? !state.includeScreenshot)
+
+        case WebCompatReporterViewActionType.toggleBlockedList:
+            return state.copy(includeBlockedList: action.includeBlockedList ?? !state.includeBlockedList)
+
+        default:
+            return defaultState(from: state)
+        }
+    }
+
+    static func defaultState(from state: WebCompatReporterState) -> WebCompatReporterState {
+        return WebCompatReporterState(
+            windowUUID: state.windowUUID,
+            url: state.url,
+            selectedCategory: state.selectedCategory,
+            selectedSubOptionID: state.selectedSubOptionID,
+            additionalDetails: state.additionalDetails,
+            includeScreenshot: state.includeScreenshot,
+            includeBlockedList: state.includeBlockedList
+        )
+    }
+
+    static func == (lhs: WebCompatReporterState, rhs: WebCompatReporterState) -> Bool {
+        return lhs.url == rhs.url
+            && lhs.selectedCategory == rhs.selectedCategory
+            && lhs.selectedSubOptionID == rhs.selectedSubOptionID
+            && lhs.additionalDetails == rhs.additionalDetails
+            && lhs.includeScreenshot == rhs.includeScreenshot
+            && lhs.includeBlockedList == rhs.includeBlockedList
+    }
+}

--- a/firefox-ios/Client/Redux/GlobalState/AppComponent.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppComponent.swift
@@ -22,4 +22,5 @@ enum AppComponent {
     case nativeErrorPage
     case shortcutsLibrary
     case translationSettings
+    case webCompatReporter
 }

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -38,6 +38,7 @@ struct AppState: StateType, Sendable {
                 case (.nativeErrorPage(let state), .nativeErrorPage): return state as? S
                 case (.shortcutsLibrary(let state), .shortcutsLibrary): return state as? S
                 case (.translationSettings(let state), .translationSettings): return state as? S
+                case (.webCompatReporter(let state), .webCompatReporter): return state as? S
                 default: return nil
                 }
             }.first(where: {
@@ -91,7 +92,8 @@ let middlewares = [
     SummarizerMiddleware().summarizerProvider,
     TermsOfUseMiddleware().termsOfUseProvider,
     TranslationsMiddleware().translationsProvider,
-    TranslationSettingsMiddleware().translationSettingsProvider
+    TranslationSettingsMiddleware().translationSettingsProvider,
+    WebCompatReporterMiddleware().webCompatReporterProvider
 ]
 
 // In order for us to mock and test the middlewares easier,

--- a/firefox-ios/Client/Redux/GlobalState/PresentedComponentsState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/PresentedComponentsState.swift
@@ -24,6 +24,7 @@ enum ComponentState: Sendable, Equatable {
     case nativeErrorPage(NativeErrorPageState)
     case shortcutsLibrary(ShortcutsLibraryState)
     case translationSettings(TranslationSettingsState)
+    case webCompatReporter(WebCompatReporterState)
 
     static let reducer: Reducer<Self> = { state, action in
         switch state {
@@ -47,6 +48,8 @@ enum ComponentState: Sendable, Equatable {
         case .shortcutsLibrary(let state): return .shortcutsLibrary(ShortcutsLibraryState.reducer(state, action))
         case .translationSettings(let state):
             return .translationSettings(TranslationSettingsState.reducer(state, action))
+        case .webCompatReporter(let state):
+            return .webCompatReporter(WebCompatReporterState.reducer(state, action))
         }
     }
 
@@ -70,6 +73,7 @@ enum ComponentState: Sendable, Equatable {
         case .nativeErrorPage: return .nativeErrorPage
         case .shortcutsLibrary: return .shortcutsLibrary
         case .translationSettings: return .translationSettings
+        case .webCompatReporter: return .webCompatReporter
         }
     }
 
@@ -92,6 +96,7 @@ enum ComponentState: Sendable, Equatable {
         case .nativeErrorPage(let state): return state.windowUUID
         case .shortcutsLibrary(let state): return state.windowUUID
         case .translationSettings(let state): return state.windowUUID
+        case .webCompatReporter(let state): return state.windowUUID
         }
     }
 }
@@ -164,6 +169,8 @@ struct PresentedComponentsState: Sendable, Equatable {
                 components.append(.shortcutsLibrary(ShortcutsLibraryState(windowUUID: uuid)))
             case .translationSettings:
                 components.append(.translationSettings(TranslationSettingsState(windowUUID: uuid)))
+            case .webCompatReporter:
+                components.append(.webCompatReporter(WebCompatReporterState(windowUUID: uuid)))
             }
         default:
             return components

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4564,6 +4564,118 @@ extension String {
     }
 }
 
+// MARK: - WebCompat Reporter
+extension String {
+    public struct WebCompatReporter {
+        public struct Category {
+            public static let SiteNotUsable = MZLocalizedString(
+                key: "", // WebCompatReporter.Category.SiteNotUsable.v152
+                tableName: "WebCompatReporter",
+                value: "Site is not usable",
+                comment: "Title of the issue category a user picks when a site does not work at all, in the Report a Website Issue form."
+            )
+            public static let DesignBroken = MZLocalizedString(
+                key: "", // WebCompatReporter.Category.DesignBroken.v152
+                tableName: "WebCompatReporter",
+                value: "Design is broken",
+                comment: "Title of the issue category a user picks when a site's layout or design is broken, in the Report a Website Issue form."
+            )
+            public static let VideoOrAudio = MZLocalizedString(
+                key: "", // WebCompatReporter.Category.VideoOrAudio.v152
+                tableName: "WebCompatReporter",
+                value: "Video or audio does not play",
+                comment: "Title of the issue category a user picks when video or audio does not play on a site, in the Report a Website Issue form."
+            )
+            public static let Other = MZLocalizedString(
+                key: "", // WebCompatReporter.Category.Other.v152
+                tableName: "WebCompatReporter",
+                value: "Other",
+                comment: "Title of the issue category a user picks for problems not covered by the other options, in the Report a Website Issue form."
+            )
+        }
+        public struct SubOption {
+            public static let BrowserBlocked = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.BrowserBlocked.v152
+                tableName: "WebCompatReporter",
+                value: "Browser is blocked or unsupported",
+                comment: "A specific sub-option under the 'Site is not usable' issue category in the Report a Website Issue form."
+            )
+            public static let PageNotLoading = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.PageNotLoading.v152
+                tableName: "WebCompatReporter",
+                value: "Page not loading correctly",
+                comment: "A specific sub-option under the 'Site is not usable' issue category in the Report a Website Issue form."
+            )
+            public static let MissingItems = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.MissingItems.v152
+                tableName: "WebCompatReporter",
+                value: "Missing items",
+                comment: "A specific sub-option under the 'Site is not usable' issue category in the Report a Website Issue form."
+            )
+            public static let ButtonsNotWorking = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.ButtonsNotWorking.v152
+                tableName: "WebCompatReporter",
+                value: "Buttons or links not working",
+                comment: "A specific sub-option under the 'Site is not usable' issue category in the Report a Website Issue form."
+            )
+            public static let ImagesNotLoaded = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.ImagesNotLoaded.v152
+                tableName: "WebCompatReporter",
+                value: "Images not loaded",
+                comment: "A specific sub-option under the 'Design is broken' issue category in the Report a Website Issue form."
+            )
+            public static let ItemsOverlapped = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.ItemsOverlapped.v152
+                tableName: "WebCompatReporter",
+                value: "Items are overlapped",
+                comment: "A specific sub-option under the 'Design is broken' issue category in the Report a Website Issue form."
+            )
+            public static let ItemsMisaligned = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.ItemsMisaligned.v152
+                tableName: "WebCompatReporter",
+                value: "Items are misaligned",
+                comment: "A specific sub-option under the 'Design is broken' issue category in the Report a Website Issue form."
+            )
+            public static let ItemsNotVisible = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.ItemsNotVisible.v152
+                tableName: "WebCompatReporter",
+                value: "Items not fully visible",
+                comment: "A specific sub-option under the 'Design is broken' issue category in the Report a Website Issue form."
+            )
+            public static let NoVideo = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.NoVideo.v152
+                tableName: "WebCompatReporter",
+                value: "There is no video",
+                comment: "A specific sub-option under the 'Video or audio does not play' issue category in the Report a Website Issue form."
+            )
+            public static let NoAudio = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.NoAudio.v152
+                tableName: "WebCompatReporter",
+                value: "There is no audio",
+                comment: "A specific sub-option under the 'Video or audio does not play' issue category in the Report a Website Issue form."
+            )
+            public static let MediaControlsBroken = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.MediaControlsBroken.v152
+                tableName: "WebCompatReporter",
+                value: "Media controls are broken or missing",
+                comment: "A specific sub-option under the 'Video or audio does not play' issue category in the Report a Website Issue form."
+            )
+            public static let PlaybackFails = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.PlaybackFails.v152
+                tableName: "WebCompatReporter",
+                value: "The video or audio does not play",
+                comment: "A specific sub-option under the 'Video or audio does not play' issue category in the Report a Website Issue form."
+            )
+            public static let CaptionsMissing = MZLocalizedString(
+                key: "", // WebCompatReporter.SubOption.CaptionsMissing.v152
+                tableName: "WebCompatReporter",
+                value: "Captions are missing",
+                comment: "A specific sub-option under the 'Video or audio does not play' issue category in the Report a Website Issue form."
+            )
+        }
+    }
+}
+
 // MARK: - What's New
 extension String {
     /// The localizations for the custom implemented content on the WebView

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -1,0 +1,121 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
+    private var mockStore: MockStoreForMiddleware<AppState>!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        setupStore()
+    }
+
+    override func tearDown() async throws {
+        DependencyHelperMock().reset()
+        resetStore()
+        try await super.tearDown()
+    }
+
+    // MARK: - viewDidLoad
+
+    func test_viewDidLoad_dispatchesDidLoadInitialDraftWithURL() throws {
+        let subject = createSubject()
+        let action = WebCompatReporterViewAction(
+            url: "https://example.com",
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.viewDidLoad
+        )
+
+        subject.webCompatReporterProvider(mockStore.state, action)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WebCompatReporterMiddlewareAction)
+        let dispatchedType = try XCTUnwrap(dispatched.actionType as? WebCompatReporterMiddlewareActionType)
+        XCTAssertEqual(dispatchedType, WebCompatReporterMiddlewareActionType.didLoadInitialDraft)
+        XCTAssertEqual(dispatched.url, "https://example.com")
+        subject.webCompatReporterProvider = { _, _ in }
+    }
+
+    // MARK: - submit
+
+    func test_submit_doesNotDispatch() {
+        let subject = createSubject()
+        let action = WebCompatReporterViewAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.submit
+        )
+
+        subject.webCompatReporterProvider(mockStore.state, action)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        subject.webCompatReporterProvider = { _, _ in }
+    }
+
+    // MARK: - Pure view actions are not handled by the middleware
+
+    func test_selectCategory_doesNotDispatchViaMiddleware() {
+        let subject = createSubject()
+        let action = WebCompatReporterViewAction(
+            category: .siteNotUsable,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.selectCategory
+        )
+
+        subject.webCompatReporterProvider(mockStore.state, action)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        subject.webCompatReporterProvider = { _, _ in }
+    }
+
+    // MARK: - Unrelated action
+
+    func test_unrelatedAction_doesNotDispatch() {
+        let subject = createSubject()
+        let action = WebCompatReporterMiddlewareAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterMiddlewareActionType.didLoadInitialDraft
+        )
+
+        subject.webCompatReporterProvider(mockStore.state, action)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        subject.webCompatReporterProvider = { _, _ in }
+    }
+
+    // MARK: - StoreTestUtility
+
+    func setupAppState() -> AppState {
+        return AppState(
+            presentedComponents: PresentedComponentsState(
+                components: [
+                    .webCompatReporter(WebCompatReporterState(windowUUID: .XCTestDefaultUUID))
+                ]
+            )
+        )
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> WebCompatReporterMiddleware {
+        let subject = WebCompatReporterMiddleware()
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
@@ -1,0 +1,314 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class WebCompatReporterStateTests: XCTestCase {
+    // MARK: - Initialization
+
+    func test_initWithWindowUUID_returnsDefaultDraft() {
+        let subject = createSubject()
+
+        XCTAssertEqual(subject.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(subject.url, "")
+        XCTAssertNil(subject.selectedCategory)
+        XCTAssertNil(subject.selectedSubOptionID)
+        XCTAssertEqual(subject.additionalDetails, "")
+        XCTAssertTrue(subject.includeScreenshot)
+        XCTAssertFalse(subject.includeBlockedList)
+    }
+
+    func test_canSubmitAndCanPreview_falseUntilCategorySelected() {
+        let withoutCategory = createSubject()
+        XCTAssertFalse(withoutCategory.canSubmit)
+        XCTAssertFalse(withoutCategory.canPreview)
+
+        let withCategory = WebCompatReporterState(
+            windowUUID: .XCTestDefaultUUID,
+            url: "https://example.com",
+            selectedCategory: .siteNotUsable
+        )
+        XCTAssertTrue(withCategory.canSubmit)
+        XCTAssertTrue(withCategory.canPreview)
+    }
+
+    // MARK: - Reducer - didLoadInitialDraft
+
+    func test_didLoadInitialDraft_seedsURL() {
+        let initialState = createSubject()
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterMiddlewareAction(
+            url: "https://example.com",
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterMiddlewareActionType.didLoadInitialDraft
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.url, "https://example.com")
+    }
+
+    func test_didLoadInitialDraft_withNilURL_preservesExistingURL() {
+        let initialState = WebCompatReporterState(windowUUID: .XCTestDefaultUUID, url: "https://existing.com")
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterMiddlewareAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterMiddlewareActionType.didLoadInitialDraft
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.url, "https://existing.com")
+    }
+
+    // MARK: - Reducer - editURL
+
+    func test_editURL_updatesURL() {
+        let initialState = createSubject()
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterViewAction(
+            url: "https://edited.com",
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.editURL
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.url, "https://edited.com")
+    }
+
+    // MARK: - Reducer - selectCategory
+
+    func test_selectCategory_setsCategory() {
+        let initialState = createSubject()
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterViewAction(
+            category: .videoOrAudio,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.selectCategory
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.selectedCategory, .videoOrAudio)
+    }
+
+    func test_selectCategory_clearsPreviousSubOption() {
+        let initialState = WebCompatReporterState(
+            windowUUID: .XCTestDefaultUUID,
+            url: "",
+            selectedCategory: .siteNotUsable,
+            selectedSubOptionID: "page_not_loading"
+        )
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterViewAction(
+            category: .designBroken,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.selectCategory
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.selectedCategory, .designBroken)
+        XCTAssertNil(newState.selectedSubOptionID)
+    }
+
+    func test_selectCategory_sameCategory_keepsSubOption() {
+        let initialState = WebCompatReporterState(
+            windowUUID: .XCTestDefaultUUID,
+            url: "",
+            selectedCategory: .siteNotUsable,
+            selectedSubOptionID: "page_not_loading"
+        )
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterViewAction(
+            category: .siteNotUsable,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.selectCategory
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.selectedSubOptionID, "page_not_loading")
+    }
+
+    // MARK: - Reducer - selectSubOption
+
+    func test_selectSubOption_setsSubOption() {
+        let initialState = WebCompatReporterState(
+            windowUUID: .XCTestDefaultUUID,
+            url: "",
+            selectedCategory: .siteNotUsable
+        )
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterViewAction(
+            subOptionID: "missing_items",
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.selectSubOption
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.selectedSubOptionID, "missing_items")
+    }
+
+    // MARK: - Reducer - setAdditionalDetails
+
+    func test_setAdditionalDetails_updatesDetails() {
+        let initialState = createSubject()
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterViewAction(
+            additionalDetails: "Buttons are unresponsive",
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.setAdditionalDetails
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.additionalDetails, "Buttons are unresponsive")
+    }
+
+    // MARK: - Reducer - toggles
+
+    func test_toggleScreenshot_withoutValue_flipsCurrent() {
+        let initialState = createSubject()
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterViewAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.toggleScreenshot
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertFalse(newState.includeScreenshot)
+    }
+
+    func test_toggleScreenshot_withExplicitValue_setsValue() {
+        let initialState = createSubject()
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterViewAction(
+            includeScreenshot: false,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.toggleScreenshot
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertFalse(newState.includeScreenshot)
+    }
+
+    func test_toggleBlockedList_withoutValue_flipsCurrent() {
+        let initialState = createSubject()
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterViewAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.toggleBlockedList
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertTrue(newState.includeBlockedList)
+    }
+
+    // MARK: - Edge Cases
+
+    func test_unknownAction_returnsDefaultState() {
+        let initialState = createSubject()
+        let reducer = WebCompatReporterState.reducer
+
+        struct UnknownAction: Action {
+            let windowUUID: WindowUUID
+            let actionType: ActionType
+        }
+
+        let action = UnknownAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterMiddlewareActionType.didLoadInitialDraft
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState, initialState)
+    }
+
+    func test_actionWithDifferentWindowUUID_returnsDefaultState() {
+        let initialState = WebCompatReporterState(windowUUID: .XCTestDefaultUUID, url: "https://example.com")
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterViewAction(
+            url: "https://other.com",
+            windowUUID: WindowUUID(),
+            actionType: WebCompatReporterViewActionType.editURL
+        )
+
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState, initialState)
+    }
+
+    // MARK: - Equality
+
+    func test_equality_sameValues_returnsTrue() {
+        let state1 = WebCompatReporterState(windowUUID: .XCTestDefaultUUID, url: "https://example.com")
+        let state2 = WebCompatReporterState(windowUUID: .XCTestDefaultUUID, url: "https://example.com")
+
+        XCTAssertEqual(state1, state2)
+    }
+
+    func test_equality_differentURL_returnsFalse() {
+        let state1 = WebCompatReporterState(windowUUID: .XCTestDefaultUUID, url: "https://a.com")
+        let state2 = WebCompatReporterState(windowUUID: .XCTestDefaultUUID, url: "https://b.com")
+
+        XCTAssertNotEqual(state1, state2)
+    }
+
+    // MARK: - WebCompatIssueCategory
+
+    func test_category_idMatchesRawValue() {
+        for category in WebCompatIssueCategory.allCases {
+            XCTAssertEqual(category.id, category.rawValue)
+        }
+    }
+
+    func test_category_subOptionIDs_matchGleanReasonKeys() {
+        XCTAssertEqual(
+            WebCompatIssueCategory.siteNotUsable.subOptionIDs,
+            ["browser_blocked", "page_not_loading", "missing_items", "buttons_not_working"]
+        )
+        XCTAssertEqual(
+            WebCompatIssueCategory.designBroken.subOptionIDs,
+            ["images_not_loaded", "items_overlapped", "items_misaligned", "items_not_visible"]
+        )
+        XCTAssertEqual(
+            WebCompatIssueCategory.videoOrAudio.subOptionIDs,
+            ["no_video", "no_audio", "media_controls_broken", "playback_fails", "captions_missing"]
+        )
+    }
+
+    func test_category_other_hasNoSubOptions() {
+        XCTAssertTrue(WebCompatIssueCategory.other.subOptionIDs.isEmpty)
+    }
+
+    // MARK: - Private Helpers
+
+    private func createSubject() -> WebCompatReporterState {
+        return WebCompatReporterState(windowUUID: .XCTestDefaultUUID)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16178)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

First piece of the "Report a Website Issue" feature (FXIOS-16083). This PR adds the Redux layer only: the `WebCompatReporter` state, view and middleware actions, reducer, middleware, and registers the screen in `AppComponent`, `PresentedComponentsState`, and `AppState`, following the existing screen pattern.

There is no UI or entry point yet, so nothing is user-facing. The store remains idle until the report form, which will land in a follow-up PR, starts dispatching actions into it. The feature is also gated behind the `reportBrokenSite` Nimbus flag (disabled in Release and Beta, enabled in Developer through the debug menu). Even with the flag enabled, there is nothing visible yet.

The middleware seeds the URL on `viewDidLoad` and includes a stub for `submit`. Collecting the device and tab payload, along with sending the Glean ping, will be added in FXIOS-16177. Category and sub-option titles are currently defined in `Strings.swift` with empty keys so they are not exported for localization yet. Those keys will be populated when the form UI lands.

Testing: there is nothing to exercise manually. The PR includes 24 unit tests covering reducer state transitions (URL updates, clearing stale sub-options when the category changes, toggle behavior, and the window guard) as well as middleware dispatch behavior.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

