### PR TITLE
Bugfix FXIOS-14985 [Toolbar] Prevent status bar overlay animation dur…

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5133,7 +5133,9 @@ extension BrowserViewController: KeyboardHelperDelegate {
         // When animation duration is zero the keyboard is already showing and we don't need
         // to update the toolbar again. This is the case when we are moving between fields in a form.
         if state.animationDuration > 0 {
-            updateToolbarDisplay()
+            UIView.performWithoutAnimation {
+                updateToolbarDisplay()
+            }
         }
     }
 
@@ -5171,8 +5173,11 @@ extension BrowserViewController: KeyboardHelperDelegate {
             })
 
         cancelEditingMode()
-        updateBlurViews()
-        addOrUpdateMaskViewIfNeeded()
+        // Avoid leaking the keyboard animation context into toolbar translucency updates. (FXIOS-14985)
+        UIView.performWithoutAnimation {
+            updateBlurViews()
+            addOrUpdateMaskViewIfNeeded()
+        }
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14985)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32283)

## :bulb: Description
When the keyboard shows or hides (e.g. tapping the address bar), UIKit opens an implicit
animation context using the keyboard's curve and duration. View property changes that occur
after that context opens — but outside an explicit animation block — silently inherit that
animation. This caused `statusBarOverlay`, blur views, and the content container mask to
animate with the keyboard's timing instead of updating instantly, producing a visible flicker.

Fix: wrap `updateToolbarDisplay()` (keyboard show) and `updateBlurViews()` +
`addOrUpdateMaskViewIfNeeded()` (keyboard hide) in `UIView.performWithoutAnimation`
to isolate them from the keyboard animation context.

## :movie_camera: Demos
<!-- Attach a short before/after screen recording here — reviewers will ask for it -->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code