### PR TITLE
MTE-5575 - fix flaky login tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -401,9 +401,16 @@ class BaseTestCase: XCTestCase {
         }
 
         let passcodeInput = springboard.otherElements.secureTextFields.firstMatch
-        mozWaitForElementToExist(passcodeInput)
-        passcodeInput.tapAndTypeText("foo\n")
-        mozWaitForElementToNotExist(passcodeInput)
+
+        // On CI the springboard device-passcode overlay is intermittently not presented — the
+        // authentication grace period may still be active (no prompt shown) or the springboard
+        // accessibility hierarchy is momentarily unreadable. Wait for the prompt without failing on
+        // timeout, and only type the passcode when it is actually shown; callers assert their own
+        // destination screen afterwards.
+        if mozWaitForElementToExist(passcodeInput, timeout: TIMEOUT_LONG, failOnTimeout: false) {
+            passcodeInput.tapAndTypeText("foo\n")
+            mozWaitForElementToNotExist(passcodeInput)
+        }
     }
 
     func scrollToElement(

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LoginSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LoginSettingsScreen.swift
@@ -132,16 +132,26 @@ final class LoginSettingsScreen {
         BaseTestCase().mozWaitForElementToNotExist(match)
     }
 
+    /// Dismisses the system device-passcode prompt guarding the Passwords/Credit Cards screens.
+    ///
+    /// On CI the springboard passcode overlay is intermittently not presented — the authentication
+    /// grace period may still be active (no prompt shown) or the springboard accessibility hierarchy
+    /// is momentarily unreadable. Unconditionally waiting for the passcode field therefore times out
+    /// and fails the test even though nothing is wrong. Wait for the prompt without failing on
+    /// timeout, and only type the passcode when it is actually shown; callers assert their own
+    /// destination screen afterwards.
     func unlockLoginsView() {
         let passcodeValue = "foo\n"
+        let base = BaseTestCase()
         if sel.ONBOARDING_CONTINUE_BUTTON.element(in: app).exists {
             sel.ONBOARDING_CONTINUE_BUTTON.element(in: app).waitAndTap()
         }
 
         let passcode = sel.PASSCODE_FIELD.element(in: springboard)
-        BaseTestCase().mozWaitForElementToExist(passcode)
-        passcode.tapAndTypeText(passcodeValue)
-        BaseTestCase().mozWaitForElementToNotExist(passcode)
+        if base.mozWaitForElementToExist(passcode, timeout: TIMEOUT_LONG, failOnTimeout: false) {
+            passcode.tapAndTypeText(passcodeValue)
+            base.mozWaitForElementToNotExist(passcode)
+        }
     }
 
     func assertLoginCreatedFirstMatch() {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5575

## :bulb: Description
Fix flaky LoginTest failures 

Three LoginTest cases (testEditOneLoginEntry, testCannotSaveLoginWithoutAllFields, testDismissedChangesAreNotSaved) failed on Jenkins with Timed out waiting for element Any (Element at index 0), while passing locally.

Cause: unlockLoginsView() unconditionally hard-waited for the springboard device-passcode overlay. On CI that overlay is intermittently not presented/queryable, so the wait timed out and failed the test.

Fix: Made the passcode wait non-fatal (failOnTimeout: false) in both copies of the helper (LoginSettingsScreen.swift, BaseTestCase.swift). The passcode is now typed only when the prompt actually appears; otherwise the callers assert their own destination screen. No behavior change when the prompt is shown, and the shared CreditCardsTests callers are unaffected.
This fix requires monitoring Login tests after merging, because these tests passed locally before.
