### PR TITLE
Bugfix [Toolbar] FXIOS-16048 "Use saved passwords" text overflows button pill after portrait rotation and auth

### DIFF
--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -26,6 +26,8 @@ final class AccessoryViewProvider: UIView,
         static let spacerViewHeight: CGFloat = 4
         static let cornerRadius: CGFloat = 24.0
         static let buttonsWidth: CGFloat = 40
+        // Toolbar spacing around the autofill pill (insets + inter-item gaps).
+        static let autofillHorizontalPadding: CGFloat = 80
     }
 
     // MARK: - Properties
@@ -218,7 +220,24 @@ final class AccessoryViewProvider: UIView,
         fatalError("init(coder:) has not been implemented")
     }
 
+    /// Toolbar width left for the autofill pill once the side buttons and their spacing are removed,
+    /// recomputed each layout pass. iPhone-only (iOS 26); `nil` elsewhere so the pill sizes to content.
+    /// The pill caps this to a comfortable width around its content.
+    private var autofillFillWidth: CGFloat? {
+        guard #available(iOS 26.0, *), UIDevice.current.userInterfaceIdiom == .phone else { return nil }
+
+        let sideButtonsWidth = (navigationButtonsBarItem.customView?.bounds.width ?? 0)
+                             + (doneButton.customView?.bounds.width ?? 0)
+        let available = toolbar.bounds.width - sideButtonsWidth - UX.autofillHorizontalPadding
+        return available > 0 ? available : nil
+    }
+
     // MARK: - Lifecycle
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        autofillAccessoryView?.applyFillWidth(autofillFillWidth)
+    }
+
     override func removeFromSuperview() {
         super.removeFromSuperview()
         // Reset showing of credit card when dismissing the view

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -35,6 +35,7 @@ final class AccessoryViewProvider: UIView,
     var themeListenerCancellable: Any?
     var notificationCenter: NotificationProtocol
     private var autofillAccessoryView: AutofillAccessoryViewButtonItem?
+    private var currentAccessoryViewWidth: CGFloat = 0
     let windowUUID: WindowUUID
 
     // Stub closures - these closures will be given as selectors in a future task
@@ -220,11 +221,10 @@ final class AccessoryViewProvider: UIView,
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Toolbar width left for the autofill pill once the side buttons and their spacing are removed,
-    /// recomputed each layout pass. iPhone-only (iOS 26); `nil` elsewhere so the pill sizes to content.
-    /// The pill caps this to a comfortable width around its content.
+    /// Toolbar width left for the autofill pill once the side buttons and their spacing are removed.
+    /// Driven by geometry rather than device type
     private var autofillFillWidth: CGFloat? {
-        guard #available(iOS 26.0, *), UIDevice.current.userInterfaceIdiom == .phone else { return nil }
+        guard #available(iOS 26.0, *) else { return nil }
 
         let sideButtonsWidth = (navigationButtonsBarItem.customView?.bounds.width ?? 0)
                              + (doneButton.customView?.bounds.width ?? 0)
@@ -235,6 +235,9 @@ final class AccessoryViewProvider: UIView,
     // MARK: - Lifecycle
     override func layoutSubviews() {
         super.layoutSubviews()
+        guard bounds.width != currentAccessoryViewWidth else { return }
+
+        currentAccessoryViewWidth = bounds.width
         autofillAccessoryView?.applyFillWidth(autofillFillWidth)
     }
 
@@ -266,6 +269,9 @@ final class AccessoryViewProvider: UIView,
         }
         configureToolbarItems()
         layoutIfNeeded()
+
+        // Update pill width after reload view
+        autofillAccessoryView?.applyFillWidth(autofillFillWidth)
     }
 
     private func setupSpacer(_ spacer: UIView, width: CGFloat) {

--- a/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
@@ -27,7 +27,8 @@ final class AutofillAccessoryViewButtonItem: UIBarButtonItem {
         static let accessoryImageViewSize: CGFloat = 24
         static let accessoryButtonStackViewSpacing: CGFloat = 2
         static let cornerRadius: CGFloat = 4
-        static let iPadPadding: CGFloat = 64
+        // Horizontal padding around the content used to cap the pill's fill width
+        static let contentHorizontalPadding: CGFloat = 64
     }
 
     // MARK: - Properties
@@ -121,31 +122,16 @@ final class AutofillAccessoryViewButtonItem: UIBarButtonItem {
         containerView.addSubview(contentStackView)
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
 
-        // Use idiom-specific constraints only; iPhone width is updated externally per layout pass.
-        let isiPad = UIDevice.current.userInterfaceIdiom == .pad
-        let isiOS26 = if #available(iOS 26.0, *) { true } else { false }
-
-        if #available(iOS 26.0, *) {
-            sharesBackground = false
-            contentStackView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
-        }
-
         let leadingConstraint: NSLayoutConstraint
         let trailingConstraint: NSLayoutConstraint
-        if isiOS26, isiPad {
-            // iPad iOS 26: fixed horizontal padding inside the container.
-            leadingConstraint = contentStackView.leadingAnchor
-                .constraint(equalTo: containerView.leadingAnchor, constant: UX.iPadPadding)
-            trailingConstraint = contentStackView.trailingAnchor
-                .constraint(equalTo: containerView.trailingAnchor, constant: -UX.iPadPadding)
-        } else if isiOS26 {
-            // iPhone iOS 26: centered content clamped inside the externally-sized container.
-            leadingConstraint = contentStackView.leadingAnchor
-                .constraint(greaterThanOrEqualTo: containerView.leadingAnchor)
-            trailingConstraint = contentStackView.trailingAnchor
-                .constraint(lessThanOrEqualTo: containerView.trailingAnchor)
+        if #available(iOS 26.0, *) {
+            sharesBackground = false
+            // Content is centered and clamped inside a container whose width is set externally in `applyFillWidth`
+            contentStackView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
+            leadingConstraint = contentStackView.leadingAnchor.constraint(greaterThanOrEqualTo: containerView.leadingAnchor)
+            trailingConstraint = contentStackView.trailingAnchor.constraint(lessThanOrEqualTo: containerView.trailingAnchor)
         } else {
-            // Pre-iOS 26: content fills the container.
+            // Pre-iOS 26: content fills the container (centered by the toolbar's flexible spaces).
             leadingConstraint = contentStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor)
             trailingConstraint = contentStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
         }
@@ -164,16 +150,15 @@ final class AutofillAccessoryViewButtonItem: UIBarButtonItem {
         self.customView = containerView
     }
 
-    /// Sizes the pill to the toolbar space reported by `AccessoryViewProvider`, capped so it stays a
-    /// comfortable width around its content. Passing `nil` (iPad / pre-26) sizes the pill to content via the setup
-    /// constraints. No-ops on unchanged values so it's safe to call every layout pass.
+    /// Sizes the pill to the toolbar space reported by `AccessoryViewProvider`, capped so it stays a comfortable
+    /// width around its content. Passing `nil` (pre-26) sizes the pill to content via the setup constraints.
     func applyFillWidth(_ availableWidth: CGFloat?) {
         guard let availableWidth, availableWidth > 0 else {
             fillWidthConstraint.isActive = false
             return
         }
 
-        let width = min(availableWidth, contentWidth + UX.iPadPadding * 2)
+        let width = min(availableWidth, contentWidth + UX.contentHorizontalPadding * 2)
         if fillWidthConstraint.constant != width {
             fillWidthConstraint.constant = width
         }

--- a/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
@@ -27,13 +27,32 @@ final class AutofillAccessoryViewButtonItem: UIBarButtonItem {
         static let accessoryImageViewSize: CGFloat = 24
         static let accessoryButtonStackViewSpacing: CGFloat = 2
         static let cornerRadius: CGFloat = 4
-        static let iPadPadding: CGFloat = 80
+        static let iPadPadding: CGFloat = 64
     }
 
     // MARK: - Properties
+    private let containerView = UIView()
     private let accessoryImageView: UIImageView
     private let useAccessoryTextLabel: UILabel
     private let tappedAccessoryButtonAction: (@MainActor () -> Void)?
+
+    /// Optional explicit width constraint so the pill can fill the available toolbar space on iOS 26 iPhone
+    private lazy var fillWidthConstraint: NSLayoutConstraint = {
+        let constraint = containerView.widthAnchor.constraint(equalToConstant: 0)
+        constraint.priority = .defaultHigh
+        return constraint
+    }()
+
+    private lazy var contentStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [accessoryImageView, useAccessoryTextLabel])
+        stackView.spacing = UX.accessoryButtonStackViewSpacing
+        return stackView
+    }()
+
+    /// Natural width of the icon + label, independent of the pill's fill width.
+    private var contentWidth: CGFloat {
+        contentStackView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
+    }
 
     /// Tint color for the accessory image view.
     var accessoryImageViewTintColor: UIColor? {
@@ -97,56 +116,45 @@ final class AutofillAccessoryViewButtonItem: UIBarButtonItem {
         configureAccessibility()
         let stackViewTapped = UITapGestureRecognizer(target: self, action: #selector(tappedAccessoryButton))
 
-        // Create a container view for the stack view
-        let containerView = UIView()
-
         // Add the stack view to the container view
-        let accessoryView = UIStackView(arrangedSubviews: [accessoryImageView, useAccessoryTextLabel])
-        accessoryView.spacing = UX.accessoryButtonStackViewSpacing
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(contentStackView)
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
 
-        // Add the stack view to the container view
-        containerView.addSubview(accessoryView)
-
-        // Add constraints to provide padding
-        accessoryView.translatesAutoresizingMaskIntoConstraints = false
+        // Use idiom-specific constraints only; iPhone width is updated externally per layout pass.
         let isiPad = UIDevice.current.userInterfaceIdiom == .pad
+        let isiOS26 = if #available(iOS 26.0, *) { true } else { false }
 
         if #available(iOS 26.0, *) {
             sharesBackground = false
-            accessoryView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
+            contentStackView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
         }
 
-        let leadingConstraint = if #available(iOS 26.0, *), isiPad {
-            accessoryView.leadingAnchor
-                .constraint(
-                    equalTo: containerView.leadingAnchor,
-                    constant: UX.iPadPadding
-                )
+        let leadingConstraint: NSLayoutConstraint
+        let trailingConstraint: NSLayoutConstraint
+        if isiOS26, isiPad {
+            // iPad iOS 26: fixed horizontal padding inside the container.
+            leadingConstraint = contentStackView.leadingAnchor
+                .constraint(equalTo: containerView.leadingAnchor, constant: UX.iPadPadding)
+            trailingConstraint = contentStackView.trailingAnchor
+                .constraint(equalTo: containerView.trailingAnchor, constant: -UX.iPadPadding)
+        } else if isiOS26 {
+            // iPhone iOS 26: centered content clamped inside the externally-sized container.
+            leadingConstraint = contentStackView.leadingAnchor
+                .constraint(greaterThanOrEqualTo: containerView.leadingAnchor)
+            trailingConstraint = contentStackView.trailingAnchor
+                .constraint(lessThanOrEqualTo: containerView.trailingAnchor)
         } else {
-            accessoryView.leadingAnchor
-                .constraint(
-                greaterThanOrEqualTo: containerView.leadingAnchor
-            )
-        }
-
-        let trailingConstraint = if #available(iOS 26.0, *), isiPad {
-            accessoryView.trailingAnchor
-                .constraint(
-                    equalTo: containerView.trailingAnchor,
-                    constant: -UX.iPadPadding
-                )
-        } else {
-            accessoryView.trailingAnchor
-                .constraint(
-                lessThanOrEqualTo: containerView.trailingAnchor
-            )
+            // Pre-iOS 26: content fills the container.
+            leadingConstraint = contentStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor)
+            trailingConstraint = contentStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
         }
 
         NSLayoutConstraint.activate([
             leadingConstraint,
             trailingConstraint,
-            accessoryView.topAnchor.constraint(equalTo: containerView.topAnchor),
-            accessoryView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+            contentStackView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            contentStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
         ])
 
         containerView.layer.cornerRadius = UX.cornerRadius
@@ -154,6 +162,22 @@ final class AutofillAccessoryViewButtonItem: UIBarButtonItem {
 
         // Set the custom view as the container view
         self.customView = containerView
+    }
+
+    /// Sizes the pill to the toolbar space reported by `AccessoryViewProvider`, capped so it stays a
+    /// comfortable width around its content. Passing `nil` (iPad / pre-26) sizes the pill to content via the setup
+    /// constraints. No-ops on unchanged values so it's safe to call every layout pass.
+    func applyFillWidth(_ availableWidth: CGFloat?) {
+        guard let availableWidth, availableWidth > 0 else {
+            fillWidthConstraint.isActive = false
+            return
+        }
+
+        let width = min(availableWidth, contentWidth + UX.iPadPadding * 2)
+        if fillWidthConstraint.constant != width {
+            fillWidthConstraint.constant = width
+        }
+        fillWidthConstraint.isActive = true
     }
 
     private func configureAccessibility() {

--- a/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
+++ b/firefox-ios/Client/Frontend/Autofill/AutofillAccessoryViewButtonItem.swift
@@ -37,7 +37,6 @@ final class AutofillAccessoryViewButtonItem: UIBarButtonItem {
     private let useAccessoryTextLabel: UILabel
     private let tappedAccessoryButtonAction: (@MainActor () -> Void)?
 
-    /// Optional explicit width constraint so the pill can fill the available toolbar space on iOS 26 iPhone
     private lazy var fillWidthConstraint: NSLayoutConstraint = {
         let constraint = containerView.widthAnchor.constraint(equalToConstant: 0)
         constraint.priority = .defaultHigh


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16048)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
The problem is On iOS 26, the "Use saved password" keyboard accessory button (AutofillAccessoryViewButtonItem, hosted by AccessoryViewProvider) could render with its label breaking out of the pill after a specific rotation sequence. The button's pill kept a width measured in landscape and overflowed the portrait toolbar. Root cause: the button is a UIBarButtonItem custom view whose size the toolbar measures once and caches, it isn't re-measured on a bounds change, and its horizontal constraints left the width ambiguous, so the stale (wider) size persisted across the forced-orientation transition.

The solutions is to give the view a determinate width that's recomputed on every layout pass instead of relying on the toolbar's cached measurement.`AccessoryViewProvider.layoutSubviews()` computes the toolbar space available for the pill (toolbar width − side buttons − spacing) and passes it to the button each pass, so the width tracks the current toolbar and can't go stale on rotation.
- The button caps that width to a comfortable size around its content, so it fills nicely in landscape without crowding the Done button, and fits in portrait.

## :movie_camera: Demos

https://github.com/user-attachments/assets/f4fcd1e6-cbf0-4dfa-aa6e-369e18d2694e


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

