### PR TITLE
Add FXIOS-16180 [WebCompat] Add the report bottom-sheet shell

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -62,6 +62,9 @@ let package = Package(
         .library(
             name: "QuickAnswersKit",
             targets: ["QuickAnswersKit"]),
+        .library(
+            name: "WebCompatReporterKit",
+            targets: ["WebCompatReporterKit"]),
         .executable(
             name: "ExecutableContentBlockingGenerator",
             targets: ["ExecutableContentBlockingGenerator"]),
@@ -207,6 +210,18 @@ let package = Package(
         .testTarget(
             name: "MenuKitTests",
             dependencies: ["MenuKit"],
+            swiftSettings: [
+            ]
+        ),
+        .target(
+            name: "WebCompatReporterKit",
+            dependencies: ["Common", "ComponentLibrary"],
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"]),
+            ]),
+        .testTarget(
+            name: "WebCompatReporterKitTests",
+            dependencies: ["WebCompatReporterKit", "TestKit"],
             swiftSettings: [
             ]
         ),

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+#if DEBUG
+import Common
+import SwiftUI
+import UIKit
+
+@MainActor
+private func previewViewController(sections: [WebCompatReportViewModel.Section]) -> UIViewController {
+    let viewModel = WebCompatReportViewModel(
+        navigationTitle: "Report a Website Issue",
+        closeButtonAccessibilityLabel: "Close",
+        previewButtonTitle: "Preview",
+        isPreviewEnabled: !sections.isEmpty,
+        sections: sections
+    )
+    let sheet = WebCompatReportSheetViewController(viewModel: viewModel, theme: LightTheme())
+    let navigationController = UINavigationController(rootViewController: sheet)
+    navigationController.navigationBar.prefersLargeTitles = false
+    return navigationController
+}
+
+@available(iOS 17.0, *)
+#Preview("Empty shell") {
+    previewViewController(sections: [])
+}
+
+@available(iOS 17.0, *)
+#Preview("Placeholder sections") {
+    previewViewController(sections: [
+        .init(id: "url", rows: [.init(id: "url", title: "https://example.com")]),
+        .init(id: "issue", rows: [.init(id: "issue", title: "Website issue")]),
+        .init(id: "advanced", rows: [
+            .init(id: "screenshot", title: "Include screenshot"),
+            .init(id: "blocklist", title: "Include blocked list")
+        ])
+    ])
+}
+#endif

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -1,0 +1,162 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+
+/// The intents the sheet emits. The Client translates these into dispatched
+/// Redux actions and coordinator navigation; the view controller itself never
+/// dismisses or navigates.
+@MainActor
+public protocol WebCompatReportSheetDelegate: AnyObject {
+    func webCompatReportSheetDidTapClose()
+    func webCompatReportSheetDidTapPreview()
+}
+
+/// The "Report a Website Issue" bottom-sheet content, presented inside a
+/// navigation controller by the Client and shown as an iOS-26 sheet
+/// (`.large` detent + grabber). It is store-agnostic: the Client configures it
+/// with a `WebCompatReportViewModel` and receives close/preview intents through
+/// `WebCompatReportSheetDelegate`. The list is a compositional inset-grouped
+/// collection view; the shell renders whatever sections the view model carries
+/// (empty for now — later PRs add the issue picker and the fields).
+public final class WebCompatReportSheetViewController: UIViewController,
+                                                       ThemeApplicable,
+                                                       UICollectionViewDelegate {
+    public weak var delegate: WebCompatReportSheetDelegate?
+
+    private var viewModel: WebCompatReportViewModel
+    private var theme: Theme
+
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeLayout())
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.delegate = self
+        return collectionView
+    }()
+
+    private lazy var dataSource = makeDataSource()
+
+    private lazy var closeButton: UIBarButtonItem = {
+        let image = UIImage(named: StandardImageIdentifiers.Large.cross)?.withRenderingMode(.alwaysTemplate)
+        let button = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(didTapClose))
+        return button
+    }()
+
+    private lazy var previewButton = UIBarButtonItem(
+        title: nil,
+        style: .done,
+        target: self,
+        action: #selector(didTapPreview)
+    )
+
+    public init(viewModel: WebCompatReportViewModel, theme: Theme) {
+        self.viewModel = viewModel
+        self.theme = theme
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigationItem()
+        setupCollectionView()
+        configure(with: viewModel)
+        applyTheme(theme: theme)
+    }
+
+    // MARK: - Configuration
+
+    /// Renders the latest mapped state. Safe to call before or after the view loads.
+    public func configure(with viewModel: WebCompatReportViewModel) {
+        self.viewModel = viewModel
+        guard isViewLoaded else { return }
+        navigationItem.title = viewModel.navigationTitle
+        closeButton.accessibilityLabel = viewModel.closeButtonAccessibilityLabel
+        previewButton.title = viewModel.previewButtonTitle
+        previewButton.isEnabled = viewModel.isPreviewEnabled
+        applySnapshot()
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigationItem() {
+        navigationItem.leftBarButtonItem = closeButton
+        navigationItem.rightBarButtonItem = previewButton
+        navigationItem.largeTitleDisplayMode = .never
+    }
+
+    private func setupCollectionView() {
+        view.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func makeLayout(backgroundColor: UIColor? = nil) -> UICollectionViewCompositionalLayout {
+        var config = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+        config.headerMode = .none
+        config.footerMode = .none
+        config.backgroundColor = backgroundColor
+        return UICollectionViewCompositionalLayout.list(using: config)
+    }
+
+    // MARK: - Data source
+
+    private func makeDataSource()
+    -> UICollectionViewDiffableDataSource<WebCompatReportViewModel.Section, WebCompatReportViewModel.Row> {
+        let rowRegistration = UICollectionView.CellRegistration<
+            UICollectionViewListCell, WebCompatReportViewModel.Row
+        > { cell, _, row in
+            var content = cell.defaultContentConfiguration()
+            content.text = row.title
+            cell.contentConfiguration = content
+        }
+
+        return UICollectionViewDiffableDataSource(
+            collectionView: collectionView
+        ) { collectionView, indexPath, row in
+            collectionView.dequeueConfiguredReusableCell(using: rowRegistration, for: indexPath, item: row)
+        }
+    }
+
+    private func applySnapshot(animated: Bool = false) {
+        var snapshot = NSDiffableDataSourceSnapshot<WebCompatReportViewModel.Section, WebCompatReportViewModel.Row>()
+        for section in viewModel.sections {
+            snapshot.appendSections([section])
+            snapshot.appendItems(section.rows, toSection: section)
+        }
+        dataSource.apply(snapshot, animatingDifferences: animated)
+    }
+
+    // MARK: - Actions
+
+    @objc
+    private func didTapClose() {
+        delegate?.webCompatReportSheetDidTapClose()
+    }
+
+    @objc
+    private func didTapPreview() {
+        delegate?.webCompatReportSheetDidTapPreview()
+    }
+
+    // MARK: - ThemeApplicable
+
+    public func applyTheme(theme: Theme) {
+        self.theme = theme
+        view.backgroundColor = theme.colors.layer1
+        collectionView.backgroundColor = theme.colors.layer1
+        collectionView.setCollectionViewLayout(makeLayout(backgroundColor: theme.colors.layer1), animated: false)
+        navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// The store-agnostic snapshot the `WebCompatReportSheetViewController` renders.
+/// The Client maps `WebCompatReporterState` onto this so the package never
+/// imports Redux; previews build one with a mock.
+public struct WebCompatReportViewModel: Equatable, Sendable {
+    /// A grouped section in the sheet's list. Later PRs (the issue picker, the
+    /// URL/details/advanced fields) populate `rows`; the shell leaves it empty.
+    public struct Section: Hashable, Sendable {
+        public let id: String
+        public let rows: [Row]
+
+        public init(id: String, rows: [Row]) {
+            self.id = id
+            self.rows = rows
+        }
+    }
+
+    public struct Row: Hashable, Sendable {
+        public let id: String
+        public let title: String
+
+        public init(id: String, title: String) {
+            self.id = id
+            self.title = title
+        }
+    }
+
+    public let navigationTitle: String
+    public let closeButtonAccessibilityLabel: String
+    public let previewButtonTitle: String
+    public let isPreviewEnabled: Bool
+    public let sections: [Section]
+
+    public init(navigationTitle: String,
+                closeButtonAccessibilityLabel: String,
+                previewButtonTitle: String,
+                isPreviewEnabled: Bool,
+                sections: [Section] = []) {
+        self.navigationTitle = navigationTitle
+        self.closeButtonAccessibilityLabel = closeButtonAccessibilityLabel
+        self.previewButtonTitle = previewButtonTitle
+        self.isPreviewEnabled = isPreviewEnabled
+        self.sections = sections
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import CoreGraphics
+
+/// Layout constants for the WebCompat "Report a Website Issue" bottom sheet,
+/// matching the iOS Figma source (Mobile Assembly File 2026, node 23608-71142).
+enum WebCompatReporterUX {
+    enum Spacing {
+        static let screenHorizontal: CGFloat = 16
+        static let sectionGap: CGFloat = 24
+        static let rowVertical: CGFloat = 12
+        static let interItem: CGFloat = 8
+    }
+
+    enum Card {
+        static let cornerRadius: CGFloat = 16
+        static let contentInset: CGFloat = 16
+    }
+
+    enum Sheet {
+        static let cornerRadius: CGFloat = 24
+    }
+
+    enum Control {
+        static let minimumTapTarget: CGFloat = 44
+    }
+}

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+@testable import WebCompatReporterKit
+
+@MainActor
+final class WebCompatReportSheetViewControllerTests: XCTestCase {
+    func testConfigure_setsNavigationTitleAndCloseAccessibilityLabel() {
+        let subject = createSubject()
+        subject.loadViewIfNeeded()
+
+        XCTAssertEqual(subject.navigationItem.title, "Report a Website Issue")
+        XCTAssertEqual(subject.navigationItem.leftBarButtonItem?.accessibilityLabel, "Close")
+    }
+
+    func testConfigure_disablesPreviewButton_whenPreviewNotEnabled() {
+        let subject = createSubject(isPreviewEnabled: false)
+        subject.loadViewIfNeeded()
+
+        XCTAssertEqual(subject.navigationItem.rightBarButtonItem?.isEnabled, false)
+    }
+
+    func testReconfigure_updatesPreviewEnabledState() {
+        let subject = createSubject(isPreviewEnabled: false)
+        subject.loadViewIfNeeded()
+
+        subject.configure(with: makeViewModel(isPreviewEnabled: true))
+
+        XCTAssertEqual(subject.navigationItem.rightBarButtonItem?.isEnabled, true)
+    }
+
+    func testConfigure_withSections_populatesList() {
+        let subject = createSubject()
+        subject.loadViewIfNeeded()
+
+        subject.configure(with: makeViewModel(sections: [
+            .init(id: "url", rows: [.init(id: "url", title: "https://example.com")]),
+            .init(id: "advanced", rows: [
+                .init(id: "screenshot", title: "Include screenshot"),
+                .init(id: "blocklist", title: "Include blocked list")
+            ])
+        ]))
+
+        let collectionView = subject.view.subviews.compactMap { $0 as? UICollectionView }.first
+        XCTAssertEqual(collectionView?.numberOfSections, 2)
+        XCTAssertEqual(collectionView?.numberOfItems(inSection: 1), 2)
+    }
+
+    func testCloseButton_notifiesDelegate() {
+        let delegate = MockWebCompatReportSheetDelegate()
+        let subject = createSubject()
+        subject.delegate = delegate
+        subject.loadViewIfNeeded()
+
+        tap(subject.navigationItem.leftBarButtonItem)
+
+        XCTAssertEqual(delegate.didTapCloseCallCount, 1)
+        XCTAssertEqual(delegate.didTapPreviewCallCount, 0)
+    }
+
+    func testPreviewButton_notifiesDelegate() {
+        let delegate = MockWebCompatReportSheetDelegate()
+        let subject = createSubject(isPreviewEnabled: true)
+        subject.delegate = delegate
+        subject.loadViewIfNeeded()
+
+        tap(subject.navigationItem.rightBarButtonItem)
+
+        XCTAssertEqual(delegate.didTapPreviewCallCount, 1)
+        XCTAssertEqual(delegate.didTapCloseCallCount, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        isPreviewEnabled: Bool = false,
+        sections: [WebCompatReportViewModel.Section] = []
+    ) -> WebCompatReportViewModel {
+        return WebCompatReportViewModel(
+            navigationTitle: "Report a Website Issue",
+            closeButtonAccessibilityLabel: "Close",
+            previewButtonTitle: "Preview",
+            isPreviewEnabled: isPreviewEnabled,
+            sections: sections
+        )
+    }
+
+    private func createSubject(isPreviewEnabled: Bool = false) -> WebCompatReportSheetViewController {
+        return WebCompatReportSheetViewController(
+            viewModel: makeViewModel(isPreviewEnabled: isPreviewEnabled),
+            theme: LightTheme()
+        )
+    }
+
+    private func tap(_ item: UIBarButtonItem?) {
+        guard let item, let action = item.action else { return }
+        _ = item.target?.perform(action)
+    }
+}
+
+private final class MockWebCompatReportSheetDelegate: WebCompatReportSheetDelegate {
+    var didTapCloseCallCount = 0
+    var didTapPreviewCallCount = 0
+
+    func webCompatReportSheetDidTapClose() {
+        didTapCloseCallCount += 1
+    }
+
+    func webCompatReportSheetDidTapPreview() {
+        didTapPreviewCallCount += 1
+    }
+}

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -222,6 +222,7 @@ class CodeCoverageGate {
             !$0.contains("/AccessibilityIdentifiers.swift") &&
             !$0.contains("ImageIdentifiers.swift") &&
             !$0.contains("Protocol.swift") &&
+            !$0.contains("/Preview/") &&
             !$0.contains("Dangerfile.swift")
         }
     }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -855,6 +855,7 @@
 		818BCC742E463BAD008309B1 /* CuratedRecommendationCacheUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818BCC732E463BA5008309B1 /* CuratedRecommendationCacheUtility.swift */; };
 		819656152C80C55300E62323 /* MainMenuState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819656142C80C55300E62323 /* MainMenuState.swift */; };
 		819656172C80C6F300E62323 /* MenuKit in Frameworks */ = {isa = PBXBuildFile; productRef = 819656162C80C6F300E62323 /* MenuKit */; };
+		8CC185F72FF6A0D1004A124F /* WebCompatReporterKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8CC185F62FF6A0D1004A124F /* WebCompatReporterKit */; };
 		819656192C80ECFE00E62323 /* MainMenuMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819656182C80ECFE00E62323 /* MainMenuMiddleware.swift */; };
 		819820612E4A344E00086890 /* CuratedRecommendationCacheUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819820602E4A344800086890 /* CuratedRecommendationCacheUtilityTests.swift */; };
 		81A3F6F02C2DAEE200BDD86B /* MainMenuCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A3F6EF2C2DAEE200BDD86B /* MainMenuCoordinator.swift */; };
@@ -12095,6 +12096,7 @@
 				EDD5924A2FC1090C0015EF9E /* ModifiedCopy in Frameworks */,
 				5A984D362C8A3407007938C9 /* Kingfisher in Frameworks */,
 				819656172C80C6F300E62323 /* MenuKit in Frameworks */,
+				8CC185F72FF6A0D1004A124F /* WebCompatReporterKit in Frameworks */,
 				8AB30EC82B6C038600BD9A9B /* Lottie in Frameworks */,
 				5A871488292EA1440039A5BD /* Fuzi in Frameworks */,
 				0B8E0FF41A932BD500161DC3 /* ImageIO.framework in Frameworks */,
@@ -17982,6 +17984,7 @@
 				E177989F2BD8043800F6F0EB /* ToolbarKit */,
 				5A984D352C8A3407007938C9 /* Kingfisher */,
 				819656162C80C6F300E62323 /* MenuKit */,
+				8CC185F62FF6A0D1004A124F /* WebCompatReporterKit */,
 				EDD2A7F72CDACE7C00ED464C /* UnifiedSearchKit */,
 				ED6C8DAB2CE6A4BB00D7F7F3 /* Sentry-Dynamic */,
 				0BF802E12CFF0937005633E5 /* Shared */,
@@ -33374,6 +33377,10 @@
 		819656162C80C6F300E62323 /* MenuKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MenuKit;
+		};
+		8CC185F62FF6A0D1004A124F /* WebCompatReporterKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WebCompatReporterKit;
 		};
 		8A05B0042A69A0C40011B622 /* Common */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -35,6 +35,7 @@ final class BrowserCoordinator: BaseCoordinator,
                           SearchEngineSelectionCoordinatorDelegate,
                           TermsOfUseDelegate,
                           ShareSheetCoordinatorDelegate,
+                          WebCompatReportCoordinatorDelegate,
                           FeatureFlaggable {
     private struct UX {
         static let searchEnginePopoverSize = CGSize(width: 250, height: 536)
@@ -628,6 +629,22 @@ final class BrowserCoordinator: BaseCoordinator,
 
     func presentSiteProtections() {
         showETPMenu(sourceView: browserViewController.addressToolbarContainer)
+    }
+
+    func presentReportBrokenSite(url: URL?) {
+        let reportViewController = WebCompatReportViewController(windowUUID: windowUUID, reportedURL: url)
+        reportViewController.reportCoordinator = self
+        if let sheetPresentationController = reportViewController.sheetPresentationController {
+            sheetPresentationController.detents = [.large()]
+            sheetPresentationController.prefersGrabberVisible = true
+        }
+        router.present(reportViewController, animated: true, completion: nil)
+    }
+
+    // MARK: - WebCompatReportCoordinatorDelegate
+
+    func webCompatReportViewControllerDidFinish() {
+        router.dismiss(animated: true, completion: nil)
     }
 
     func presentSavePDFController() {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -33,6 +33,9 @@ protocol MainMenuCoordinatorDelegate: AnyObject {
     func presentSiteProtections()
 
     @MainActor
+    func presentReportBrokenSite(url: URL?)
+
+    @MainActor
     func showPrintSheet()
 
     @MainActor
@@ -146,7 +149,7 @@ class MainMenuCoordinator: BaseCoordinator {
             navigationHandler?.showPrintSheet()
 
         case .reportBrokenSite:
-            presentReportBrokenSite(url: destination.url)
+            navigationHandler?.presentReportBrokenSite(url: destination.url)
 
         case .shareSheet:
             navigationHandler?.showShareSheetForCurrentlySelectedTab()
@@ -214,15 +217,6 @@ class MainMenuCoordinator: BaseCoordinator {
     }
 
     // MARK: - Private helpers
-
-    private func presentReportBrokenSite(url: URL?) {
-        let reportViewController = WebCompatReportViewController(windowUUID: windowUUID, reportedURL: url)
-        if let sheetPresentationController = reportViewController.sheetPresentationController {
-            sheetPresentationController.detents = [.medium(), .large()]
-            sheetPresentationController.prefersGrabberVisible = true
-        }
-        router.present(reportViewController, animated: true, completion: nil)
-    }
 
     private func createMainMenuViewController() -> MainMenuViewController {
         let mainMenuViewController = MainMenuViewController(windowUUID: windowUUID, profile: profile)

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -3,30 +3,39 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import Foundation
+import Redux
 import Shared
 import UIKit
+import WebCompatReporterKit
 
-/// Placeholder bottom sheet presented from the main menu "Report a Website Issue" entry.
-/// The full reporting form is implemented in FXIOS-16180; this shell only establishes the
-/// navigation route and presentation so the menu entry has a destination.
-final class WebCompatReportViewController: UIViewController, Themeable {
+@MainActor
+protocol WebCompatReportCoordinatorDelegate: AnyObject {
+    /// The user asked to dismiss the report sheet; the coordinator owns the dismissal.
+    func webCompatReportViewControllerDidFinish()
+}
+
+/// Store-connected container for the "Report a Website Issue" bottom sheet.
+/// It presents the store-agnostic `WebCompatReportSheetViewController` from
+/// `WebCompatReporterKit` as its root, subscribes to `WebCompatReporterState`,
+/// maps the state to the sheet's view model, and forwards the sheet's close and
+/// preview intents to Redux and the coordinator. The sheet view controller never
+/// dismisses or navigates itself.
+final class WebCompatReportViewController: UINavigationController,
+                                           StoreSubscriber,
+                                           Themeable,
+                                           WebCompatReportSheetDelegate {
+    typealias SubscriberStateType = WebCompatReporterState
+
     var themeManager: ThemeManager
     var themeListenerCancellable: Any?
     var notificationCenter: NotificationProtocol
     var currentWindowUUID: UUID? { windowUUID }
 
+    weak var reportCoordinator: WebCompatReportCoordinatorDelegate?
+
     private let windowUUID: WindowUUID
     private let reportedURL: URL?
-
-    private let titleLabel: UILabel = .build { label in
-        label.adjustsFontForContentSizeCategory = true
-        label.font = FXFontStyles.Bold.title3.scaledFont()
-        label.numberOfLines = 0
-        label.textAlignment = .center
-        label.text = .MainMenu.ToolsSection.ReportBrokenSite
-        label.accessibilityTraits.insert(.header)
-    }
+    private let sheetViewController: WebCompatReportSheetViewController
 
     init(
         windowUUID: WindowUUID,
@@ -38,7 +47,14 @@ final class WebCompatReportViewController: UIViewController, Themeable {
         self.reportedURL = reportedURL
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
+        let initialState = WebCompatReporterState(windowUUID: windowUUID)
+        self.sheetViewController = WebCompatReportSheetViewController(
+            viewModel: WebCompatReportViewController.makeViewModel(from: initialState),
+            theme: themeManager.getCurrentTheme(for: windowUUID)
+        )
         super.init(nibName: nil, bundle: nil)
+        setViewControllers([sheetViewController], animated: false)
+        sheetViewController.delegate = self
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -47,23 +63,84 @@ final class WebCompatReportViewController: UIViewController, Themeable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupLayout()
         listenForThemeChanges(withNotificationCenter: notificationCenter)
         applyTheme()
+        subscribeToRedux()
+        store.dispatch(WebCompatReporterViewAction(
+            url: reportedURL?.absoluteString,
+            windowUUID: windowUUID,
+            actionType: WebCompatReporterViewActionType.viewDidLoad
+        ))
     }
 
-    private func setupLayout() {
-        view.addSubview(titleLabel)
-        NSLayoutConstraint.activate([
-            titleLabel.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor),
-            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16)
-        ])
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        unsubscribeFromRedux()
     }
+
+    // MARK: - Redux
+
+    func subscribeToRedux() {
+        store.dispatch(ComponentAction(
+            windowUUID: windowUUID,
+            actionType: ComponentActionType.addComponent,
+            component: .webCompatReporter
+        ))
+        let uuid = windowUUID
+        store.subscribe(self, transform: {
+            $0.select { appState in
+                WebCompatReporterState(appState: appState, uuid: uuid)
+            }
+        })
+    }
+
+    func unsubscribeFromRedux() {
+        store.dispatch(ComponentAction(
+            windowUUID: windowUUID,
+            actionType: ComponentActionType.removeComponent,
+            component: .webCompatReporter
+        ))
+        store.unsubscribe(self)
+    }
+
+    func newState(state: WebCompatReporterState) {
+        sheetViewController.configure(with: WebCompatReportViewController.makeViewModel(from: state))
+    }
+
+    // MARK: - View model
+
+    private static func makeViewModel(from state: WebCompatReporterState) -> WebCompatReportViewModel {
+        return WebCompatReportViewModel(
+            navigationTitle: .MainMenu.ToolsSection.ReportBrokenSite,
+            closeButtonAccessibilityLabel: .WebCompatReporter.Sheet.CloseButtonAccessibilityLabel,
+            previewButtonTitle: .WebCompatReporter.Sheet.PreviewButton,
+            isPreviewEnabled: state.canPreview
+        )
+    }
+
+    // MARK: - WebCompatReportSheetDelegate
+
+    func webCompatReportSheetDidTapClose() {
+        store.dispatch(WebCompatReporterViewAction(
+            windowUUID: windowUUID,
+            actionType: WebCompatReporterViewActionType.cancel
+        ))
+        reportCoordinator?.webCompatReportViewControllerDidFinish()
+    }
+
+    func webCompatReportSheetDidTapPreview() {
+        store.dispatch(WebCompatReporterViewAction(
+            windowUUID: windowUUID,
+            actionType: WebCompatReporterViewActionType.preview
+        ))
+    }
+
+    // MARK: - Themeable
 
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         view.backgroundColor = theme.colors.layer1
-        titleLabel.textColor = theme.colors.textPrimary
+        navigationBar.tintColor = theme.colors.actionPrimary
+        sheetViewController.applyTheme(theme: theme)
     }
 }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4718,6 +4718,20 @@ extension String {
                 comment: "A specific sub-option under the 'Video or audio does not play' issue category in the Report a Website Issue form."
             )
         }
+        public struct Sheet {
+            public static let PreviewButton = MZLocalizedString(
+                key: "", // WebCompatReporter.Sheet.PreviewButton.v152
+                tableName: "WebCompatReporter",
+                value: "Preview",
+                comment: "Title of the navigation bar button that opens a preview of the report before sending, in the Report a Website Issue form."
+            )
+            public static let CloseButtonAccessibilityLabel = MZLocalizedString(
+                key: "", // WebCompatReporter.Sheet.CloseButtonAccessibilityLabel.v152
+                tableName: "WebCompatReporter",
+                value: "Close",
+                comment: "Accessibility label for the navigation bar button that dismisses the Report a Website Issue form without sending a report."
+            )
+        }
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuCoordinatorTests.swift
@@ -70,6 +70,17 @@ final class MainMenuCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockRouter.dismissCalled, 1)
     }
 
+    func testHandleNavigation_reportBrokenSite_callsPresentReportBrokenSiteOnDelegate() {
+        let subject = createSubject()
+        let mockDelegate = MockMainMenuCoordinatorDelegate()
+        subject.navigationHandler = mockDelegate
+
+        subject.navigateTo(MenuNavigationDestination(.reportBrokenSite), animated: false)
+        mockRouter.savedCompletion?()
+
+        XCTAssertEqual(mockDelegate.presentReportBrokenSiteCalled, 1)
+    }
+
     func testHandleNavigation_webpageSummary_callsDelegate() {
         let subject = createSubject()
         let mockDelegate = MockMainMenuCoordinatorDelegate()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -21,13 +21,24 @@ final class WebCompatReportViewControllerTests: XCTestCase {
         try await super.tearDown()
     }
 
-    func testViewDidLoad_appliesThemeAndAddsSingleTitleElement() {
+    func testViewDidLoad_appliesThemeAndHostsSingleRootViewController() {
         let subject = createSubject(reportedURL: URL(string: "https://example.com"))
 
         subject.loadViewIfNeeded()
 
         XCTAssertNotNil(subject.view.backgroundColor, "applyTheme should set a background color")
-        XCTAssertEqual(subject.view.subviews.count, 1, "Placeholder shows only the title label")
+        XCTAssertEqual(subject.viewControllers.count, 1, "The report sheet is the single root view controller")
+    }
+
+    func testDidTapClose_notifiesCoordinatorToDismiss() {
+        let coordinator = MockWebCompatReportCoordinatorDelegate()
+        let subject = createSubject(reportedURL: nil)
+        subject.reportCoordinator = coordinator
+        subject.loadViewIfNeeded()
+
+        subject.webCompatReportSheetDidTapClose()
+
+        XCTAssertEqual(coordinator.didFinishCallCount, 1)
     }
 
     func testSimpleCreation_hasNoLeaks() {
@@ -38,5 +49,13 @@ final class WebCompatReportViewControllerTests: XCTestCase {
 
     private func createSubject(reportedURL: URL?) -> WebCompatReportViewController {
         return WebCompatReportViewController(windowUUID: windowUUID, reportedURL: reportedURL)
+    }
+}
+
+private final class MockWebCompatReportCoordinatorDelegate: WebCompatReportCoordinatorDelegate {
+    var didFinishCallCount = 0
+
+    func webCompatReportViewControllerDidFinish() {
+        didFinishCallCount += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockMainMenuCoordinatorDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockMainMenuCoordinatorDelegate.swift
@@ -14,6 +14,8 @@ class MockMainMenuCoordinatorDelegate: MainMenuCoordinatorDelegate {
     private(set) var updateZoomPageBarVisibilityCalled = 0
     private(set) var presentSavePDFControllerCalled = 0
     private(set) var presentSiteProtectionsCalled = 0
+    private(set) var presentReportBrokenSiteCalled = 0
+    private(set) var presentReportBrokenSiteURL: URL?
     private(set) var showPrintSheetCalled = 0
     private(set) var showReaderModeCalled = 0
     private(set) var showShareSheetForCurrentlySelectedTabCalled = 0
@@ -50,6 +52,11 @@ class MockMainMenuCoordinatorDelegate: MainMenuCoordinatorDelegate {
 
     func presentSiteProtections() {
         presentSiteProtectionsCalled += 1
+    }
+
+    func presentReportBrokenSite(url: URL?) {
+        presentReportBrokenSiteCalled += 1
+        presentReportBrokenSiteURL = url
     }
 
     func showPrintSheet() {

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -48,6 +48,11 @@
         },
         {
           "containerPath" : "container:..\/BrowserKit",
+          "identifier" : "WebCompatReporterKit",
+          "name" : "WebCompatReporterKit"
+        },
+        {
+          "containerPath" : "container:..\/BrowserKit",
           "identifier" : "WebEngine",
           "name" : "WebEngine"
         },
@@ -204,6 +209,13 @@
         "containerPath" : "container:..\/BrowserKit",
         "identifier" : "ToolbarKitTests",
         "name" : "ToolbarKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/BrowserKit",
+        "identifier" : "WebCompatReporterKitTests",
+        "name" : "WebCompatReporterKitTests"
       }
     },
     {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16180)
<!-- Github issue: the # linked at the bottom of the Jira ticket -->

## :bulb: Description
Adds the report bottom-sheet shell for the WebCompat "Report a Website Issue" flow.

- New `WebCompatReporterKit` BrowserKit package with the store-agnostic UIKit sheet: an iOS-26 `.large` sheet (grabber + X/cancel + Preview/primary nav buttons) and a `UICollectionView` compositional inset-grouped list container that later PRs fill in. Previewable in isolation with a mock view model.
- Client side: `WebCompatReportViewController` subscribes to `WebCompatReporterState` ([FXIOS-16178](https://mozilla-hub.atlassian.net/browse/FXIOS-16178)), maps it to the package view model, and forwards the close/preview intents. Presentation and dismissal are owned by `BrowserCoordinator`, so the menu entry from [FXIOS-16179](https://mozilla-hub.atlassian.net/browse/FXIOS-16179) now opens the real shell.

Shell only — the issue picker ([FXIOS-16181](https://mozilla-hub.atlassian.net/browse/FXIOS-16181)), fields ([FXIOS-16182](https://mozilla-hub.atlassian.net/browse/FXIOS-16182)), submit ([FXIOS-16185](https://mozilla-hub.atlassian.net/browse/FXIOS-16185)), and preview screen ([FXIOS-16186](https://mozilla-hub.atlassian.net/browse/FXIOS-16186)) come in follow-ups. Strings are staged with empty keys so l10n doesn't export them until the feature ships.

## :test_tube: Testing
1. Run the **Fennec** scheme (the `report-broken-site` flag defaults on in developer builds).
2. Load any web page, then open the **☰ menu → More → "Report a Website Issue"**.
3. Expect an iOS-26 **large bottom sheet** with a grabber, an **X** (close) on the left and a **Preview** button on the right, titled "Report a Website Issue", over an empty grouped list — this is the shell, so no fields yet. **Preview is disabled** because no issue is selected.
4. Tap **X** → the sheet dismisses.

To review the shell in isolation: select the `WebCompatReporterKit` scheme on an **iOS 26.5** simulator and open the `#Preview`s in `WebCompatReportSheetPreview.swift` (empty + populated variants).

## :movie_camera: Demos
| Before | After |
| - | - |
| Empty placeholder sheet | <!-- drop the sim screenshot of the sheet here --> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description o
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardshiprequirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

[FXIOS-16178]: https://mozilla-hub.atlassian.net/browse/FXIOS-16178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-16179]: https://mozilla-hub.atlassian.net/browse/FXIOS-16179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-16181]: https://mozilla-hub.atlassian.net/browse/FXIOS-16181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ