### PR TITLE
Add FXIOS-16199 [Google Lens] Hide Google Lens in private browsing mode

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -245,8 +245,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
         case SearchEngineSelectionMiddlewareActionType.didClearAlternativeSearchEngine:
             return handleDidClearAlternativeSearchEngine(state: state, action: action)
 
-        case ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine:
-            return handleSearchEngineDidChange(state: state, action: action)
+        case ToolbarMiddlewareActionType.googleLensAvailabilityDidChange:
+            return handleGoogleLensAvailabilityDidChange(state: state, action: action)
 
         default:
             return defaultState(from: state)
@@ -265,7 +265,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
             leadingPageActions: [ToolbarActionConfiguration](),
             trailingPageActions: [ToolbarActionConfiguration](),
             browserActions: [ToolbarActionConfiguration](),
-            editingAccessoryAction: editingAccessoryAction(isGoogleLensEnabled: toolbarAction.isGoogleLensEnabled ?? false),
+            editingAccessoryAction: nil,
             borderPosition: borderPosition,
             url: nil,
             searchTerm: nil,
@@ -1138,7 +1138,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         )
     }
 
-    private static func handleSearchEngineDidChange(state: Self, action: Action) -> Self {
+    private static func handleGoogleLensAvailabilityDidChange(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarMiddlewareAction,
               let isGoogleLensEnabled = toolbarAction.isGoogleLensEnabled else {
             return defaultState(from: state)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -36,7 +36,6 @@ struct ToolbarAction: Action {
     let shouldAnimate: Bool?
     let middleButton: NavigationBarMiddleButtonType?
     let isTranslationsEnabled: Bool?
-    let isGoogleLensEnabled: Bool?
     let translationConfiguration: TranslationConfiguration?
     let previousTabScreenshot: UIImage?
     let nextTabScreenshot: UIImage?
@@ -68,7 +67,6 @@ struct ToolbarAction: Action {
          shouldAnimate: Bool? = nil,
          middleButton: NavigationBarMiddleButtonType? = nil,
          isTranslationsEnabled: Bool? = nil,
-         isGoogleLensEnabled: Bool? = nil,
          translationConfiguration: TranslationConfiguration? = nil,
          previousTabScreenshot: UIImage? = nil,
          nextTabScreenshot: UIImage? = nil,
@@ -103,7 +101,6 @@ struct ToolbarAction: Action {
         self.canSummarize = canSummarize
         self.middleButton = middleButton
         self.isTranslationsEnabled = isTranslationsEnabled
-        self.isGoogleLensEnabled = isGoogleLensEnabled
         self.translationConfiguration = translationConfiguration
         self.previousTabScreenshot = previousTabScreenshot
         self.nextTabScreenshot = nextTabScreenshot
@@ -179,7 +176,7 @@ enum ToolbarMiddlewareActionType: ActionType {
     case didTapButton
     case customA11yAction
     case urlDidChange
-    case didUpdateDefaultSearchEngine
+    case googleLensAvailabilityDidChange
     case didClearSearch
     case didStartDragInteraction
     case didSwipeToOpenTabTray

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -103,10 +103,10 @@ final class ToolbarMiddleware {
                 displayNavBorder: displayBorder,
                 middleButton: middleButton,
                 isTranslationsEnabled: prefs.boolForKey(PrefsKeys.Settings.translationsFeature) ?? true,
-                isGoogleLensEnabled: isGoogleLensToolbarEntryPointAvailable(),
                 windowUUID: uuid,
                 actionType: ToolbarActionType.didLoadToolbars)
             store.dispatch(action)
+            dispatchGoogleLensAvailability(for: uuid)
 
         case GeneralBrowserMiddlewareActionType.websiteDidScroll:
             guard let scrollOffset = action.scrollOffset else { return }
@@ -181,12 +181,10 @@ final class ToolbarMiddleware {
             store.dispatch(action)
 
         case ToolbarActionType.searchEngineDidChange:
-            let action = ToolbarMiddlewareAction(
-                isGoogleLensEnabled: isGoogleLensToolbarEntryPointAvailable(),
-                windowUUID: action.windowUUID,
-                actionType: ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine
-            )
-            store.dispatch(action)
+            dispatchGoogleLensAvailability(for: action.windowUUID)
+
+        case ToolbarActionType.urlDidChange:
+            updateGoogleLensAvailabilityIfBrowsingModeChanged(windowUUID: action.windowUUID, state: state)
 
         case ToolbarActionType.didSubmitSearchTerm:
             // After a user submits a search term, we want to record it in our history storage via recent search provider.
@@ -568,8 +566,22 @@ final class ToolbarMiddleware {
         return windowManager.tabManager(for: uuid)
     }
 
-    private func isGoogleLensToolbarEntryPointAvailable() -> Bool {
+    // Only re-dispatch when Google Lens availability would actually change (i.e. the browsing mode flipped it),
+    // to avoid churning on every URL.
+    private func updateGoogleLensAvailabilityIfBrowsingModeChanged(windowUUID: WindowUUID, state: AppState) {
+        guard let toolbarState = state.componentState(ToolbarState.self, for: .toolbar, window: windowUUID)
+        else { return }
+
+        let shouldShow = isGoogleLensAvailable(for: windowUUID)
+        let isShowing = toolbarState.addressToolbar.editingAccessoryAction?.actionType == .googleLens
+        guard shouldShow != isShowing else { return }
+
+        dispatchGoogleLensAvailability(for: windowUUID)
+    }
+
+    private func isGoogleLensAvailable(for windowUUID: WindowUUID) -> Bool {
         guard featureFlagsProvider.isEnabled(.googleLens),
+              tabManager(for: windowUUID)?.selectedTab?.isPrivate != true,
               let defaultEngine = searchEnginesManager.defaultEngine,
               !defaultEngine.isCustomEngine
         else { return false }
@@ -580,5 +592,14 @@ final class ToolbarMiddleware {
         // App Services can return regional Google engine IDs such as "google-b-1-m".
         let isGoogleDefaultEngine = engineID == googleEngineID || engineID.hasPrefix("\(googleEngineID)-")
         return isGoogleDefaultEngine
+    }
+
+    private func dispatchGoogleLensAvailability(for windowUUID: WindowUUID) {
+        let action = ToolbarMiddlewareAction(
+            isGoogleLensEnabled: isGoogleLensAvailable(for: windowUUID),
+            windowUUID: windowUUID,
+            actionType: ToolbarMiddlewareActionType.googleLensAvailabilityDidChange
+        )
+        store.dispatch(action)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -156,7 +156,7 @@ struct ToolbarState: ScreenState, Sendable {
             ToolbarActionType.didStartEditingUrl, ToolbarActionType.cancelEdit,
             ToolbarActionType.cancelEditOnHomepage,
             ToolbarActionType.keyboardStateDidChange, ToolbarActionType.websiteLoadingStateDidChange,
-            ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine, ToolbarActionType.clearSearch,
+            ToolbarMiddlewareActionType.googleLensAvailabilityDidChange, ToolbarActionType.clearSearch,
             ToolbarActionType.didDeleteSearchTerm, ToolbarActionType.didEnterSearchTerm,
             ToolbarActionType.didSetSearchTerm, ToolbarActionType.didStartTyping,
             ToolbarActionType.animationStateChanged, ToolbarActionType.translucencyDidChange,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -92,43 +92,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertNil(newState.editingAccessoryAction)
     }
 
-    func test_didLoadToolbarsAction_withGoogleLensEnabled_seedsEditingAccessoryAction() {
-        setupStore()
-        let initialState = createSubject()
-        let reducer = addressBarReducer()
-
-        let newState = reducer(
-            initialState,
-            ToolbarAction(
-                addressBorderPosition: .top,
-                isGoogleLensEnabled: true,
-                windowUUID: windowUUID,
-                actionType: ToolbarActionType.didLoadToolbars
-            )
-        )
-
-        XCTAssertEqual(newState.editingAccessoryAction?.actionType, .googleLens)
-    }
-
-    func test_didLoadToolbarsAction_withGoogleLensDisabled_doesNotSeedEditingAccessoryAction() {
-        setupStore()
-        let initialState = createSubject()
-        let reducer = addressBarReducer()
-
-        let newState = reducer(
-            initialState,
-            ToolbarAction(
-                addressBorderPosition: .top,
-                isGoogleLensEnabled: false,
-                windowUUID: windowUUID,
-                actionType: ToolbarActionType.didLoadToolbars
-            )
-        )
-
-        XCTAssertNil(newState.editingAccessoryAction)
-    }
-
-    func test_didUpdateDefaultSearchEngineAction_withGoogleLensDisabled_removesEditingAccessoryAction() {
+    func test_googleLensAvailabilityDidChangeAction_withGoogleLensDisabled_removesEditingAccessoryAction() {
         setupStore()
         let initialState = createSubject()
         let reducer = addressBarReducer()
@@ -138,7 +102,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
             ToolbarMiddlewareAction(
                 isGoogleLensEnabled: true,
                 windowUUID: windowUUID,
-                actionType: ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine
+                actionType: ToolbarMiddlewareActionType.googleLensAvailabilityDidChange
             )
         )
         let newState = reducer(
@@ -146,14 +110,14 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
             ToolbarMiddlewareAction(
                 isGoogleLensEnabled: false,
                 windowUUID: windowUUID,
-                actionType: ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine
+                actionType: ToolbarMiddlewareActionType.googleLensAvailabilityDidChange
             )
         )
 
         XCTAssertNil(newState.editingAccessoryAction)
     }
 
-    func test_didUpdateDefaultSearchEngineAction_withGoogleLensEnabled_setsEditingAccessoryAction() {
+    func test_googleLensAvailabilityDidChangeAction_withGoogleLensEnabled_setsEditingAccessoryAction() {
         setupStore()
         let initialState = createSubject()
         let reducer = addressBarReducer()
@@ -177,7 +141,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
             ToolbarMiddlewareAction(
                 isGoogleLensEnabled: true,
                 windowUUID: windowUUID,
-                actionType: ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine
+                actionType: ToolbarMiddlewareActionType.googleLensAvailabilityDidChange
             )
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -66,13 +66,17 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         let borderPosition = toolbarManager.getAddressBorderPosition(for: .top, isPrivate: false, scrollY: 0)
         let displayBorder = toolbarManager.shouldDisplayNavigationBorder(toolbarPosition: .top)
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
         XCTAssertEqual(actionType, ToolbarActionType.didLoadToolbars)
         XCTAssertEqual(actionCalled.toolbarPosition, action.toolbarPosition)
         XCTAssertEqual(actionCalled.addressBorderPosition, borderPosition)
         XCTAssertEqual(actionCalled.displayNavBorder, displayBorder)
         XCTAssertEqual(actionCalled.middleButton, .newTab)
-        XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
+
+        let lensAction = try XCTUnwrap(mockStore.dispatchedActions.last as? ToolbarMiddlewareAction)
+        XCTAssertEqual(lensAction.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
+        XCTAssertEqual(lensAction.isGoogleLensEnabled, false)
 
         let savedValue = try XCTUnwrap(
             mockGleanWrapper.savedValues.first as? String
@@ -97,7 +101,9 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.toolbarProvider(mockStore.state, action)
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.last as? ToolbarMiddlewareAction)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
         XCTAssertEqual(actionCalled.isGoogleLensEnabled, true)
     }
 
@@ -116,7 +122,9 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.toolbarProvider(mockStore.state, action)
 
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarAction)
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.last as? ToolbarMiddlewareAction)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
         XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
     }
 
@@ -139,7 +147,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
-                       ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
         XCTAssertEqual(actionCalled.isGoogleLensEnabled, true)
     }
 
@@ -162,7 +170,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
-                       ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
         XCTAssertEqual(actionCalled.isGoogleLensEnabled, true)
     }
 
@@ -183,7 +191,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
-                       ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
         XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
     }
 
@@ -206,7 +214,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
-                       ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
         XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
     }
 
@@ -226,8 +234,103 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
         XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
-                       ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
         XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
+    }
+
+    func testBrowserDidLoad_withGoogleLensEnabledInPrivateMode_dispatchesWithGoogleLensDisabled() throws {
+        let featureFlagsProvider = MockNimbusFeatureFlags()
+        featureFlagsProvider.enabledFlags = [.googleLens]
+        tabManager.selectedTab = MockTab(profile: profile, isPrivate: true, windowUUID: windowUUID)
+        let subject = createSubject(
+            manager: toolbarManager,
+            featureFlagsProvider: featureFlagsProvider,
+            searchEnginesManager: MockSearchEnginesManager(
+                searchEngines: [makeSearchEngine(engineID: OpenSearchEngine.googleEngineID)]
+            )
+        )
+        let action = GeneralBrowserMiddlewareAction(
+            toolbarPosition: .top,
+            windowUUID: windowUUID,
+            actionType: GeneralBrowserMiddlewareActionType.browserDidLoad)
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.last as? ToolbarMiddlewareAction)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
+        XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
+    }
+
+    func testUrlDidChange_whenEnteringPrivateModeWithLensShowing_dispatchesGoogleLensDisabled() throws {
+        mockStore = MockStoreForMiddleware(state: setupAppState(isGoogleLensAccessoryShowing: true))
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+
+        let featureFlagsProvider = MockNimbusFeatureFlags()
+        featureFlagsProvider.enabledFlags = [.googleLens]
+        tabManager.selectedTab = MockTab(profile: profile, isPrivate: true, windowUUID: windowUUID)
+        let subject = createSubject(
+            manager: toolbarManager,
+            featureFlagsProvider: featureFlagsProvider,
+            searchEnginesManager: MockSearchEnginesManager(
+                searchEngines: [makeSearchEngine(engineID: OpenSearchEngine.googleEngineID)]
+            )
+        )
+        let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.urlDidChange)
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
+        XCTAssertEqual(actionCalled.isGoogleLensEnabled, false)
+    }
+
+    func testUrlDidChange_whenLeavingPrivateModeWithLensHidden_dispatchesGoogleLensEnabled() throws {
+        mockStore = MockStoreForMiddleware(state: setupAppState(isGoogleLensAccessoryShowing: false))
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+
+        let featureFlagsProvider = MockNimbusFeatureFlags()
+        featureFlagsProvider.enabledFlags = [.googleLens]
+        tabManager.selectedTab = MockTab(profile: profile, isPrivate: false, windowUUID: windowUUID)
+        let subject = createSubject(
+            manager: toolbarManager,
+            featureFlagsProvider: featureFlagsProvider,
+            searchEnginesManager: MockSearchEnginesManager(
+                searchEngines: [makeSearchEngine(engineID: OpenSearchEngine.googleEngineID)]
+            )
+        )
+        let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.urlDidChange)
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? ToolbarMiddlewareAction)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionCalled.actionType as? ToolbarMiddlewareActionType,
+                       ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
+        XCTAssertEqual(actionCalled.isGoogleLensEnabled, true)
+    }
+
+    func testUrlDidChange_whenLensVisibilityUnchanged_doesNotDispatch() throws {
+        mockStore = MockStoreForMiddleware(state: setupAppState(isGoogleLensAccessoryShowing: true))
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+
+        let featureFlagsProvider = MockNimbusFeatureFlags()
+        featureFlagsProvider.enabledFlags = [.googleLens]
+        tabManager.selectedTab = MockTab(profile: profile, isPrivate: false, windowUUID: windowUUID)
+        let subject = createSubject(
+            manager: toolbarManager,
+            featureFlagsProvider: featureFlagsProvider,
+            searchEnginesManager: MockSearchEnginesManager(
+                searchEngines: [makeSearchEngine(engineID: OpenSearchEngine.googleEngineID)]
+            )
+        )
+        let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.urlDidChange)
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        XCTAssertTrue(mockStore.dispatchedActions.isEmpty)
     }
 
     func testBrowserDidLoad_withHomeCustomMiddleButton_dispatchesDidLoadToolbars() throws {
@@ -246,7 +349,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         let borderPosition = toolbarManager.getAddressBorderPosition(for: .top, isPrivate: false, scrollY: 0)
         let displayBorder = toolbarManager.shouldDisplayNavigationBorder(toolbarPosition: .top)
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 2)
         XCTAssertEqual(actionType, ToolbarActionType.didLoadToolbars)
         XCTAssertEqual(actionCalled.toolbarPosition, action.toolbarPosition)
         XCTAssertEqual(actionCalled.addressBorderPosition, borderPosition)
@@ -1208,6 +1311,36 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
                     )
                 ]
             )
+        )
+    }
+
+    private func setupAppState(isGoogleLensAccessoryShowing: Bool) -> AppState {
+        var addressBarState = AddressBarState(windowUUID: windowUUID)
+        addressBarState.editingAccessoryAction = isGoogleLensAccessoryShowing ? makeGoogleLensAccessoryAction() : nil
+        var toolbarState = ToolbarState(windowUUID: windowUUID)
+        toolbarState.addressToolbar = addressBarState
+
+        return AppState(
+            presentedComponents: PresentedComponentsState(
+                components: [
+                    .browserViewController(
+                        BrowserViewControllerState(
+                            windowUUID: windowUUID
+                        )
+                    ),
+                    .toolbar(toolbarState)
+                ]
+            )
+        )
+    }
+
+    private func makeGoogleLensAccessoryAction() -> ToolbarActionConfiguration {
+        return ToolbarActionConfiguration(
+            actionType: .googleLens,
+            iconName: StandardImageIdentifiers.Medium.logoGoogleLens,
+            isEnabled: true,
+            a11yLabel: .AddressToolbar.GoogleLens.A11yLabel,
+            a11yId: AccessibilityIdentifiers.Browser.AddressToolbar.googleLensButton
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
@@ -249,7 +249,7 @@ final class ToolbarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.navigationToolbar, initialState.navigationToolbar)
     }
 
-    func test_didUpdateDefaultSearchEngineAction_updatesAddressToolbarGoogleLensAvailability() {
+    func test_googleLensAvailabilityDidChangeAction_updatesAddressToolbarGoogleLensAvailability() {
         let initialState = createSubject()
         let reducer = toolbarReducer()
 
@@ -258,7 +258,7 @@ final class ToolbarStateTests: XCTestCase, StoreTestUtility {
             ToolbarMiddlewareAction(
                 isGoogleLensEnabled: true,
                 windowUUID: windowUUID,
-                actionType: ToolbarMiddlewareActionType.didUpdateDefaultSearchEngine)
+                actionType: ToolbarMiddlewareActionType.googleLensAvailabilityDidChange)
         )
 
         XCTAssertEqual(newState.addressToolbar.editingAccessoryAction?.actionType, .googleLens)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16199)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34560)

## :bulb: Description
- Hide the Google Lens address toolbar entry point in private browsing mode

### 📝 Technical Notes
- Also did some renaming/refactoring to cleanly consider browsing mode in the toolbar middleware
- The Google Lens web image context menu entry point is still available in private browsing mode

## :movie_camera: Demos
| Before | After |
| ------------- | ------------- |
| <img width="1206" height="2622" alt="Screenshot iPhone 17 07-07-2026 at 3 50 22 PM" src="https://github.com/user-attachments/assets/f111bdf6-e6d2-4308-b44e-fa882a5b8dbb" /> | <img width="1206" height="2622" alt="Screenshot iPhone 17 07-07-2026 at 3 48 46 PM" src="https://github.com/user-attachments/assets/89007dbe-bd3f-4e7c-9d1f-524df045e64a" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

