### PR TITLE
Refactor FXIOS-13181 [Logging] Use extra argument for fatals and avoid it for non-fatal logs

### DIFF
--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/ImageHandler.swift
@@ -73,10 +73,9 @@ final class DefaultImageHandler: ImageHandler {
             return try getBundleImage(assetName: assetName)
         } catch {
             logger.log(
-                "Could not get image from bundle",
+                "Could not get image from bundle with asset name \(assetName)",
                 level: .warning,
-                category: .images,
-                extra: ["assetName": assetName]
+                category: .images
             )
             throw error
         }

--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -64,13 +64,17 @@ public actor DefaultTabDataStore: TabDataStore {
             if shouldLogFileFailure {
                 let errorMessage: String
                 errorMessage = shouldLogBackupFailure
-                                ? "Failed to open window data (including backup data) for UUID: \(uuid)"
-                                : "Failed to open window data (but backup recovery worked) for UUID: \(uuid)"
+                                ? "Failed to open window data (including backup data)"
+                                : "Failed to open window data (but backup recovery worked)"
                 logger.log(
                     errorMessage,
                     level: .fatal,
                     category: .tabs,
-                    extra: ["fileInfo": fileInfoMessage, "backupFileInfo": backupInfoMessage]
+                    extra: [
+                        "windowUUID": uuid.uuidString,
+                        "fileInfo": fileInfoMessage,
+                        "backupFileInfo": backupInfoMessage
+                    ]
                 )
             }
         }

--- a/BrowserKit/Sources/TabDataStore/TabDataStore.swift
+++ b/BrowserKit/Sources/TabDataStore/TabDataStore.swift
@@ -67,9 +67,10 @@ public actor DefaultTabDataStore: TabDataStore {
                                 ? "Failed to open window data (including backup data) for UUID: \(uuid)"
                                 : "Failed to open window data (but backup recovery worked) for UUID: \(uuid)"
                 logger.log(
-                    "\(errorMessage) File Info: [\(fileInfoMessage)] Backup File Info: [\(backupInfoMessage)]",
+                    errorMessage,
                     level: .fatal,
-                    category: .tabs
+                    category: .tabs,
+                    extra: ["fileInfo": fileInfoMessage, "backupFileInfo": backupInfoMessage]
                 )
             }
         }

--- a/firefox-ios/Client/Application/AdsClientDocumentsDirectoryMigration.swift
+++ b/firefox-ios/Client/Application/AdsClientDocumentsDirectoryMigration.swift
@@ -48,10 +48,9 @@ struct AdsClientDocumentsDirectoryMigration {
                     try fileManager.removeItem(at: databaseURL)
                     return didFail
                 } catch {
-                    logger.log("Failed to remove legacy ads client database",
+                    logger.log("Failed to remove legacy ads client database: \(error.localizedDescription)",
                                level: .warning,
-                               category: .storage,
-                               extra: ["error": error.localizedDescription])
+                               category: .storage)
                     return true
                 }
             }

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -238,10 +238,9 @@ final class AppLaunchUtil: FeatureFlaggable, Sendable {
 
             browserProfile?.migrateHistoryToPlaces(
                 callback: { result in
-                    self.logger.log("Successfully migrated history",
+                    self.logger.log("Successfully migrated history in \(result.totalDuration / 1000) seconds",
                                     level: .info,
-                                    category: .sync,
-                                    extra: ["durationSeconds": "\(result.totalDuration / 1000)"])
+                                    category: .sync)
 
                     UserDefaults.standard.setValue(true, forKey: PrefsKeys.PlacesHistoryMigrationSucceeded)
                     NotificationCenter.default.post(name: .TopSitesUpdated, object: nil)

--- a/firefox-ios/Client/Application/DefaultBrowserUtility.swift
+++ b/firefox-ios/Client/Application/DefaultBrowserUtility.swift
@@ -156,13 +156,9 @@ class DefaultBrowserUtility {
         let postAPIStatus = userDefault.bool(forKey: PrefsKeys.DidDismissDefaultBrowserMessage)
 
         logger.log(
-            "Performing migration - current status info",
+            "Performing migration - deeplink status: \(preAPIStatus), API or user set status: \(postAPIStatus)",
             level: .info,
-            category: .setup,
-            extra: [
-                "currentDeeplink": "\(preAPIStatus)",
-                "currentAPIOrUserSetToDefaultStatus": "\(postAPIStatus)"
-            ]
+            category: .setup
         )
 
         // If either one of these statuses are true, meaning we have been set to default,

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineProvider.swift
@@ -133,9 +133,10 @@ final class ASSearchEngineProvider: SearchEngineProvider, Sendable {
         guard let iconPopulator = iconDataFetcher, let selector else {
             let logExtra1 = iconDataFetcher == nil ? "nil" : "ok"
             let logExtra2 = selector == nil ? "nil" : "ok"
-            logger.log("[SEC] Icon fetcher and/or selector are nil. (\(logExtra1), \(logExtra2))",
+            logger.log("[SEC] Icon fetcher and/or selector are nil.",
                        level: .fatal,
-                       category: .remoteSettings)
+                       category: .remoteSettings,
+                       extra: ["iconFetcher": logExtra1, "selector": logExtra2])
             completion([])
             return
         }

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASTranslationModelsFetcher.swift
@@ -98,10 +98,9 @@ final class ASTranslationModelsFetcher: TranslationModelsFetcherProtocol {
         }
 
         logger.log(
-            "Translator record selected",
+            "Translator record selected with record id \(record.id)",
             level: .info,
-            category: .translations,
-            extra: ["recordId": record.id]
+            category: .translations
         )
 
         return try? await getAttachment(record: record)
@@ -302,10 +301,9 @@ final class ASTranslationModelsFetcher: TranslationModelsFetcherProtocol {
             }
 
             logger.log(
-                "Model record selected",
+                "Model record selected with record id \(record.id)",
                 level: .info,
-                category: .translations,
-                extra: ["recordId": "\(record.id)"]
+                category: .translations
             )
 
             languageModelFiles[fields.fileType] = [
@@ -383,10 +381,9 @@ final class ASTranslationModelsFetcher: TranslationModelsFetcherProtocol {
 
         guard !buckets.isEmpty else {
             logger.log(
-                "No model records found",
+                "No model records found for source language \(sourceLang) and target language \(targetLang)",
                 level: .warning,
-                category: .translations,
-                extra: ["sourceLang": sourceLang, "targetLang": targetLang]
+                category: .translations
             )
             return []
         }
@@ -396,10 +393,9 @@ final class ASTranslationModelsFetcher: TranslationModelsFetcherProtocol {
             else { return [] }
 
         logger.log(
-            "Selected model version",
+            "Selected model version \(bestVersion) for source language \(sourceLang) and target language \(targetLang)",
             level: .info,
-            category: .translations,
-            extra: ["version": bestVersion, "sourceLang": sourceLang, "targetLang": targetLang]
+            category: .translations
         )
 
         return buckets[bestVersion] ?? []

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsGleanTelemetry.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsGleanTelemetry.swift
@@ -27,17 +27,13 @@ final class RemoteSettingsGleanTelemetry: RemoteSettingsTelemetry {
             value: extras.value
         )
         gleanWrapper.recordEvent(for: GleanMetrics.RemoteSettings.uptakeRemotesettings, extras: extra)
+        let uptakeInfo = "value: \(extras.value ?? "nil"), source: \(extras.source ?? "nil"), "
+            + "trigger: \(extras.trigger ?? "nil"), duration: \(extras.duration ?? "nil"), "
+            + "errorName: \(extras.errorName ?? "nil")"
         logger.log(
-            "Remote Settings uptake",
+            "Remote Settings uptake - \(uptakeInfo)",
             level: .debug,
-            category: .remoteSettings,
-            extra: [
-                "value": extras.value ?? "nil",
-                "source": extras.source ?? "nil",
-                "trigger": extras.trigger ?? "nil",
-                "duration": extras.duration ?? "nil",
-                "errorName": extras.errorName ?? "nil",
-            ]
+            category: .remoteSettings
         )
     }
 }

--- a/firefox-ios/Client/Application/WindowManager.swift
+++ b/firefox-ios/Client/Application/WindowManager.swift
@@ -135,7 +135,10 @@ final class WindowManagerImplementation: WindowManager {
         guard let window = window(for: windowUUID) else {
             if !AppConstants.isRunningUnitTest {
                 assertionFailure("No window for UUID: \(windowUUID). This is a client error. It will return nil in production but querying a non-existent window is always indicative of a bug.")
-                logger.log("No window for UUID: \(windowUUID)", level: .fatal, category: .window)
+                logger.log("No window for UUID",
+                           level: .fatal,
+                           category: .window,
+                           extra: ["windowUUID": "\(windowUUID)"])
             }
             return nil
         }
@@ -143,7 +146,10 @@ final class WindowManagerImplementation: WindowManager {
         guard let manager = window.tabManager else {
             if !AppConstants.isRunningUnitTest {
                 assertionFailure("Valid window but no TabManager for UUID: \(windowUUID). This is a client error. It will return nil in production but is indicative of a bug.")
-                logger.log("Window alive, but no TabManager for UUID: \(windowUUID)", level: .fatal, category: .window)
+                logger.log("Window alive, but no TabManager for UUID",
+                           level: .fatal,
+                           category: .window,
+                           extra: ["windowUUID": "\(windowUUID)"])
             }
             return nil
         }
@@ -219,9 +225,10 @@ final class WindowManagerImplementation: WindowManager {
                     // clean up the UUID(s) that we know won't be used. We expect a certain number of
                     // these fatal errors to be logged for users previously impacted by the above, and
                     // then it should fall to zero.
-                    logger.log("Detected multiple window tab files on iPhone (UUID count: \(uuidCount))",
+                    logger.log("Detected multiple window tab files on iPhone",
                                level: .fatal,
-                               category: .window)
+                               category: .window,
+                               extra: ["uuidCount": "\(uuidCount)"])
                     let uuidsToDelete = Array(onDiskUUIDs.dropFirst())
                     Task { [tabDataStore] in
                         await tabDataStore.removeWindowData(forUUIDs: uuidsToDelete)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -854,11 +854,10 @@ final class BrowserCoordinator: BaseCoordinator,
         if let coordinator = childCoordinators.first(where: { $0 is ShareSheetCoordinator }) as? ShareSheetCoordinator {
             // The share sheet extension coordinator wasn't correctly removed in the last share session. Attempt to recover.
             logger.log(
-                "ShareSheetCoordinator already exists when it shouldn't. Removing and recreating it to access share sheet",
+                "ShareSheetCoordinator already exists when it shouldn't. Removing and recreating it to access share sheet."
+                + " Existing coordinator UUID: \(coordinator.windowUUID), BrowserCoordinator UUID: \(windowUUID)",
                 level: .info,
-                category: .shareSheet,
-                extra: ["existing ShareSheetCoordinator UUID": "\(coordinator.windowUUID)",
-                        "BrowserCoordinator windowUUID": "\(windowUUID)"]
+                category: .shareSheet
             )
 
             coordinator.dismiss()

--- a/firefox-ios/Client/Coordinators/Library/DownloadsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/DownloadsCoordinator.swift
@@ -54,11 +54,10 @@ class DownloadsCoordinator: BaseCoordinator,
         if let coordinator = childCoordinators.first(where: { $0 is ShareSheetCoordinator }) as? ShareSheetCoordinator {
             // The share sheet extension coordinator wasn't correctly removed in the last share session. Attempt to recover.
             logger.log(
-                "ShareSheetCoordinator already exists when it shouldn't. Removing and recreating it to access share sheet",
+                "ShareSheetCoordinator already exists when it shouldn't. Removing and recreating it to access share sheet."
+                + " Existing coordinator UUID: \(coordinator.windowUUID)",
                 level: .info,
-                category: .shareSheet,
-                extra: ["existing ShareSheetCoordinator UUID": "\(coordinator.windowUUID)",
-                        "DownloadsCoordinator windowUUID": "N/A"]
+                category: .shareSheet
             )
 
             coordinator.dismiss()

--- a/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/LibraryCoordinator.swift
@@ -100,11 +100,10 @@ class LibraryCoordinator: BaseCoordinator,
         if let coordinator = childCoordinators.first(where: { $0 is ShareSheetCoordinator }) as? ShareSheetCoordinator {
             // The share sheet extension coordinator wasn't correctly removed in the last share session. Attempt to recover.
             logger.log(
-                "ShareSheetCoordinator already exists when it shouldn't. Removing and recreating it to access share sheet",
+                "ShareSheetCoordinator already exists when it shouldn't. Removing and recreating it to access share sheet."
+                + " Existing coordinator UUID: \(coordinator.windowUUID), LibraryCoordinator UUID: \(windowUUID)",
                 level: .info,
-                category: .shareSheet,
-                extra: ["existing ShareSheetCoordinator UUID": "\(coordinator.windowUUID)",
-                        "LibraryCoordinator windowUUID": "\(windowUUID)"]
+                category: .shareSheet
             )
 
             coordinator.dismiss()

--- a/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
+++ b/firefox-ios/Client/Experiments/RecordedNimbusContext.swift
@@ -220,7 +220,7 @@ final class RecordedNimbusContext: RecordedContext, @unchecked Sendable {
             logger.log("toJson error thrown while creating JSON string", level: .warning, category: .experiments)
             return "{}"
         }
-        logger.log("toJson end", level: .debug, category: .experiments, extra: ["json": jsonString])
+        logger.log("toJson end: \(jsonString)", level: .debug, category: .experiments)
         return jsonString
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
@@ -112,9 +112,10 @@ final class CreditCardBottomSheetViewModel {
                         completion(nil)
                         return
                     }
-                    logger.log("Unable to save credit card with error: \(error)",
+                    logger.log("Unable to save credit card",
                                level: .fatal,
-                               category: .autofill)
+                               category: .autofill,
+                               description: "\(error)")
                     completion(error)
                 }
             }
@@ -126,9 +127,10 @@ final class CreditCardBottomSheetViewModel {
                         completion(nil)
                         return
                     }
-                    logger.log("Unable to save credit card with error: \(error)",
+                    logger.log("Unable to save credit card",
                                level: .fatal,
-                               category: .autofill)
+                               category: .autofill,
+                               description: "\(error)")
                     completion(error)
                 }
             }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -190,9 +190,10 @@ struct CreditCardInputView: ThemeableView {
                                 viewModel.dismiss?(.updatedCard, true)
                                 return
                             }
-                            viewModel.logger.log("Unable to update card with error: \(error)",
+                            viewModel.logger.log("Unable to update card",
                                                  level: .fatal,
-                                                 category: .autofill)
+                                                 category: .autofill,
+                                                 description: "\(error)")
                             viewModel.dismiss?(.none, false)
                         }
                     }
@@ -204,9 +205,10 @@ struct CreditCardInputView: ThemeableView {
                                 viewModel.dismiss?(.savedCard, true)
                                 return
                             }
-                            viewModel.logger.log("Unable to save credit card with error: \(error)",
+                            viewModel.logger.log("Unable to save credit card",
                                                  level: .fatal,
-                                                 category: .autofill)
+                                                 category: .autofill,
+                                                 description: "\(error)")
                             viewModel.dismiss?(.savedCard, false)
                         }
                     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -489,10 +489,9 @@ extension BrowserViewController: WKNavigationDelegate {
             // Only automatically attempt to reload the crashed
             // tab three times before giving up.
             if tab.consecutiveCrashes < 3 {
-                logger.log("The webview has crashed, trying to reload.",
+                logger.log("The webview has crashed, trying to reload. Attempt number: \(tab.consecutiveCrashes)",
                            level: .warning,
-                           category: .webview,
-                           extra: ["Attempt number": "\(tab.consecutiveCrashes)"])
+                           category: .webview)
 
                 tabsTelemetry.trackConsecutiveCrashTelemetry(attemptNumber: tab.consecutiveCrashes)
 
@@ -1005,12 +1004,9 @@ extension BrowserViewController: WKNavigationDelegate {
 
     private func handleDownloadError(tab: Tab?, request: URLRequest, error: (any Error)?) {
         navigationHandler?.removeDocumentLoading()
-        logger.log("Failed to download Document",
+        logger.log("Failed to download Document: \(error?.localizedDescription ?? "Unknown error")",
                    level: .warning,
-                   category: .webview,
-                   extra: [
-                    "error": error?.localizedDescription ?? "",
-                    "url": request.url?.absoluteString ?? "Unknown URL"])
+                   category: .webview)
         guard let error, let webView = tab?.webView else { return }
         showErrorPage(webView: webView, error: error)
     }
@@ -1139,12 +1135,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
                 if isNoInternetError || isCertificateError {
                     if isCertificateError {
-                        NativeErrorPageHelper.logCertificateErrorDetails(
-                            error: error,
-                            url: url,
-                            errorPageURL: errorPageURL,
-                            logger: logger
-                        )
+                        NativeErrorPageHelper.logCertificateErrorDetails(error: error, logger: logger)
                     }
                     // TODO: FXIOS-15800 Move error type determination to NativeErrorPageMiddleware
                     let action = NativeErrorPageAction(

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1413,18 +1413,14 @@ class BrowserViewController: UIViewController,
 
     /// Logging current Nimbus state
     private func logCurrentNimbusExperimentsState() {
-        var currentExperimentsDictionary = [String: String]()
-        Experiments.shared.getAvailableExperiments()
-            .enumerated()
-            .forEach { index, experiment in
-                currentExperimentsDictionary["experiment \(index)"] = mirrorToString(experiment)
-            }
+        let currentExperiments = Experiments.shared.getAvailableExperiments()
+            .map { mirrorToString($0) }
+            .joined(separator: ", ")
 
         logger.log(
-            "Current Nimbus available experiments configuration",
+            "Current Nimbus available experiments configuration: \(currentExperiments)",
             level: .info,
-            category: .experiments,
-            extra: currentExperimentsDictionary,
+            category: .experiments
         )
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -568,18 +568,20 @@ class SearchViewController: SiteTableViewController,
             withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
             for: indexPath
         ) as? TwoLineImageOverlayCell else {
-            logger.log("Failed to dequeue TwoLineImageOverlayCell at indexPath: \(indexPath)",
+            logger.log("Failed to dequeue TwoLineImageOverlayCell",
                        level: .fatal,
-                       category: .lifecycle)
+                       category: .lifecycle,
+                       extra: ["indexPath": "\(indexPath)"])
             return UITableViewCell()
         }
         guard let oneLineTableViewCell = tableView.dequeueReusableCell(
             withIdentifier: OneLineTableViewCell.cellIdentifier,
             for: indexPath
         ) as? OneLineTableViewCell else {
-            logger.log("Failed to dequeue OneLineTableViewCell at indexPath: \(indexPath)",
+            logger.log("Failed to dequeue OneLineTableViewCell",
                        level: .fatal,
-                       category: .lifecycle)
+                       category: .lifecycle,
+                       extra: ["indexPath": "\(indexPath)"])
             return UITableViewCell()
         }
         return getCellForSection(twoLineImageOverlayCell,

--- a/firefox-ios/Client/Frontend/Extensions/SiriShortcuts.swift
+++ b/firefox-ios/Client/Frontend/Extensions/SiriShortcuts.swift
@@ -63,10 +63,9 @@ class SiriShortcuts {
             }
         } catch {
             logger.log(
-                "Could not get voice shortcurts: \(error.localizedDescription)",
+                "Could not get voice shortcuts: \(error.localizedDescription)",
                 level: .warning,
-                category: .settings,
-                extra: nil
+                category: .settings
             )
         }
     }

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -366,10 +366,9 @@ class ErrorPageHelper {
 
         components.queryItems = queryItems
         if let urlWithQuery = components.url {
-            logger.log("An error page will show.",
+            logger.log("An error page will show. Error code: \(error.code)",
                        level: .info,
-                       category: .webview,
-                       extra: ["Error code": "\(error.code)"])
+                       category: .webview)
 
             TelemetryWrapper.shared.recordEvent(
                 category: .information,

--- a/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Downloads/DownloadsPanel.swift
@@ -286,9 +286,10 @@ class DownloadsPanel: UIViewController,
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: TwoLineImageOverlayCell.cellIdentifier,
                                                        for: indexPath) as? TwoLineImageOverlayCell else {
-            logger.log("Failed to dequeue TwoLineImageOverlayCell at indexPath: \(indexPath)",
+            logger.log("Failed to dequeue TwoLineImageOverlayCell",
                        level: .fatal,
-                       category: .library)
+                       category: .library,
+                       extra: ["indexPath": "\(indexPath)"])
             return UITableViewCell()
         }
 

--- a/firefox-ios/Client/Frontend/Library/Reader/ReaderPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Reader/ReaderPanel.swift
@@ -359,9 +359,10 @@ class ReadingListPanel: UITableViewController,
             withIdentifier: "ReadingListTableViewCell",
             for: indexPath
         ) as? ReadingListTableViewCell else {
-            logger.log("Failed to dequeue ReadingListTableViewCell at indexPath: \(indexPath)",
+            logger.log("Failed to dequeue ReadingListTableViewCell",
                        level: .fatal,
-                       category: .library)
+                       category: .library,
+                       extra: ["indexPath": "\(indexPath)"])
             return UITableViewCell()
         }
         if let record = records?[indexPath.row] {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -104,26 +104,15 @@ class NativeErrorPageHelper {
     }
 
     /// Logs diagnostic details for a certificate error to aid debugging.
-    static func logCertificateErrorDetails(
-        error: NSError,
-        url: URL,
-        errorPageURL: URL,
-        logger: Logger
-    ) {
+    static func logCertificateErrorDetails(error: NSError, logger: Logger) {
         let hasUnderlyingError = error.userInfo[NSUnderlyingErrorKey] != nil
         let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError
         let hasCertErrorCode = underlying?.userInfo[Constants.cfStreamErrorCodeKey] != nil
         logger.log(
-            "NativeErrorPage: Dispatching certificate error",
+            "NativeErrorPage: Dispatching certificate error with code \(error.code)."
+            + " Has underlying error: \(hasUnderlyingError), has cert error code: \(hasCertErrorCode)",
             level: .debug,
-            category: .webview,
-            extra: [
-                "errorCode": "\(error.code)",
-                "hasUnderlyingError": "\(hasUnderlyingError)",
-                "hasCertErrorCode": "\(hasCertErrorCode)",
-                "url": url.absoluteString,
-                "errorPageURL": errorPageURL.absoluteString
-            ]
+            category: .webview
         )
     }
 

--- a/firefox-ios/Client/Frontend/Reader/SchemeHandler/ReaderModeSchemeHandler.swift
+++ b/firefox-ios/Client/Frontend/Reader/SchemeHandler/ReaderModeSchemeHandler.swift
@@ -106,10 +106,9 @@ final class ReaderModeSchemeHandler: NSObject, WKURLSchemeHandler {
                                 category: .library)
             } catch {
                 urlSchemeTask.didFailWithError(TinyRouterError.mapError(error))
-                self.logger.log("Reader-mode scheme task failed.",
+                self.logger.log("Reader-mode scheme task failed with error type: \(TinyRouterError.mapError(error))",
                                 level: .warning,
-                                category: .library,
-                                extra: ["error type": "\(TinyRouterError.mapError(error))"])
+                                category: .library)
             }
         }
         requestTasks[id] = requestTask

--- a/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppIconSelection/AppIconSelectionView.swift
@@ -90,7 +90,10 @@ struct AppIconSelectionView: View, ThemeApplicable, FeatureFlaggable {
         // If the user is resetting to the default app icon, we need to set the alternative icon to nil.
         UIApplication.shared.setAlternateIconName(appIcon.appIconAssetName) { error in
             guard error == nil else {
-                logger.log("Failed to set an alternative app icon [\(appIcon)]", level: .fatal, category: .appIcon)
+                logger.log("Failed to set an alternative app icon",
+                           level: .fatal,
+                           category: .appIcon,
+                           extra: ["appIcon": "\(appIcon)"])
                 ensureMainThread {
                     self.isShowingErrorAlert = true
 

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -654,9 +654,10 @@ class AppSettingsTableViewController: SettingsTableViewController,
             tableView,
             viewForHeaderInSection: section
         ) as? ThemedTableSectionHeaderFooterView else {
-            logger.log("Failed to cast or retrieve ThemedTableSectionHeaderFooterView for section: \(section)",
+            logger.log("Failed to cast or retrieve ThemedTableSectionHeaderFooterView",
                        level: .fatal,
-                       category: .lifecycle)
+                       category: .lifecycle,
+                       extra: ["section": "\(section)"])
             return UIView()
         }
         return headerView

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -218,9 +218,10 @@ final class SearchSettingsTableViewController: ThemedTableViewController,
             withIdentifier: ThemedSubtitleTableViewCell.cellIdentifier,
             for: indexPath
         ) as? ThemedSubtitleTableViewCell else {
-            logger.log("Failed to dequeue ThemedSubtitleTableViewCell at indexPath: \(indexPath)",
+            logger.log("Failed to dequeue ThemedSubtitleTableViewCell",
                        level: .fatal,
-                       category: .lifecycle)
+                       category: .lifecycle,
+                       extra: ["indexPath": "\(indexPath)"])
             return UITableViewCell()
         }
 

--- a/firefox-ios/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/FindInPageHelper.swift
@@ -38,9 +38,10 @@ class FindInPageHelper: TabContentScript {
         didReceiveScriptMessage message: WKScriptMessage
     ) {
         guard let data = message.body as? [String: Int] else {
-            logger.log("Invalid data message body in FindInPageHelper: \(message.body)",
+            logger.log("Invalid data message body in FindInPageHelper",
                        level: .fatal,
-                       category: .library)
+                       category: .library,
+                       extra: ["messageBody": "\(message.body)"])
             return
         }
 

--- a/firefox-ios/Client/Frontend/TabContentsScripts/LocalRequestHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/LocalRequestHelper.swift
@@ -27,9 +27,10 @@ class LocalRequestHelper: TabContentScript {
         else { return }
 
         guard let params = message.body as? [String: String] else {
-            logger.log("Invalid data message body in LocalRequestHelper: \(message.body)",
+            logger.log("Invalid data message body in LocalRequestHelper",
                        level: .fatal,
-                       category: .library)
+                       category: .library,
+                       extra: ["messageBody": "\(message.body)"])
             return
         }
 

--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
@@ -191,9 +191,10 @@ class CertificatesViewController: UIViewController,
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerView = tableView.dequeueReusableHeaderFooterView(
             withIdentifier: CertificatesHeaderView.cellIdentifier) as? CertificatesHeaderView else {
-            logger.log("Failed to dequeue CertificatesHeaderView with identifier \(CertificatesHeaderView.cellIdentifier)",
+            logger.log("Failed to dequeue CertificatesHeaderView",
                        level: .fatal,
-                       category: .certificate)
+                       category: .certificate,
+                       extra: ["identifier": CertificatesHeaderView.cellIdentifier])
             return UIView()
         }
         var items: [CertificatesHeaderItem] = []

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -528,10 +528,10 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
                     errorType: serviceError.telemetryDescription
                 )
                 logger.log(
-                    "Unable to detect language from page to determine if eligible for translations.",
+                    "Unable to detect language from page to determine if eligible for translations."
+                    + " LanguageDetector error: \(error.localizedDescription)",
                     level: .warning,
-                    category: .translations,
-                    extra: ["LanguageDetector error": "\(error.localizedDescription)"]
+                    category: .translations
                 )
             }
         }
@@ -620,10 +620,9 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
                 errorType: serviceError.telemetryDescription
             )
             logger.log(
-                "Unable to translate page, so translation failed.",
+                "Unable to translate page, so translation failed. Translations error: \(error.localizedDescription)",
                 level: .warning,
-                category: .translations,
-                extra: ["Translations error": "\(error.localizedDescription)"]
+                category: .translations
             )
             self.handleErrorFromTranslatingPage(windowUUID: windowUUID, on: tab)
         }
@@ -753,10 +752,9 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
         }
 
         logger.log(
-            "Missing translationFlowId for this window; generating fallback UUID.",
+            "Missing translationFlowId for window \(windowUUID); generating fallback UUID.",
             level: .warning,
-            category: .translations,
-            extra: ["windowUUID": "\(windowUUID)"]
+            category: .translations
         )
 
         return UUID()

--- a/firefox-ios/Client/TabManagement/Document/DocumentLogger.swift
+++ b/firefox-ios/Client/TabManagement/Document/DocumentLogger.swift
@@ -31,8 +31,7 @@ class DocumentLogger {
             logger.log(
                 "Document is missing but finished downloading",
                 level: .info,
-                category: .webview,
-                extra: ["url": url.absoluteString]
+                category: .webview
             )
         }
         pending[url] = false

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -676,13 +676,9 @@ final class TabManagerImplementation: NSObject,
         }
 
         if tab.url == nil {
-            logger.log("Tab restored has empty URL",
+            logger.log("Tab restored has empty URL. tabID: \(tabData.id.uuidString), lastUsedTime: \(tabData.lastUsedTime)",
                        level: .debug,
-                       category: .tabs,
-                       extra: [
-                        "tabID": tabData.id.uuidString,
-                        "lastUsedTime": tabData.lastUsedTime.description
-                       ])
+                       category: .tabs)
         }
     }
 

--- a/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
+++ b/firefox-ios/Client/Telemetry/TabErrorTelemetryHelper.swift
@@ -104,11 +104,9 @@ final class TabErrorTelemetryHelper {
         guard let tabCounts = defaults.object(forKey: entryPoint.defaultsKey) as? [String: Int],
               let expectedTabCount = tabCounts[window.uuidString] else { return }
         guard let currentTabCount = getTotalTabCount(window: window) else {
-            logger.log("Can't validate tab count. Tab manager unavailable.",
+            logger.log("Can't validate tab count. Tab manager unavailable for window \(window.uuidString).",
                        level: .info,
-                       category: .tabs,
-                       extra: ["uuid": window.uuidString]
-            )
+                       category: .tabs)
             return
         }
 
@@ -172,10 +170,12 @@ final class TabErrorTelemetryHelper {
            ]
 
         if significantLossDetected {
-            logger.log("Tab loss detected \(entryPoint.logInfo).",
+            var logExtras = extras
+            logExtras["entryPoint"] = entryPoint.logInfo
+            logger.log("Tab loss detected.",
                        level: .fatal,
                        category: .tabs,
-                       extra: extras)
+                       extra: logExtras)
         }
 
         // Only send the telemetry event for the foregrounding log so we don't mess with our existing metrics

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -224,9 +224,10 @@ open class BrowserProfile: Profile,
         do {
             return try self.files.getAndEnsureDirectory()
         } catch {
-            logger.log("Could not create directory at root path: \(error)",
+            logger.log("Could not create directory at root path",
                        level: .fatal,
-                       category: .setup)
+                       category: .setup,
+                       extra: ["error": "\(error)"])
             fatalError("Could not create directory at root path: \(error)")
         }
     }()

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -542,14 +542,11 @@ public class RustSyncManager: NSObject, SyncManager, @unchecked Sendable {
             let telemetryData = syncResult.telemetryJson ??
                 "(No telemetry data was returned)"
             let telemetryMessage = "\(String(describing: telemetryData))"
-            let syncDetails = ["status": "\(syncResult.status)",
-                               "declinedEngines": "\(declinedEngines)",
-                               "telemetry": telemetryMessage]
 
-            self.logger.log("Finished syncing",
+            self.logger.log("Finished syncing with status: \(syncResult.status), declined engines: \(declinedEngines)",
                             level: .info,
                             category: .sync,
-                            extra: syncDetails)
+                            extra: ["telemetry": telemetryMessage])
 
             if let declined = syncResult.declined {
                 self.updateEnginePrefs(declined: declined)

--- a/firefox-ios/Storage/DiskImageStore.swift
+++ b/firefox-ios/Storage/DiskImageStore.swift
@@ -44,9 +44,10 @@ public actor DefaultDiskImageStore: DiskImageStore {
         do {
             self.filesDir = try files.getAndEnsureDirectory(namespace)
         } catch {
-            logger.log("Could not create directory at root path: \(error)",
+            logger.log("Could not create directory at root path",
                        level: .fatal,
-                       category: .storage)
+                       category: .storage,
+                       extra: ["error": "\(error)"])
             fatalError("Could not create directory at root path: \(error)")
         }
 

--- a/firefox-ios/Storage/SQL/BrowserDB.swift
+++ b/firefox-ios/Storage/SQL/BrowserDB.swift
@@ -33,9 +33,10 @@ public final class BrowserDB: Sendable {
 
             self.db = SwiftData(filename: self.databasePath, schema: schema, files: files)
         } catch {
-            logger.log("Could not create directory at root path: \(error)",
+            logger.log("Could not create directory at root path",
                        level: .fatal,
-                       category: .storage)
+                       category: .storage,
+                       extra: ["error": "\(error)"])
             fatalError("Could not create directory at root path: \(error)")
         }
     }

--- a/firefox-ios/Storage/SQL/BrowserSchema.swift
+++ b/firefox-ios/Storage/SQL/BrowserSchema.swift
@@ -1648,11 +1648,9 @@ open class BrowserSchema: Schema {
             do {
                 try db.executeChange(sql)
             } catch let err as NSError {
-                let extra = ["table": "clients", "errorDescription": "\(err.localizedDescription)", "sql": "\(sql)"]
-                logger.log("Error altering clients table",
+                logger.log("Error altering clients table: \(err.localizedDescription), sql: \(sql)",
                            level: .warning,
-                           category: .storage,
-                           extra: extra)
+                           category: .storage)
                 return .failure
             }
         }

--- a/firefox-ios/Storage/ThirdParty/SwiftData.swift
+++ b/firefox-ios/Storage/ThirdParty/SwiftData.swift
@@ -450,11 +450,9 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         // If we cannot even open the database file, return `nil` to force SwiftData
         // into using a `FailedSQLiteDBConnection` so we can retry opening again later.
         if !doOpen() {
-            let extra = ["filename" : filename]
-            logger.log("Cannot open a database connection.",
+            logger.log("Cannot open a database connection to \(filename).",
                        level: .warning,
-                       category: .storage,
-                       extra: extra)
+                       category: .storage)
             return nil
         }
 
@@ -1098,9 +1096,10 @@ open class ConcreteSQLiteDBConnection: SQLiteDBConnection {
         DispatchQueue.global().sync {
             guard !SwiftData.corruptionLogsWritten.contains(dbFilename) else { return }
 
-            logger.log("Corrupt DB detected! DB filename: \(dbFilename)",
+            logger.log("Corrupt DB detected!",
                        level: .fatal,
-                       category: .storage)
+                       category: .storage,
+                       extra: ["dbFilename": dbFilename])
 
             let dbFileSize = ("file://\(dbFilename)".asURL)?.allocatedFileSize() ?? 0
             logger.log("Corrupt DB file size: \(dbFileSize) bytes",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DocumentLoggerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DocumentLoggerTests.swift
@@ -63,6 +63,26 @@ final class DocumentLoggerTests: XCTestCase {
         XCTAssertNil(logger.savedExtra?[subject.downloadExtraKey])
     }
 
+    func testRegisterDownloadFinish_missingDocument_logsWithoutExtra() {
+        let subject = createSubject()
+
+        subject.registerDownloadFinish(url: URL(string: "https://www.example.com")!)
+
+        XCTAssertEqual(logger.savedMessage, "Document is missing but finished downloading")
+        XCTAssertEqual(logger.savedLevel, .info)
+        XCTAssertNil(logger.savedExtra)
+    }
+
+    func testRegisterDownloadFinish_registeredDocument_doesntLog() {
+        let subject = createSubject()
+        let url = URL(string: "https://www.example.com")!
+
+        subject.registerDownloadStart(url: url)
+        subject.registerDownloadFinish(url: url)
+
+        XCTAssertNil(logger.savedMessage)
+    }
+
     private func createSubject() -> DocumentLogger {
         let logger = DocumentLogger(logger: logger)
         trackForMemoryLeaks(logger)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import TestKit
 import XCTest
 
 @testable import Client
@@ -224,6 +225,39 @@ final class NativeErrorPageHelperTests: XCTestCase {
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
         XCTAssertNil(model.advancedSection)
         XCTAssertTrue(model.isRegularUI)
+    }
+
+    // MARK: - logCertificateErrorDetails
+
+    func testLogCertificateErrorDetails_withUnderlyingError_logsDiagnosticsInMessageWithoutExtra() throws {
+        let logger = MockLogger()
+        let error = makeBadCertDomainError()
+
+        NativeErrorPageHelper.logCertificateErrorDetails(error: error, logger: logger)
+
+        let message = try XCTUnwrap(logger.savedMessage)
+        XCTAssertEqual(logger.savedLevel, .debug)
+        XCTAssertTrue(message.contains("\(error.code)"))
+        XCTAssertTrue(message.contains("Has underlying error: true"))
+        XCTAssertTrue(message.contains("has cert error code: true"))
+        XCTAssertNil(logger.savedExtra)
+    }
+
+    func testLogCertificateErrorDetails_withoutUnderlyingError_logsFalseDiagnostics() throws {
+        let logger = MockLogger()
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorServerCertificateUntrusted,
+            userInfo: [:]
+        )
+
+        NativeErrorPageHelper.logCertificateErrorDetails(error: error, logger: logger)
+
+        let message = try XCTUnwrap(logger.savedMessage)
+        XCTAssertEqual(logger.savedLevel, .debug)
+        XCTAssertTrue(message.contains("Has underlying error: false"))
+        XCTAssertTrue(message.contains("has cert error code: false"))
+        XCTAssertNil(logger.savedExtra)
     }
 
     // MARK: - getCertDetails

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -187,6 +187,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(
             mockLogger.savedMessage,
             "Unable to detect language from page to determine if eligible for translations."
+            + " LanguageDetector error: \(TestError.example.localizedDescription)"
         )
         XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
         XCTAssertEqual(mockTranslationsTelemetry.pageLanguageIdentificationFailedCalledCount, 1)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13181)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28669)

## :bulb: Description

Applies the logging policy from the issue across the Client target (44 call sites in 32 files):

- **Fatal logs (19 sites)**: the message is now a string literal, with variables moved to the `extra` argument (or `description:` for errors, matching the existing idiom). Rationale: `DefaultLogger` sends only the raw `message` to Sentry as the event message, so interpolation fragments issue grouping, while `extra`/`description` are attached to the event as extras.
- **Non-fatal logs (25 sites)**: metadata previously passed via `extra` is now interpolated into the message, and the `extra` argument is dropped. Rationale: for non-fatal levels `CrashManager.send` only records a breadcrumb from the raw message — extras were silently discarded, so this data never reached breadcrumbs before.

Judgment calls worth reviewer attention (per the "no PII in logs" rule — folding these into breadcrumb messages would have *added* PII to Sentry, so they were dropped instead of folded):

- `BrowserViewController+WebViewDelegates.handleDownloadError`: dropped the `url` extra (browsing URL); kept the error in the message.
- `NativeErrorPageHelper.logCertificateErrorDetails`: dropped the `url`/`errorPageURL` extras and their now-unused parameters (single caller updated; the helper has no test coverage). Error code and the two boolean diagnostics are folded into the message.
- `DocumentLogger.registerDownloadFinish`: dropped the `url` extra (download URL); message unchanged.
- `DownloadsCoordinator`: dropped the `"DownloadsCoordinator windowUUID": "N/A"` entry (constant, no diagnostic value); the existing coordinator's UUID is folded into the message.
- `SiriShortcuts`: also fixes the "shortcurts" typo on the same line.
- `TabErrorTelemetryHelper.sendTelemetryTabLossDetectedEvent`: `entryPoint` is added to the *log call's* extras only — the `extras` dictionary shared with the Glean event is unchanged, so telemetry is unaffected.

Tests: added coverage for the two seams whose behavior changed beyond the log format — `DocumentLoggerTests` (missing-document log keeps its literal message with no extra; registered downloads don't log) and `NativeErrorPageHelperTests` (new `logCertificateErrorDetails(error:logger:)` signature logs the diagnostics in the message with no extra, with and without an underlying error). The remaining call sites keep their existing behavior and are asserted by no current tests (checked all `savedMessage`/`savedExtra` assertions against `MockLogger`).

Validation: a script-driven audit of all 519 `logger.log` calls in `Client/` confirms zero remaining fatal-with-interpolation and zero non-fatal-with-extra sites; `swiftlint --strict` (the pre-push gate) is clean. I could not run the full unit-test suite locally (machine is on Xcode 26.0.1; the repo requires 26.5, and current `main` does not compile on 26.0.1) — relying on CI for the authoritative build/test run and happy to address anything it flags.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code — tests added for the behavior-changed seams (see description); authoritative suite run deferred to CI (local Xcode 26.0.1 cannot build current `main`, which requires 26.5)
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — n/a
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review — n/a, no new telemetry
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n — n/a, log messages only
- [ ] If needed, I updated documentation and added comments to complex code — n/a
