### PR TITLE
Add FXIOS-16243 [Google Lens] Hide Google Lens web image context menu action when non-Google search engine is selected

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -407,7 +407,7 @@ extension BrowserViewController: WKUIDelegate {
 
         if let url = image {
             if isGoogleLensActionAvailable() {
-                actionBuilder.addGoogleLens()
+                actionBuilder.addSearchWithGoogleLens(url: url, searchGoogleLens: searchGoogleLens(forImageURL:))
             }
 
             actionBuilder.addSaveImage(url: url,
@@ -429,6 +429,15 @@ extension BrowserViewController: WKUIDelegate {
         else { return false }
 
         return defaultEngine.isGoogleEngine
+    }
+
+    private func searchGoogleLens(forImageURL url: URL) {
+        getImageData(url) { [weak self] data in
+            guard let image = UIImage(data: data) else { return }
+            ensureMainThread {
+                self?.navigationHandler?.searchGoogleLens(with: image)
+            }
+        }
     }
 
     func assignWebView(_ webView: WKWebView?) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -406,7 +406,9 @@ extension BrowserViewController: WKUIDelegate {
                                contentContainer: contentContainer)
 
         if let url = image {
-            actionBuilder.addSearchWithGoogleLens(url: url, searchGoogleLens: searchGoogleLens(forImageURL:))
+            if isGoogleLensActionAvailable() {
+                actionBuilder.addGoogleLens()
+            }
 
             actionBuilder.addSaveImage(url: url,
                                        getImageData: getImageData,
@@ -420,13 +422,13 @@ extension BrowserViewController: WKUIDelegate {
         return actionBuilder.build()
     }
 
-    func searchGoogleLens(forImageURL url: URL) {
-        getImageData(url) { [weak self] data in
-            guard let image = UIImage(data: data) else { return }
-            ensureMainThread {
-                self?.navigationHandler?.searchGoogleLens(with: image)
-            }
-        }
+    private func isGoogleLensActionAvailable() -> Bool {
+        guard featureFlagsProvider.isEnabled(.googleLens),
+              let defaultEngine = searchEnginesManager.defaultEngine,
+              !defaultEngine.isCustomEngine
+        else { return false }
+
+        return defaultEngine.isGoogleEngine
     }
 
     func assignWebView(_ webView: WKWebView?) {

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -38,6 +38,12 @@ final class OpenSearchEngine: NSObject, NSSecureCoding, Sendable, TrendingSearch
     private let searchQueryComponentKey: String?
     static let googleEngineID = "google"
 
+    /// Whether this engine is Google, including regional variants.
+    /// App Services can return regional Google engine IDs such as "google-b-1-m".
+    var isGoogleEngine: Bool {
+        engineID == Self.googleEngineID || engineID.hasPrefix("\(Self.googleEngineID)-")
+    }
+
     var headerSearchTitle: String {
         guard engineID != Self.googleEngineID else {
             return .Search.GoogleEngineSectionTitle

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -586,12 +586,7 @@ final class ToolbarMiddleware {
               !defaultEngine.isCustomEngine
         else { return false }
 
-        let engineID = defaultEngine.engineID
-        let googleEngineID = OpenSearchEngine.googleEngineID
-
-        // App Services can return regional Google engine IDs such as "google-b-1-m".
-        let isGoogleDefaultEngine = engineID == googleEngineID || engineID.hasPrefix("\(googleEngineID)-")
-        return isGoogleDefaultEngine
+        return defaultEngine.isGoogleEngine
     }
 
     private func dispatchGoogleLensAvailability(for windowUUID: WindowUUID) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/OpenSearchEngineTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/OpenSearchEngineTests.swift
@@ -124,6 +124,35 @@ class OpenSearchEngineTests: XCTestCase {
         XCTAssertNil(url)
     }
 
+    func test_isGoogleEngine_withGoogleEngineID_returnsTrue() {
+        XCTAssertTrue(makeEngine(engineID: OpenSearchEngine.googleEngineID).isGoogleEngine)
+    }
+
+    func test_isGoogleEngine_withRegionalGoogleEngineID_returnsTrue() {
+        XCTAssertTrue(makeEngine(engineID: "\(OpenSearchEngine.googleEngineID)-b-1-m").isGoogleEngine)
+    }
+
+    func test_isGoogleEngine_withNonGoogleEngineID_returnsFalse() {
+        XCTAssertFalse(makeEngine(engineID: "bing").isGoogleEngine)
+    }
+
+    func test_isGoogleEngine_withGooglePrefixButNoSeparator_returnsFalse() {
+        XCTAssertFalse(makeEngine(engineID: "googler").isGoogleEngine)
+    }
+
+    private func makeEngine(engineID: String) -> OpenSearchEngine {
+        return OpenSearchEngine(
+            engineID: engineID,
+            shortName: engineID,
+            telemetrySuffix: nil,
+            image: UIImage(),
+            searchTemplate: "some link",
+            suggestTemplate: nil,
+            trendingTemplate: nil,
+            isCustomEngine: false
+        )
+    }
+
     /// For generating test `OpenSearchEngine` data.
     public enum TestSearchEngine {
         case youtube, wikipedia


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16243)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34564)

## :bulb: Description
- Hide Google Lens web image context menu action when non-Google search engine is selected

### 📝 Technical Notes
- Similar to the Google Lens address bar button, we want to hide the context menu when the selected search engine is not Google

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

