### PR TITLE
Add FXIOS-16065 [Google Lens] Connect Google Lens web image context menu action to Upload API

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1170,7 +1170,8 @@ final class BrowserCoordinator: BaseCoordinator,
             parentCoordinatorDelegate: self,
             router: router
         ) { [weak self] image in
-            self?.handleGoogleLensImage(image)
+            guard let image else { return }
+            self?.searchGoogleLens(with: image)
         }
         add(child: coordinator)
         coordinator.start()
@@ -1179,36 +1180,7 @@ final class BrowserCoordinator: BaseCoordinator,
                                             actionType: GeneralBrowserActionType.leaveOverlay))
     }
 
-    private func handleGoogleLensPhotoPick(_ results: [PHPickerResult]) {
-        guard let provider = results.first?.itemProvider else { return }
-        guard provider.canLoadObject(ofClass: UIImage.self) else {
-            logger.log("Google Lens: picked item cannot be loaded as an image",
-                       level: .warning,
-                       category: .coordinator)
-            return
-        }
-        provider.loadObject(ofClass: UIImage.self) { [weak self] object, error in
-            let image = object as? UIImage
-            let errorDescription = error?.localizedDescription
-            DispatchQueue.main.async {
-                guard let self else { return }
-                if let image {
-                    self.handleGoogleLensImage(image)
-                } else if let errorDescription {
-                    self.logger.log("Google Lens: failed to load picked image: \(errorDescription)",
-                                    level: .warning,
-                                    category: .coordinator)
-                } else {
-                    self.logger.log("Google Lens: picker returned a non-image object",
-                                    level: .warning,
-                                    category: .coordinator)
-                }
-            }
-        }
-    }
-
-    private func handleGoogleLensImage(_ image: UIImage?) {
-        guard let image else { return }
+    func searchGoogleLens(with image: UIImage) {
         guard let tab = tabManager.selectedTab else {
             logger.log("Google Lens: no selected tab to load the upload request",
                        level: .warning,
@@ -1223,6 +1195,33 @@ final class BrowserCoordinator: BaseCoordinator,
             return
         }
         _ = tab.loadRequest(request)
+    }
+    private func handleGoogleLensPhotoPick(_ results: [PHPickerResult]) {
+        guard let provider = results.first?.itemProvider else { return }
+        guard provider.canLoadObject(ofClass: UIImage.self) else {
+            logger.log("Google Lens: picked item cannot be loaded as an image",
+                       level: .warning,
+                       category: .coordinator)
+            return
+        }
+        provider.loadObject(ofClass: UIImage.self) { [weak self] object, error in
+            let image = object as? UIImage
+            let errorDescription = error?.localizedDescription
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if let image {
+                    self.searchGoogleLens(with: image)
+                } else if let errorDescription {
+                    self.logger.log("Google Lens: failed to load picked image: \(errorDescription)",
+                                    level: .warning,
+                                    category: .coordinator)
+                } else {
+                    self.logger.log("Google Lens: picker returned a non-image object",
+                                    level: .warning,
+                                    category: .coordinator)
+                }
+            }
+        }
     }
 
     func showPrivacyNoticeLink(url: URL) {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Storage
+import UIKit
 import WebKit
 import SummarizeKit
 import QuickAnswersKit
@@ -130,6 +131,9 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
 
     @MainActor
     func showGoogleLensCamera()
+
+    @MainActor
+    func searchGoogleLens(with image: UIImage)
 
     @MainActor
     func showQuickAnswers(transitionType: QuickAnswersTransitionType)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -163,7 +163,7 @@ class WebContextMenuActionsProvider {
 
     @MainActor
     func addSaveImage(url: URL,
-                      getImageData: @escaping (URL, @Sendable @escaping (Data) -> Void) -> Void,
+                      getImageData: @escaping (URL, @escaping @MainActor @Sendable (Data) -> Void) -> Void,
                       writeToPhotoAlbum: @escaping @MainActor (UIImage) -> Void) {
         actions.append(UIAction(
             title: .ContextMenuSaveImage,
@@ -187,12 +187,15 @@ class WebContextMenuActionsProvider {
     }
 
     @MainActor
-    func addGoogleLens() {
+    func addSearchWithGoogleLens(url: URL, searchGoogleLens: @escaping @MainActor (URL) -> Void) {
         actions.append(UIAction(
             title: .ContextMenuGoogleLens,
-            image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.logoGoogleLens),
+            image: UIImage.templateImageNamed(StandardImageIdentifiers.Medium.logoGoogleLens),
             identifier: UIAction.Identifier("linkContextMenu.googleLens")
-        ) { _ in })
+        ) { [weak self] _ in
+            searchGoogleLens(url)
+            self?.recordOptionSelectedTelemetry(option: .googleLens)
+        })
     }
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -406,7 +406,7 @@ extension BrowserViewController: WKUIDelegate {
                                contentContainer: contentContainer)
 
         if let url = image {
-            actionBuilder.addGoogleLens()
+            actionBuilder.addSearchWithGoogleLens(url: url, searchGoogleLens: searchGoogleLens(forImageURL:))
 
             actionBuilder.addSaveImage(url: url,
                                        getImageData: getImageData,
@@ -418,6 +418,15 @@ extension BrowserViewController: WKUIDelegate {
         }
 
         return actionBuilder.build()
+    }
+
+    func searchGoogleLens(forImageURL url: URL) {
+        getImageData(url) { [weak self] data in
+            guard let image = UIImage(data: data) else { return }
+            ensureMainThread {
+                self?.navigationHandler?.searchGoogleLens(with: image)
+            }
+        }
     }
 
     func assignWebView(_ webView: WKWebView?) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5082,14 +5082,16 @@ extension BrowserViewController: UIAdaptivePresentationControllerDelegate {
 
 extension BrowserViewController {
     /// Used to get the context menu save image in the context menu, shown from long press on webview links
-    func getImageData(_ url: URL, success: @Sendable @escaping (Data) -> Void) {
+    func getImageData(_ url: URL, success: @escaping @MainActor @Sendable (Data) -> Void) {
         makeURLSession(
             userAgent: UserAgent.fxaUserAgent,
             configuration: URLSessionConfiguration.defaultMPTCP).dataTask(with: url
             ) { (data, response, error) in
             if validatedHTTPResponse(response, statusCode: 200..<300) != nil,
                let data = data {
-                success(data)
+                ensureMainThread {
+                    success(data)
+                }
             }
         }.resume()
     }

--- a/firefox-ios/Client/Telemetry/ContextMenuTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/ContextMenuTelemetry.swift
@@ -17,6 +17,7 @@ struct ContextMenuTelemetry {
         case saveImage
         case copyImage
         case copyImageLink
+        case googleLens
     }
 
     enum OriginExtra: String {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -57,6 +57,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
     var showQuickAnswersCalled = 0
     var showGoogleLensPhotoPickerCalled = 0
     var showGoogleLensCameraCalled = 0
+    var searchGoogleLensCalled = 0
 
     func show(settings: Client.Route.SettingsSection, onDismiss: (() -> Void)?) {
         showSettingsCalled += 1
@@ -190,6 +191,10 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
 
     func showGoogleLensCamera() {
         showGoogleLensCameraCalled += 1
+    }
+
+    func searchGoogleLens(with image: UIImage) {
+        searchGoogleLensCalled += 1
     }
 
     // MARK: - BrowserDelegate


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16065)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34544)

## :bulb: Description
- Connects the Google Lens web image context menu action entry point to process and load Lens results in the current tab.

## :movie_camera: Demos
https://github.com/user-attachments/assets/d482b406-f9d1-460c-9ecb-bd1ab6c0933d

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

