### PR TITLE
Add FXIOS-14817 [BrowserKit] Centralize the usage of UIScreen.main.value(forKey: _displayCornerRadius) to get device corner radius

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/UIViewExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/UIViewExtension.swift
@@ -84,11 +84,11 @@ extension UIView {
     }
 
     /// Sets the corner radius to the devices current corner radius
-    func applyScreenCornerRadius() {
+    public func applyScreenCornerRadius() {
         if #available(iOS 26.0, *) {
-            self.cornerConfiguration = UICornerConfiguration.corners(radius: .containerConcentric(minimum: 0))
+            cornerConfiguration = UICornerConfiguration.corners(radius: .containerConcentric(minimum: 0))
         } else {
-            self.layer.cornerRadius = UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat ?? 0
+            layer.cornerRadius = UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat ?? 0
         }
     }
 }

--- a/BrowserKit/Sources/Common/Extensions/UIViewExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/UIViewExtension.swift
@@ -82,7 +82,7 @@ extension UIView {
         layer.shadowRadius = shadow.blurRadius / 2
         layer.shadowOpacity = shadow.opacity
     }
-    
+
     /// Sets the corner radius to the devices current corner radius
     func applyScreenCornerRadius() {
         if #available(iOS 26.0, *) {

--- a/BrowserKit/Sources/Common/Extensions/UIViewExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/UIViewExtension.swift
@@ -82,4 +82,13 @@ extension UIView {
         layer.shadowRadius = shadow.blurRadius / 2
         layer.shadowOpacity = shadow.opacity
     }
+    
+    /// Sets the corner radius to the devices current corner radius
+    func applyScreenCornerRadius() {
+        if #available(iOS 26.0, *) {
+            self.cornerConfiguration = UICornerConfiguration.corners(radius: .containerConcentric(minimum: 0))
+        } else {
+            self.layer.cornerRadius = UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat ?? 0
+        }
+    }
 }

--- a/BrowserKit/Sources/Common/Utilities/DeviceInfo.swift
+++ b/BrowserKit/Sources/Common/Utilities/DeviceInfo.swift
@@ -6,6 +6,7 @@ import Foundation
 import UIKit
 
 open class DeviceInfo {
+    // Should not be used on iOS 26+
     @MainActor
     public static var deviceCornerRadius: CGFloat? {
         return UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat
@@ -13,9 +14,14 @@ open class DeviceInfo {
 
     @MainActor
     @available(iOS 26.0, *)
-    open class func deviceCornerConfiguration() -> UICornerConfiguration {
-        let cornerRadius = deviceCornerRadius ?? 0
-        return UICornerConfiguration.corners(radius: UICornerRadius.fixed(cornerRadius))
+    open class func deviceCornerConfiguration(minimumRadius: CGFloat) -> UICornerConfiguration {
+        return UICornerConfiguration.corners(radius: .containerConcentric(minimum: minimumRadius))
+    }
+
+    @MainActor
+    @available(iOS 26.0, *)
+    open class func deviceCornerConfigurtion(minimumRadius: CGFloat, view: UIView) {
+        view.cornerConfiguration = UICornerConfiguration.corners(radius: .containerConcentric(minimum: minimumRadius))
     }
 
     open class func isSimulator() -> Bool {

--- a/BrowserKit/Sources/Common/Utilities/DeviceInfo.swift
+++ b/BrowserKit/Sources/Common/Utilities/DeviceInfo.swift
@@ -3,27 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import UIKit
 
 open class DeviceInfo {
-    // Should not be used on iOS 26+
-    @MainActor
-    public static var deviceCornerRadius: CGFloat? {
-        return UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat
-    }
-
-    @MainActor
-    @available(iOS 26.0, *)
-    open class func deviceCornerConfiguration(minimumRadius: CGFloat) -> UICornerConfiguration {
-        return UICornerConfiguration.corners(radius: .containerConcentric(minimum: minimumRadius))
-    }
-
-    @MainActor
-    @available(iOS 26.0, *)
-    open class func deviceCornerConfigurtion(minimumRadius: CGFloat, view: UIView) {
-        view.cornerConfiguration = UICornerConfiguration.corners(radius: .containerConcentric(minimum: minimumRadius))
-    }
-
     open class func isSimulator() -> Bool {
         return ProcessInfo.processInfo.environment["SIMULATOR_ROOT"] != nil
     }

--- a/BrowserKit/Sources/Common/Utilities/DeviceInfo.swift
+++ b/BrowserKit/Sources/Common/Utilities/DeviceInfo.swift
@@ -11,6 +11,13 @@ open class DeviceInfo {
         return UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat
     }
 
+    @MainActor
+    @available(iOS 26.0, *)
+    open class func deviceCornerConfiguration() -> UICornerConfiguration {
+        let cornerRadius = deviceCornerRadius ?? 0
+        return UICornerConfiguration.corners(radius: UICornerRadius.fixed(cornerRadius))
+    }
+
     open class func isSimulator() -> Bool {
         return ProcessInfo.processInfo.environment["SIMULATOR_ROOT"] != nil
     }

--- a/BrowserKit/Sources/Common/Utilities/DeviceInfo.swift
+++ b/BrowserKit/Sources/Common/Utilities/DeviceInfo.swift
@@ -3,8 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import UIKit
 
 open class DeviceInfo {
+    @MainActor
+    public static var deviceCornerRadius: CGFloat? {
+        return UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat
+    }
+
     open class func isSimulator() -> Bool {
         return ProcessInfo.processInfo.environment["SIMULATOR_ROOT"] != nil
     }

--- a/BrowserKit/Sources/QuickAnswersKit/UI/CrossDissolveTransitionAnimator.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/CrossDissolveTransitionAnimator.swift
@@ -35,7 +35,7 @@ final class CrossDissolveTransitionAnimator: NSObject,
         static let crossDissolveInitialScale: CGFloat = 0.2
         @MainActor
         static let screenCornerRadius: CGFloat = {
-            return UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat ?? 0.0
+            return DeviceInfo.deviceCornerRadius ?? 0.0
         }()
     }
     private let themeManager: any ThemeManager

--- a/BrowserKit/Sources/QuickAnswersKit/UI/CrossDissolveTransitionAnimator.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/CrossDissolveTransitionAnimator.swift
@@ -33,10 +33,6 @@ final class CrossDissolveTransitionAnimator: NSObject,
         static let springAnimationDamping: CGFloat = 0.8
         static let springAnimationVelocity: CGFloat = 1.0
         static let crossDissolveInitialScale: CGFloat = 0.2
-        @MainActor
-        static let screenCornerRadius: CGFloat = {
-            return DeviceInfo.deviceCornerRadius ?? 0.0
-        }()
     }
     private let themeManager: any ThemeManager
     private let windowUUID: WindowUUID
@@ -96,7 +92,7 @@ final class CrossDissolveTransitionAnimator: NSObject,
         presentedController.view.transform = presentationInitialTransform(in: containerView)
         presentedController.view.alpha = 0.0
         presentedController.view.clipsToBounds = true
-        presentedController.view.layer.cornerRadius = UX.screenCornerRadius
+        presentedController.view.applyScreenCornerRadius()
 
         UIView.animate(
             withDuration: UX.springAnimationDuration,

--- a/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
@@ -22,7 +22,7 @@ final class TabWebViewPreview: UIView, ThemeApplicable {
     /// Whether the next screenshot has invalid layout. When this is true we draw only the Favicon in the preview
     private var layoutWasInvalidated = false
     private var screenCornerRadius: CGFloat {
-        return UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat ?? 0.0
+        return DeviceInfo.deviceCornerRadius ?? 0.0
     }
 
     // MARK: - Inits

--- a/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/TabWebViewPreview.swift
@@ -21,9 +21,6 @@ final class TabWebViewPreview: UIView, ThemeApplicable {
     private lazy var faviconImageView: FaviconImageView = .build()
     /// Whether the next screenshot has invalid layout. When this is true we draw only the Favicon in the preview
     private var layoutWasInvalidated = false
-    private var screenCornerRadius: CGFloat {
-        return DeviceInfo.deviceCornerRadius ?? 0.0
-    }
 
     // MARK: - Inits
     init() {
@@ -38,12 +35,12 @@ final class TabWebViewPreview: UIView, ThemeApplicable {
     // MARK: - Layout
     private func setupLayout() {
         layer.shadowRadius = UX.backgroundShadowCornerRadius
-        layer.cornerRadius = screenCornerRadius
+        applyScreenCornerRadius()
         layer.shadowOpacity = UX.backgroundShadowOpacity
         layer.shadowOffset = UX.backgroundShadowOffset
         layer.masksToBounds = false
 
-        webPageScreenshotImageView.layer.cornerRadius = screenCornerRadius
+        webPageScreenshotImageView.applyScreenCornerRadius()
         addSubviews(webPageScreenshotImageView, faviconImageView)
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14817)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31974)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added a static variable to `DeviceInfo` and replaced existing usages of `UIScreen.main.value(forKey: _displayCornerRadius)` with `DeviceInfo.deviceCornerRadius`.


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

