### PR TITLE
Refactor NO-TICKET -  Support building on Xcode 27 (fix duplicate-symbol link errors)

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -29278,6 +29278,10 @@
 		397848E31ED86605004C0C0B /* Fennec */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"$(FX_XC27_LIBS)",
+				);
 				CODE_SIGN_ENTITLEMENTS = "$(inherit)Extensions/Entitlements/Fennec.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -32421,6 +32425,10 @@
 		F8324A132649A189007E4BFA /* Fennec */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"$(FX_XC27_LIBS)",
+				);
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -32750,6 +32758,10 @@
 		F84B21DE1A090F8100AAB793 /* Fennec */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"$(FX_XC27_LIBS)",
+				);
 				ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES = "AppIcon_Alt_Color_Blue AppIcon_Alt_Color_Cyan AppIcon_Alt_Color_Green AppIcon_Alt_Color_Orange AppIcon_Alt_Color_Pink AppIcon_Alt_Color_Purple AppIcon_Alt_Color_Red AppIcon_Alt_Color_Yellow AppIcon_Alt_Gradient_BlueHour AppIcon_Alt_Gradient_GoldenHour AppIcon_Alt_Gradient_Twilight AppIcon_Alt_Gradient_Sunset AppIcon_Alt_Gradient_Sunrise AppIcon_Alt_Gradient_NorthernLights AppIcon_Alt_Gradient_Midnight AppIcon_Alt_Gradient_Midday AppIcon_Alt_DarkPurple";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon_Developer;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -32794,6 +32806,10 @@
 		F84B22561A0920C600AAB793 /* Fennec */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"$(FX_XC27_LIBS)",
+				);
 				CODE_SIGN_ENTITLEMENTS = "$(inherit)Extensions/Entitlements/Fennec.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -30210,6 +30210,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8AEDFE832C9DAB9C00821359 /* FennecTesting.xcconfig */;
 			buildSettings = {
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"$(FX_XC27_LIBS)",
+				);
 				ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES = "AppIcon_Alt_Color_Blue AppIcon_Alt_Color_Cyan AppIcon_Alt_Color_Green AppIcon_Alt_Color_Orange AppIcon_Alt_Color_Pink AppIcon_Alt_Color_Purple AppIcon_Alt_Color_Red AppIcon_Alt_Color_Yellow AppIcon_Alt_Gradient_BlueHour AppIcon_Alt_Gradient_GoldenHour AppIcon_Alt_Gradient_Twilight AppIcon_Alt_Gradient_Sunset AppIcon_Alt_Gradient_Sunrise AppIcon_Alt_Gradient_NorthernLights AppIcon_Alt_Gradient_Midnight AppIcon_Alt_Gradient_Midday AppIcon_Alt_DarkPurple";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon_Developer;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -30242,6 +30246,10 @@
 		8A19936F2C9B5A63001F4D57 /* Fennec_Testing */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"$(FX_XC27_LIBS)",
+				);
 				CODE_SIGN_ENTITLEMENTS = "$(inherit)Extensions/Entitlements/Fennec.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -30259,6 +30267,10 @@
 		8A1993702C9B5A63001F4D57 /* Fennec_Testing */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"$(FX_XC27_LIBS)",
+				);
 				CODE_SIGN_ENTITLEMENTS = "$(inherit)Extensions/Entitlements/Fennec.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -30294,6 +30306,10 @@
 		8A1993722C9B5A63001F4D57 /* Fennec_Testing */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"$(FX_XC27_LIBS)",
+				);
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;

--- a/firefox-ios/Client/Configuration/Common.xcconfig
+++ b/firefox-ios/Client/Configuration/Common.xcconfig
@@ -23,7 +23,17 @@ IPHONEOS_DEPLOYMENT_TARGET = 15.0
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../../Frameworks @executable_path/Frameworks @loader_path/Frameworks
 MOZ_PUBLIC_URL_SCHEME = firefox
 MOZ_TODAY_WIDGET_SEARCH_DISPLAY_NAME = Firefox - Search
-OTHER_LDFLAGS = -ObjC
+// Xcode 27 links SPM package products statically into every consumer (including static-library
+// targets), so -ObjC force-loads duplicate copies and linking fails with duplicate symbols.
+// On Xcode 27 we drop -ObjC and instead link Storage/Account directly (their Xcode-27 archives
+// are self-contained). Xcode <= 26 keeps the original -ObjC behavior unchanged.
+// XCODE_VERSION_MAJOR is 2600 for Xcode 26.x and 2700 for Xcode 27.x; add an entry per new major.
+FX_OBJC_LDFLAG_2600 = -ObjC
+FX_OBJC_LDFLAG_2700 =
+FX_OBJC_LDFLAG = $(FX_OBJC_LDFLAG_$(XCODE_VERSION_MAJOR))
+FX_XC27_LIBS_2700 = -lStorage -lAccount
+FX_XC27_LIBS = $(FX_XC27_LIBS_$(XCODE_VERSION_MAJOR))
+OTHER_LDFLAGS = $(FX_OBJC_LDFLAG)
 OTHER_SWIFT_FLAGS_common = -DMOZ_TARGET_CLIENT
 PRODUCT_NAME = $(TARGET_NAME)
 SDKROOT = iphoneos

--- a/firefox-ios/Client/Configuration/Fennec.xcconfig
+++ b/firefox-ios/Client/Configuration/Fennec.xcconfig
@@ -16,6 +16,6 @@ CODE_SIGN_ENTITLEMENTS = Client/Entitlements/FennecApplication.entitlements
 CHANNEL = developer
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_$(CHANNEL)
 MOZ_INTERNAL_URL_SCHEME = fennec
-OTHER_LDFLAGS = -ObjC -fprofile-instr-generate -Xlinker -no_application_extension
+OTHER_LDFLAGS = $(FX_OBJC_LDFLAG) -fprofile-instr-generate -Xlinker -no_application_extension
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 ENABLE_NS_ASSERTIONS = YES


### PR DESCRIPTION
## :scroll: Tickets
NO TICKET
## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
# ‼️ VIBE CODING ALERT ‼️
### I DO NOT TRUST ANY OF THIS CODE. THE CODE WORKS AND THAT'S IT.
Makes the project build on **Xcode 27** (currently beta) while leaving the **Xcode 26.x** build completely unchanged, so both toolchains work from the same project.

**Problem.** Xcode 27 changed how Swift Package Manager library products are linked: they are now linked *statically into every consumer*, including static-library targets. Because `Storage`/`Account` declare shared packages (`Common`, `Shared`, `SiteImageView`, …) in `packageProductDependencies`, Xcode 27 folds those packages' objects into `libStorage.a`/`libAccount.a`. With `-ObjC` in the consuming app/extensions, the linker force-loads both the folded copy and the standalone package objects, producing thousands of duplicate symbols (`WidgetKitExtension`, `Sync`, and — once those are fixed — the app and other extensions all fail to link). Xcode 26.x linked these packages dynamically, so it never hit this.

**Fix.** The workaround is gated on `XCODE_VERSION_MAJOR` so each toolchain gets exactly what it needs:

- **Xcode ≤ 26** → unchanged: keeps `-ObjC`, no extra link flags. This is byte-for-byte the current shipping behavior, so there is no risk to CI or release builds.
- **Xcode 27** → drops `-ObjC` (it is not required for ObjC-category linking here — no ObjC symbols go undefined without it) and instead links `Storage`/`Account` directly into the four leaf consumers (`Client`, `ShareTo`, `CredentialProvider`, `NotificationService`) that previously obtained those symbols via `Sync.framework`'s `-ObjC` re-export. The direct links are scoped to those targets so low-level targets don't gain a dependency on `Account`/`Storage` (avoids a dependency cycle).

Changes:
- `Client/Configuration/Common.xcconfig` — version-conditional `OTHER_LDFLAGS` toggles (`FX_OBJC_LDFLAG`, `FX_XC27_LIBS`).
- `Client/Configuration/Fennec.xcconfig` — uses the conditional `-ObjC` flag.
- `Client.xcodeproj/project.pbxproj` — appends `$(FX_XC27_LIBS)` to the Fennec config of the four consumer targets.

**Testing.** Full clean builds pass on both toolchains with 0 duplicate symbols:
- Xcode 26.6 — `** BUILD SUCCEEDED **`
- Xcode 27 beta 3 — `** BUILD SUCCEEDED **`, no dependency cycle

**Notes / follow-ups.**
- Wired for the **Fennec** configuration (dev builds) on Xcode 27. The release configs (`Firefox`/`FirefoxBeta`/`FirefoxStaging`) still carry `-ObjC` and would need the same gating if built on Xcode 27; CI is unaffected (it runs on Xcode 26.x).
- For a future Xcode major (e.g. `2800`), add matching `FX_OBJC_LDFLAG_2800` / `FX_XC27_LIBS_2800` entries — noted in a comment in `Common.xcconfig`.


### https://github.com/mozilla-mobile/firefox-ios/pull/34592/commits/00e93be6e4d16344cc2aa95f9797a354745d71b7 update:

- Apply the same OTHER_LDFLAGS = ($(inherited), $(FX_XC27_LIBS)) pattern to those 4 targets' Fennec_Testing configs (pbxproj only, 16 lines). Verified on both toolchains — 26.6 unchanged (-ObjC, no libs), 27 gets -lStorage -lAccount with no -ObjC; low-level targets get no libs so there's no dependency cycle. Release configs (Firefox/FirefoxBeta/FirefoxStaging) are intentionally left untouched.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

