### PR TITLE
[MTE-5588] - fix flaky Login, ShareToolbar, Bookmark and CreditCard t…

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -403,14 +403,22 @@ class BaseTestCase: XCTestCase {
         let passcodeInput = springboard.otherElements.secureTextFields.firstMatch
 
         // On CI the springboard device-passcode overlay is intermittently not presented — the
-        // authentication grace period may still be active (no prompt shown) or the springboard
-        // accessibility hierarchy is momentarily unreadable. Wait for the prompt without failing on
-        // timeout, and only type the passcode when it is actually shown; callers assert their own
-        // destination screen afterwards.
-        if mozWaitForElementToExist(passcodeInput, timeout: TIMEOUT_LONG, failOnTimeout: false) {
-            passcodeInput.tapAndTypeText("foo\n")
-            mozWaitForElementToNotExist(passcodeInput)
+        // authentication grace period may still be active (no prompt shown) — and when it is
+        // presented the first keystrokes are occasionally dropped, leaving the screen locked. Type
+        // the passcode and retry until the prompt is dismissed (the "unlocked" signal for every
+        // screen this guards); callers assert their own destination afterwards. First detection
+        // uses the long timeout because the prompt can be slow to present on CI.
+        guard mozWaitForElementToExist(passcodeInput, timeout: TIMEOUT_LONG, failOnTimeout: false) else {
+            return
         }
+        var attempts = 3
+        repeat {
+            passcodeInput.tapAndTypeText("foo\n")
+            if mozWaitForElementToNotExist(passcodeInput, timeout: TIMEOUT, failOnTimeout: false) {
+                return
+            }
+            attempts -= 1
+        } while passcodeInput.exists && attempts > 0
     }
 
     func scrollToElement(

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -830,7 +830,9 @@ class BookmarksTests: FeatureFlaggedTestBase {
 
     private func longPressBookmarkCell() {
         let bookMarkCell = app.cells["BookmarksCell"]
-        scrollToElement(bookMarkCell)
+        // Scroll until the cell is actually hittable, not merely visible: in landscape the cell can
+        // be on-screen but not hittable, and press() then throws "Not hittable" on the first press.
+        scrollToElement(bookMarkCell, isHittable: true)
         let contextMenuTable = app.tables["Context Menu"]
         bookMarkCell.pressWithRetry(duration: 1.5, element: contextMenuTable)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -444,7 +444,10 @@ class LoginTest: BaseTestCase {
         let editButton = app.buttons["Edit"]
         savedCredentials.waitAndTap()
         editButton.waitAndTap()
-        // Focus the username field explicitly; relying on auto-focus after Edit is flaky on CI
+        // Focus the username field explicitly; relying on auto-focus after Edit is flaky on CI.
+        // Wait for the detail list to finish presenting first, otherwise the Username cell is
+        // queried mid edit-mode transition and the tap times out (matches testEditOneLoginEntry).
+        mozWaitForElementToExist(app.tables["Login Detail List"])
         app.tables["Login Detail List"].cells.elementContainingText("Username").waitAndTap()
         clearAndEnterText(text: "test")
         passwordCell.waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LoginSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LoginSettingsScreen.swift
@@ -135,11 +135,12 @@ final class LoginSettingsScreen {
     /// Dismisses the system device-passcode prompt guarding the Passwords/Credit Cards screens.
     ///
     /// On CI the springboard passcode overlay is intermittently not presented — the authentication
-    /// grace period may still be active (no prompt shown) or the springboard accessibility hierarchy
-    /// is momentarily unreadable. Unconditionally waiting for the passcode field therefore times out
-    /// and fails the test even though nothing is wrong. Wait for the prompt without failing on
-    /// timeout, and only type the passcode when it is actually shown; callers assert their own
-    /// destination screen afterwards.
+    /// grace period may still be active (no prompt shown) — and when it is presented the first
+    /// keystrokes are occasionally dropped, leaving the screen locked. This types the passcode and
+    /// retries until the prompt is dismissed, which is the "unlocked" signal for every screen this
+    /// guards, so it stays agnostic to the destination (Passwords list, Credit Cards list, …).
+    /// Callers assert their own destination screen afterwards. If the grace period is active the
+    /// prompt never appears and this returns immediately.
     func unlockLoginsView() {
         let passcodeValue = "foo\n"
         let base = BaseTestCase()
@@ -148,10 +149,18 @@ final class LoginSettingsScreen {
         }
 
         let passcode = sel.PASSCODE_FIELD.element(in: springboard)
-        if base.mozWaitForElementToExist(passcode, timeout: TIMEOUT_LONG, failOnTimeout: false) {
-            passcode.tapAndTypeText(passcodeValue)
-            base.mozWaitForElementToNotExist(passcode)
+        // First detection uses the long timeout because the prompt can be slow to present on CI.
+        guard base.mozWaitForElementToExist(passcode, timeout: TIMEOUT_LONG, failOnTimeout: false) else {
+            return
         }
+        var attempts = 3
+        repeat {
+            passcode.tapAndTypeText(passcodeValue)
+            if base.mozWaitForElementToNotExist(passcode, timeout: TIMEOUT, failOnTimeout: false) {
+                return
+            }
+            attempts -= 1
+        } while passcode.exists && attempts > 0
     }
 
     func assertLoginCreatedFirstMatch() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -142,18 +142,20 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
         app.launch()
         if #available(iOS 17, *) {
             tapToolbarShareButtonAndSelectOption(option: "Save to Files", url: pdfUrl)
-            let saveLocation = iPad() ? app.staticTexts["On My iPad"] : app.staticTexts["On My iPhone"]
-            // The system "Save to Files" picker is slow to present on CI and the share-sheet tap
-            // does not always open it, so re-tap the option while the share sheet is still up.
+            // Anchor on the Files picker's own Save button rather than a location label such as
+            // "On My iPhone": the picker opens on whichever location was last used (iCloud Drive,
+            // On My iPhone, …), so the label is not reliably present, whereas Save always is.
+            // The share-sheet tap does not always open the picker on CI, so re-tap it if needed.
+            let saveButton = app.buttons["Save"]
             var attempts = 2
-            while !saveLocation.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) && attempts > 0 {
+            while !saveButton.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) && attempts > 0 {
                 let saveToFilesCell = app.collectionViews.cells["Save to Files"]
                 guard saveToFilesCell.exists else { break }
                 saveToFilesCell.tapOnApp()
                 attempts -= 1
             }
-            mozWaitForElementToExist(saveLocation, timeout: TIMEOUT_LONG)
-            app.buttons["Save"].waitAndTap()
+            mozWaitForElementToExist(saveButton, timeout: TIMEOUT_LONG)
+            saveButton.waitAndTap()
             waitForTabsButton()
         }
     }
@@ -180,7 +182,14 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
         // The Markup tool opens
         if #available(iOS 26, *) {
             if !iPad() {
-                app.navigationBars.buttons["More"].waitAndTap()
+                // iOS 26.3 renamed this navbar overflow button "More" -> "View More" (same rename
+                // as the share sheet, see MTE-5253). Tap whichever label is present.
+                let moreButton = app.navigationBars.buttons["More"]
+                if moreButton.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) {
+                    moreButton.waitAndTap()
+                } else {
+                    app.navigationBars.buttons["View More"].waitAndTap()
+                }
                 mozWaitForElementToExist(app.buttons["Markup"])
                 mozWaitForElementToExist(app.buttons["Close"])
                 mozWaitForElementToExist(app.otherElements["Drawing-Palette"])
@@ -201,15 +210,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
         app.buttons["Reader View"].waitAndTap()
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
-        if #available(iOS 26, *), !app.collectionViews.cells[option].exists {
-            app.scrollViews.cells["View More"].waitAndTap(timeout: 10)
-        }
-        if #available(iOS 16, *) {
-            mozWaitForElementToExist(app.collectionViews.cells[option])
-            app.collectionViews.cells[option].tapOnApp()
-        } else {
-            app.buttons[option].waitAndTap()
-        }
+        selectShareSheetOption(option)
     }
 
     private func tapToolbarShareButtonAndSelectOption(option: String, url: String = url_3) {
@@ -220,8 +221,21 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
         navigator.openURL(url)
         waitUntilPageLoad()
         app.buttons[AccessibilityIdentifiers.Toolbar.shareButton].waitAndTap()
-        if #available(iOS 26, *), !app.collectionViews.cells[option].exists {
-            app.scrollViews.cells["View More"].waitAndTap(timeout: 10)
+        selectShareSheetOption(option)
+    }
+
+    /// Selects `option` from the system share sheet, expanding via "View More" only when needed.
+    ///
+    /// The instant `.exists` check used previously raced the share-sheet presentation animation:
+    /// when the option was about to appear directly, the check was still false and the helper went
+    /// hunting for a "View More" expander that never showed, timing out. Wait for the option first
+    /// and only fall back to expanding the sheet when it genuinely isn't in the collapsed layout.
+    private func selectShareSheetOption(_ option: String) {
+        if #available(iOS 26, *) {
+            let optionCell = app.collectionViews.cells[option]
+            if !optionCell.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) {
+                app.scrollViews.cells["View More"].waitAndTap(timeout: 10)
+            }
         }
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.collectionViews.cells[option])


### PR DESCRIPTION
…ests

## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5588

## :bulb: Description
Another attempt to fix flaky CI tests, these tests will require future monitoring.
- unlockLoginsView: retry typing the passcode until the prompt is dismissed, instead of skipping when it's slow.
- testDismissedChangesAreNotSaved: wait for the detail list before tapping the Username cell.
- ShareToolbar: wait for the share option before tapping "View More"; tolerate the iOS 26.3 "More"→"View More" rename; anchor Save-to-Files on the Save button, not "On My iPhone".
- testLongTapRecentlySavedLink: scroll until the bookmark cell is hittable, not just visible.

