### PR TITLE
Add FXIOS-16208 [Google Lens] Telemetry

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
+++ b/BrowserKit/Sources/ToolbarKit/ToolbarButton.swift
@@ -115,15 +115,18 @@ class ToolbarButton: UIButton,
         accessibilityLabel = element.a11yLabel
         accessibilityHint = element.a11yHint
 
-        // Remove all existing actions for .touchUpInside before adding the new one
-        // This ensures that we do not accumulate multiple actions for the same event,
-        // which can cause the action to be called multiple times when the button is tapped.
-        // By removing all existing actions first, we guarantee that only the new action
-        // will be associated with the .touchUpInside event.
+        // Remove all existing actions before adding the new one. This ensures that we do
+        // not accumulate multiple actions for the same event, which can cause the action to
+        // be called multiple times when the button is tapped. A button uses either
+        // .touchUpInside (regular buttons) or .menuActionTriggered (menu buttons), so we
+        // clear both to guarantee that only the new action remains.
         removeTarget(nil, action: nil, for: .touchUpInside)
+        removeTarget(nil, action: nil, for: .menuActionTriggered)
         configureMenuIfNeeded(for: element)
         if element.menuElements.isEmpty {
             addAction(action, for: .touchUpInside)
+        } else {
+            addAction(action, for: .menuActionTriggered)
         }
 
         showsLargeContentViewer = true

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1733,7 +1733,9 @@
 		C7CDBEFD2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CDBEFC2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift */; };
 		C7F051522D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */; };
 		C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */; };
+		A1B2C3D40000000000000002 /* GoogleLensTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */; };
 		C7F051582D9F098200EC52C0 /* ContextMenuTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */; };
+		A1B2C3D40000000000000004 /* GoogleLensTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000003 /* GoogleLensTelemetryTests.swift */; };
 		C7F051692DB2F38000EC52C0 /* ContextMenuPreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051682DB2F38000EC52C0 /* ContextMenuPreviewViewController.swift */; };
 		C7F5331A2E5799AA0089DEC7 /* ShortcutsLibraryTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F533192E5799AA0089DEC7 /* ShortcutsLibraryTelemetry.swift */; };
 		C7F5331E2E57A8A00089DEC7 /* ShortcutsLibraryMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F5331D2E57A8A00089DEC7 /* ShortcutsLibraryMiddleware.swift */; };
@@ -10738,7 +10740,9 @@
 		C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDeletionUtilityTelemetryTests.swift; sourceTree = "<group>"; };
 		C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDeletionUtilityTelemetry.swift; sourceTree = "<group>"; };
 		C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetry.swift; sourceTree = "<group>"; };
+		A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLensTelemetry.swift; sourceTree = "<group>"; };
 		C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetryTests.swift; sourceTree = "<group>"; };
+		A1B2C3D40000000000000003 /* GoogleLensTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLensTelemetryTests.swift; sourceTree = "<group>"; };
 		C7F051682DB2F38000EC52C0 /* ContextMenuPreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPreviewViewController.swift; sourceTree = "<group>"; };
 		C7F533192E5799AA0089DEC7 /* ShortcutsLibraryTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsLibraryTelemetry.swift; sourceTree = "<group>"; };
 		C7F5331D2E57A8A00089DEC7 /* ShortcutsLibraryMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsLibraryMiddleware.swift; sourceTree = "<group>"; };
@@ -14668,6 +14672,7 @@
 				8CFBC1892ECF44C400E5B22B /* ActionExtensionTelemetryTests.swift */,
 				8ADA19A12E7DB86400E95E5E /* NotificationManagerTelemetryTests.swift */,
 				C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */,
+				A1B2C3D40000000000000003 /* GoogleLensTelemetryTests.swift */,
 				8A87E98B2E70792F006F0239 /* FxSuggestTelemetryTests.swift */,
 				C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */,
 				0A686B3B2CDB70DC0090E146 /* MainMenuTelemetryTests.swift */,
@@ -16898,6 +16903,7 @@
 				AB3DB0C82B596739001D32CB /* AppStartupTelemetry.swift */,
 				8A0DF2C12D6D1C670066EC00 /* AutoplaySettingTelemetry.swift */,
 				C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */,
+				A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */,
 				3933D4F32EF3357D00C0C4E3 /* DefaultBrowserUtilityTelemetry.swift */,
 				8A732A812DE8AFCA0099F575 /* FxSuggestTelemetry.swift */,
 				8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */,
@@ -19652,6 +19658,7 @@
 				C7CDBEFD2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift in Sources */,
 				8A48807E2E68923200AD43D5 /* GleanHttpUploader.swift in Sources */,
 				C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */,
+				A1B2C3D40000000000000002 /* GoogleLensTelemetry.swift in Sources */,
 				0E4AF8652D764046002E4238 /* DownloadProgressManager.swift in Sources */,
 				819656192C80ECFE00E62323 /* MainMenuMiddleware.swift in Sources */,
 				E127313D28B6AD99006F39D2 /* WallpaperSettingsViewModel.swift in Sources */,
@@ -20604,6 +20611,7 @@
 				81DAB2F12C88F02500F4BE98 /* MainMenuViewControllerTests.swift in Sources */,
 				C25018E72ECC88440071506F /* BridgeTests.swift in Sources */,
 				C7F051582D9F098200EC52C0 /* ContextMenuTelemetryTests.swift in Sources */,
+				A1B2C3D40000000000000004 /* GoogleLensTelemetryTests.swift in Sources */,
 				219935F12B07DFA200E5966F /* TabDisplayPanelTests.swift in Sources */,
 				0B7B053D2D647D00007FD7AC /* TemporaryDocumentTests.swift in Sources */,
 				C714D6372E46570700FC02E6 /* ShortcutsLibraryStateTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1171,7 +1171,7 @@ final class BrowserCoordinator: BaseCoordinator,
             router: router
         ) { [weak self] image in
             guard let image else { return }
-            self?.searchGoogleLens(with: image, entryPoint: .addressToolbar)
+            self?.searchGoogleLens(with: image, source: .camera)
         }
         add(child: coordinator)
         coordinator.start()
@@ -1180,13 +1180,14 @@ final class BrowserCoordinator: BaseCoordinator,
                                             actionType: GeneralBrowserActionType.leaveOverlay))
     }
 
-    func searchGoogleLens(with image: UIImage, entryPoint: GoogleLensUploadEntryPoint) {
+    func searchGoogleLens(with image: UIImage, source: GoogleLensTelemetry.Source) {
         guard let tab = tabManager.selectedTab else {
             logger.log("Google Lens: no selected tab to load the upload request",
                        level: .warning,
                        category: .coordinator)
             return
         }
+        let entryPoint: GoogleLensUploadEntryPoint = source == .contextMenu ? .webImageContextMenu : .addressToolbar
         let viewportSize = tab.webView?.bounds.size ?? browserViewController.view.bounds.size
         guard let request = googleLensService.makeUploadRequest(for: image,
                                                                 viewportSize: viewportSize,
@@ -1196,6 +1197,7 @@ final class BrowserCoordinator: BaseCoordinator,
                        category: .coordinator)
             return
         }
+        browserViewController.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: source)
         _ = tab.loadRequest(request)
     }
     private func handleGoogleLensPhotoPick(_ results: [PHPickerResult]) {
@@ -1212,7 +1214,7 @@ final class BrowserCoordinator: BaseCoordinator,
             DispatchQueue.main.async {
                 guard let self else { return }
                 if let image {
-                    self.searchGoogleLens(with: image, entryPoint: .addressToolbar)
+                    self.searchGoogleLens(with: image, source: .photoPicker)
                 } else if let errorDescription {
                     self.logger.log("Google Lens: failed to load picked image: \(errorDescription)",
                                     level: .warning,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -133,7 +133,7 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     func showGoogleLensCamera()
 
     @MainActor
-    func searchGoogleLens(with image: UIImage, entryPoint: GoogleLensUploadEntryPoint)
+    func searchGoogleLens(with image: UIImage, source: GoogleLensTelemetry.Source)
 
     @MainActor
     func showQuickAnswers(transitionType: QuickAnswersTransitionType)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -436,9 +436,18 @@ extension BrowserViewController: WKUIDelegate {
         getImageData(url) { [weak self] data in
             guard let image = UIImage(data: data) else { return }
             ensureMainThread {
-                self?.navigationHandler?.searchGoogleLens(with: image, entryPoint: .webImageContextMenu)
+                self?.navigationHandler?.searchGoogleLens(with: image, source: .contextMenu)
             }
         }
+    }
+
+    /// Reports the completion of an in-flight Google Lens image search (see `googleLensSearches`)
+    /// once its results page finishes loading or fails, then clears the tracked state.
+    private func recordGoogleLensSearchCompletedIfNeeded(for tab: Tab?, succeeded: Bool) {
+        guard let tab, let search = googleLensSearches.removeValue(forKey: tab.tabUUID) else { return }
+        GoogleLensTelemetry().searchCompleted(source: search.source,
+                                              succeeded: succeeded,
+                                              httpStatusCode: search.httpStatusCode)
     }
 
     func assignWebView(_ webView: WKWebView?) {
@@ -819,6 +828,15 @@ extension BrowserViewController: WKNavigationDelegate {
         tabManager[webView]?.mimeType = response.mimeType
         notificationCenter.post(name: .TabMimeTypeDidSet, withUserInfo: windowUUID.userInfo)
 
+        // Check for google lens web navigation response to record http status code extra
+        if let tab = tabManager[webView],
+           googleLensSearches[tab.tabUUID] != nil,
+           navigationResponse.isForMainFrame,
+           let httpResponse = response as? HTTPURLResponse,
+           responseURL?.host?.contains("google.com") == true {
+            googleLensSearches[tab.tabUUID]?.httpStatusCode = httpResponse.statusCode
+        }
+
         var request: URLRequest?
         if let url = responseURL {
             request = pendingRequests.removeValue(forKey: url.absoluteString)
@@ -1044,6 +1062,7 @@ extension BrowserViewController: WKNavigationDelegate {
                                             value: .webviewFail)
 
         webviewTelemetry.cancel()
+        recordGoogleLensSearchCompletedIfNeeded(for: tabManager[webView], succeeded: false)
     }
 
     /// Invoked when an error occurs while starting to load data for the main frame.
@@ -1062,6 +1081,7 @@ extension BrowserViewController: WKNavigationDelegate {
                                             value: .webviewFailProvisional)
 
         webviewTelemetry.cancel()
+        recordGoogleLensSearchCompletedIfNeeded(for: tabManager[webView], succeeded: false)
 
         // Ignore the "Frame load interrupted" error that is triggered when we cancel a request
         // to open an external application and hand it over to UIApplication.openURL(). The result
@@ -1247,6 +1267,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
         webviewTelemetry.stop()
+        recordGoogleLensSearchCompletedIfNeeded(for: tabManager[webView], succeeded: true)
 
         if let url = webView.url, InternalURL(url) == nil {
             if let title = webView.title,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -373,6 +373,7 @@ class BrowserViewController: UIViewController,
 
     let profile: Profile
     let tabManager: TabManager
+    var googleLensSearches = [TabUUID: GoogleLensSearchState]()
     let crashTracker: CrashTracker
     let ratingPromptManager: RatingPromptManager
     private(set) var browserViewControllerState: BrowserViewControllerState?

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -319,11 +319,13 @@ final class ToolbarMiddleware {
             toolbarTelemetry.googleLensButtonTapped()
 
         case .googleLensPhotoLibrary:
+            toolbarTelemetry.googleLensContextMenuOptionSelected(option: .photoPicker)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showGoogleLensPhotoPicker)
             store.dispatch(action)
 
         case .googleLensTakePhoto:
+            toolbarTelemetry.googleLensContextMenuOptionSelected(option: .camera)
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showGoogleLensCamera)
             store.dispatch(action)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -315,6 +315,9 @@ final class ToolbarMiddleware {
                                               actionType: GeneralBrowserActionType.showShare)
             store.dispatch(action)
 
+        case .googleLens:
+            toolbarTelemetry.googleLensButtonTapped()
+
         case .googleLensPhotoLibrary:
             let action = GeneralBrowserAction(windowUUID: action.windowUUID,
                                               actionType: GeneralBrowserActionType.showGoogleLensPhotoPicker)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarTelemetry.swift
@@ -69,6 +69,10 @@ struct ToolbarTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.Toolbar.searchButtonTapped, extras: isPrivateExtra)
     }
 
+    func googleLensButtonTapped() {
+        gleanWrapper.recordEvent(for: GleanMetrics.ToolbarGoogleLensButton.tapped)
+    }
+
     func tabTrayButtonTapped(isPrivate: Bool) {
         let isPrivateExtra = GleanMetrics.Toolbar.TabTrayButtonTappedExtra(isPrivate: isPrivate)
         gleanWrapper.recordEvent(for: GleanMetrics.Toolbar.tabTrayButtonTapped, extras: isPrivateExtra)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarTelemetry.swift
@@ -6,6 +6,11 @@ import Foundation
 import Glean
 
 struct ToolbarTelemetry {
+    enum GoogleLensContextMenuOption: String {
+        case photoPicker
+        case camera
+    }
+
     private let gleanWrapper: GleanWrapper
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
@@ -71,6 +76,12 @@ struct ToolbarTelemetry {
 
     func googleLensButtonTapped() {
         gleanWrapper.recordEvent(for: GleanMetrics.ToolbarGoogleLensButton.tapped)
+    }
+
+    func googleLensContextMenuOptionSelected(option: GoogleLensContextMenuOption) {
+        let optionExtra = GleanMetrics.ToolbarGoogleLensButtonContextMenu.OptionSelectedExtra(option: option.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.ToolbarGoogleLensButtonContextMenu.optionSelected,
+                                 extras: optionExtra)
     }
 
     func tabTrayButtonTapped(isPrivate: Bool) {

--- a/firefox-ios/Client/Glean/gleanProbes.xcfilelist
+++ b/firefox-ios/Client/Glean/gleanProbes.xcfilelist
@@ -9,6 +9,7 @@ $(PROJECT_DIR)/Client/Glean/probes/autofill.credit_cards.yaml
 $(PROJECT_DIR)/Client/Glean/probes/autofill.email_mask.yaml
 $(PROJECT_DIR)/Client/Glean/probes/autofill.password_generator.yaml
 $(PROJECT_DIR)/Client/Glean/probes/autofill.passwords.yaml
+$(PROJECT_DIR)/Client/Glean/probes/google_lens.yaml
 $(PROJECT_DIR)/Client/Glean/probes/history.yaml
 $(PROJECT_DIR)/Client/Glean/probes/homepage.shortcuts_library.yaml
 $(PROJECT_DIR)/Client/Glean/probes/library.bookmarks_panel.yaml

--- a/firefox-ios/Client/Glean/glean_index.yaml
+++ b/firefox-ios/Client/Glean/glean_index.yaml
@@ -17,6 +17,7 @@ metrics_files:
   - firefox-ios/Client/Glean/probes/autofill.password_generator.yaml
   - firefox-ios/Client/Glean/probes/autofill.passwords.yaml
   - firefox-ios/Client/Glean/probes/broken_site_report.yaml
+  - firefox-ios/Client/Glean/probes/google_lens.yaml
   - firefox-ios/Client/Glean/probes/history.yaml
   - firefox-ios/Client/Glean/probes/homepage.shortcuts_library.yaml
   - firefox-ios/Client/Glean/probes/library.bookmarks_panel.yaml

--- a/firefox-ios/Client/Glean/probes/google_lens.yaml
+++ b/firefox-ios/Client/Glean/probes/google_lens.yaml
@@ -1,0 +1,48 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the metrics that are recorded by the Glean SDK. They are
+# automatically converted to Swift code at build time using the `glean_parser`
+# PyPI package.
+
+# This file is organized (roughly) alphabetically by metric names
+# for easy navigation
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+$tags:
+  - GoogleLens
+
+###############################################################################
+# Documentation
+###############################################################################
+
+google_lens:
+  search_completed:
+    type: event
+    description: |
+      Recorded when the Google Lens results page is displayed to the user
+      (or fails to load) after an image search.
+    extra_keys:
+      source:
+        type: string
+        description: |
+          Where the Google Lens search was initiated from.
+          Options are listed in the GoogleLensTelemetry.Source enumeration.
+      succeeded:
+        type: boolean
+        description: |
+          Whether the Google Lens results page loaded successfully.
+      http_status:
+        type: quantity
+        description: |
+          The HTTP status code of the Google Lens upload response, when available.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16208
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never

--- a/firefox-ios/Client/Glean/probes/google_lens.yaml
+++ b/firefox-ios/Client/Glean/probes/google_lens.yaml
@@ -42,7 +42,7 @@ google_lens:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16208
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34604
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/search.yaml
+++ b/firefox-ios/Client/Glean/probes/search.yaml
@@ -127,20 +127,6 @@ search:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
-  google_lens_enabled:
-    type: boolean
-    description: |
-      Whether the user has the Google Lens image search feature enabled in the settings.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-16208
-    data_reviews:
-      - TBD
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: never
-    metadata:
-      tags:
-        - GoogleLens
 
 # Trending Searches
 search.trending_searches:
@@ -250,3 +236,19 @@ search.recent_searches:
     metadata:
       tags:
         - RecentSearches
+
+user.search:
+  google_lens_enabled:
+    type: boolean
+    description: |
+      Whether the user has the Google Lens image search feature enabled in the settings.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16208
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34604
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - GoogleLens

--- a/firefox-ios/Client/Glean/probes/search.yaml
+++ b/firefox-ios/Client/Glean/probes/search.yaml
@@ -127,6 +127,20 @@ search:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+  google_lens_enabled:
+    type: boolean
+    description: |
+      Whether the user has the Google Lens image search feature enabled in the settings.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16208
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - GoogleLens
 
 # Trending Searches
 search.trending_searches:

--- a/firefox-ios/Client/Glean/probes/toolbar.yaml
+++ b/firefox-ios/Client/Glean/probes/toolbar.yaml
@@ -344,7 +344,7 @@ toolbar.google_lens_button:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16208
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34604
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -367,7 +367,7 @@ toolbar.google_lens_button.context_menu:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16208
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34604
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/toolbar.yaml
+++ b/firefox-ios/Client/Glean/probes/toolbar.yaml
@@ -335,6 +335,23 @@ toolbar:
       - fx-ios-data-stewards@mozilla.com
     expires: never
 
+toolbar.google_lens_button:
+  tapped:
+    type: event
+    description: |
+      Recorded when the user initiates the Google Lens flow by tapping
+      the Google Lens icon on the address toolbar.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16208
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - GoogleLens
+
 # Awesomebar related telemetry
 awesomebar:
   location:

--- a/firefox-ios/Client/Glean/probes/toolbar.yaml
+++ b/firefox-ios/Client/Glean/probes/toolbar.yaml
@@ -352,6 +352,29 @@ toolbar.google_lens_button:
       tags:
         - GoogleLens
 
+toolbar.google_lens_button.context_menu:
+  option_selected:
+    type: event
+    description: |
+      Recorded when the user selects an option from the Google Lens address toolbar
+      button context menu.
+    extra_keys:
+      option:
+        type: string
+        description: |
+          The option selected from the context menu.
+          Options are listed in the ToolbarTelemetry.GoogleLensContextMenuOption enumeration.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16208
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - GoogleLens
+
 # Awesomebar related telemetry
 awesomebar:
   location:

--- a/firefox-ios/Client/Glean/tags.yaml
+++ b/firefox-ios/Client/Glean/tags.yaml
@@ -48,6 +48,9 @@ CreditCards:
 DownloadsPanel:
   description: Corresponds to the library screen's downloads panel where the user can view their downloads.
 
+GoogleLens:
+  description: Corresponds to the Google Lens image search feature and its entry points (toolbar button and web image context menu).
+
 History:
   description: Corresponds to the internal data store of history within the app. Not to be confused with `HistoryPanel`, which refers to the History screen in the library.
 

--- a/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+struct GoogleLensSearchState {
+    let source: GoogleLensTelemetry.Source
+    var httpStatusCode: Int?
+}
+
+struct GoogleLensTelemetry {
+    enum Source: String {
+        case camera
+        case photoPicker
+        case contextMenu
+    }
+
+    private let gleanWrapper: GleanWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
+    func searchCompleted(source: Source, succeeded: Bool, httpStatusCode: Int?) {
+        let extra = GleanMetrics.GoogleLens.SearchCompletedExtra(
+            httpStatus: httpStatusCode.map(Int32.init),
+            source: source.rawValue,
+            succeeded: succeeded
+        )
+        gleanWrapper.recordEvent(for: GleanMetrics.GoogleLens.searchCompleted, extras: extra)
+    }
+}

--- a/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
@@ -8,6 +8,11 @@ import Glean
 struct GoogleLensSearchState {
     let source: GoogleLensTelemetry.Source
     var httpStatusCode: Int?
+
+    init(source: GoogleLensTelemetry.Source, httpStatusCode: Int? = nil) {
+        self.source = source
+        self.httpStatusCode = httpStatusCode
+    }
 }
 
 struct GoogleLensTelemetry {

--- a/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
@@ -23,6 +23,10 @@ struct GoogleLensTelemetry {
         self.gleanWrapper = gleanWrapper
     }
 
+    func googleLensEnabled(_ enabled: Bool) {
+        gleanWrapper.setBoolean(for: GleanMetrics.Search.googleLensEnabled, value: enabled)
+    }
+
     func searchCompleted(source: Source, succeeded: Bool, httpStatusCode: Int?) {
         let extra = GleanMetrics.GoogleLens.SearchCompletedExtra(
             httpStatus: httpStatusCode.map(Int32.init),

--- a/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
@@ -24,7 +24,7 @@ struct GoogleLensTelemetry {
     }
 
     func googleLensEnabled(_ enabled: Bool) {
-        gleanWrapper.setBoolean(for: GleanMetrics.Search.googleLensEnabled, value: enabled)
+        gleanWrapper.setBoolean(for: GleanMetrics.UserSearch.googleLensEnabled, value: enabled)
     }
 
     func searchCompleted(source: Source, succeeded: Bool, httpStatusCode: Int?) {

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -42,6 +42,7 @@ enum SearchLocation: String {
 // FIXME: FXIOS-13987 Make truly thread safe
 class TelemetryWrapper: TelemetryWrapperProtocol,
                         UserFeaturePreferenceProvider,
+                        FeatureFlaggable,
                         Notifiable,
                         @unchecked Sendable {
     typealias ExtraKey = TelemetryWrapper.EventExtraKey
@@ -332,6 +333,11 @@ class TelemetryWrapper: TelemetryWrapperProtocol,
             let summarizerTelemetry = SummarizerTelemetry()
             summarizerTelemetry.summarizationEnabled(summarizerNimbusUtils.isSummarizeFeatureToggledOn)
             summarizerTelemetry.summarizationShakeGestureEnabled(summarizerNimbusUtils.isShakeGestureEnabled)
+        }
+
+        // Record Google Lens user preference
+        if featureFlagsProvider.isEnabled(.googleLens) {
+            GoogleLensTelemetry().googleLensEnabled(userPreferences.getPreferenceFor(.googleLens))
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -58,7 +58,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
     var showGoogleLensPhotoPickerCalled = 0
     var showGoogleLensCameraCalled = 0
     var searchGoogleLensCalled = 0
-    var searchGoogleLensEntryPoint: GoogleLensUploadEntryPoint?
+    var searchGoogleLensSource: GoogleLensTelemetry.Source?
 
     func show(settings: Client.Route.SettingsSection, onDismiss: (() -> Void)?) {
         showSettingsCalled += 1
@@ -194,9 +194,9 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
         showGoogleLensCameraCalled += 1
     }
 
-    func searchGoogleLens(with image: UIImage, entryPoint: GoogleLensUploadEntryPoint) {
+    func searchGoogleLens(with image: UIImage, source: GoogleLensTelemetry.Source) {
         searchGoogleLensCalled += 1
-        searchGoogleLensEntryPoint = entryPoint
+        searchGoogleLensSource = source
     }
 
     // MARK: - BrowserDelegate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -505,7 +505,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
     // MARK: - Google Lens search completion
 
     @MainActor
-    func testWebViewDidFinish_reportsAndClearsPendingGoogleLensSearch() {
+    func testWebViewDidFinish_clearsPendingGoogleLensSearch() {
         let subject = createSubject()
         let tab = createTab()
         tabManager.tabs = [tab]
@@ -519,7 +519,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
     }
 
     @MainActor
-    func testWebViewDidFailProvisionalNavigation_reportsAndClearsPendingGoogleLensSearch() {
+    func testWebViewDidFailProvisionalNavigation_clearsPendingGoogleLensSearch() {
         let subject = createSubject()
         let tab = createTab()
         tabManager.tabs = [tab]

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -501,4 +501,49 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
 
         XCTAssertTrue(screenshotHelper.takeScreenshotCalled)
     }
+
+    // MARK: - Google Lens search completion
+
+    @MainActor
+    func testWebViewDidFinish_reportsAndClearsPendingGoogleLensSearch() {
+        let subject = createSubject()
+        let tab = createTab()
+        tabManager.tabs = [tab]
+        tabManager.selectedTab = tab
+        subject.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: .camera)
+
+        subject.webView(tab.webView!, didFinish: nil)
+
+        XCTAssertNil(subject.googleLensSearches[tab.tabUUID],
+                     "Finishing navigation should report and clear the pending Google Lens search")
+    }
+
+    @MainActor
+    func testWebViewDidFailProvisionalNavigation_reportsAndClearsPendingGoogleLensSearch() {
+        let subject = createSubject()
+        let tab = createTab()
+        tabManager.tabs = [tab]
+        subject.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: .contextMenu)
+
+        // Code 102 ("Frame load interrupted") makes the delegate return early right after the
+        // Google Lens reporting, keeping the test free of error-page side effects.
+        subject.webView(tab.webView!,
+                        didFailProvisionalNavigation: nil,
+                        withError: NSError(domain: "WebKitErrorDomain", code: 102))
+
+        XCTAssertNil(subject.googleLensSearches[tab.tabUUID],
+                     "A failed navigation should report and clear the pending Google Lens search")
+    }
+
+    @MainActor
+    func testWebViewDidFinish_withoutPendingGoogleLensSearch_doesNothing() {
+        let subject = createSubject()
+        let tab = createTab()
+        tabManager.tabs = [tab]
+        tabManager.selectedTab = tab
+
+        subject.webView(tab.webView!, didFinish: nil)
+
+        XCTAssertTrue(subject.googleLensSearches.isEmpty)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/GoogleLensTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/GoogleLensTelemetryTests.swift
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import XCTest
+
+@testable import Client
+
+final class GoogleLensTelemetryTests: XCTestCase {
+    var subject: GoogleLensTelemetry?
+    var gleanWrapper: MockGleanWrapper!
+
+    override func setUp() {
+        super.setUp()
+        gleanWrapper = MockGleanWrapper()
+        subject = GoogleLensTelemetry(gleanWrapper: gleanWrapper)
+    }
+
+    override func tearDown() {
+        subject = nil
+        gleanWrapper = nil
+        super.tearDown()
+    }
+
+    func testRecordEvent_SearchCompleted() throws {
+        let event = GleanMetrics.GoogleLens.searchCompleted
+        typealias EventExtrasType = GleanMetrics.GoogleLens.SearchCompletedExtra
+
+        subject?.searchCompleted(source: .camera, succeeded: true, httpStatusCode: 200)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.source, GoogleLensTelemetry.Source.camera.rawValue)
+        XCTAssertEqual(savedExtras.succeeded, true)
+        XCTAssertEqual(savedExtras.httpStatus, 200)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
+    func testRecordEvent_SearchCompleted_withoutStatusCode() throws {
+        typealias EventExtrasType = GleanMetrics.GoogleLens.SearchCompletedExtra
+
+        subject?.searchCompleted(source: .contextMenu, succeeded: false, httpStatusCode: nil)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+
+        XCTAssertEqual(savedExtras.source, GoogleLensTelemetry.Source.contextMenu.rawValue)
+        XCTAssertEqual(savedExtras.succeeded, false)
+        XCTAssertNil(savedExtras.httpStatus)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/GoogleLensTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/GoogleLensTelemetryTests.swift
@@ -39,6 +39,17 @@ final class GoogleLensTelemetryTests: XCTestCase {
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
+    func testSetBoolean_GoogleLensEnabled() throws {
+        let metric = GleanMetrics.UserSearch.googleLensEnabled
+
+        subject?.googleLensEnabled(true)
+
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? BooleanMetricType)
+
+        XCTAssertEqual(gleanWrapper.setBooleanCalled, 1)
+        XCTAssert(savedMetric === metric, "Received \(savedMetric) instead of \(metric)")
+    }
+
     func testRecordEvent_SearchCompleted_withoutStatusCode() throws {
         typealias EventExtrasType = GleanMetrics.GoogleLens.SearchCompletedExtra
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -837,11 +837,32 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
     func testDidTapButton_tapOnGoogleLensPhotoLibraryButton_dispatchesShowGoogleLensPhotoPicker() throws {
         try didTapButton(buttonType: .googleLensPhotoLibrary,
                          expectedActionType: GeneralBrowserActionType.showGoogleLensPhotoPicker)
+
+        try assertGoogleLensContextMenuOptionSelected(option: .photoPicker)
     }
 
     func testDidTapButton_tapOnGoogleLensTakePhotoButton_dispatchesShowGoogleLensCamera() throws {
         try didTapButton(buttonType: .googleLensTakePhoto,
                          expectedActionType: GeneralBrowserActionType.showGoogleLensCamera)
+
+        try assertGoogleLensContextMenuOptionSelected(option: .camera)
+    }
+
+    private func assertGoogleLensContextMenuOptionSelected(
+        option: ToolbarTelemetry.GoogleLensContextMenuOption
+    ) throws {
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents.first
+                as? EventMetricType<GleanMetrics.ToolbarGoogleLensButtonContextMenu.OptionSelectedExtra>
+        )
+        let savedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras.first as? GleanMetrics.ToolbarGoogleLensButtonContextMenu.OptionSelectedExtra
+        )
+        let event = GleanMetrics.ToolbarGoogleLensButtonContextMenu.optionSelected
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 1)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+        XCTAssertEqual(savedExtras.option, option.rawValue)
     }
 
     func testDidTapButton_tapOnSearchButton_dispatchesDidStartEditingUrl() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -815,6 +815,25 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(savedExtras.isPrivate, false)
     }
 
+    func testDidTapButton_tapOnGoogleLensButton_recordsButtonTappedTelemetry() throws {
+        let subject = createSubject(manager: toolbarManager)
+        let action = ToolbarMiddlewareAction(
+            buttonType: .googleLens,
+            gestureType: .tap,
+            windowUUID: windowUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton)
+
+        subject.toolbarProvider(mockStore.state, action)
+
+        let savedMetric = try XCTUnwrap(
+            mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>
+        )
+        let event = GleanMetrics.ToolbarGoogleLensButton.tapped
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
     func testDidTapButton_tapOnGoogleLensPhotoLibraryButton_dispatchesShowGoogleLensPhotoPicker() throws {
         try didTapButton(buttonType: .googleLensPhotoLibrary,
                          expectedActionType: GeneralBrowserActionType.showGoogleLensPhotoPicker)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16208)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34580)

## :bulb: Description
- Add initial telemetry for Google Lens

### 📝 Technical Notes
**New Probes:**

| Probe Name | Extra Keys | Trigger |
| ------------- | ------------- | ------------- |
| `toolbar.google_lens_button.tapped` |  | Recorded when the user initiates the Google Lens flow by tapping the Google Lens icon on the address toolbar. |
| `toolbar.google_lens_button.context_menu.option_selected` | `option`: `camera` \| `photoPicker` | Recorded when the user selects an option from the Google Lens address toolbar button context menu. |
| `google_lens.search_completed` | source: `camera` \| `photoPicker` \| `contextMenu` <br> <br> `succeeded`: Boolean <br> <br> `http_status`: integer | Recorded when the Google Lens results page is displayed to the user (or fails to load) after an image search. |
| `user.search.google_lens_enabled` |  | Whether the user has the Google Lens image search feature enabled in the settings. Triggered by backgrounding the app. |

- [context_menu.option_selected](https://dictionary.telemetry.mozilla.org/apps/firefox_ios/metrics/context_menu_option_selected) can now have `option: googleLens` as an extra key. This was technically implemented automatically in FXIOS-16065
  - Web context menu telemetry is currently broken and not being recorded (see FXIOS-16276 for more details)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

