### PR TITLE
Bugfix FXIOS-15549 Minimal address bar should expand before reaching pull to refresh

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -431,9 +431,13 @@ final class LegacyTabScrollController: NSObject,
     ) {
         if keyPath == "contentSize" {
             ensureMainThread { [weak self] in
-                guard let self, self.shouldUpdateUIWhenScrolling, self.toolbarsShowing else { return }
+                guard let self else { return }
 
-                self.showToolbars(animated: true)
+                // When the content is no longer scrollable example a page adds an overlay that shrinks the
+                // document, the user can't reveal the toolbars by scrolling, force them visible if collapsed.
+                if !self.hasScrollableContent, self.isToolbarStateCollapsed {
+                    self.showToolbars(animated: false)
+                }
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -149,6 +149,37 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         XCTAssertNotNil(pullRefresh)
     }
 
+    func testContentSizeChange_WhenCollapsedAndContentBecomesNonScrollable_ShowsToolbar() throws {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        let scrollView = try XCTUnwrap(tab.webView?.scrollView)
+        // Collapse while the content is still scrollable, as only a scroll gesture can.
+        subject.hideToolbars(animated: false)
+        XCTAssertTrue(subject.isToolbarStateCollapsed)
+
+        // Simulate an overlay shrinking the document so it can no longer be scrolled.
+        scrollView.contentSize = CGSize(width: 200, height: 10)
+        subject.observeValue(forKeyPath: "contentSize", of: scrollView, change: nil, context: nil)
+
+        XCTAssertFalse(subject.isToolbarStateCollapsed)
+    }
+
+    func testContentSizeChange_WhenCollapsedAndContentStaysScrollable_KeepsToolbarCollapsed() throws {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+
+        let scrollView = try XCTUnwrap(tab.webView?.scrollView)
+        subject.hideToolbars(animated: false)
+        XCTAssertTrue(subject.isToolbarStateCollapsed)
+
+        // Content grows but is still taller than the viewport, so the toolbar must stay collapsed.
+        scrollView.contentSize = CGSize(width: 200, height: 3000)
+        subject.observeValue(forKeyPath: "contentSize", of: scrollView, change: nil, context: nil)
+
+        XCTAssertTrue(subject.isToolbarStateCollapsed)
+    }
+
     // MARK: - overKeyboardScrollHeight Helper Method Tests
     func testOverKeyboardScrollHeight_minimalEnabledWithHomeIndicator_returnsZero() {
         let subject = createSubject()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15549)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33323)

## :bulb: Description
- Show toolbar if the content becomes not scrollable example a popup appears and the toolbar is collapsed, force showToolbars so the user can reload or interact with the urlbar


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

