### PR TITLE
Add FXIOS-16061 [Google Lens] Present camera for Google Lens

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1568,7 +1568,11 @@
 		BDE2DB332DB1024E002FAE26 /* TabWebViewPreviewAppearanceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE2DB322DB1024E002FAE26 /* TabWebViewPreviewAppearanceConfiguration.swift */; };
 		C0FFE71000000000000000A3 /* worldCupConfetti.json in Resources */ = {isa = PBXBuildFile; fileRef = C0FFE71000000000000000A2 /* worldCupConfetti.json */; };
 		C209316E2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */; };
+		FB16062100000000000000A2 /* PhotoPickerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062100000000000000A1 /* PhotoPickerCoordinator.swift */; };
+		FB16062200000000000000A2 /* CameraCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062200000000000000A1 /* CameraCoordinator.swift */; };
 		C20931722F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */; };
+		FB16062100000000000000B2 /* PhotoPickerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062100000000000000B1 /* PhotoPickerCoordinatorTests.swift */; };
+		FB16062200000000000000B2 /* CameraCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062200000000000000B1 /* CameraCoordinatorTests.swift */; };
 		C2126EF82F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2126EF72F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift */; };
 		C2126EFA2F447A46001C01FE /* SummarizerNimbusUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */; };
 		C21326992F5713F000746393 /* SummarizerLanguageProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21326982F5713F000746393 /* SummarizerLanguageProviderTests.swift */; };
@@ -10512,7 +10516,11 @@
 		C1DF4F71AB33BAB7B199F361 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C1F24EFFB6E9B114849A4DB3 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersCoordinator.swift; sourceTree = "<group>"; };
+		FB16062100000000000000A1 /* PhotoPickerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerCoordinator.swift; sourceTree = "<group>"; };
+		FB16062200000000000000A1 /* CameraCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCoordinator.swift; sourceTree = "<group>"; };
 		C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersCoordinatorTests.swift; sourceTree = "<group>"; };
+		FB16062100000000000000B1 /* PhotoPickerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerCoordinatorTests.swift; sourceTree = "<group>"; };
+		FB16062200000000000000B1 /* CameraCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCoordinatorTests.swift; sourceTree = "<group>"; };
 		C2126EF72F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerLanguageExpansionConfiguration.swift; sourceTree = "<group>"; };
 		C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerNimbusUtilsTests.swift; sourceTree = "<group>"; };
 		C21326982F5713F000746393 /* SummarizerLanguageProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerLanguageProviderTests.swift; sourceTree = "<group>"; };
@@ -14440,6 +14448,7 @@
 				0B6153DF2E24E316000D2FBD /* SummarizeCoordinator.swift */,
 				C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */,
 				FB16062100000000000000A1 /* PhotoPickerCoordinator.swift */,
+				FB16062200000000000000A1 /* CameraCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -14471,6 +14480,7 @@
 				0B6153E12E24ECCA000D2FBD /* SummarizeCoordinatorTests.swift */,
 				C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */,
 				FB16062100000000000000B1 /* PhotoPickerCoordinatorTests.swift */,
+				FB16062200000000000000B1 /* CameraCoordinatorTests.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -19591,6 +19601,7 @@
 				C8A4137428BE58C900D8EFEA /* WallpaperMetadataCodableProtocol.swift in Sources */,
 				C209316E2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift in Sources */,
 				FB16062100000000000000A2 /* PhotoPickerCoordinator.swift in Sources */,
+				FB16062200000000000000A2 /* CameraCoordinator.swift in Sources */,
 				FB16062100000000000000E2 /* GoogleLensImageProcessor.swift in Sources */,
 				FB16062100000000000000E4 /* GoogleLensRequestBuilder.swift in Sources */,
 				FB16062100000000000000E6 /* GoogleLensService.swift in Sources */,
@@ -20932,6 +20943,7 @@
 				8AABBD052A0041380089941E /* MockCoordinator.swift in Sources */,
 				C20931722F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift in Sources */,
 				FB16062100000000000000B2 /* PhotoPickerCoordinatorTests.swift in Sources */,
+				FB16062200000000000000B2 /* CameraCoordinatorTests.swift in Sources */,
 				FB16062100000000000000D2 /* GoogleLensImageProcessorTests.swift in Sources */,
 				FB16062100000000000000D4 /* GoogleLensRequestBuilderTests.swift in Sources */,
 				FB16062100000000000000D6 /* GoogleLensServiceTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1568,10 +1568,8 @@
 		BDE2DB332DB1024E002FAE26 /* TabWebViewPreviewAppearanceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE2DB322DB1024E002FAE26 /* TabWebViewPreviewAppearanceConfiguration.swift */; };
 		C0FFE71000000000000000A3 /* worldCupConfetti.json in Resources */ = {isa = PBXBuildFile; fileRef = C0FFE71000000000000000A2 /* worldCupConfetti.json */; };
 		C209316E2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */; };
-		FB16062100000000000000A2 /* PhotoPickerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062100000000000000A1 /* PhotoPickerCoordinator.swift */; };
 		FB16062200000000000000A2 /* CameraCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062200000000000000A1 /* CameraCoordinator.swift */; };
 		C20931722F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */; };
-		FB16062100000000000000B2 /* PhotoPickerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062100000000000000B1 /* PhotoPickerCoordinatorTests.swift */; };
 		FB16062200000000000000B2 /* CameraCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062200000000000000B1 /* CameraCoordinatorTests.swift */; };
 		C2126EF82F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2126EF72F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift */; };
 		C2126EFA2F447A46001C01FE /* SummarizerNimbusUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */; };
@@ -10516,10 +10514,8 @@
 		C1DF4F71AB33BAB7B199F361 /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C1F24EFFB6E9B114849A4DB3 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersCoordinator.swift; sourceTree = "<group>"; };
-		FB16062100000000000000A1 /* PhotoPickerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerCoordinator.swift; sourceTree = "<group>"; };
 		FB16062200000000000000A1 /* CameraCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCoordinator.swift; sourceTree = "<group>"; };
 		C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersCoordinatorTests.swift; sourceTree = "<group>"; };
-		FB16062100000000000000B1 /* PhotoPickerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerCoordinatorTests.swift; sourceTree = "<group>"; };
 		FB16062200000000000000B1 /* CameraCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCoordinatorTests.swift; sourceTree = "<group>"; };
 		C2126EF72F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerLanguageExpansionConfiguration.swift; sourceTree = "<group>"; };
 		C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerNimbusUtilsTests.swift; sourceTree = "<group>"; };

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1133,19 +1133,14 @@ final class BrowserCoordinator: BaseCoordinator,
         let coordinator = PhotoPickerCoordinator(
             parentCoordinatorDelegate: self,
             router: router
-        ) { [weak self] results in
-            // Empty results means the user dismissed the picker without choosing, leave the
-            // address bar's edit/overlay state only once a photo is actually selected.
-            guard let self, !results.isEmpty else { return }
-            store.dispatch(
-                GeneralBrowserAction(showOverlay: false,
-                                     windowUUID: self.windowUUID,
-                                     actionType: GeneralBrowserActionType.leaveOverlay)
-            )
+        ) { _ in
             // TODO FXIOS-16064: Send the picked image to the Lens API and navigate to the result
         }
         add(child: coordinator)
         coordinator.start()
+        store.dispatch(GeneralBrowserAction(showOverlay: false,
+                                            windowUUID: self.windowUUID,
+                                            actionType: GeneralBrowserActionType.leaveOverlay))
     }
 
     func showGoogleLensCamera() {
@@ -1153,19 +1148,14 @@ final class BrowserCoordinator: BaseCoordinator,
         let coordinator = CameraCoordinator(
             parentCoordinatorDelegate: self,
             router: router
-        ) { [weak self] image in
-            // A nil image means the user cancelled the capture (or no camera was available);
-            // leave the address bar's edit/overlay state only once a photo is actually taken.
-            guard let self, image != nil else { return }
-            store.dispatch(
-                GeneralBrowserAction(showOverlay: false,
-                                     windowUUID: self.windowUUID,
-                                     actionType: GeneralBrowserActionType.leaveOverlay)
-            )
+        ) { _ in
             // TODO FXIOS-16064: Send the captured image to the Lens API and navigate to the result
         }
         add(child: coordinator)
         coordinator.start()
+        store.dispatch(GeneralBrowserAction(showOverlay: false,
+                                            windowUUID: self.windowUUID,
+                                            actionType: GeneralBrowserActionType.leaveOverlay))
     }
 
     func showPrivacyNoticeLink(url: URL) {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1148,6 +1148,26 @@ final class BrowserCoordinator: BaseCoordinator,
         coordinator.start()
     }
 
+    func showGoogleLensCamera() {
+        guard !childCoordinators.contains(where: { $0 is CameraCoordinator }) else { return }
+        let coordinator = CameraCoordinator(
+            parentCoordinatorDelegate: self,
+            router: router
+        ) { [weak self] image in
+            // A nil image means the user cancelled the capture (or no camera was available);
+            // leave the address bar's edit/overlay state only once a photo is actually taken.
+            guard let self, image != nil else { return }
+            store.dispatch(
+                GeneralBrowserAction(showOverlay: false,
+                                     windowUUID: self.windowUUID,
+                                     actionType: GeneralBrowserActionType.leaveOverlay)
+            )
+            // TODO FXIOS-16064: Send the captured image to the Lens API and navigate to the result
+        }
+        add(child: coordinator)
+        coordinator.start()
+    }
+
     func showPrivacyNoticeLink(url: URL) {
         let linkVC = TermsOfUseLinkViewController(
             url: url,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -125,9 +125,11 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     @MainActor
     func showWorldCupCountryPicker()
 
-    /// Shows the system photo-library picker and sends the picked image to the Lens API.
     @MainActor
     func showGoogleLensPhotoPicker()
+
+    @MainActor
+    func showGoogleLensCamera()
 
     @MainActor
     func showQuickAnswers(transitionType: QuickAnswersTransitionType)

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -12,6 +12,7 @@ final class CameraCoordinator: BaseCoordinator,
     private let onComplete: (UIImage?) -> Void
     private let isCameraAvailable: () -> Bool
     private let cameraAuthorizationStatus: () -> AVAuthorizationStatus
+    private let requestCameraAccess: () async -> Bool
 
     init(parentCoordinatorDelegate: ParentCoordinatorDelegate?,
          router: Router,
@@ -19,11 +20,15 @@ final class CameraCoordinator: BaseCoordinator,
          cameraAuthorizationStatus: @escaping () -> AVAuthorizationStatus = {
              AVCaptureDevice.authorizationStatus(for: .video)
          },
+         requestCameraAccess: @escaping () async -> Bool = {
+             await AVCaptureDevice.requestAccess(for: .video)
+         },
          onComplete: @escaping (UIImage?) -> Void) {
         self.parentCoordinatorDelegate = parentCoordinatorDelegate
         self.onComplete = onComplete
         self.isCameraAvailable = isCameraAvailable
         self.cameraAuthorizationStatus = cameraAuthorizationStatus
+        self.requestCameraAccess = requestCameraAccess
         super.init(router: router)
     }
 
@@ -40,19 +45,29 @@ final class CameraCoordinator: BaseCoordinator,
             self?.finish(with: nil)
         }
 
-        guard isCameraAccessDenied else { return }
-        presentCameraAccessDeniedAlert(over: picker)
+        switch cameraAuthorizationStatus() {
+        case .denied, .restricted:
+            // Access was refused in a previous session: surface the alert over the interface.
+            presentCameraAccessDeniedAlert(over: picker)
+        case .notDetermined:
+            // Presenting the interface triggers the system permission prompt; dismiss the
+            // interface if the user refuses access, without surfacing a second alert.
+            Task { [weak self] in await self?.dismissCameraInterfaceIfAccessRefused() }
+        default:
+            break
+        }
     }
 
     // MARK: - Camera permission
-    private var isCameraAccessDenied: Bool {
-        let status = cameraAuthorizationStatus()
-        return status == .denied || status == .restricted
+    func dismissCameraInterfaceIfAccessRefused() async {
+        let granted = await requestCameraAccess()
+        guard !granted else { return }
+        dismissCameraInterface()
     }
 
     private func presentCameraAccessDeniedAlert(over presenter: UIViewController) {
         let alert = UIAlertController.cameraAccessDisabledAlert { [weak self] _ in
-            self?.dismissCameraAccessDeniedViewfinder()
+            self?.dismissCameraInterface()
         }
 
         if let transitionCoordinator = presenter.transitionCoordinator {
@@ -64,7 +79,8 @@ final class CameraCoordinator: BaseCoordinator,
         }
     }
 
-    func dismissCameraAccessDeniedViewfinder() {
+    /// Dismisses the camera interface and ends the flow without a captured image.
+    func dismissCameraInterface() {
         router.dismiss(animated: true)
         finish(with: nil)
     }

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -14,14 +14,16 @@ final class CameraCoordinator: BaseCoordinator,
     private let cameraAuthorizationStatus: AVAuthorizationStatus
     private let requestCameraAccess: () async -> Bool
 
-    init(parentCoordinatorDelegate: ParentCoordinatorDelegate?,
-         router: Router,
-         isCameraAvailable: Bool = UIImagePickerController.isSourceTypeAvailable(.camera),
-         cameraAuthorizationStatus: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video),
-         requestCameraAccess: @escaping () async -> Bool = {
-             await AVCaptureDevice.requestAccess(for: .video)
-         },
-         onComplete: @escaping (UIImage?) -> Void) {
+    init(
+        parentCoordinatorDelegate: ParentCoordinatorDelegate?,
+        router: Router,
+        isCameraAvailable: Bool = UIImagePickerController.isSourceTypeAvailable(.camera),
+        cameraAuthorizationStatus: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video),
+        requestCameraAccess: @escaping () async -> Bool = {
+            await AVCaptureDevice.requestAccess(for: .video)
+        },
+        onComplete: @escaping (UIImage?) -> Void
+    ) {
         self.parentCoordinatorDelegate = parentCoordinatorDelegate
         self.onComplete = onComplete
         self.isCameraAvailable = isCameraAvailable

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import AVFoundation
+
+/// Presents the system camera capture UI and owns its delegate conformance.
+final class CameraCoordinator: BaseCoordinator,
+                               UIImagePickerControllerDelegate,
+                               UINavigationControllerDelegate {
+    private weak var parentCoordinatorDelegate: ParentCoordinatorDelegate?
+    private let onComplete: (UIImage?) -> Void
+    private let isCameraAvailable: () -> Bool
+    private let cameraAuthorizationStatus: () -> AVAuthorizationStatus
+
+    init(parentCoordinatorDelegate: ParentCoordinatorDelegate?,
+         router: Router,
+         isCameraAvailable: @escaping () -> Bool = { UIImagePickerController.isSourceTypeAvailable(.camera) },
+         cameraAuthorizationStatus: @escaping () -> AVAuthorizationStatus = {
+             AVCaptureDevice.authorizationStatus(for: .video)
+         },
+         onComplete: @escaping (UIImage?) -> Void) {
+        self.parentCoordinatorDelegate = parentCoordinatorDelegate
+        self.onComplete = onComplete
+        self.isCameraAvailable = isCameraAvailable
+        self.cameraAuthorizationStatus = cameraAuthorizationStatus
+        super.init(router: router)
+    }
+
+    func start() {
+        guard isCameraAvailable() else {
+            finish(with: nil)
+            return
+        }
+
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = self
+        router.present(picker, animated: true) { [weak self] in
+            self?.finish(with: nil)
+        }
+
+        guard isCameraAccessDenied else { return }
+        presentCameraAccessDeniedAlert(over: picker)
+    }
+
+    // MARK: - Camera permission
+    private var isCameraAccessDenied: Bool {
+        let status = cameraAuthorizationStatus()
+        return status == .denied || status == .restricted
+    }
+
+    private func presentCameraAccessDeniedAlert(over presenter: UIViewController) {
+        let alert = UIAlertController.cameraAccessDisabledAlert { [weak self] _ in
+            self?.dismissCameraAccessDeniedViewfinder()
+        }
+
+        if let transitionCoordinator = presenter.transitionCoordinator {
+            transitionCoordinator.animate(alongsideTransition: nil) { [weak presenter] _ in
+                presenter?.present(alert, animated: true)
+            }
+        } else {
+            presenter.present(alert, animated: true)
+        }
+    }
+
+    func dismissCameraAccessDeniedViewfinder() {
+        router.dismiss(animated: true)
+        finish(with: nil)
+    }
+
+    private func finish(with image: UIImage?) {
+        onComplete(image)
+        parentCoordinatorDelegate?.didFinish(from: self)
+    }
+
+    // MARK: - UIImagePickerControllerDelegate
+    func imagePickerController(_ picker: UIImagePickerController,
+                               didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        router.dismiss(animated: true)
+        finish(with: info[.originalImage] as? UIImage)
+    }
+
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        router.dismiss(animated: true)
+        finish(with: nil)
+    }
+}

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -10,16 +10,14 @@ final class CameraCoordinator: BaseCoordinator,
                                UINavigationControllerDelegate {
     private weak var parentCoordinatorDelegate: ParentCoordinatorDelegate?
     private let onComplete: (UIImage?) -> Void
-    private let isCameraAvailable: () -> Bool
-    private let cameraAuthorizationStatus: () -> AVAuthorizationStatus
+    private let isCameraAvailable: Bool
+    private let cameraAuthorizationStatus: AVAuthorizationStatus
     private let requestCameraAccess: () async -> Bool
 
     init(parentCoordinatorDelegate: ParentCoordinatorDelegate?,
          router: Router,
-         isCameraAvailable: @escaping () -> Bool = { UIImagePickerController.isSourceTypeAvailable(.camera) },
-         cameraAuthorizationStatus: @escaping () -> AVAuthorizationStatus = {
-             AVCaptureDevice.authorizationStatus(for: .video)
-         },
+         isCameraAvailable: Bool = UIImagePickerController.isSourceTypeAvailable(.camera),
+         cameraAuthorizationStatus: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video),
          requestCameraAccess: @escaping () async -> Bool = {
              await AVCaptureDevice.requestAccess(for: .video)
          },
@@ -33,7 +31,7 @@ final class CameraCoordinator: BaseCoordinator,
     }
 
     func start() {
-        guard isCameraAvailable() else {
+        guard isCameraAvailable else {
             finish(with: nil)
             return
         }
@@ -45,13 +43,12 @@ final class CameraCoordinator: BaseCoordinator,
             self?.finish(with: nil)
         }
 
-        switch cameraAuthorizationStatus() {
+        switch cameraAuthorizationStatus {
         case .denied, .restricted:
-            // Access was refused in a previous session: surface the alert over the interface.
             presentCameraAccessDeniedAlert(over: picker)
         case .notDetermined:
-            // Presenting the interface triggers the system permission prompt; dismiss the
-            // interface if the user refuses access, without surfacing a second alert.
+            // If not determined, presenting the interface triggers the system permission prompt.
+            // Dismiss the interface if the user refuses access.
             Task { [weak self] in await self?.dismissCameraInterfaceIfAccessRefused() }
         default:
             break
@@ -70,6 +67,7 @@ final class CameraCoordinator: BaseCoordinator,
             self?.dismissCameraInterface()
         }
 
+        // Wait for picker to finish presenting before presenting alert over it (in the case of .denied and .restricted)
         if let transitionCoordinator = presenter.transitionCoordinator {
             transitionCoordinator.animate(alongsideTransition: nil) { [weak presenter] _ in
                 presenter?.present(alert, animated: true)

--- a/firefox-ios/Client/Coordinators/PhotoPickerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PhotoPickerCoordinator.swift
@@ -2,11 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Common
-import Foundation
-import Photos
 import PhotosUI
-import UIKit
 
 /// Presents the system photo library picker and owns its delegate conformance.
 final class PhotoPickerCoordinator: BaseCoordinator, PHPickerViewControllerDelegate {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -88,6 +88,7 @@ enum GeneralBrowserActionType: ActionType {
     case shakeMotionEnded
     case showTranslationLanguagePicker
     case showGoogleLensPhotoPicker
+    case showGoogleLensCamera
 }
 
 struct GeneralBrowserMiddlewareAction: Action {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -41,6 +41,7 @@ struct BrowserViewControllerState: ScreenState {
         case passwordGenerator
         case translationLanguagePicker(TranslationLanguagePickerData)
         case googleLensPhotoPicker
+        case googleLensCamera
     }
 
     let windowUUID: WindowUUID
@@ -396,6 +397,8 @@ struct BrowserViewControllerState: ScreenState {
             return handleShowTranslationLanguagePickerAction(state: state, action: action)
         case GeneralBrowserActionType.showGoogleLensPhotoPicker:
             return handleShowGoogleLensPhotoPickerAction(state: state, action: action)
+        case GeneralBrowserActionType.showGoogleLensCamera:
+            return handleShowGoogleLensCameraAction(state: state, action: action)
         default:
             return passthroughState(from: state, action: action)
         }
@@ -757,6 +760,22 @@ struct BrowserViewControllerState: ScreenState {
             shouldShowReaderModeBarSummarizerButton: state.shouldShowReaderModeBarSummarizerButton,
             browserViewType: state.browserViewType,
             displayView: .googleLensPhotoPicker,
+            microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
+            autoTranslatePromptState: AutoTranslatePromptState.reducer(state.autoTranslatePromptState, action))
+    }
+
+    @MainActor
+    private static func handleShowGoogleLensCameraAction(
+        state: BrowserViewControllerState,
+        action: GeneralBrowserAction
+    ) -> BrowserViewControllerState {
+        return BrowserViewControllerState(
+            searchScreenState: state.searchScreenState,
+            toast: state.toast,
+            windowUUID: state.windowUUID,
+            shouldShowReaderModeBarSummarizerButton: state.shouldShowReaderModeBarSummarizerButton,
+            browserViewType: state.browserViewType,
+            displayView: .googleLensCamera,
             microsurveyState: MicrosurveyPromptState.reducer(state.microsurveyState, action),
             autoTranslatePromptState: AutoTranslatePromptState.reducer(state.autoTranslatePromptState, action))
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2995,6 +2995,8 @@ class BrowserViewController: UIViewController,
             presentTranslationLanguagePicker(data: data, sourceButton: state.buttonTapped)
         case .googleLensPhotoPicker:
             navigationHandler?.showGoogleLensPhotoPicker()
+        case .googleLensCamera:
+            navigationHandler?.showGoogleLensCamera()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -319,6 +319,11 @@ final class ToolbarMiddleware {
                                               actionType: GeneralBrowserActionType.showGoogleLensPhotoPicker)
             store.dispatch(action)
 
+        case .googleLensTakePhoto:
+            let action = GeneralBrowserAction(windowUUID: action.windowUUID,
+                                              actionType: GeneralBrowserActionType.showGoogleLensCamera)
+            store.dispatch(action)
+
         case .search:
             toolbarTelemetry.searchButtonTapped(isPrivate: toolbarState.isPrivateMode)
             let action = ToolbarAction(windowUUID: action.windowUUID, actionType: ToolbarActionType.didStartEditingUrl)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerStateTests.swift
@@ -60,6 +60,18 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.displayView, .googleLensPhotoPicker)
     }
 
+    func testShowGoogleLensCameraAction() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.displayView)
+
+        let action = getAction(for: .showGoogleLensCamera)
+        let newState = reducer(initialState, action)
+
+        XCTAssertEqual(newState.displayView, .googleLensCamera)
+    }
+
     func testShowPasswordGeneratorAction() {
         let initialState = createSubject()
         let reducer = browserViewControllerReducer()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -429,6 +429,29 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertTrue(subject.childCoordinators.first is PhotoPickerCoordinator)
     }
 
+    func testShowGoogleLensCamera_whenCameraUnavailable_doesNotPresentOrLeaveChild() {
+        // The simulator has no camera, so the coordinator finishes immediately and cleans
+        // itself up without presenting anything.
+        let subject = createSubject()
+
+        subject.showGoogleLensCamera()
+
+        XCTAssertTrue(subject.childCoordinators.isEmpty)
+        XCTAssertEqual(mockRouter.presentCalled, 0)
+    }
+
+    func testShowGoogleLensCamera_whenCameraCoordinatorAlreadyPresent_doesNotAddDuplicate() {
+        let subject = createSubject()
+        let existing = CameraCoordinator(parentCoordinatorDelegate: subject,
+                                         router: mockRouter) { _ in }
+        subject.add(child: existing)
+
+        subject.showGoogleLensCamera()
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertTrue(subject.childCoordinators.first is CameraCoordinator)
+    }
+
     func testShowQRCode_presentsQRCodeNavigationController() {
         let subject = createSubject()
         let delegate = MockQRCodeViewControllerDelegate()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import AVFoundation
 import Common
 import UIKit
 
@@ -135,13 +136,15 @@ final class CameraCoordinatorTests: XCTestCase {
 
     // MARK: - Helper Methods
     private func createSubject(isCameraAvailable: Bool = true,
+                               cameraAuthorizationStatus: AVAuthorizationStatus = .authorized,
                                requestCameraAccess: @escaping () async -> Bool = { false },
                                onComplete: @escaping (UIImage?) -> Void = { _ in },
                                file: StaticString = #filePath,
                                line: UInt = #line) -> CameraCoordinator {
         let subject = CameraCoordinator(parentCoordinatorDelegate: parentCoordinator,
                                         router: router,
-                                        isCameraAvailable: { isCameraAvailable },
+                                        isCameraAvailable: isCameraAvailable,
+                                        cameraAuthorizationStatus: cameraAuthorizationStatus,
                                         requestCameraAccess: requestCameraAccess,
                                         onComplete: onComplete)
         trackForMemoryLeaks(subject, file: file, line: line)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -29,10 +29,10 @@ final class CameraCoordinatorTests: XCTestCase {
     func test_start_whenCameraUnavailable_finishesWithNilAndNotifiesParent() {
         var completionCalled = 0
         var completionImage: UIImage?
-        let subject = createSubject(isCameraAvailable: false) { image in
+        let subject = createSubject(isCameraAvailable: false, onComplete: { image in
             completionCalled += 1
             completionImage = image
-        }
+        })
 
         subject.start()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -71,7 +71,7 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.dismissCalled, 1)
     }
 
-    func test_dismissCameraAccessDeniedViewfinder_dismissesAndFinishesWithNil() {
+    func test_dismissCameraInterface_dismissesAndFinishesWithNil() {
         var completionCalled = 0
         var completionImage: UIImage?
         let subject = createSubject(onComplete: { image in
@@ -79,12 +79,41 @@ final class CameraCoordinatorTests: XCTestCase {
             completionImage = image
         })
 
-        subject.dismissCameraAccessDeniedViewfinder()
+        subject.dismissCameraInterface()
 
         XCTAssertEqual(router.dismissCalled, 1)
         XCTAssertEqual(completionCalled, 1)
         XCTAssertNil(completionImage)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    func test_dismissCameraInterfaceIfAccessRefused_whenRefused_dismissesAndFinishesWithNil() async {
+        var completionCalled = 0
+        var completionImage: UIImage?
+        let subject = createSubject(requestCameraAccess: { false },
+                                    onComplete: { image in
+            completionCalled += 1
+            completionImage = image
+        })
+
+        await subject.dismissCameraInterfaceIfAccessRefused()
+
+        XCTAssertEqual(router.dismissCalled, 1)
+        XCTAssertEqual(completionCalled, 1)
+        XCTAssertNil(completionImage)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    func test_dismissCameraInterfaceIfAccessRefused_whenGranted_keepsInterfacePresented() async {
+        var completionCalled = 0
+        let subject = createSubject(requestCameraAccess: { true },
+                                    onComplete: { _ in completionCalled += 1 })
+
+        await subject.dismissCameraInterfaceIfAccessRefused()
+
+        XCTAssertEqual(router.dismissCalled, 0)
+        XCTAssertEqual(completionCalled, 0)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 0)
     }
 
     func test_didCancel_callsCompletionWithNilAndNotifiesParent() {
@@ -106,12 +135,14 @@ final class CameraCoordinatorTests: XCTestCase {
 
     // MARK: - Helper Methods
     private func createSubject(isCameraAvailable: Bool = true,
+                               requestCameraAccess: @escaping () async -> Bool = { false },
                                onComplete: @escaping (UIImage?) -> Void = { _ in },
                                file: StaticString = #filePath,
                                line: UInt = #line) -> CameraCoordinator {
         let subject = CameraCoordinator(parentCoordinatorDelegate: parentCoordinator,
                                         router: router,
                                         isCameraAvailable: { isCameraAvailable },
+                                        requestCameraAccess: requestCameraAccess,
                                         onComplete: onComplete)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -1,0 +1,119 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+import UIKit
+
+@testable import Client
+
+@MainActor
+final class CameraCoordinatorTests: XCTestCase {
+    private var router: MockRouter!
+    private var parentCoordinator: MockParentCoordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        router = MockRouter(navigationController: MockNavigationController())
+        parentCoordinator = MockParentCoordinator()
+    }
+
+    override func tearDown() async throws {
+        router = nil
+        parentCoordinator = nil
+        try await super.tearDown()
+    }
+
+    func test_start_whenCameraUnavailable_finishesWithNilAndNotifiesParent() {
+        var completionCalled = 0
+        var completionImage: UIImage?
+        let subject = createSubject(isCameraAvailable: false) { image in
+            completionCalled += 1
+            completionImage = image
+        }
+
+        subject.start()
+
+        XCTAssertEqual(router.presentCalled, 0)
+        XCTAssertEqual(completionCalled, 1)
+        XCTAssertNil(completionImage)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    func test_didFinishPicking_withImage_callsCompletionAndNotifiesParent() {
+        let expectedImage = UIImage()
+        var completionImage: UIImage?
+        let subject = createSubject(onComplete: { completionImage = $0 })
+        let picker = UIImagePickerController()
+
+        subject.imagePickerController(picker, didFinishPickingMediaWithInfo: [.originalImage: expectedImage])
+
+        XCTAssertIdentical(completionImage, expectedImage)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+        XCTAssertEqual(router.dismissCalled, 1)
+    }
+
+    func test_didFinishPicking_withoutImage_callsCompletionWithNil() {
+        var completionCalled = 0
+        var completionImage: UIImage?
+        let subject = createSubject(onComplete: { image in
+            completionCalled += 1
+            completionImage = image
+        })
+        let picker = UIImagePickerController()
+
+        subject.imagePickerController(picker, didFinishPickingMediaWithInfo: [:])
+
+        XCTAssertEqual(completionCalled, 1)
+        XCTAssertNil(completionImage)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+        XCTAssertEqual(router.dismissCalled, 1)
+    }
+
+    func test_dismissCameraAccessDeniedViewfinder_dismissesAndFinishesWithNil() {
+        var completionCalled = 0
+        var completionImage: UIImage?
+        let subject = createSubject(onComplete: { image in
+            completionCalled += 1
+            completionImage = image
+        })
+
+        subject.dismissCameraAccessDeniedViewfinder()
+
+        XCTAssertEqual(router.dismissCalled, 1)
+        XCTAssertEqual(completionCalled, 1)
+        XCTAssertNil(completionImage)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    func test_didCancel_callsCompletionWithNilAndNotifiesParent() {
+        var completionCalled = 0
+        var completionImage: UIImage?
+        let subject = createSubject(onComplete: { image in
+            completionCalled += 1
+            completionImage = image
+        })
+        let picker = UIImagePickerController()
+
+        subject.imagePickerControllerDidCancel(picker)
+
+        XCTAssertEqual(completionCalled, 1)
+        XCTAssertNil(completionImage)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+        XCTAssertEqual(router.dismissCalled, 1)
+    }
+
+    // MARK: - Helper Methods
+    private func createSubject(isCameraAvailable: Bool = true,
+                               onComplete: @escaping (UIImage?) -> Void = { _ in },
+                               file: StaticString = #filePath,
+                               line: UInt = #line) -> CameraCoordinator {
+        let subject = CameraCoordinator(parentCoordinatorDelegate: parentCoordinator,
+                                        router: router,
+                                        isCameraAvailable: { isCameraAvailable },
+                                        onComplete: onComplete)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -56,6 +56,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
     var openLearnMoreFromNativeErrorPageCalled = 0
     var showQuickAnswersCalled = 0
     var showGoogleLensPhotoPickerCalled = 0
+    var showGoogleLensCameraCalled = 0
 
     func show(settings: Client.Route.SettingsSection, onDismiss: (() -> Void)?) {
         showSettingsCalled += 1
@@ -185,6 +186,10 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
 
     func showGoogleLensPhotoPicker() {
         showGoogleLensPhotoPickerCalled += 1
+    }
+
+    func showGoogleLensCamera() {
+        showGoogleLensCameraCalled += 1
     }
 
     // MARK: - BrowserDelegate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -675,6 +675,11 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
                          expectedActionType: GeneralBrowserActionType.showGoogleLensPhotoPicker)
     }
 
+    func testDidTapButton_tapOnGoogleLensTakePhotoButton_dispatchesShowGoogleLensCamera() throws {
+        try didTapButton(buttonType: .googleLensTakePhoto,
+                         expectedActionType: GeneralBrowserActionType.showGoogleLensCamera)
+    }
+
     func testDidTapButton_tapOnSearchButton_dispatchesDidStartEditingUrl() throws {
         let subject = createSubject(manager: toolbarManager)
         let action = ToolbarMiddlewareAction(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16061)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34405)

## :bulb: Description
- Present system camera interface when selected from the Google Lens address toolbar entry point

### 📝 Technical Notes
- System camera permission prompt is requested on first use (if not already determined elsewhere e.g. qr code reader). 
- When camera access has been denied, the camera-access-disabled alert is shown over the camera interface, and tapping "Okay" closes the interface and returns to the browser.
- Capturing a new photo will not do anything besides close the camera interface until [FXIOS-16064: Implement Google Lens search for address bar entry point](https://mozilla-hub.atlassian.net/browse/FXIOS-16064) is implemented

## :movie_camera: Demos
https://github.com/user-attachments/assets/d458a4d0-54f8-4a3e-be5d-c3fcd98a69fe

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

