### PR TITLE
[MTE-5616] - fixes for CI failures

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -413,7 +413,7 @@ class BaseTestCase: XCTestCase {
         }
         var attempts = 3
         repeat {
-            passcodeInput.tapAndTypeText("foo\n")
+            passcodeInput.tapAndTypeTextWhenFocused("foo\n")
             if mozWaitForElementToNotExist(passcodeInput, timeout: TIMEOUT, failOnTimeout: false) {
                 return
             }
@@ -718,6 +718,48 @@ extension XCUIElement {
         self.mozWaitForElementToExist(timeout: timeout)
         self.tap()
         self.typeText(text)
+    }
+
+    /// Whether the element currently holds keyboard focus, read via KVC on the accessibility snapshot.
+    var hasKeyboardFocus: Bool {
+        return (self.value(forKey: "hasKeyboardFocus") as? Bool) ?? false
+    }
+
+    /// Waits until the element reports keyboard focus. Returns false on timeout instead of failing.
+    @discardableResult
+    func waitForKeyboardFocus(timeout: TimeInterval = TIMEOUT) -> Bool {
+        let predicate = NSPredicate(format: "hasKeyboardFocus == true")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    /// Taps and types text, but only once the field has keyboard focus.
+    ///
+    /// On CI some fields (the springboard passcode overlay, the address bar) are occasionally
+    /// presented without keyboard focus, so a plain `typeText` raises "Neither element nor any
+    /// descendant has keyboard focus" and aborts the test. This re-taps up to `tapAttempts` times
+    /// until focus is acquired before typing, and returns false (rather than failing hard) if it
+    /// never is, so callers can retry.
+    @discardableResult
+    func tapAndTypeTextWhenFocused(
+        _ text: String,
+        timeout: TimeInterval? = TIMEOUT,
+        focusTimeout: TimeInterval = 5,
+        tapAttempts: Int = 3
+    ) -> Bool {
+        self.mozWaitForElementToExist(timeout: timeout)
+        var attempts = tapAttempts
+        repeat {
+            if !hasKeyboardFocus {
+                self.tap()
+            }
+            if waitForKeyboardFocus(timeout: focusTimeout) {
+                self.typeText(text)
+                return true
+            }
+            attempts -= 1
+        } while attempts > 0
+        return false
     }
 
     func tapWithRetry() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LoginSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LoginSettingsScreen.swift
@@ -155,7 +155,7 @@ final class LoginSettingsScreen {
         }
         var attempts = 3
         repeat {
-            passcode.tapAndTypeText(passcodeValue)
+            passcode.tapAndTypeTextWhenFocused(passcodeValue)
             if base.mozWaitForElementToNotExist(passcode, timeout: TIMEOUT, failOnTimeout: false) {
                 return
             }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerUrlBarNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerUrlBarNavigation.swift
@@ -44,7 +44,9 @@ func registerUrlBarNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIAppli
             // Workaround BB iOS13 be sure tap happens on url bar
             searchTextField.waitAndTap()
             searchTextField.waitAndTap()
-            searchTextField.typeText(url)
+            // On CI the field is occasionally focus-less after tapping, which makes typeText abort;
+            // wait for keyboard focus (re-tapping if needed) before typing.
+            searchTextField.tapAndTypeTextWhenFocused(url)
             searchTextField.typeText("\r")
         }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5616

## :bulb: Description
This is another attempt to fix flaky login tests on CI. 

The tests failed because typeText was being called on fields (the passcode overlay, the URL bar) that hadn't received keyboard focus yet on CI — which throws Neither element nor any descendant has keyboard focus and aborts the test before any retry can help.

I added a tapAndTypeTextWhenFocused helper that waits for keyboard focus (re-tapping if needed) before typing, and returns false instead of crashing if focus never comes. Then I used it in the three spots that were failing:
- unlockLoginsView() in BaseTestCase.swift and LoginSettingsScreen.swift (the passcode entry — fixes the 5 LoginTest failures)
- LoadURLByTyping in registerUrlBarNavigation.swift (fixes the AuthenticationTest failure)
All the login tests (not just the flaky ones) have been verified locally with 100% rate pass.
