### PR TITLE
Revert "Bugfix FXIOS-16276 Restore web context menu telemetry broken by tab-leak fix (#34603)

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -34,10 +34,10 @@ class WebContextMenuActionsProvider {
                 title: .ContextMenuOpenInNewTab,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus),
                 identifier: UIAction.Identifier(rawValue: "linkContextMenu.openInNewTab")
-            ) { [weak currentTab] _ in
+            ) { [weak self, weak currentTab] _ in
                 guard let currentTab else { return }
                 addTab(url, false, currentTab)
-                self.recordOptionSelectedTelemetry(option: .openInNewTab)
+                self?.recordOptionSelectedTelemetry(option: .openInNewTab)
             })
     }
 
@@ -48,10 +48,10 @@ class WebContextMenuActionsProvider {
                 title: .ContextMenuOpenInNewPrivateTab,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.privateMode),
                 identifier: UIAction.Identifier("linkContextMenu.openInNewPrivateTab")
-            ) { [weak currentTab] _ in
+            ) { [weak self, weak currentTab] _ in
                 guard let currentTab else { return }
                 addTab(url, true, currentTab)
-                self.recordOptionSelectedTelemetry(option: .openInNewPrivateTab)
+                self?.recordOptionSelectedTelemetry(option: .openInNewPrivateTab)
             })
     }
 
@@ -62,9 +62,9 @@ class WebContextMenuActionsProvider {
                 title: .ContextMenuBookmarkLink,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
                 identifier: UIAction.Identifier("linkContextMenu.bookmarkLink")
-            ) { _ in
+            ) { [weak self] _ in
                 addBookmark(url.absoluteString, title, nil)
-                self.recordOptionSelectedTelemetry(option: .bookmarkLink)
+                self?.recordOptionSelectedTelemetry(option: .bookmarkLink)
                 BookmarksTelemetry().addBookmark(eventLabel: .pageActionMenu)
             }
         )
@@ -84,9 +84,9 @@ class WebContextMenuActionsProvider {
                 title: .RemoveBookmarkContextMenuTitle,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                 identifier: UIAction.Identifier("linkContextMenu.removeBookmarkLink")
-            ) { _ in
+            ) { [weak self] _ in
                 removeBookmark(urlString, title, nil)
-                self.recordOptionSelectedTelemetry(option: .removeBookmark)
+                self?.recordOptionSelectedTelemetry(option: .removeBookmark)
                 BookmarksTelemetry().deleteBookmark(eventLabel: .pageActionMenu)
             }
         )
@@ -100,7 +100,7 @@ class WebContextMenuActionsProvider {
                 StandardImageIdentifiers.Large.download
             ),
             identifier: UIAction.Identifier("linkContextMenu.download")
-        ) { [weak currentTab] _ in
+        ) { [weak self, weak currentTab] _ in
             ensureMainThread {
                 guard let currentTab else { return }
                 // This checks if download is a blob, if yes, begin blob download process
@@ -111,7 +111,7 @@ class WebContextMenuActionsProvider {
                     assignWebView(currentTab.webView)
                     let request = URLRequest(url: url)
                     currentTab.webView?.load(request)
-                    self.recordOptionSelectedTelemetry(option: .downloadLink)
+                    self?.recordOptionSelectedTelemetry(option: .downloadLink)
                 }
             }
         })
@@ -123,9 +123,9 @@ class WebContextMenuActionsProvider {
             title: .ContextMenuCopyLink,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.link),
             identifier: UIAction.Identifier("linkContextMenu.copyLink")
-        ) { _ in
+        ) { [weak self] _ in
             UIPasteboard.general.url = url
-            self.recordOptionSelectedTelemetry(option: .copyLink)
+            self?.recordOptionSelectedTelemetry(option: .copyLink)
         })
     }
 
@@ -140,7 +140,7 @@ class WebContextMenuActionsProvider {
             title: .ContextMenuShareLink,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.shareApple),
             identifier: UIAction.Identifier("linkContextMenu.share")
-        ) { _ in
+        ) { [weak self] _ in
             guard let tab = tabManager[webView],
                   let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper
             else { return }
@@ -157,7 +157,7 @@ class WebContextMenuActionsProvider {
                 toastContainer: contentContainer,
                 popoverArrowDirection: .unknown
             )
-            self.recordOptionSelectedTelemetry(option: .shareLink)
+            self?.recordOptionSelectedTelemetry(option: .shareLink)
         })
     }
 
@@ -168,7 +168,7 @@ class WebContextMenuActionsProvider {
         actions.append(UIAction(
             title: .ContextMenuSaveImage,
             identifier: UIAction.Identifier("linkContextMenu.saveImage")
-        ) { _ in
+        ) { [weak self] _ in
             getImageData(url) { data in
                 if url.pathExtension.lowercased() == "gif" {
                     PHPhotoLibrary.shared().performChanges {
@@ -182,7 +182,7 @@ class WebContextMenuActionsProvider {
                     }
                 }
             }
-            self.recordOptionSelectedTelemetry(option: .saveImage)
+            self?.recordOptionSelectedTelemetry(option: .saveImage)
         })
     }
 
@@ -192,9 +192,9 @@ class WebContextMenuActionsProvider {
             title: .ContextMenuGoogleLens,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Medium.logoGoogleLens),
             identifier: UIAction.Identifier("linkContextMenu.googleLens")
-        ) { _ in
+        ) { [weak self] _ in
             searchGoogleLens(url)
-            self.recordOptionSelectedTelemetry(option: .googleLens)
+            self?.recordOptionSelectedTelemetry(option: .googleLens)
         })
     }
 
@@ -203,24 +203,27 @@ class WebContextMenuActionsProvider {
         actions.append(UIAction(
             title: .ContextMenuCopyImage,
             identifier: UIAction.Identifier("linkContextMenu.copyImage")
-        ) { _ in
+        ) { [weak self] _ in
+            guard let self else { return }
             // put the actual image on the clipboard
             // do this asynchronously just in case we're in a low bandwidth situation
             let pasteboard = UIPasteboard.general
             pasteboard.url = url as URL
             let changeCount = pasteboard.changeCount
             let application = UIApplication.shared
-            self.taskId = application.beginBackgroundTask(expirationHandler: {
-                application.endBackgroundTask(self.taskId)
+            self.taskId = application.beginBackgroundTask(expirationHandler: { [weak self] in
+                guard let taskId = self?.taskId else { return }
+                application.endBackgroundTask(taskId)
             })
 
             makeURLSession(
                 userAgent: UserAgent.fxaUserAgent,
                 configuration: URLSessionConfiguration.defaultMPTCP
-            ).dataTask(with: url) { (data, response, error) in
+            ).dataTask(with: url) { [weak self] (data, response, error) in
                 ensureMainThread {
+                    guard let taskId = self?.taskId else { return }
                     guard validatedHTTPResponse(response, statusCode: 200..<300) != nil else {
-                        application.endBackgroundTask(self.taskId)
+                        application.endBackgroundTask(taskId)
                         return
                     }
 
@@ -233,7 +236,7 @@ class WebContextMenuActionsProvider {
                         pasteboard.addImageWithData(imageData, forURL: url)
                     }
 
-                    application.endBackgroundTask(self.taskId)
+                    application.endBackgroundTask(taskId)
                 }
             }.resume()
             self.recordOptionSelectedTelemetry(option: .copyImage)
@@ -245,9 +248,9 @@ class WebContextMenuActionsProvider {
         actions.append(UIAction(
             title: .ContextMenuCopyImageLink,
             identifier: UIAction.Identifier("linkContextMenu.copyImageLink")
-        ) { _ in
+        ) { [weak self] _ in
             UIPasteboard.general.url = url as URL
-            self.recordOptionSelectedTelemetry(option: .copyImageLink)
+            self?.recordOptionSelectedTelemetry(option: .copyImageLink)
         })
     }
 


### PR DESCRIPTION
This reverts commit d6d52edbc61a6e930cdb7f53cbd9039913821296.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16276)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34602)

## :bulb: Description
- Reverting #34603, an attempt to fix a broken web context menu action (`copy image`) and all `context_menu.option_selected` telemetry, reintroducing a memory leak originally resolved in #33734
- This will fix the memory leaks at the cost of re-breaking the web image context menu `copy image` action and `context_menu.option_selected` telemetry

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

