### PR TITLE
[no-ticket] Consolidate Firefox Unit Tests Workflows

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2062,9 +2062,17 @@ workflows:
         title: "Post thread starter"
         is_always_run: true
         inputs:
-        - webhook_url: "$WEBHOOK_SLACK_MOBILE_ALERTS_SANDBOX"
+        - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
         - channel: "#mobile-alerts-sandbox"
         - message: "Firefox iOS weekly unit test results :thread:"
+        - message_on_error: "Firefox iOS weekly unit test results :thread:"
+        - pretext:
+        - pretext_on_error:
+        - author_name: ''
+        - title:
+        - title_on_error:
+        - fields:
+        - buttons:
         - footer: Mobile Test Engineering
         - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
         - output_thread_ts: UNIT_TESTS_THREAD_TS
@@ -2072,7 +2080,7 @@ workflows:
         title: "Report iPhone 17 (iOS 26.5)"
         is_always_run: true
         inputs:
-        - webhook_url: "$WEBHOOK_SLACK_MOBILE_ALERTS_SANDBOX"
+        - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
         - channel: "#mobile-alerts-sandbox"
         - thread_ts: $UNIT_TESTS_THREAD_TS
         - author_name: ''
@@ -2092,7 +2100,7 @@ workflows:
         title: "Report iPhone 16 (iOS 18.6)"
         is_always_run: true
         inputs:
-        - webhook_url: "$WEBHOOK_SLACK_MOBILE_ALERTS_SANDBOX"
+        - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
         - channel: "#mobile-alerts-sandbox"
         - thread_ts: $UNIT_TESTS_THREAD_TS
         - author_name: ''
@@ -2104,7 +2112,6 @@ workflows:
         - message_on_error:
         - fields: |
             Branch | ${BITRISE_GIT_BRANCH}
-            Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
         - buttons: |
             Build Log|${BITRISE_BUILD_URL}
             Test Results|${BITRISE_BUILD_URL}?tab=tests
@@ -2112,7 +2119,7 @@ workflows:
         title: "Report iPhone 15 (iOS 17.5)"
         is_always_run: true
         inputs:
-        - webhook_url: "$WEBHOOK_SLACK_MOBILE_ALERTS_SANDBOX"
+        - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
         - channel: "#mobile-alerts-sandbox"
         - thread_ts: $UNIT_TESTS_THREAD_TS
         - author_name: ''
@@ -2124,7 +2131,6 @@ workflows:
         - message_on_error:
         - fields: |
             Branch | ${BITRISE_GIT_BRANCH}
-            Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
         - buttons: |
             Build Log|${BITRISE_BUILD_URL}
             Test Results|${BITRISE_BUILD_URL}?tab=tests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2094,6 +2094,10 @@ workflows:
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile
     - 3_provisioning_and_npm_installation
+    envs:
+    - opts:
+        is_expand: false
+      MAX_TEST_REPETITIONS: "3"
     steps:
     - xcode-test@6:
         timeout: 6000
@@ -2104,7 +2108,7 @@ workflows:
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
         - test_plan: UnitTest
         - test_repetition_mode: until_failure
-        - maximum_test_repetitions: 3
+        - maximum_test_repetitions: $MAX_TEST_REPETITIONS
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" "-parallel-testing-enabled" "NO" "-parallel-testing-worker-count" "2" -skipMacroValidation'
     - deploy-to-bitrise-io@2: {}
     - script@1:
@@ -2151,6 +2155,7 @@ workflows:
         - fields: |
             iOS Simulator | iPhone 17 (iOS 26.5)
             Branch | ${BITRISE_GIT_BRANCH}
+            Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
             Failed Tests | ${UNIT_TESTS_FAILED_LIST}
         - buttons: |
             Build Log|${BITRISE_BUILD_URL}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2005,59 +2005,59 @@ workflows:
         is_expand: false
       MAX_TEST_REPETITIONS: "3"
     steps:
-    - xcode-build-for-test@3:
-        title: "Build for Testing"
-        inputs:
-        - scheme: Fennec
-        - configuration: Fennec_Testing
-        - project_path: firefox-ios/Client.xcodeproj
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
-        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
-    - script@1:
-        title: "Create .xctestrun files for all iOS versions"
-        inputs:
-        - content: |-
-            SOURCE_FILE="$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun"
-            cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun"
-            cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun"
-    - xcode-test-without-building@0:
-        title: "Unit Tests - iPhone 17 (iOS 26.5), $MAX_TEST_REPETITIONS repetitions"
-        timeout: 6000
-        is_always_run: true
-        inputs:
-        - project_path: firefox-ios/Client.xcodeproj
-        - scheme: Fennec
-        - configuration: Fennec_Testing
-        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
-        - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun
-        - test_repetition_mode: until_failure
-        - maximum_test_repetitions: $MAX_TEST_REPETITIONS
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-    - deploy-to-bitrise-io@2: {}
-    - xcode-test-without-building@0:
-        title: "Unit Tests - iPhone 16 (iOS 18.6)"
-        timeout: 6000
-        is_always_run: true
-        inputs:
-        - project_path: firefox-ios/Client.xcodeproj
-        - scheme: Fennec
-        - configuration: Fennec_Testing
-        - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6
-        - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-    - deploy-to-bitrise-io@2: {}
-    - xcode-test-without-building@0:
-        title: "Unit Tests - iPhone 15 (iOS 17.5)"
-        timeout: 6000
-        is_always_run: true
-        inputs:
-        - project_path: firefox-ios/Client.xcodeproj
-        - scheme: Fennec
-        - configuration: Fennec_Testing
-        - destination: platform=iOS Simulator,name=iPhone 15,OS=17.5
-        - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-    - deploy-to-bitrise-io@2: {}
+#     - xcode-build-for-test@3:
+#         title: "Build for Testing"
+#         inputs:
+#         - scheme: Fennec
+#         - configuration: Fennec_Testing
+#         - project_path: firefox-ios/Client.xcodeproj
+#         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
+#         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
+#     - script@1:
+#         title: "Create .xctestrun files for all iOS versions"
+#         inputs:
+#         - content: |-
+#             SOURCE_FILE="$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun"
+#             cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun"
+#             cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun"
+#     - xcode-test-without-building@0:
+#         title: "Unit Tests - iPhone 17 (iOS 26.5), $MAX_TEST_REPETITIONS repetitions"
+#         timeout: 6000
+#         is_always_run: true
+#         inputs:
+#         - project_path: firefox-ios/Client.xcodeproj
+#         - scheme: Fennec
+#         - configuration: Fennec_Testing
+#         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
+#         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun
+#         - test_repetition_mode: until_failure
+#         - maximum_test_repetitions: $MAX_TEST_REPETITIONS
+#         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+#     - deploy-to-bitrise-io@2: {}
+#     - xcode-test-without-building@0:
+#         title: "Unit Tests - iPhone 16 (iOS 18.6)"
+#         timeout: 6000
+#         is_always_run: true
+#         inputs:
+#         - project_path: firefox-ios/Client.xcodeproj
+#         - scheme: Fennec
+#         - configuration: Fennec_Testing
+#         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6
+#         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun
+#         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+#     - deploy-to-bitrise-io@2: {}
+#     - xcode-test-without-building@0:
+#         title: "Unit Tests - iPhone 15 (iOS 17.5)"
+#         timeout: 6000
+#         is_always_run: true
+#         inputs:
+#         - project_path: firefox-ios/Client.xcodeproj
+#         - scheme: Fennec
+#         - configuration: Fennec_Testing
+#         - destination: platform=iOS Simulator,name=iPhone 15,OS=17.5
+#         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun
+#         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+#     - deploy-to-bitrise-io@2: {}
     - slack@4:
         title: "Post thread starter"
         is_always_run: true
@@ -2076,64 +2076,64 @@ workflows:
         - footer: Mobile Test Engineering
         - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
         - output_thread_ts: UNIT_TESTS_THREAD_TS
-    - slack@4:
-        title: "Report iPhone 17 (iOS 26.5)"
-        is_always_run: true
-        inputs:
-        - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
-        - channel: "#mobile-alerts-sandbox"
-        - thread_ts: $UNIT_TESTS_THREAD_TS
-        - author_name: ''
-        - pretext: ":white_check_mark: iPhone 17 (iOS 26.5)"
-        - pretext_on_error: ":x: iPhone 17 (iOS 26.5)"
-        - title:
-        - title_on_error:
-        - message:
-        - message_on_error:
-        - fields: |
-            Branch | ${BITRISE_GIT_BRANCH}
-            Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
-        - buttons: |
-            Build Log|${BITRISE_BUILD_URL}
-            Test Results|${BITRISE_BUILD_URL}?tab=tests
-    - slack@4:
-        title: "Report iPhone 16 (iOS 18.6)"
-        is_always_run: true
-        inputs:
-        - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
-        - channel: "#mobile-alerts-sandbox"
-        - thread_ts: $UNIT_TESTS_THREAD_TS
-        - author_name: ''
-        - pretext: ":white_check_mark: iPhone 16 (iOS 18.6)"
-        - pretext_on_error: ":x: iPhone 16 (iOS 18.6)"
-        - title:
-        - title_on_error:
-        - message:
-        - message_on_error:
-        - fields: |
-            Branch | ${BITRISE_GIT_BRANCH}
-        - buttons: |
-            Build Log|${BITRISE_BUILD_URL}
-            Test Results|${BITRISE_BUILD_URL}?tab=tests
-    - slack@4:
-        title: "Report iPhone 15 (iOS 17.5)"
-        is_always_run: true
-        inputs:
-        - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
-        - channel: "#mobile-alerts-sandbox"
-        - thread_ts: $UNIT_TESTS_THREAD_TS
-        - author_name: ''
-        - pretext: ":white_check_mark: iPhone 15 (iOS 17.5)"
-        - pretext_on_error: ":x: iPhone 15 (iOS 17.5)"
-        - title:
-        - title_on_error:
-        - message:
-        - message_on_error:
-        - fields: |
-            Branch | ${BITRISE_GIT_BRANCH}
-        - buttons: |
-            Build Log|${BITRISE_BUILD_URL}
-            Test Results|${BITRISE_BUILD_URL}?tab=tests
+#     - slack@4:
+#         title: "Report iPhone 17 (iOS 26.5)"
+#         is_always_run: true
+#         inputs:
+#         - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
+#         - channel: "#mobile-alerts-sandbox"
+#         - thread_ts: $UNIT_TESTS_THREAD_TS
+#         - author_name: ''
+#         - pretext: ":white_check_mark: iPhone 17 (iOS 26.5)"
+#         - pretext_on_error: ":x: iPhone 17 (iOS 26.5)"
+#         - title:
+#         - title_on_error:
+#         - message:
+#         - message_on_error:
+#         - fields: |
+#             Branch | ${BITRISE_GIT_BRANCH}
+#             Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
+#         - buttons: |
+#             Build Log|${BITRISE_BUILD_URL}
+#             Test Results|${BITRISE_BUILD_URL}?tab=tests
+#     - slack@4:
+#         title: "Report iPhone 16 (iOS 18.6)"
+#         is_always_run: true
+#         inputs:
+#         - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
+#         - channel: "#mobile-alerts-sandbox"
+#         - thread_ts: $UNIT_TESTS_THREAD_TS
+#         - author_name: ''
+#         - pretext: ":white_check_mark: iPhone 16 (iOS 18.6)"
+#         - pretext_on_error: ":x: iPhone 16 (iOS 18.6)"
+#         - title:
+#         - title_on_error:
+#         - message:
+#         - message_on_error:
+#         - fields: |
+#             Branch | ${BITRISE_GIT_BRANCH}
+#         - buttons: |
+#             Build Log|${BITRISE_BUILD_URL}
+#             Test Results|${BITRISE_BUILD_URL}?tab=tests
+#     - slack@4:
+#         title: "Report iPhone 15 (iOS 17.5)"
+#         is_always_run: true
+#         inputs:
+#         - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
+#         - channel: "#mobile-alerts-sandbox"
+#         - thread_ts: $UNIT_TESTS_THREAD_TS
+#         - author_name: ''
+#         - pretext: ":white_check_mark: iPhone 15 (iOS 17.5)"
+#         - pretext_on_error: ":x: iPhone 15 (iOS 17.5)"
+#         - title:
+#         - title_on_error:
+#         - message:
+#         - message_on_error:
+#         - fields: |
+#             Branch | ${BITRISE_GIT_BRANCH}
+#         - buttons: |
+#             Build Log|${BITRISE_BUILD_URL}
+#             Test Results|${BITRISE_BUILD_URL}?tab=tests
 
   #
   # *****%*****%***** FOCUS WORKFLOWS *****%*****%*****

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2054,96 +2054,82 @@ workflows:
 #         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
 #     - deploy-to-bitrise-io@2:
 #         is_always_run: true
+    - script@1:
+        title: "Build test results table"
+        is_always_run: true
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            envman add --key XCRESULT_26_5 --value "$BITRISE_XCRESULT_PATH"
+            # envman add --key XCRESULT_18_6 --value "$BITRISE_XCRESULT_PATH"
+            # envman add --key XCRESULT_17_5 --value "$BITRISE_XCRESULT_PATH"
+
+            ROWS=""
+
+            add_row() {
+              local label="$1"
+              local xcresult_path="$2"
+
+              if [ -z "$xcresult_path" ]; then
+                return
+              fi
+
+              local test_result
+              test_result=$(xcrun xcresulttool get test-results summary --path "$xcresult_path" --compact | jq -r '.result')
+
+              local result
+              if [ "$test_result" = "Passed" ]; then
+                result=":white_check_mark:"
+              else
+                result=":x:"
+              fi
+
+              local row
+              row=$(printf '%-22s| %s' "$label" "$result")
+
+              if [ -z "$ROWS" ]; then
+                ROWS="$row"
+              else
+                ROWS=$(printf '%s\n%s' "$ROWS" "$row")
+              fi
+            }
+
+            add_row "iPhone 17 (iOS 26.5)" "${XCRESULT_26_5:-}"
+            add_row "iPhone 16 (iOS 18.6)" "${XCRESULT_18_6:-}"
+            add_row "iPhone 15 (iOS 17.5)" "${XCRESULT_17_5:-}"
+
+            envman add --key UNIT_TESTS_TABLE_ROWS --value "$ROWS"
     - slack@4:
-        title: "Post thread starter"
+        title: "Post test results"
         is_always_run: true
         inputs:
         - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
         - channel: "#mobile-alerts-sandbox"
-        - pretext: ":white_check_mark: Firefox iOS weekly unit test results :thread:"
-        - pretext_on_error: ":x: Firefox iOS weekly unit test results :thread:"
+        - pretext: "Firefox iOS weekly unit test results"
+        - pretext_on_error: "Firefox iOS weekly unit test results"
         - author_name: ''
-        - title:
-        - title_on_error:
-        - message:
-        - message_on_error:
-        - fields:
-        - buttons:
-        - color: "#CCCCCC"
-        - color_on_error: "#CCCCCC"
-        - footer: Mobile Test Engineering
-        - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
-        - output_thread_ts: UNIT_TESTS_THREAD_TS
-    - slack@4:
-        title: "Report iPhone 17 (iOS 26.5)"
-        is_always_run: true
-        inputs:
-        - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
-        - channel: "#mobile-alerts-sandbox"
-        - thread_ts: $UNIT_TESTS_THREAD_TS
-        - author_name: ''
-        - pretext: "iPhone 17 (iOS 26.5)"
-        - pretext_on_error: "iPhone 17 (iOS 26.5)"
         - title:
         - title_on_error:
         - color: "#CCCCCC"
         - color_on_error: "#CCCCCC"
-        - message:
-        - message_on_error:
-        - footer:
-        - footer_icon:
+        - message: |-
+            ```
+            ${UNIT_TESTS_TABLE_ROWS}
+            ```
+        - message_on_error: |-
+            ```
+            ${UNIT_TESTS_TABLE_ROWS}
+            ```
         - fields: |
             Branch | ${BITRISE_GIT_BRANCH}
             Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
         - buttons: |
             Build Log|${BITRISE_BUILD_URL}
             Test Results|${BITRISE_BUILD_URL}?tab=tests
-#     - slack@4:
-#         title: "Report iPhone 16 (iOS 18.6)"
-#         is_always_run: true
-#         inputs:
-#         - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
-#         - channel: "#mobile-alerts-sandbox"
-#         - thread_ts: $UNIT_TESTS_THREAD_TS
-#         - author_name: ''
-#         - pretext: ":white_check_mark: iPhone 16 (iOS 18.6)"
-#         - pretext_on_error: ":x: iPhone 16 (iOS 18.6)"
-#         - title:
-#         - title_on_error:
-#         - color: "#CCCCCC"
-#         - color_on_error: "#CCCCCC"
-#         - message:
-#         - message_on_error:
-#         - footer:
-#         - footer_icon:
-#         - fields: |
-#             Branch | ${BITRISE_GIT_BRANCH}
-#         - buttons: |
-#             Build Log|${BITRISE_BUILD_URL}
-#             Test Results|${BITRISE_BUILD_URL}?tab=tests
-#     - slack@4:
-#         title: "Report iPhone 15 (iOS 17.5)"
-#         is_always_run: true
-#         inputs:
-#         - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
-#         - channel: "#mobile-alerts-sandbox"
-#         - thread_ts: $UNIT_TESTS_THREAD_TS
-#         - author_name: ''
-#         - pretext: ":white_check_mark: iPhone 15 (iOS 17.5)"
-#         - pretext_on_error: ":x: iPhone 15 (iOS 17.5)"
-#         - title:
-#         - title_on_error:
-#         - color: "#CCCCCC"
-#         - color_on_error: "#CCCCCC"
-#         - message:
-#         - message_on_error:
-#         - footer:
-#         - footer_icon:
-#         - fields: |
-#             Branch | ${BITRISE_GIT_BRANCH}
-#         - buttons: |
-#             Build Log|${BITRISE_BUILD_URL}
-#             Test Results|${BITRISE_BUILD_URL}?tab=tests
+        - footer: Mobile Test Engineering
+        - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
 
   #
   # *****%*****%***** FOCUS WORKFLOWS *****%*****%*****

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1991,30 +1991,33 @@ workflows:
         stack: osx-xcode-26.2.x
         machine_type_id: g2.mac.large
 
-  # Firefox_Unit_Tests runs the unit tests multiple times across the latest iOS versions on weekdays to identify flaky tests.
-  # The trends are reported on Bitrise Insights, and results are posted as a Slack thread (one reply per iOS version)
-  # to #mobile-alerts-sandbox.
-  Firefox_Unit_Tests:
+  # Firefox_Unit_Tests_iOS_Versions ensures all unit tests pass on the supported iOS versions.
+  # This workflow runs weekly on Tuesday.
+  # The results are reported to #tmp-firefox-ios-unit-tests.
+  Firefox_Unit_Tests_iOS_Versions:
     before_run:
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile
     - 3_provisioning_and_npm_installation
     - skip_macro_validation
-    envs:
-    - opts:
-        is_expand: false
-      MAX_TEST_REPETITIONS: "3"
     steps:
     - xcode-build-for-test@3:
         title: "Build for Testing"
         inputs:
         - scheme: Fennec
         - configuration: Fennec_Testing
-        - project_path: firefox-ios/Client.xcodeproj
+        - project_path: /Users/vagrant/git/firefox-ios/Client.xcodeproj
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
+    - script@1:
+        title: "Create .xctestrun files for all iOS versions"
+        inputs:
+        - content: |-
+            SOURCE_FILE="$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun"
+            cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun"
+            cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun"
     - xcode-test-without-building@0:
-        title: "Unit Tests - iPhone 17 (iOS 26.5), $MAX_TEST_REPETITIONS repetitions"
+        title: "Unit Tests - iPhone 17 (iOS 26.5), 3 repetitions"
         timeout: 6000
         is_always_run: true
         inputs:
@@ -2024,112 +2027,66 @@ workflows:
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun
         - test_repetition_mode: until_failure
-        - maximum_test_repetitions: $MAX_TEST_REPETITIONS
+        - maximum_test_repetitions: "3"
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-    - deploy-to-bitrise-io@2:
+    - xcode-test-without-building@0:
+        title: "Unit Tests - iPhone 16 (iOS 18.6)"
+        timeout: 6000
         is_always_run: true
-#     - xcode-test-without-building@0:
-#         title: "Unit Tests - iPhone 16 (iOS 18.6)"
-#         timeout: 6000
-#         is_always_run: true
-#         inputs:
-#         - project_path: firefox-ios/Client.xcodeproj
-#         - scheme: Fennec
-#         - configuration: Fennec_Testing
-#         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6
-#         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun
-#         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-#     - deploy-to-bitrise-io@2:
-#         is_always_run: true
-#     - xcode-test-without-building@0:
-#         title: "Unit Tests - iPhone 15 (iOS 17.5)"
-#         timeout: 6000
-#         is_always_run: true
-#         inputs:
-#         - project_path: firefox-ios/Client.xcodeproj
-#         - scheme: Fennec
-#         - configuration: Fennec_Testing
-#         - destination: platform=iOS Simulator,name=iPhone 15,OS=17.5
-#         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun
-#         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-#     - deploy-to-bitrise-io@2:
-#         is_always_run: true
+        inputs:
+        - project_path: firefox-ios/Client.xcodeproj
+        - scheme: Fennec
+        - configuration: Fennec_Testing
+        - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6
+        - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+    - xcode-test-without-building@0:
+        title: "Unit Tests - iPhone 15 (iOS 17.5)"
+        timeout: 6000
+        is_always_run: true
+        inputs:
+        - project_path: firefox-ios/Client.xcodeproj
+        - scheme: Fennec
+        - configuration: Fennec_Testing
+        - destination: platform=iOS Simulator,name=iPhone 15,OS=17.5
+        - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+    - deploy-to-bitrise-io@2: {}
     - script@1:
-        title: "Build test results table"
+        title: "Capture Xcode Version Info"
         is_always_run: true
         inputs:
         - content: |-
             #!/usr/bin/env bash
-            set -euo pipefail
+            set -e
 
-            envman add --key XCRESULT_26_5 --value "$BITRISE_XCRESULT_PATH"
-            # envman add --key XCRESULT_18_6 --value "$BITRISE_XCRESULT_PATH"
-            # envman add --key XCRESULT_17_5 --value "$BITRISE_XCRESULT_PATH"
+            # Get Xcode version and build version
+            XCODE_VER=$(xcodebuild -version | head -n 1 | sed 's/Xcode //g')
+            BUILD_VER=$(xcodebuild -version | grep "Build version" | sed 's/Build version //g')
+            echo "Xcode Version: $XCODE_VER"
+            echo "Build Version: $BUILD_VER"
 
-            ROWS=""
-
-            add_row() {
-              local label="$1"
-              local xcresult_path="$2"
-
-              if [ -z "$xcresult_path" ]; then
-                return
-              fi
-
-              local test_result
-              test_result=$(xcrun xcresulttool get test-results summary --path "$xcresult_path" --compact | jq -r '.result')
-
-              local result
-              if [ "$test_result" = "Passed" ]; then
-                result=":white_check_mark:"
-              else
-                result=":x:"
-              fi
-
-              local row
-              row=$(printf '%-22s| %s' "$label" "$result")
-
-              if [ -z "$ROWS" ]; then
-                ROWS="$row"
-              else
-                ROWS=$(printf '%s\n%s' "$ROWS" "$row")
-              fi
-            }
-
-            add_row "iPhone 17 (iOS 26.5)" "${XCRESULT_26_5:-}"
-            add_row "iPhone 16 (iOS 18.6)" "${XCRESULT_18_6:-}"
-            add_row "iPhone 15 (iOS 17.5)" "${XCRESULT_17_5:-}"
-
-            envman add --key UNIT_TESTS_TABLE_ROWS --value "$ROWS"
+            # Export to environment for Slack notification
+            envman add --key XCODE_VERSION_INFO --value "$XCODE_VER ($BUILD_VER)"
     - slack@4:
-        title: "Post test results"
-        is_always_run: true
         inputs:
-        - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
-        - channel: "#mobile-alerts-sandbox"
-        - pretext: "Firefox iOS weekly unit test results"
-        - pretext_on_error: "Firefox iOS weekly unit test results"
+        - webhook_url: $WEBHOOK_SLACK_MOBILE_ALERTS_SANDBOX
         - author_name: ''
+        - pretext: ":white_check_mark: Firefox iOS Unit Tests"
+        - pretext_on_error: ":x: Firefox iOS Unit Tests"
         - title:
         - title_on_error:
-        - color: "#CCCCCC"
-        - color_on_error: "#CCCCCC"
-        - message: |-
-            ```
-            ${UNIT_TESTS_TABLE_ROWS}
-            ```
-        - message_on_error: |-
-            ```
-            ${UNIT_TESTS_TABLE_ROWS}
-            ```
-        - fields: |
-            Branch | ${BITRISE_GIT_BRANCH}
-            Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
-        - buttons: |
-            Build Log|${BITRISE_BUILD_URL}
-            Test Results|${BITRISE_BUILD_URL}?tab=tests
+        - message:
+        - message_on_error:
         - footer: Mobile Test Engineering
+        - footer_on_error: Mobile Test Engineering
         - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
+        - footer_icon_on_error: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
+        - fields: |
+            iOS Simulators | iPhone 17 (iOS 26.5) [3 iterations], iPhone 16 (iOS 18.6), iPhone 15 (iOS 17.5)
+            Branch | ${BITRISE_GIT_BRANCH}
+            Xcode Version | ${XCODE_VERSION_INFO}
+        - buttons: Test Results|${BITRISE_BUILD_URL}?tab=tests
 
   #
   # *****%*****%***** FOCUS WORKFLOWS *****%*****%*****

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2088,6 +2088,7 @@ workflows:
 
   # Firefox_Unit_Tests runs the unit tests multiple times on weekdays to identify flaky tests on the latest iOS version.
   # The trends are reported on Bitrise Insights.
+  # The results are also reported to #tmp-firefox-ios-unit-tests.
   Firefox_Unit_Tests:
     before_run:
     - 1_git_clone_and_post_clone
@@ -2106,6 +2107,54 @@ workflows:
         - maximum_test_repetitions: 3
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" "-parallel-testing-enabled" "NO" "-parallel-testing-worker-count" "2" -skipMacroValidation'
     - deploy-to-bitrise-io@2: {}
+    - script@1:
+        title: "Extract Failed Tests"
+        is_always_run: true
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            xcrun xcresulttool get test-results tests --path "$BITRISE_XCRESULT_PATH" --compact > test_results.json
+
+            mapfile -t FAILED_TESTS < <(jq -r '[.. | objects | select(.nodeType? == "Test Case" and .result? == "Failed") | .nodeIdentifier] | unique | .[]' test_results.json)
+            FAILED_COUNT=${#FAILED_TESTS[@]}
+
+            if [ "$FAILED_COUNT" -eq 0 ]; then
+              FAILED_LIST="None"
+            else
+              MAX_LISTED=25
+              FAILED_LIST=$(printf '• %s\n' "${FAILED_TESTS[@]:0:$MAX_LISTED}")
+              if [ "$FAILED_COUNT" -gt "$MAX_LISTED" ]; then
+                FAILED_LIST="${FAILED_LIST}$'\n'... and $((FAILED_COUNT - MAX_LISTED)) more"
+              fi
+            fi
+
+            envman add --key UNIT_TESTS_FAILED_COUNT --value "$FAILED_COUNT"
+            envman add --key UNIT_TESTS_FAILED_LIST --value "$FAILED_LIST"
+    - slack@4:
+        is_always_run: true
+        inputs:
+        - webhook_url: $WEBHOOK_SLACK_FIREFOX_IOS_UNIT_TESTS
+        - channel: "#mobile-alerts-sandbox"
+        - author_name: ''
+        - pretext: ":white_check_mark: Firefox iOS Unit Tests"
+        - pretext_on_error: ":x: Firefox iOS Unit Tests"
+        - title:
+        - title_on_error:
+        - message:
+        - message_on_error:
+        - footer: Mobile Test Engineering
+        - footer_on_error: Mobile Test Engineering
+        - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
+        - footer_icon_on_error: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
+        - fields: |
+            iOS Simulator | iPhone 17 (iOS 26.5)
+            Branch | ${BITRISE_GIT_BRANCH}
+            Failed Tests | ${UNIT_TESTS_FAILED_LIST}
+        - buttons: |
+            Build Log|${BITRISE_BUILD_URL}
+            Test Results|${BITRISE_BUILD_URL}?tab=tests
 
   #
   # *****%*****%***** FOCUS WORKFLOWS *****%*****%*****

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2070,7 +2070,7 @@ workflows:
             envman add --key XCODE_VERSION_INFO --value "$XCODE_VER ($BUILD_VER)"
     - slack@4:
         inputs:
-        - webhook_url: $WEBHOOK_SLACK_MOBILE_ALERTS_SANDBOX
+        - webhook_url: $WEBHOOK_SLACK_FIREFOX_IOS_UNIT_TESTS
         - author_name: ''
         - pretext: ":white_check_mark: Firefox iOS Unit Tests"
         - pretext_on_error: ":x: Firefox iOS Unit Tests"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2018,7 +2018,7 @@ workflows:
             cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun"
     - xcode-test-without-building@0:
         title: "Unit Tests - iPhone 17 (iOS 26.5), 3 repetitions"
-        timeout: 6000
+        timeout: 1800
         is_always_run: true
         inputs:
         - project_path: firefox-ios/Client.xcodeproj

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2083,8 +2083,7 @@ workflows:
         - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
         - footer_icon_on_error: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
         - fields: |
-            iOS Simulators | iPhone 17 (iOS 26.5) [3 iterations], iPhone 16 (iOS 18.6), iPhone 15 (iOS 17.5)
-            Branch | ${BITRISE_GIT_BRANCH}
+            iOS Simulators | iPhone 17 - iOS 26.5 (3 repetitions), iPhone 16 - iOS 18.6, iPhone 15 - iOS 17.5
             Xcode Version | ${XCODE_VERSION_INFO}
         - buttons: Test Results|${BITRISE_BUILD_URL}?tab=tests
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1991,22 +1991,26 @@ workflows:
         stack: osx-xcode-26.2.x
         machine_type_id: g2.mac.large
 
-  # Firefox_Unit_Tests_iOS_Versions ensures all unit tests pass on the supported iOS versions.
-  # This workflow runs weekly on Tuesday.
-  # The results are reported to #tmp-firefox-ios-unit-tests.
-  Firefox_Unit_Tests_iOS_Versions:
+  # Firefox_Unit_Tests runs the unit tests multiple times across the latest iOS versions on weekdays to identify flaky tests.
+  # The trends are reported on Bitrise Insights, and results are posted as a Slack thread (one reply per iOS version)
+  # to #mobile-alerts-sandbox.
+  Firefox_Unit_Tests:
     before_run:
     - 1_git_clone_and_post_clone
     - 2_certificate_and_profile
     - 3_provisioning_and_npm_installation
     - skip_macro_validation
+    envs:
+    - opts:
+        is_expand: false
+      MAX_TEST_REPETITIONS: "3"
     steps:
     - xcode-build-for-test@3:
         title: "Build for Testing"
         inputs:
         - scheme: Fennec
         - configuration: Fennec_Testing
-        - project_path: /Users/vagrant/git/firefox-ios/Client.xcodeproj
+        - project_path: firefox-ios/Client.xcodeproj
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
     - script@1:
@@ -2017,7 +2021,7 @@ workflows:
             cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun"
             cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun"
     - xcode-test-without-building@0:
-        title: "Unit Tests - iPhone 17 (iOS 26.5)"
+        title: "Unit Tests - iPhone 17 (iOS 26.5), $MAX_TEST_REPETITIONS repetitions"
         timeout: 6000
         is_always_run: true
         inputs:
@@ -2026,7 +2030,10 @@ workflows:
         - configuration: Fennec_Testing
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun
+        - test_repetition_mode: until_failure
+        - maximum_test_repetitions: $MAX_TEST_REPETITIONS
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+    - deploy-to-bitrise-io@2: {}
     - xcode-test-without-building@0:
         title: "Unit Tests - iPhone 16 (iOS 18.6)"
         timeout: 6000
@@ -2038,6 +2045,7 @@ workflows:
         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6
         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+    - deploy-to-bitrise-io@2: {}
     - xcode-test-without-building@0:
         title: "Unit Tests - iPhone 15 (iOS 17.5)"
         timeout: 6000
@@ -2050,113 +2058,73 @@ workflows:
         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun
         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
     - deploy-to-bitrise-io@2: {}
-    - script@1:
-        title: "Capture Xcode Version Info"
-        is_always_run: true
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -e
-
-            # Get Xcode version and build version
-            XCODE_VER=$(xcodebuild -version | head -n 1 | sed 's/Xcode //g')
-            BUILD_VER=$(xcodebuild -version | grep "Build version" | sed 's/Build version //g')
-            echo "Xcode Version: $XCODE_VER"
-            echo "Build Version: $BUILD_VER"
-
-            # Export to environment for Slack notification
-            envman add --key XCODE_VERSION_INFO --value "$XCODE_VER ($BUILD_VER)"
     - slack@4:
-        inputs:
-        - webhook_url: $WEBHOOK_SLACK_FIREFOX_IOS_UNIT_TESTS
-        - author_name: ''
-        - pretext: ":white_check_mark: Firefox iOS Unit Tests"
-        - pretext_on_error: ":x: Firefox iOS Unit Tests"
-        - title:
-        - title_on_error:
-        - message:
-        - message_on_error:
-        - footer: Mobile Test Engineering
-        - footer_on_error: Mobile Test Engineering
-        - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
-        - footer_icon_on_error: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
-        - fields: |
-            iOS Simulators | iPhone 17 (iOS 26.5), iPhone 16 (iOS 18.6), iPhone 15 (iOS 17.5)
-            Branch | ${BITRISE_GIT_BRANCH}
-            Xcode Version | ${XCODE_VERSION_INFO}
-        - buttons: Test Results|${BITRISE_BUILD_URL}?tab=tests
-
-  # Firefox_Unit_Tests runs the unit tests multiple times on weekdays to identify flaky tests on the latest iOS version.
-  # The trends are reported on Bitrise Insights.
-  # The results are also reported to #tmp-firefox-ios-unit-tests.
-  Firefox_Unit_Tests:
-    before_run:
-    - 1_git_clone_and_post_clone
-    - 2_certificate_and_profile
-    - 3_provisioning_and_npm_installation
-    envs:
-    - opts:
-        is_expand: false
-      MAX_TEST_REPETITIONS: "3"
-    steps:
-    - xcode-test@6:
-        timeout: 6000
-        inputs:
-        - project_path: firefox-ios/Client.xcodeproj
-        - scheme: Fennec
-        - configuration: Fennec_Testing
-        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
-        - test_plan: UnitTest
-        - test_repetition_mode: until_failure
-        - maximum_test_repetitions: $MAX_TEST_REPETITIONS
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" "-parallel-testing-enabled" "NO" "-parallel-testing-worker-count" "2" -skipMacroValidation'
-    - deploy-to-bitrise-io@2: {}
-    - script@1:
-        title: "Extract Failed Tests"
+        title: "Post thread starter"
         is_always_run: true
         inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -euo pipefail
-
-            xcrun xcresulttool get test-results tests --path "$BITRISE_XCRESULT_PATH" --compact > test_results.json
-
-            mapfile -t FAILED_TESTS < <(jq -r '[.. | objects | select(.nodeType? == "Test Case" and .result? == "Failed") | .nodeIdentifier] | unique | .[]' test_results.json)
-            FAILED_COUNT=${#FAILED_TESTS[@]}
-
-            if [ "$FAILED_COUNT" -eq 0 ]; then
-              FAILED_LIST="None"
-            else
-              MAX_LISTED=25
-              FAILED_LIST=$(printf '• %s\n' "${FAILED_TESTS[@]:0:$MAX_LISTED}")
-              if [ "$FAILED_COUNT" -gt "$MAX_LISTED" ]; then
-                FAILED_LIST="${FAILED_LIST}$'\n'... and $((FAILED_COUNT - MAX_LISTED)) more"
-              fi
-            fi
-
-            envman add --key UNIT_TESTS_FAILED_COUNT --value "$FAILED_COUNT"
-            envman add --key UNIT_TESTS_FAILED_LIST --value "$FAILED_LIST"
-    - slack@4:
-        is_always_run: true
-        inputs:
-        - webhook_url: "$SLACK_WEBHOOK"
+        - webhook_url: "$WEBHOOK_SLACK_MOBILE_ALERTS_SANDBOX"
         - channel: "#mobile-alerts-sandbox"
+        - message: "Firefox iOS weekly unit test results :thread:"
+        - footer: Mobile Test Engineering
+        - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
+        - output_thread_ts: UNIT_TESTS_THREAD_TS
+    - slack@4:
+        title: "Report iPhone 17 (iOS 26.5)"
+        is_always_run: true
+        inputs:
+        - webhook_url: "$WEBHOOK_SLACK_MOBILE_ALERTS_SANDBOX"
+        - channel: "#mobile-alerts-sandbox"
+        - thread_ts: $UNIT_TESTS_THREAD_TS
         - author_name: ''
-        - pretext: ":white_check_mark: Firefox iOS Unit Tests"
-        - pretext_on_error: ":x: Firefox iOS Unit Tests"
+        - pretext: ":white_check_mark: iPhone 17 (iOS 26.5)"
+        - pretext_on_error: ":x: iPhone 17 (iOS 26.5)"
         - title:
         - title_on_error:
         - message:
         - message_on_error:
-        - footer: Mobile Test Engineering
-        - footer_on_error: Mobile Test Engineering
-        - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
-        - footer_icon_on_error: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
         - fields: |
-            iOS Simulator | iPhone 17 (iOS 26.5)
             Branch | ${BITRISE_GIT_BRANCH}
             Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
-            Failed Tests | ${UNIT_TESTS_FAILED_LIST}
+        - buttons: |
+            Build Log|${BITRISE_BUILD_URL}
+            Test Results|${BITRISE_BUILD_URL}?tab=tests
+    - slack@4:
+        title: "Report iPhone 16 (iOS 18.6)"
+        is_always_run: true
+        inputs:
+        - webhook_url: "$WEBHOOK_SLACK_MOBILE_ALERTS_SANDBOX"
+        - channel: "#mobile-alerts-sandbox"
+        - thread_ts: $UNIT_TESTS_THREAD_TS
+        - author_name: ''
+        - pretext: ":white_check_mark: iPhone 16 (iOS 18.6)"
+        - pretext_on_error: ":x: iPhone 16 (iOS 18.6)"
+        - title:
+        - title_on_error:
+        - message:
+        - message_on_error:
+        - fields: |
+            Branch | ${BITRISE_GIT_BRANCH}
+            Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
+        - buttons: |
+            Build Log|${BITRISE_BUILD_URL}
+            Test Results|${BITRISE_BUILD_URL}?tab=tests
+    - slack@4:
+        title: "Report iPhone 15 (iOS 17.5)"
+        is_always_run: true
+        inputs:
+        - webhook_url: "$WEBHOOK_SLACK_MOBILE_ALERTS_SANDBOX"
+        - channel: "#mobile-alerts-sandbox"
+        - thread_ts: $UNIT_TESTS_THREAD_TS
+        - author_name: ''
+        - pretext: ":white_check_mark: iPhone 15 (iOS 17.5)"
+        - pretext_on_error: ":x: iPhone 15 (iOS 17.5)"
+        - title:
+        - title_on_error:
+        - message:
+        - message_on_error:
+        - fields: |
+            Branch | ${BITRISE_GIT_BRANCH}
+            Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
         - buttons: |
             Build Log|${BITRISE_BUILD_URL}
             Test Results|${BITRISE_BUILD_URL}?tab=tests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1997,9 +1997,9 @@ workflows:
   Firefox_Unit_Tests:
     before_run:
     - 1_git_clone_and_post_clone
-    - 2_certificate_and_profile
-    - 3_provisioning_and_npm_installation
-    - skip_macro_validation
+    # - 2_certificate_and_profile
+    # - 3_provisioning_and_npm_installation
+    # - skip_macro_validation
     envs:
     - opts:
         is_expand: false
@@ -2073,8 +2073,8 @@ workflows:
         - title_on_error:
         - fields:
         - buttons:
-        - color:
-        - color_on_error:
+        - color: "#CCCCCC"
+        - color_on_error: "#CCCCCC"
         - footer: Mobile Test Engineering
         - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
         - output_thread_ts: UNIT_TESTS_THREAD_TS
@@ -2089,7 +2089,7 @@ workflows:
         - pretext:
         - author_name: ''
         - title:
-        - color:
+        - color: "#CCCCCC"
         - fields:
         - buttons:
 #     - slack@4:
@@ -2104,8 +2104,8 @@ workflows:
 #         - pretext_on_error: ":x: iPhone 17 (iOS 26.5)"
 #         - title:
 #         - title_on_error:
-#         - color:
-#         - color_on_error:
+#         - color: "#CCCCCC"
+#         - color_on_error: "#CCCCCC"
 #         - message:
 #         - message_on_error:
 #         - fields: |
@@ -2126,8 +2126,8 @@ workflows:
 #         - pretext_on_error: ":x: iPhone 16 (iOS 18.6)"
 #         - title:
 #         - title_on_error:
-#         - color:
-#         - color_on_error:
+#         - color: "#CCCCCC"
+#         - color_on_error: "#CCCCCC"
 #         - message:
 #         - message_on_error:
 #         - fields: |
@@ -2147,8 +2147,8 @@ workflows:
 #         - pretext_on_error: ":x: iPhone 15 (iOS 17.5)"
 #         - title:
 #         - title_on_error:
-#         - color:
-#         - color_on_error:
+#         - color: "#CCCCCC"
+#         - color_on_error: "#CCCCCC"
 #         - message:
 #         - message_on_error:
 #         - fields: |

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2135,7 +2135,7 @@ workflows:
     - slack@4:
         is_always_run: true
         inputs:
-        - webhook_url: $WEBHOOK_SLACK_FIREFOX_IOS_UNIT_TESTS
+        - webhook_url: "$SLACK_WEBHOOK"
         - channel: "#mobile-alerts-sandbox"
         - author_name: ''
         - pretext: ":white_check_mark: Firefox iOS Unit Tests"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1997,43 +1997,37 @@ workflows:
   Firefox_Unit_Tests:
     before_run:
     - 1_git_clone_and_post_clone
-    # - 2_certificate_and_profile
-    # - 3_provisioning_and_npm_installation
-    # - skip_macro_validation
+    - 2_certificate_and_profile
+    - 3_provisioning_and_npm_installation
+    - skip_macro_validation
     envs:
     - opts:
         is_expand: false
       MAX_TEST_REPETITIONS: "3"
     steps:
-#     - xcode-build-for-test@3:
-#         title: "Build for Testing"
-#         inputs:
-#         - scheme: Fennec
-#         - configuration: Fennec_Testing
-#         - project_path: firefox-ios/Client.xcodeproj
-#         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
-#         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
-#     - script@1:
-#         title: "Create .xctestrun files for all iOS versions"
-#         inputs:
-#         - content: |-
-#             SOURCE_FILE="$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun"
-#             cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun"
-#             cp "$SOURCE_FILE" "$BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun"
-#     - xcode-test-without-building@0:
-#         title: "Unit Tests - iPhone 17 (iOS 26.5), $MAX_TEST_REPETITIONS repetitions"
-#         timeout: 6000
-#         is_always_run: true
-#         inputs:
-#         - project_path: firefox-ios/Client.xcodeproj
-#         - scheme: Fennec
-#         - configuration: Fennec_Testing
-#         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
-#         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun
-#         - test_repetition_mode: until_failure
-#         - maximum_test_repetitions: $MAX_TEST_REPETITIONS
-#         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-#     - deploy-to-bitrise-io@2: {}
+    - xcode-build-for-test@3:
+        title: "Build for Testing"
+        inputs:
+        - scheme: Fennec
+        - configuration: Fennec_Testing
+        - project_path: firefox-ios/Client.xcodeproj
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" -allowProvisioningUpdates DEVELOPMENT_TEAM=$APPLE_TEAM_ID'
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
+    - xcode-test-without-building@0:
+        title: "Unit Tests - iPhone 17 (iOS 26.5), $MAX_TEST_REPETITIONS repetitions"
+        timeout: 6000
+        is_always_run: true
+        inputs:
+        - project_path: firefox-ios/Client.xcodeproj
+        - scheme: Fennec
+        - configuration: Fennec_Testing
+        - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
+        - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun
+        - test_repetition_mode: until_failure
+        - maximum_test_repetitions: $MAX_TEST_REPETITIONS
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+    - deploy-to-bitrise-io@2:
+        is_always_run: true
 #     - xcode-test-without-building@0:
 #         title: "Unit Tests - iPhone 16 (iOS 18.6)"
 #         timeout: 6000
@@ -2045,7 +2039,8 @@ workflows:
 #         - destination: platform=iOS Simulator,name=iPhone 16,OS=18.6
 #         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator18.6-arm64.xctestrun
 #         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-#     - deploy-to-bitrise-io@2: {}
+#     - deploy-to-bitrise-io@2:
+#         is_always_run: true
 #     - xcode-test-without-building@0:
 #         title: "Unit Tests - iPhone 15 (iOS 17.5)"
 #         timeout: 6000
@@ -2057,20 +2052,21 @@ workflows:
 #         - destination: platform=iOS Simulator,name=iPhone 15,OS=17.5
 #         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator17.5-arm64.xctestrun
 #         - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
-#     - deploy-to-bitrise-io@2: {}
+#     - deploy-to-bitrise-io@2:
+#         is_always_run: true
     - slack@4:
         title: "Post thread starter"
         is_always_run: true
         inputs:
         - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
         - channel: "#mobile-alerts-sandbox"
-        - message: ":white_check_mark: Firefox iOS weekly unit test results :thread:"
-        - message_on_error: ":x: Firefox iOS weekly unit test results :thread:"
-        - pretext:
-        - pretext_on_error:
+        - pretext: ":white_check_mark: Firefox iOS weekly unit test results :thread:"
+        - pretext_on_error: ":x: Firefox iOS weekly unit test results :thread:"
         - author_name: ''
         - title:
         - title_on_error:
+        - message:
+        - message_on_error:
         - fields:
         - buttons:
         - color: "#CCCCCC"
@@ -2079,41 +2075,29 @@ workflows:
         - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
         - output_thread_ts: UNIT_TESTS_THREAD_TS
     - slack@4:
-        title: "Test threaded reply"
+        title: "Report iPhone 17 (iOS 26.5)"
         is_always_run: true
         inputs:
         - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
         - channel: "#mobile-alerts-sandbox"
         - thread_ts: $UNIT_TESTS_THREAD_TS
-        - message: "Test message in thread"
-        - pretext:
         - author_name: ''
+        - pretext: "iPhone 17 (iOS 26.5)"
+        - pretext_on_error: "iPhone 17 (iOS 26.5)"
         - title:
+        - title_on_error:
         - color: "#CCCCCC"
-        - fields:
-        - buttons:
-#     - slack@4:
-#         title: "Report iPhone 17 (iOS 26.5)"
-#         is_always_run: true
-#         inputs:
-#         - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
-#         - channel: "#mobile-alerts-sandbox"
-#         - thread_ts: $UNIT_TESTS_THREAD_TS
-#         - author_name: ''
-#         - pretext: ":white_check_mark: iPhone 17 (iOS 26.5)"
-#         - pretext_on_error: ":x: iPhone 17 (iOS 26.5)"
-#         - title:
-#         - title_on_error:
-#         - color: "#CCCCCC"
-#         - color_on_error: "#CCCCCC"
-#         - message:
-#         - message_on_error:
-#         - fields: |
-#             Branch | ${BITRISE_GIT_BRANCH}
-#             Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
-#         - buttons: |
-#             Build Log|${BITRISE_BUILD_URL}
-#             Test Results|${BITRISE_BUILD_URL}?tab=tests
+        - color_on_error: "#CCCCCC"
+        - message:
+        - message_on_error:
+        - footer:
+        - footer_icon:
+        - fields: |
+            Branch | ${BITRISE_GIT_BRANCH}
+            Maximum Test Repetitions | ${MAX_TEST_REPETITIONS}
+        - buttons: |
+            Build Log|${BITRISE_BUILD_URL}
+            Test Results|${BITRISE_BUILD_URL}?tab=tests
 #     - slack@4:
 #         title: "Report iPhone 16 (iOS 18.6)"
 #         is_always_run: true
@@ -2130,6 +2114,8 @@ workflows:
 #         - color_on_error: "#CCCCCC"
 #         - message:
 #         - message_on_error:
+#         - footer:
+#         - footer_icon:
 #         - fields: |
 #             Branch | ${BITRISE_GIT_BRANCH}
 #         - buttons: |
@@ -2151,6 +2137,8 @@ workflows:
 #         - color_on_error: "#CCCCCC"
 #         - message:
 #         - message_on_error:
+#         - footer:
+#         - footer_icon:
 #         - fields: |
 #             Branch | ${BITRISE_GIT_BRANCH}
 #         - buttons: |

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2064,8 +2064,8 @@ workflows:
         inputs:
         - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
         - channel: "#mobile-alerts-sandbox"
-        - message: "Firefox iOS weekly unit test results :thread:"
-        - message_on_error: "Firefox iOS weekly unit test results :thread:"
+        - message: ":white_check_mark: Firefox iOS weekly unit test results :thread:"
+        - message_on_error: ":x: Firefox iOS weekly unit test results :thread:"
         - pretext:
         - pretext_on_error:
         - author_name: ''
@@ -2073,9 +2073,25 @@ workflows:
         - title_on_error:
         - fields:
         - buttons:
+        - color:
+        - color_on_error:
         - footer: Mobile Test Engineering
         - footer_icon: https://avatars.slack-edge.com/2025-06-24/9097205871668_a01e2ac8089c067ea5f8_512.png
         - output_thread_ts: UNIT_TESTS_THREAD_TS
+    - slack@4:
+        title: "Test threaded reply"
+        is_always_run: true
+        inputs:
+        - api_token: "$SLACK_TESTOPS_BOT_TOKEN"
+        - channel: "#mobile-alerts-sandbox"
+        - thread_ts: $UNIT_TESTS_THREAD_TS
+        - message: "Test message in thread"
+        - pretext:
+        - author_name: ''
+        - title:
+        - color:
+        - fields:
+        - buttons:
 #     - slack@4:
 #         title: "Report iPhone 17 (iOS 26.5)"
 #         is_always_run: true
@@ -2088,6 +2104,8 @@ workflows:
 #         - pretext_on_error: ":x: iPhone 17 (iOS 26.5)"
 #         - title:
 #         - title_on_error:
+#         - color:
+#         - color_on_error:
 #         - message:
 #         - message_on_error:
 #         - fields: |
@@ -2108,6 +2126,8 @@ workflows:
 #         - pretext_on_error: ":x: iPhone 16 (iOS 18.6)"
 #         - title:
 #         - title_on_error:
+#         - color:
+#         - color_on_error:
 #         - message:
 #         - message_on_error:
 #         - fields: |
@@ -2127,6 +2147,8 @@ workflows:
 #         - pretext_on_error: ":x: iPhone 15 (iOS 17.5)"
 #         - title:
 #         - title_on_error:
+#         - color:
+#         - color_on_error:
 #         - message:
 #         - message_on_error:
 #         - fields: |


### PR DESCRIPTION
## :scroll: Tickets

## :bulb: Description
Consolidate the existing preventative unit test hardening workflows: `Firefox_Unit_Tests` and `Firefox_Unit_Tests_iOS_Versions`. We can just run the unit tests using different versions of iOS simulators in the same workflow. The unit tests run against the most recent iOS versions 3 times.

## :movie_camera: Demos
<img width="622" height="224" alt="Screenshot 2026-07-14 at 01 40 13" src="https://github.com/user-attachments/assets/3a9668cb-178b-4229-9188-70ae3aa75333" />



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our PR naming guidelines
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code