### PR TITLE
MTE-5579 - multiple fixes for flaky tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -444,6 +444,8 @@ class LoginTest: BaseTestCase {
         let editButton = app.buttons["Edit"]
         savedCredentials.waitAndTap()
         editButton.waitAndTap()
+        // Focus the username field explicitly; relying on auto-focus after Edit is flaky on CI
+        app.tables["Login Detail List"].cells.elementContainingText("Username").waitAndTap()
         clearAndEnterText(text: "test")
         passwordCell.waitAndTap()
         clearAndEnterText(text: "pass")
@@ -522,26 +524,53 @@ class LoginTest: BaseTestCase {
 
     private func validateLoginTextFieldsCanBeCopied(indexField: Int, copiedText: String, field: String) {
         app.tables[loginList].cells.element(boundBy: defaultNumRowsLoginsList).waitAndTap()
-        // Long tap on the Website field and then tap on Copy
-        app.tables.cells.element(boundBy: indexField).press(forDuration: 1.5)
-        app.staticTexts["Copy"].waitAndTap()
+        // Long tap on the field and then tap on Copy
+        let fieldCell = app.tables.cells.element(boundBy: indexField)
+        mozWaitForElementToExist(fieldCell)
+        let copyMenuItem = app.staticTexts["Copy"]
+        revealCalloutMenuItem(copyMenuItem) {
+            fieldCell.press(forDuration: 1.5)
+        }
+        copyMenuItem.waitAndTap()
         // Validate text was copied
         app.buttons["Passwords"].waitAndTap()
         let passwordSearchField = app.searchFields[passwordssQuery.searchPasswords]
-        if #available(iOS 17, *) {
-            passwordSearchField.press(forDuration: 1.5)
-        } else {
-            passwordSearchField.waitAndTap()
-            passwordSearchField.waitAndTap()
+        let pasteMenuItem = app.staticTexts["Paste"]
+        revealCalloutMenuItem(pasteMenuItem) {
+            if #available(iOS 17, *) {
+                passwordSearchField.press(forDuration: 1.5)
+            } else {
+                passwordSearchField.waitAndTap()
+                passwordSearchField.waitAndTap()
+            }
         }
-        app.staticTexts["Paste"].waitAndTap()
+        pasteMenuItem.waitAndTap()
         mozWaitForElementToExist(passwordSearchField)
         XCTAssertEqual(passwordSearchField.value! as? String,
                        copiedText,
                        "The \(field)) text was not copied")
     }
 
+    /// Repeats `gesture` until `menuItem` (an edit-callout entry such as Copy/Paste) appears.
+    /// The callout menu does not reliably show on the first gesture on CI, so retry a few times.
+    private func revealCalloutMenuItem(_ menuItem: XCUIElement, maxAttempts: Int = 3, gesture: () -> Void) {
+        var attempts = maxAttempts
+        repeat {
+            gesture()
+            if menuItem.mozWaitForElementToExist(timeout: 5, failOnTimeout: false) {
+                return
+            }
+            attempts -= 1
+        } while attempts > 0
+    }
+
     private func clearAndEnterText(text: String) {
+        mozWaitForElementToExist(app.keyboards.firstMatch)
+        // The keyboard does not expand automatically sometimes
+        if app.keyboards.buttons["Continue"].exists {
+            app.keyboards.buttons["Continue"].waitAndTap()
+            mozWaitForElementToNotExist(app.keyboards.buttons["Continue"])
+        }
         mozWaitForElementToExist(app.keyboards.keys["delete"])
         app.keyboards.keys["delete"].press(forDuration: 1.2)
         enterTextInField(typedText: text)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -142,11 +142,17 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
         app.launch()
         if #available(iOS 17, *) {
             tapToolbarShareButtonAndSelectOption(option: "Save to Files", url: pdfUrl)
-            if !iPad() {
-                mozWaitForElementToExist(app.staticTexts["On My iPhone"])
-            } else {
-                mozWaitForElementToExist(app.staticTexts["On My iPad"])
+            let saveLocation = iPad() ? app.staticTexts["On My iPad"] : app.staticTexts["On My iPhone"]
+            // The system "Save to Files" picker is slow to present on CI and the share-sheet tap
+            // does not always open it, so re-tap the option while the share sheet is still up.
+            var attempts = 2
+            while !saveLocation.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) && attempts > 0 {
+                let saveToFilesCell = app.collectionViews.cells["Save to Files"]
+                guard saveToFilesCell.exists else { break }
+                saveToFilesCell.tapOnApp()
+                attempts -= 1
             }
+            mozWaitForElementToExist(saveLocation, timeout: TIMEOUT_LONG)
             app.buttons["Save"].waitAndTap()
             waitForTabsButton()
         }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5579

## :bulb: Description
Fixed three flaky XCUITests by making them resilient to gestures that silently don't take effect on CI. In testDismissedChangesAreNotSaved, added an explicit tap on the username field after "Edit" (instead of relying on flaky auto-focus) so the keyboard is guaranteed up, plus hardened clearAndEnterText to handle a collapsed keyboard. In testLoginCopyPaste, added a retry helper that repeats the long-press/gesture until the "Copy"/"Paste" callout menu actually appears; and in testSharePdfFileSaveToFile, extended the wait to 20s and re-tap "Save to Files" if the system Files picker is not present.

