### PR TITLE
[MTE-5617] - Fix iPad flaky tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -88,8 +88,16 @@ class BaseTestCase: XCTestCase {
         }
         if icon.exists {
             if #available(iOS 26, *), iPad() {
-                iPadIcon.press(forDuration: 1.0)
-                springboard.buttons["Options"].tapWithRetry()
+                // iPad can match >1 icon and may lack the "Options" step. Press whichever icon
+                // opens the menu (fallback to primary) and tap "Options" only if present.
+                let removeAppButton = springboard.buttons["Remove App"]
+                for candidate in [iPadIcon, icon] where candidate.exists {
+                    candidate.press(forDuration: 1.0)
+                    springboard.buttons["Options"].tapIfExists()
+                    if removeAppButton.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) {
+                        break
+                    }
+                }
             } else {
                 icon.press(forDuration: 1.0)
             }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/JumpBackInScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/JumpBackInScreen.swift
@@ -55,6 +55,13 @@ final class JumpBackInScreen {
     func longPressFirstItem(duration: TimeInterval = 2, timeout: TimeInterval = TIMEOUT) {
         BaseTestCase().mozWaitForElementToExist(firstItemCell, timeout: timeout)
         firstItemCell.press(forDuration: duration)
+        // Long-press intermittently fails to open the menu on iPad; re-press (not tap) until it
+        // appears. No extra press happens when the first one succeeds.
+        var attempts = 3
+        while !contextMenuTable.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) && attempts > 0 {
+            firstItemCell.press(forDuration: duration)
+            attempts -= 1
+        }
     }
 
     func assertContextMenuExists() {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5617

## :bulb: Description
The iPad (iOS 26) app-uninstall flow pressed the wrong springboard icon and hard-failed when the "Options" button was absent, cascading through a chain of 10s timeouts (688s / 395s wasted) and failing the setup of otherwise-passing tests. Now it presses whichever icon opens the context menu (falling back to the primary icon) and taps "Options" only if present. iPad-only branch; the iPhone path is unchanged.
- Fixes EngagementNotificationTests.testDontAllowNotifications
- Fixes DisplaySettingTests.testCheckDisplaySettingsDefault

2. longPressFirstItem() — JumpBackInScreen.swift
The long-press intermittently failed to open the Jump Back In context menu on iPad. Now it re-presses (never taps, which would dismiss an open menu) until the menu appears; when the first press works, no extra press happens, so the iPhone path is effectively unchanged.
- Fixes JumpBackInTests.testLongTapOnJumpBackInLink
