### PR TITLE
Add MTE-5565 Add timeout to the testSSL

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SSLWarningScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SSLWarningScreen.swift
@@ -16,7 +16,7 @@ final class SSLWarningScreen {
 
     func waitForWarning() {
         let warning = sel.WARNING_MESSAGE.element(in: app)
-        BaseTestCase().mozWaitForElementToExist(warning)
+        BaseTestCase().mozWaitForElementToExist(warning, timeout: TIMEOUT_LONG)
     }
 
     func assertWarningVisible() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5565)

## :bulb: Description
This PR adds a timeout when the test opens the URL `https://expired.badssl.com/`. Sometimes this webpage takes longer to load.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

