### PR TITLE
Bugfix FXIOS-16222 [Toolbar] Number in the tab tray screen’s tab counter is not centered

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/TabNumberButton.swift
@@ -56,10 +56,11 @@ final class TabNumberButton: ToolbarButton, TabCountable {
     private func setupLayout() {
         addSubview(countLabel)
         NSLayoutConstraint.activate([
-            countLabel.topAnchor.constraint(equalTo: topAnchor),
+            countLabel.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
             countLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             countLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
-            countLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
+            countLabel.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+            countLabel.centerYAnchor.constraint(equalTo: centerYAnchor, constant: 1)
         ])
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16222)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34521)

## :bulb: Description
Centers tab number within new Nova icon.

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 17 28 09" src="https://github.com/user-attachments/assets/8672a4bd-d4a6-4af4-8db6-d01a140eafe3" /> | <img width="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 17 29 42" src="https://github.com/user-attachments/assets/3900bf94-26b8-486d-be57-e41218f9cb07" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

