### PR TITLE
[MTE-5615] - Fix flaky CookiePersistenceTests on firefox

### DIFF
--- a/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
+++ b/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
@@ -14,6 +14,9 @@ public struct LaunchArguments {
     public static let SkipSponsoredShortcuts = "FIREFOX_SKIP_SPONSORED_SHORTCUTS"
     public static let SkipTermsOfUse = "FIREFOX_SKIP_TERMS_OF_USE"
     public static let ClearProfile = "FIREFOX_CLEAR_PROFILE"
+    /// Clears the WKWebView website data store (cookies, local storage, cache) on launch. Web data
+    /// lives in WKWebsiteDataStore, which ClearProfile does not touch.
+    public static let ClearWebData = "FIREFOX_CLEAR_WEB_DATA"
     public static let StageServer = "FIREFOX_USE_STAGE_SERVER"
     public static let FxAChinaServer = "FIREFOX_USE_FXA_CHINA_SERVER"
     public static let DeviceName = "DEVICE_NAME"

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -6,6 +6,7 @@ import Common
 import Foundation
 import Shared
 import Kingfisher
+import WebKit
 
 import class MozillaAppServices.HardcodedNimbusFeatures
 
@@ -223,6 +224,15 @@ class UITestAppDelegate: AppDelegate {
         // If the app is running from a XCUITest reset all settings in the app
         if ProcessInfo.processInfo.arguments.contains(LaunchArguments.ClearProfile) {
             resetApplication()
+        }
+
+        // Opt-in: WKWebView cookies/site data live in WKWebsiteDataStore, which ClearProfile does not
+        // clear. Only cleared when this argument is present so it doesn't reset web state for every test.
+        if ProcessInfo.processInfo.arguments.contains(LaunchArguments.ClearWebData) {
+            WKWebsiteDataStore.default().removeData(
+                ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+                modifiedSince: .distantPast
+            ) {}
         }
 
         Tab.ChangeUserAgent.clear()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CookiePersistenceTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 final class CookiePersistenceTests: BaseTestCase {
@@ -13,13 +14,9 @@ final class CookiePersistenceTests: BaseTestCase {
     let topSitesTitle = ["Facebook", "YouTube", "Wikipedia"]
 
     override func setUp() async throws {
-        // Fresh install the app
-        // removeApp() does not work on iOS 15 and 16 intermittently
-        if #available(iOS 17, *) {
-            removeApp()
-        }
-
-        // The app is correctly installed
+        // Start each test with a clean WKWebView cookie store (ClearProfile alone doesn't clear it)
+        // instead of relying on a fragile fresh install via removeApp().
+        launchArguments.append(LaunchArguments.ClearWebData)
         try await super.setUp()
         browserScreen = BrowserScreen(app: app)
         toolbarScreen = ToolbarScreen(app: app)
@@ -102,13 +99,10 @@ final class CookiePersistenceTests: BaseTestCase {
     }
 
     private func relaunchApp() {
-        // Restart the app
         app.terminate()
-
-        // Wait a moment if needed (optional but sometimes helpful)
         _ = app.wait(for: .notRunning, timeout: TIMEOUT)
-
-        // Launch it again
+        // Relaunch without ClearWebData so the web cookie store persists — this is what the test verifies.
+        app.launchArguments = app.launchArguments.filter { $0 != LaunchArguments.ClearWebData }
         app.launch()
     }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5615

## :bulb: Description
The cookie tests reset state between tests with removeApp() (flaky), and ClearProfile only clears HTTPCookieStorage — not the WKWebsiteDataStore where the WKWebView fixture's cookies actually live. So login cookies leaked between tests and the initial LOGGED_OUT assertion failed.

Changes:
- LaunchArguments.swift – added opt-in arg ClearWebData = "FIREFOX_CLEAR_WEB_DATA".
- UITestAppDelegate.swift – on launch, when ClearWebData is set, clear WKWebsiteDataStore (all web data). Gated on the new arg only, so no other test is affected; UITest-only code.
- CookiePersistenceTests.swift – setUp now opts into ClearWebData instead of calling removeApp(); relaunchApp() relaunches without ClearWebData so cookies persist across the in-test relaunch (the behavior under test).

Scoped to CookiePersistenceTests only, fixes both Fennec and Firefox schemes.
