### PR TITLE
Bugfix FXIOS-16021 Fix save password glitch

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
@@ -109,7 +109,12 @@ class AddCredentialViewController: UIViewController, Themeable {
     }
 
     @objc
-    func addCredential() {
+    private func addCredential() {
+        // Ensure any active fields are dismissed, so that things like
+        // the requisite https:// prefix are included before saving
+        [websiteField, usernameField, passwordField]
+            .forEach { $0?.resignFirstResponder() }
+
         guard let hostname = websiteField?.text,
               let username = usernameField?.text,
               let password = passwordField?.text else {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16021)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34185)

## :bulb: Description

Fixes edge case bug with the save passwords screen; we have to make sure we dismiss editing before attempting to save.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

