### PR TITLE
Bugfix FXIOS-16197 [TopSites] Add tile order for AdsClient

### DIFF
--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
@@ -38,9 +38,14 @@ final class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, Feature
         case noDataAvailable
     }
 
-    enum TileOrder: String {
+    enum TileOrder: String, CaseIterable {
         case position1 = "newtab_mobile_tile_1"
         case position2 = "newtab_mobile_tile_2"
+
+        /// Placement identifiers in the order tiles should be displayed.
+        static var placementOrder: [String] {
+            return allCases.map { $0.rawValue }
+        }
     }
 
     init(
@@ -103,10 +108,7 @@ final class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, Feature
 
         let requestBody = RequestBody(
             context_id: contextId,
-            placements: [
-                AdPlacement(placement: TileOrder.position1.rawValue, count: 1),
-                AdPlacement(placement: TileOrder.position2.rawValue, count: 1)
-            ]
+            placements: TileOrder.placementOrder.map { AdPlacement(placement: $0, count: 1) }
         )
 
         var request = URLRequest(url: resourceEndpoint)
@@ -144,20 +146,15 @@ final class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, Feature
 
     private func fetchTilesWithAdsClient(completion: @escaping (UnifiedTileResult) -> Void) {
         logger.log("Fetching tiles with ads client", level: .info, category: .homepage)
-        let mozAdRequests = [
-            MozAdsPlacementRequest(iabContent: nil, placementId: TileOrder.position1.rawValue),
-            MozAdsPlacementRequest(iabContent: nil, placementId: TileOrder.position2.rawValue)
-        ]
+        let mozAdRequests = TileOrder.placementOrder.map {
+            MozAdsPlacementRequest(iabContent: nil, placementId: $0)
+        }
         do {
             let mozAdsTiles = try adsClient.requestTileAds(
                 mozAdRequests: mozAdRequests,
                 options: nil
             )
-            // `requestTileAds` returns a dictionary keyed by placement, which has no
-            // guaranteed iteration order. Reconstruct the tiles following the placement
-            // order so the first sponsored tile is always shown first.
-            let placementOrder = [TileOrder.position1.rawValue, TileOrder.position2.rawValue]
-            let unifiedTiles: [UnifiedTile] = placementOrder.compactMap { placement in
+            let unifiedTiles: [UnifiedTile] = TileOrder.placementOrder.compactMap { placement in
                 guard let mozAdsTile = mozAdsTiles[placement] else { return nil }
                 return UnifiedTile.from(name: placement, mozAdsTile: mozAdsTile)
             }
@@ -175,8 +172,7 @@ final class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, Feature
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             let tilesDictionary = try decoder.decode([String: [UnifiedTile]].self, from: data)
-            let placementOrder = [TileOrder.position1.rawValue, TileOrder.position2.rawValue]
-            let tiles = placementOrder.compactMap { tilesDictionary[$0] }.flatMap { $0 }
+            let tiles = TileOrder.placementOrder.compactMap { tilesDictionary[$0] }.flatMap { $0 }
 
             guard !tiles.isEmpty else {
                 completion(.failure(Error.noDataAvailable))

--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
@@ -150,10 +150,18 @@ final class UnifiedAdsProvider: URLCaching, UnifiedAdsProviderInterface, Feature
         ]
         do {
             let mozAdsTiles = try adsClient.requestTileAds(
-                mozAdRequests: mozAdRequests, options: nil)
-            let unifiedTiles: [UnifiedTile] = mozAdsTiles.map { name, mozAdsTile in
-                UnifiedTile.from(name: name, mozAdsTile: mozAdsTile)
+                mozAdRequests: mozAdRequests,
+                options: nil
+            )
+            // `requestTileAds` returns a dictionary keyed by placement, which has no
+            // guaranteed iteration order. Reconstruct the tiles following the placement
+            // order so the first sponsored tile is always shown first.
+            let placementOrder = [TileOrder.position1.rawValue, TileOrder.position2.rawValue]
+            let unifiedTiles: [UnifiedTile] = placementOrder.compactMap { placement in
+                guard let mozAdsTile = mozAdsTiles[placement] else { return nil }
+                return UnifiedTile.from(name: placement, mozAdsTile: mozAdsTile)
             }
+
             logger.log("Ads client request successful", level: .info, category: .homepage)
             completion(.success(unifiedTiles))
         } catch let error {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsProviderTests.swift
@@ -305,12 +305,89 @@ class UnifiedAdsProviderTests: XCTestCase {
             switch result {
             case let .success(tiles):
                 XCTAssertEqual(tiles.count, 2)
-                let actual = Dictionary(uniqueKeysWithValues: tiles.map { ($0.name, $0.url) })
-                let expected = [
-                    "newtab_mobile_tile_1": "https://www.test1.com",
-                    "newtab_mobile_tile_2": "https://www.test5.com"
-                ]
-                XCTAssertEqual(actual, expected)
+                XCTAssertEqual(tiles[0].url, "https://www.test1.com")
+                XCTAssertEqual(tiles[1].url, "https://www.test5.com")
+            default:
+                XCTFail("Expected success, got \(result) instead")
+            }
+        }
+    }
+
+    func testFetchTilesWithAdsClient_whenInvertedOrder_thenReturnsProperTileOrder() {
+        setupNimbusAdsClientTesting(isEnabled: true)
+
+        let adTile1 = MozAdsTile(
+            blockKey: "12345",
+            callbacks: MozAdsCallbacks(
+                click: "https://www.test2.com",
+                impression: "https://www.test3.com",
+                report: nil
+            ),
+            format: "tile",
+            imageUrl: "https://www.test4.com",
+            name: "newtab_mobile_tile_1",
+            url: "https://www.test1.com"
+        )
+
+        let adTile2 = MozAdsTile(
+            blockKey: "6789",
+            callbacks: MozAdsCallbacks(
+                click: "https://www.test6.com",
+                impression: "https://www.test7.com",
+                report: nil
+            ),
+            format: "tile",
+            imageUrl: "https://www.test8.com",
+            name: "newtab_mobile_tile_2",
+            url: "https://www.test5.com"
+        )
+
+        // Insert position2 before position1 to verify the order does not depend
+        // on the dictionary's iteration order.
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_2": adTile2,
+            "newtab_mobile_tile_1": adTile1
+        ]
+
+        let subject = createSubject()
+
+        subject.fetchTiles { result in
+            switch result {
+            case let .success(tiles):
+                XCTAssertEqual(tiles.count, 2)
+                XCTAssertEqual(tiles[0].url, "https://www.test1.com")
+                XCTAssertEqual(tiles[1].url, "https://www.test5.com")
+            default:
+                XCTFail("Expected success, got \(result) instead")
+            }
+        }
+    }
+
+    func testFetchTilesWithAdsClient_whenOnlyFirstPlacement_thenReturnsSingleTile() {
+        setupNimbusAdsClientTesting(isEnabled: true)
+
+        let adTile1 = MozAdsTile(
+            blockKey: "12345",
+            callbacks: MozAdsCallbacks(
+                click: "https://www.test2.com",
+                impression: "https://www.test3.com",
+                report: nil
+            ),
+            format: "tile",
+            imageUrl: "https://www.test4.com",
+            name: "newtab_mobile_tile_1",
+            url: "https://www.test1.com"
+        )
+
+        mockAdsClient.mockAdsTiles = ["newtab_mobile_tile_1": adTile1]
+
+        let subject = createSubject()
+
+        subject.fetchTiles { result in
+            switch result {
+            case let .success(tiles):
+                XCTAssertEqual(tiles.count, 1)
+                XCTAssertEqual(tiles[0].url, "https://www.test1.com")
             default:
                 XCTFail("Expected success, got \(result) instead")
             }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16197)

## :bulb: Description
The legacy sponsored tiles provider preserved tile order, but the new ads client one did not. This fixes that.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

