### PR TITLE
Add FXIOS-16198 [WC] Retire the World Cup sports widget after the tournament ends

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupMiddleware.swift
@@ -76,7 +76,14 @@ final class WorldCupMiddleware {
             dispatch(snapshot: .empty)
             return
         }
-        guard worldCupStore.isFeatureEnabledAndSectionEnabled else { return }
+        // Dispatch a hidden snapshot rather than bailing silently so that a
+        // foreground/initialize after the feature has been disabled (e.g. the
+        // World Cup end date has passed) clears any stale section still in the
+        // Redux state instead of waiting for the next feed poll to re-evaluate.
+        guard worldCupStore.isFeatureEnabledAndSectionEnabled else {
+            dispatch(snapshot: .empty)
+            return
+        }
         feed.start()
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupStore.swift
@@ -24,6 +24,10 @@ protocol WorldCupStoreProtocol {
     /// Returns true when the World Cup countdown target date has been reached.
     var hasWorldCupStarted: Bool { get }
 
+    /// Returns true once the fixed World Cup end date has passed, after which the
+    /// feature is fully retired regardless of the Nimbus flag or user preference.
+    var hasWorldCupEnded: Bool { get }
+
     /// Whether the celebration (confetti) animation is enabled.
     var isCelebrationAnimationEnabled: Bool { get }
 
@@ -42,6 +46,9 @@ protocol WorldCupStoreProtocol {
 
 /// A Store for all the preferences and feature flags related to the WorldCup feature.
 struct WorldCupStore: WorldCupStoreProtocol, FeatureFlaggable {
+    /// Fixed UTC instant at which the World Cup feature retires
+    static let worldCupEndDateString = "2026-07-20T08:00:00Z"
+
     private var iso8601Formatter: ISO8601DateFormatter {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
@@ -63,6 +70,7 @@ struct WorldCupStore: WorldCupStoreProtocol, FeatureFlaggable {
     }
 
     var isFeatureEnabled: Bool {
+        guard !hasWorldCupEnded else { return false }
         return featureFlagsProvider.isEnabled(.worldCupWidget)
     }
 
@@ -102,6 +110,11 @@ struct WorldCupStore: WorldCupStoreProtocol, FeatureFlaggable {
         return dateProvider.now() >= startDate
     }
 
+    var hasWorldCupEnded: Bool {
+        guard let endDate = worldCupEndDate else { return false }
+        return dateProvider.now() >= endDate
+    }
+
     var isCelebrationAnimationEnabled: Bool {
         return nimbusFeature.value().showCelebrationAnimation
     }
@@ -114,6 +127,10 @@ struct WorldCupStore: WorldCupStoreProtocol, FeatureFlaggable {
     private var worldCupStartDate: Date? {
         let dateString = nimbusFeature.value().countdownTargetDate
         return iso8601Formatter.date(from: dateString)
+    }
+
+    private var worldCupEndDate: Date? {
+        return iso8601Formatter.date(from: Self.worldCupEndDateString)
     }
 
     func setIsHomepageSectionEnabled(_ isEnabled: Bool) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -189,6 +189,34 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.worldCupProvider = { _, _ in }
     }
 
+    func test_didBecomeActive_whenFeatureDisabledAfterMilestone2_dispatchesHiddenSectionWithoutStartingFeed() throws {
+        mockWorldCupStore.isMilestone2 = true
+        mockWorldCupStore.isFeatureEnabled = false
+        mockWorldCupStore.isHomepageSectionEnabled = true
+        let feed = MockWorldCupFeed()
+        let subject = createSubject(feed: feed)
+        let action = HomepageAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageMiddlewareActionType.didBecomeActive
+        )
+
+        let expectation = XCTestExpectation(description: "didUpdate dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.worldCupProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WorldCupAction)
+        let actionType = try XCTUnwrap(dispatched.actionType as? WorldCupMiddlewareActionType)
+
+        XCTAssertEqual(actionType, .didUpdate)
+        XCTAssertFalse(dispatched.shouldShowHomepageWorldCupSection)
+        XCTAssertTrue(dispatched.matches.isEmpty)
+        XCTAssertEqual(feed.startCalled, 0)
+        subject.worldCupProvider = { _, _ in }
+    }
+
     // MARK: - WorldCupActionType.selectTeam
 
     func test_selectTeam_persistsTeamAndKicksOffFetch() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupStoreTests.swift
@@ -206,6 +206,60 @@ final class WorldCupStoreTests: XCTestCase {
         XCTAssertFalse(subject.hasWorldCupStarted)
     }
 
+    func test_hasWorldCupEnded_whenNowIsAfterEndDate_returnsTrue() {
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date("2026-07-20T08:00:01Z"))
+        )
+
+        XCTAssertTrue(subject.hasWorldCupEnded)
+    }
+
+    func test_hasWorldCupEnded_atEndDate_returnsTrue() {
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date(WorldCupStore.worldCupEndDateString))
+        )
+
+        XCTAssertTrue(subject.hasWorldCupEnded)
+    }
+
+    func test_hasWorldCupEnded_whenNowIsBeforeEndDate_returnsFalse() {
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date("2026-07-20T07:59:59Z"))
+        )
+
+        XCTAssertFalse(subject.hasWorldCupEnded)
+    }
+
+    // MARK: - kill switch
+
+    func test_isFeatureEnabled_afterWorldCupEnded_returnsFalseEvenWhenNimbusEnabled() {
+        setNimbusFeature(enabled: true)
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date("2026-07-20T08:00:01Z"))
+        )
+
+        XCTAssertFalse(subject.isFeatureEnabled)
+    }
+
+    func test_isFeatureEnabledAndSectionEnabled_afterWorldCupEnded_returnsFalse() {
+        setNimbusFeature(enabled: true, milestone2EnableDate: "2026-05-10T19:00:00Z")
+        mockProfile.prefs.setBool(true, forKey: PrefsKeys.HomepageSettings.WorldCupSection)
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date("2026-07-20T08:00:01Z"))
+        )
+
+        XCTAssertFalse(subject.isFeatureEnabledAndSectionEnabled)
+    }
+
+    func test_isFeatureEnabled_beforeWorldCupEnded_stillReflectsNimbus() {
+        setNimbusFeature(enabled: true)
+        let subject = createSubject(
+            dateProvider: MockDateProvider(fixedDate: iso8601Date("2026-07-20T07:59:59Z"))
+        )
+
+        XCTAssertTrue(subject.isFeatureEnabled)
+    }
+
     // MARK: - setIsHomepageSectionEnabled
 
     func test_setIsHomepageSectionEnabled_writesToPrefs() {
@@ -243,8 +297,13 @@ final class WorldCupStoreTests: XCTestCase {
 
     // MARK: - Helpers
 
+    /// A fixed instant during the tournament (after start, before the end
+    /// kill-switch) used as the default clock so tests are deterministic and do
+    /// not flip once the real date passes `WorldCupStore.worldCupEndDateString`.
+    private static let duringTournamentDate = ISO8601DateFormatter().date(from: "2026-06-15T00:00:00Z")!
+
     private func createSubject(
-        dateProvider: DateProvider = MockDateProvider(fixedDate: Date())
+        dateProvider: DateProvider = MockDateProvider(fixedDate: WorldCupStoreTests.duringTournamentDate)
     ) -> WorldCupStore {
         return WorldCupStore(
             profile: mockProfile,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupStore.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWorldCupStore.swift
@@ -12,6 +12,7 @@ final class MockWorldCupStore: WorldCupStoreProtocol {
     var selectedTeam: String?
     var isMilestone2 = false
     var hasWorldCupStarted = false
+    var hasWorldCupEnded = false
     var isCelebrationAnimationEnabled = false
 
     var setIsHomepageSectionEnabledCalled = 0


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16198)
~[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)~ ( automation not working )

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Adds date to remove widget. From all users the widget will be hidden after `2026-07-20T08:00:00Z`.
- Adds tests.
- Mimics what Android is doing in https://phabricator.services.mozilla.com/D309644

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

