### PR TITLE
[MTE-5618] - improve testFirefoxSuggestExists test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FirefoxSuggestTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FirefoxSuggestTest.swift
@@ -14,17 +14,14 @@ class FirefoxSuggestTest: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2360075
     func testFirefoxSuggestExists() {
+        // Firefox Suggest only appears once a search has been performed for the same text,
+        // so perform the search first and then search again with the same text.
+        navigator.goto(URLBarOpen)
+        urlBarAddress.typeText("sho\n")
+        navigator.nowAt(BrowserTab)
+
         navigator.goto(URLBarOpen)
         urlBarAddress.typeText("sho")
-        // Workaround for https://github.com/mozilla-mobile/firefox-ios/issues/28166
-        // Workaround: Press delete to trigger suggestions
-        let suggestCell = app.tables["SiteTable"].staticTexts["Firefox Suggest"]
-        if !suggestCell.mozWaitForElementToExist(timeout: 3, failOnTimeout: false) {
-            urlBarAddress.typeText(XCUIKeyboardKey.delete.rawValue)
-            XCTAssertTrue(suggestCell.mozWaitForElementToExist(timeout: 1, failOnTimeout: false),
-                          "Firefox Suggest did not appear even after workaround")
-        }
-        // End of workaround
         waitForElementsToExist(
             [
             app.tables["SiteTable"],


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5618

## :bulb: Description
I removed the delete workaround and replaced it with the proper flow.

What changed in FirefoxSuggestTest.swift:
- Before: typed "sho" once, then relied on pressing delete to force the suggestions to appear (the workaround for issue #28166).
- After: the test now performs a real search first — types "sho\n" to submit and load results, marks navigator.nowAt(BrowserTab), then reopens the URL bar and searches "sho" again. This is the actual condition under which Firefox Suggest surfaces, so the assertions for SiteTable, Google Search, and Firefox Suggest no longer depend on the delete hack.
