### PR TITLE
Bugfix FXIOS-16237 testUseSystemAppearance_WithRedux() flaky test attempt # 2

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ThemeSettingsControllerTests.swift
@@ -28,17 +28,13 @@ class ThemeSettingsControllerTests: XCTestCase, StoreTestUtility {
     @MainActor
     func testUseSystemAppearance_WithRedux() {
         let subject = createSubject()
+        // Force viewDidLoad so the controller subscribes to Redux before we toggle
+        subject.loadViewIfNeeded()
         let themeSwitch = createUseSystemThemeSwitch(isOn: true)
         subject.systemThemeSwitchValueChanged(control: themeSwitch)
 
-        // Needed to wait for Redux action handled async in main thread
-        let expectation = self.expectation(description: "Redux Middleware")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            expectation.fulfill()
-            XCTAssertTrue(subject.isSystemThemeOn)
-            XCTAssertEqual(subject.tableView.numberOfSections, 1)
-        }
-        waitForExpectations(timeout: 1)
+        XCTAssertTrue(subject.isSystemThemeOn)
+        XCTAssertEqual(subject.tableView.numberOfSections, 1)
     }
 
     func testUseCustomAppearance_WithRedux() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16237)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34563)

## :bulb: Description
- Fix flaky test calling to loadViewIfNeeded to  activate subscription 


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

