### PR TITLE
[MTE-5600] - Fix flaky springboard long-tap NavigationTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -619,13 +619,13 @@ class NavigationTest: FeatureFlaggedTestSuite {
     // https://mozilla.testrail.io/index.php?/cases/view/3408299
     func testLongTapFirefoxIconNewPrivateTab() throws {
         guard #available(iOS 18, *) else {
-            throw XCTSkip("Test requires iOS 18+ due to app icon springboard behavior after app.terminate()")
+            throw XCTSkip("Test requires iOS 18+ due to app icon springboard context menu behavior")
         }
         let springBoardScreen = SpringboardScreen(springboard: springboard)
         let browserScreen = BrowserScreen(app: app)
-        let onboardingScreen = OnboardingScreen(app: app, flowType: onboardingFlowType)
         waitForTabsButton()
-        app.terminate()
+        // Background instead of terminate: a SpringBoard cold-launch crashes on the simulator (code-sign kill).
+        springBoardScreen.pressHomeButton()
         if isFennec {
             springBoardScreen.assertFennecIconExists()
             springBoardScreen.longPressFennecIcon(at: 0, duration: 1.5)
@@ -634,8 +634,6 @@ class NavigationTest: FeatureFlaggedTestSuite {
             springBoardScreen.longPressFirefoxIcon(at: 0, duration: 1.5)
         }
         springBoardScreen.tapNewPrivateButton()
-        onboardingScreen.handleTermsOfService()
-        onboardingScreen.closeTour()
         browserScreen.assertPrivateModeMessageCardExists()
         navigator.openURL(website_1["url"]!)
         waitUntilPageLoad()
@@ -666,11 +664,10 @@ class NavigationTest: FeatureFlaggedTestSuite {
     // https://mozilla.testrail.io/index.php?/cases/edit/3408300
     func testLongTapFirefoxIconOpenLastBookmark() throws {
         guard #available(iOS 18, *) else {
-            throw XCTSkip("Test requires iOS 18+ due to app icon springboard behavior after app.terminate()")
+            throw XCTSkip("Test requires iOS 18+ due to app icon springboard context menu behavior")
         }
         let springBoardScreen = SpringboardScreen(springboard: springboard)
         let browserScreen = BrowserScreen(app: app)
-        let onboardingScreen = OnboardingScreen(app: app, flowType: onboardingFlowType)
 
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
@@ -680,8 +677,8 @@ class NavigationTest: FeatureFlaggedTestSuite {
         waitUntilPageLoad()
         bookmark(isLockIconOff: false)
 
-        // Terminate app and go to springboard
-        app.terminate()
+        // Background instead of terminate: a SpringBoard cold-launch crashes on the simulator (code-sign kill).
+        springBoardScreen.pressHomeButton()
 
         if isFennec {
             springBoardScreen.assertFennecIconExists()
@@ -694,10 +691,6 @@ class NavigationTest: FeatureFlaggedTestSuite {
         // Verify all context menu options are present
         springBoardScreen.assertAllContextMenuOptionsExist()
         springBoardScreen.tapOpenLastBookmarkButton()
-
-        // Close onboarding if it appears
-        onboardingScreen.handleTermsOfService()
-        onboardingScreen.closeTour()
 
         // Verify the bookmarked page opens
         waitUntilPageLoad()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SpringboardSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SpringboardSelectors.swift
@@ -20,7 +20,9 @@ struct SpringboardSelectors: SpringboardSelectorsSet {
         static let firefoxIcon = "Firefox"
         static let newTabButton = "New Tab"
         static let newPrivateTabButton = "New Private Tab"
-        static let openLastBookmarkButton = "org.mozilla.ios.Fennec.OpenLastBookmark"
+        // Matched by identifier suffix so it works on every scheme's bundle id
+        // (org.mozilla.ios.Fennec / .Firefox / .FirefoxBeta).
+        static let openLastBookmarkSuffix = ".OpenLastBookmark"
         static let appIconButton = "App Icon"
     }
 
@@ -54,8 +56,15 @@ struct SpringboardSelectors: SpringboardSelectorsSet {
         groups: ["springboard", "context-menu"]
     )
 
-    let OPEN_LAST_BOOKMARK_BUTTON = Selector.buttonId(
-        IDs.openLastBookmarkButton,
+    let OPEN_LAST_BOOKMARK_BUTTON = Selector(
+        strategy: .predicate(
+            NSPredicate(
+                format: "elementType == %d AND identifier ENDSWITH %@",
+                XCUIElement.ElementType.button.rawValue,
+                IDs.openLastBookmarkSuffix
+            )
+        ),
+        value: IDs.openLastBookmarkSuffix,
         description: "Open Last Bookmark button in springboard context menu",
         groups: ["springboard", "context-menu"]
     )


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5600

## :bulb: Description
Two problems behind the flaky springboard long-tap NavigationTest failures on the firefox-schema CI:

1. Open Last Bookmark quick action never matched on non-Fennec schemes. The selector was hardcoded to org.mozilla.ios.Fennec.OpenLastBookmark, but the quick-action identifier is derived from the app's bundle id (org.mozilla.ios.Firefox on the Firefox scheme). It now matches by identifier suffix (.OpenLastBookmark), so it resolves on every scheme.
2. Simulator code-signing crash on cold-launch via a quick action. The tests did app.terminate() and then relaunched the app by tapping a Home Screen quick action. On the simulator, a SpringBoard cold-launch of the release-signed build is killed by code signing (EXC_BAD_ACCESS / SIGKILL – Code Signature Invalid), which is what the report showed as <external symbol> crashes. Backgrounding the app (pressHomeButton) instead of terminating avoids the cold-launch entirely, matching the already-passing testLongTapFirefoxIconNewTab / testLongTapFirefoxIconAppIcon.

Tests fixed (validated on both Fennec and Firefox schemes, iOS 26.5)

- testLongTapFirefoxIconOpenLastBookmark — now passes on both schemes.
- testLongTapFirefoxIconNewPrivateTab — no longer crashes.

Test that could not be fixed

testLongTapFirefoxIconNewPrivateTab still fails on the Firefox scheme after the crash is resolved: when the app is only backgrounded, the New Private Tab quick action isn't routed to a private tab on the release build (it resumes the existing regular tab). This is an app-side routing issue, not a test issue, and it's tracked in https://github.com/mozilla-mobile/firefox-ios/issues/34571.

