### PR TITLE
Add FXIOS-16250 [Google Lens] Update web image context menu `ep` param

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1171,7 +1171,7 @@ final class BrowserCoordinator: BaseCoordinator,
             router: router
         ) { [weak self] image in
             guard let image else { return }
-            self?.searchGoogleLens(with: image)
+            self?.searchGoogleLens(with: image, entryPoint: .addressToolbar)
         }
         add(child: coordinator)
         coordinator.start()
@@ -1180,7 +1180,7 @@ final class BrowserCoordinator: BaseCoordinator,
                                             actionType: GeneralBrowserActionType.leaveOverlay))
     }
 
-    func searchGoogleLens(with image: UIImage) {
+    func searchGoogleLens(with image: UIImage, entryPoint: GoogleLensUploadEntryPoint) {
         guard let tab = tabManager.selectedTab else {
             logger.log("Google Lens: no selected tab to load the upload request",
                        level: .warning,
@@ -1188,7 +1188,9 @@ final class BrowserCoordinator: BaseCoordinator,
             return
         }
         let viewportSize = tab.webView?.bounds.size ?? browserViewController.view.bounds.size
-        guard let request = googleLensService.makeUploadRequest(for: image, viewportSize: viewportSize) else {
+        guard let request = googleLensService.makeUploadRequest(for: image,
+                                                                viewportSize: viewportSize,
+                                                                entryPoint: entryPoint) else {
             logger.log("Google Lens: failed to build upload request (image could not be processed)",
                        level: .warning,
                        category: .coordinator)
@@ -1210,7 +1212,7 @@ final class BrowserCoordinator: BaseCoordinator,
             DispatchQueue.main.async {
                 guard let self else { return }
                 if let image {
-                    self.searchGoogleLens(with: image)
+                    self.searchGoogleLens(with: image, entryPoint: .addressToolbar)
                 } else if let errorDescription {
                     self.logger.log("Google Lens: failed to load picked image: \(errorDescription)",
                                     level: .warning,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -133,7 +133,7 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     func showGoogleLensCamera()
 
     @MainActor
-    func searchGoogleLens(with image: UIImage)
+    func searchGoogleLens(with image: UIImage, entryPoint: GoogleLensUploadEntryPoint)
 
     @MainActor
     func showQuickAnswers(transitionType: QuickAnswersTransitionType)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -436,7 +436,7 @@ extension BrowserViewController: WKUIDelegate {
         getImageData(url) { [weak self] data in
             guard let image = UIImage(data: data) else { return }
             ensureMainThread {
-                self?.navigationHandler?.searchGoogleLens(with: image)
+                self?.navigationHandler?.searchGoogleLens(with: image, entryPoint: .webImageContextMenu)
             }
         }
     }

--- a/firefox-ios/Client/Frontend/GoogleLens/GoogleLensRequestBuilder.swift
+++ b/firefox-ios/Client/Frontend/GoogleLens/GoogleLensRequestBuilder.swift
@@ -3,14 +3,17 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import CoreGraphics
 
-/// Everything needed to build a Google Lens upload request: the encoded image, its
-/// dimensions, and the viewport Lens should render its result UI for.
+enum GoogleLensUploadEntryPoint: String {
+    case addressToolbar = "fntpubb"
+    case webImageContextMenu = "fcm"
+}
+
 struct GoogleLensUploadInput: Equatable {
     let jpegData: Data
     let imageDimensions: CGSize
     let viewportSize: CGSize
+    let entryPoint: GoogleLensUploadEntryPoint
 }
 
 protocol GoogleLensRequestBuilding {
@@ -22,8 +25,6 @@ protocol GoogleLensRequestBuilding {
 struct GoogleLensRequestBuilder: GoogleLensRequestBuilding {
     private enum Constants {
         static let uploadURL = "https://lens.google.com/upload"
-        /// Entry-point value for the upload-by-bytes (`/upload`) integration, provided by Google.
-        static let entryPoint = "fntpubb"
         static let imageFieldName = "encoded_image"
         static let imageFileName = "image.jpg"
         static let imageMimeType = "image/jpeg"
@@ -54,7 +55,7 @@ struct GoogleLensRequestBuilder: GoogleLensRequestBuilding {
 
     private func uploadURL(for input: GoogleLensUploadInput) -> URL {
         var queryItems = [
-            URLQueryItem(name: "ep", value: Constants.entryPoint),
+            URLQueryItem(name: "ep", value: input.entryPoint.rawValue),
             URLQueryItem(name: "st", value: String(startTimeMilliseconds())),
             URLQueryItem(name: "vpw", value: String(Int(input.viewportSize.width))),
             URLQueryItem(name: "vph", value: String(Int(input.viewportSize.height)))

--- a/firefox-ios/Client/Frontend/GoogleLens/GoogleLensService.swift
+++ b/firefox-ios/Client/Frontend/GoogleLens/GoogleLensService.swift
@@ -6,9 +6,11 @@ import UIKit
 
 protocol GoogleLensServicing {
     /// Preprocesses `image` and builds the Google Lens upload request for it.
+    /// - Parameter image: the image to upload to Google Lens.
     /// - Parameter viewportSize: the size Lens should render its result UI for.
+    /// - Parameter entryPoint: the Lens `ep` query value for the upload source.
     /// - Returns: the upload request, or `nil` if the image could not be processed.
-    func makeUploadRequest(for image: UIImage, viewportSize: CGSize) -> URLRequest?
+    func makeUploadRequest(for image: UIImage, viewportSize: CGSize, entryPoint: GoogleLensUploadEntryPoint) -> URLRequest?
 }
 
 /// Produces the Google Lens upload request for an image by composing the image
@@ -23,11 +25,14 @@ struct GoogleLensService: GoogleLensServicing {
         self.requestBuilder = requestBuilder
     }
 
-    func makeUploadRequest(for image: UIImage, viewportSize: CGSize) -> URLRequest? {
+    func makeUploadRequest( for image: UIImage,
+                            viewportSize: CGSize,
+                            entryPoint: GoogleLensUploadEntryPoint) -> URLRequest? {
         guard let processedImage = imageProcessor.process(image) else { return nil }
         let input = GoogleLensUploadInput(jpegData: processedImage.jpegData,
                                           imageDimensions: processedImage.dimensions,
-                                          viewportSize: viewportSize)
+                                          viewportSize: viewportSize,
+                                          entryPoint: entryPoint)
         return requestBuilder.makeUploadRequest(for: input)
     }
 }

--- a/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SearchSettingsTableViewController.swift
@@ -860,9 +860,7 @@ extension SearchSettingsTableViewController {
     func didToggleGoogleLens(_ toggle: ThemedSwitch) {
         userPreferences.setPreferenceFor(.googleLens, to: toggle.isOn)
         store.dispatch(ToolbarAction(windowUUID: windowUUID,
-                                     actionType: ToolbarActionType.googleLensSettingDidChange
-                                    )
-        )
+                                     actionType: ToolbarActionType.googleLensSettingDidChange))
     }
 
     @objc

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -58,6 +58,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
     var showGoogleLensPhotoPickerCalled = 0
     var showGoogleLensCameraCalled = 0
     var searchGoogleLensCalled = 0
+    var searchGoogleLensEntryPoint: GoogleLensUploadEntryPoint?
 
     func show(settings: Client.Route.SettingsSection, onDismiss: (() -> Void)?) {
         showSettingsCalled += 1
@@ -193,8 +194,9 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
         showGoogleLensCameraCalled += 1
     }
 
-    func searchGoogleLens(with image: UIImage) {
+    func searchGoogleLens(with image: UIImage, entryPoint: GoogleLensUploadEntryPoint) {
         searchGoogleLensCalled += 1
+        searchGoogleLensEntryPoint = entryPoint
     }
 
     // MARK: - BrowserDelegate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/GoogleLens/GoogleLensRequestBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/GoogleLens/GoogleLensRequestBuilderTests.swift
@@ -20,7 +20,8 @@ final class GoogleLensRequestBuilderTests: XCTestCase {
     }
 
     func test_makeUploadRequest_setsRequiredAndRecommendedQueryParams() throws {
-        let input = makeInput(viewportSize: CGSize(width: 390, height: 844))
+        let input = makeInput(viewportSize: CGSize(width: 390, height: 844),
+                              entryPoint: .addressToolbar)
 
         let request = makeSubject(localeProvider: MockLocaleProvider(languageCode: "en"))
             .makeUploadRequest(for: input)
@@ -31,6 +32,15 @@ final class GoogleLensRequestBuilderTests: XCTestCase {
         XCTAssertEqual(items["vpw"], "390")
         XCTAssertEqual(items["vph"], "844")
         XCTAssertEqual(items["hl"], "en")
+    }
+
+    func test_makeUploadRequest_usesWebImageContextMenuEntryPoint() throws {
+        let input = makeInput(entryPoint: .webImageContextMenu)
+
+        let request = makeSubject().makeUploadRequest(for: input)
+
+        let items = try queryItems(from: request)
+        XCTAssertEqual(items["ep"], "fcm")
     }
 
     func test_makeUploadRequest_omitsLanguageParam_whenLocaleProviderHasNoLanguageCode() throws {
@@ -72,10 +82,12 @@ final class GoogleLensRequestBuilderTests: XCTestCase {
     }
 
     private func makeInput(imageDimensions: CGSize = CGSize(width: 800, height: 600),
-                           viewportSize: CGSize = CGSize(width: 390, height: 844)) -> GoogleLensUploadInput {
+                           viewportSize: CGSize = CGSize(width: 390, height: 844),
+                           entryPoint: GoogleLensUploadEntryPoint = .addressToolbar) -> GoogleLensUploadInput {
         return GoogleLensUploadInput(jpegData: jpegData,
                                      imageDimensions: imageDimensions,
-                                     viewportSize: viewportSize)
+                                     viewportSize: viewportSize,
+                                     entryPoint: entryPoint)
     }
 
     private func data(_ string: String) -> Data {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/GoogleLens/GoogleLensServiceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/GoogleLens/GoogleLensServiceTests.swift
@@ -15,12 +15,15 @@ final class GoogleLensServiceTests: XCTestCase {
         let builder = MockRequestBuilder()
         let subject = GoogleLensService(imageProcessor: processor, requestBuilder: builder)
 
-        _ = subject.makeUploadRequest(for: UIImage(), viewportSize: CGSize(width: 390, height: 844))
+        _ = subject.makeUploadRequest(for: UIImage(),
+                                      viewportSize: CGSize(width: 390, height: 844),
+                                      entryPoint: .webImageContextMenu)
 
         XCTAssertEqual(builder.receivedInput,
                        GoogleLensUploadInput(jpegData: processed.jpegData,
                                              imageDimensions: processed.dimensions,
-                                             viewportSize: CGSize(width: 390, height: 844)))
+                                             viewportSize: CGSize(width: 390, height: 844),
+                                             entryPoint: .webImageContextMenu))
     }
 
     func test_makeUploadRequest_returnsBuilderRequest() {
@@ -29,7 +32,9 @@ final class GoogleLensServiceTests: XCTestCase {
         let builder = MockRequestBuilder()
         let subject = GoogleLensService(imageProcessor: processor, requestBuilder: builder)
 
-        let request = subject.makeUploadRequest(for: UIImage(), viewportSize: .zero)
+        let request = subject.makeUploadRequest(for: UIImage(),
+                                                viewportSize: .zero,
+                                                entryPoint: .addressToolbar)
 
         XCTAssertEqual(request, builder.stubbedRequest)
     }
@@ -39,7 +44,9 @@ final class GoogleLensServiceTests: XCTestCase {
         let builder = MockRequestBuilder()
         let subject = GoogleLensService(imageProcessor: processor, requestBuilder: builder)
 
-        let request = subject.makeUploadRequest(for: UIImage(), viewportSize: .zero)
+        let request = subject.makeUploadRequest(for: UIImage(),
+                                                viewportSize: .zero,
+                                                entryPoint: .addressToolbar)
 
         XCTAssertNil(request)
         XCTAssertNil(builder.receivedInput, "Builder should not be called when processing fails")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16250)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34578)

## :bulb: Description
- Use `ep=fcm` url query parameter for Google Lens web image context menu uploads

### 📝 Technical Notes
-  Keep address toolbar camera/photo uploads as `ep=fntpubb`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

