### PR TITLE
Add FXIOS-16287 [Technical Debt] [Redux] Add test helper for deallocating middleware providers to avoid retain cycles

### DIFF
--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -189,7 +189,10 @@ let package = Package(
             swiftSettings: [
             ]
         ),
-        .target(name: "TestKit", dependencies: ["Shared"]),
+        .target(
+            name: "TestKit",
+            dependencies: ["Shared", "Redux"]
+        ),
         .target(
             name: "ToolbarKit",
             dependencies: ["Common"],

--- a/BrowserKit/Sources/TestKit/EmptyMiddlewareProviderFactory.swift
+++ b/BrowserKit/Sources/TestKit/EmptyMiddlewareProviderFactory.swift
@@ -4,28 +4,15 @@
 
 import Redux
 
+// TODO: FIXME: FXIOS-16140 will expand on these provider factory methods.
+
 /// Because our current paradigm for middlewares is to strong retain `self` inside our providers, our middleware unit tests
 /// will never successfully pass the `trackForMemoryLeaks` check. We can get around this by setting an empty provider on
 /// the middleware before the end of each test. A better longterm solution would be to rewrite our providers to avoid strong
 /// retain cycles, like by injecting a whole type into the `DefaultDispatchStore` rather than just provider closures.
 /// - Returns: Returns an empty provider implementation which does not retain `self`.
-public func emptyMiddlewareProviderFactory<T>() -> Middleware<T> {
-    let emptyProvider: Middleware<T> = (
-        legacyMiddleware: emptyLegacyMiddlewareMethodFactory(),
-        modernMiddleware: emptyMiddlewareMethodFactory()
-    )
-
-    return emptyProvider
-}
-
-public func emptyMiddlewareMethodFactory<T>() -> MiddlewareMethod<T> {
-    let emptyProvider: MiddlewareMethod<T> = { _, _, _ in }
-
-    return emptyProvider
-}
-
-public func emptyLegacyMiddlewareMethodFactory<T>() -> LegacyMiddlewareMethod<T> {
-    let emptyProvider: LegacyMiddlewareMethod<T> = { _, _ in }
+public func emptyLegacyMiddlewareMethodFactory<T>() -> Middleware<T> {
+    let emptyProvider: Middleware<T> = { _, _ in }
 
     return emptyProvider
 }

--- a/BrowserKit/Sources/TestKit/EmptyMiddlewareProviderFactory.swift
+++ b/BrowserKit/Sources/TestKit/EmptyMiddlewareProviderFactory.swift
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+
+/// Because our current paradigm for middlewares is to strong retain `self` inside our providers, our middleware unit tests
+/// will never successfully pass the `trackForMemoryLeaks` check. We can get around this by setting an empty provider on
+/// the middleware before the end of each test. A better longterm solution would be to rewrite our providers to avoid strong
+/// retain cycles, like by injecting a whole type into the `DefaultDispatchStore` rather than just provider closures.
+/// - Returns: Returns an empty provider implementation which does not retain `self`.
+public func emptyMiddlewareProviderFactory<T>() -> Middleware<T> {
+    let emptyProvider: Middleware<T> = (
+        legacyMiddleware: emptyLegacyMiddlewareMethodFactory(),
+        modernMiddleware: emptyMiddlewareMethodFactory()
+    )
+
+    return emptyProvider
+}
+
+public func emptyMiddlewareMethodFactory<T>() -> MiddlewareMethod<T> {
+    let emptyProvider: MiddlewareMethod<T> = { _, _, _ in }
+
+    return emptyProvider
+}
+
+public func emptyLegacyMiddlewareMethodFactory<T>() -> LegacyMiddlewareMethod<T> {
+    let emptyProvider: LegacyMiddlewareMethod<T> = { _, _ in }
+
+    return emptyProvider
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -5,6 +5,7 @@
 import Common
 import Redux
 import Shared
+import TestKit
 import XCTest
 
 @testable import Client
@@ -60,7 +61,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(dispatched.selectedCountryId, "BRA")
         XCTAssertTrue(dispatched.matches.isEmpty)
         XCTAssertEqual(apiClient.matchesFetchCount, 0)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_homepageInitialize_whenMilestone2_fetchesMatchesAndDispatchesDidUpdate() throws {
@@ -88,7 +90,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(dispatched.matches.count, 1)
         XCTAssertEqual(apiClient.matchesFetchCount, 1)
         XCTAssertEqual(apiClient.liveFetchCount, 1)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - WorldCupActionType.didChangeHomepageSettings
@@ -107,7 +110,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(feed.startCalled, 1)
         XCTAssertEqual(feed.stopCalled, 0)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didChangeHomepageSettings_whenSectionDisabled_stopsFeed() throws {
@@ -125,7 +129,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(feed.stopCalled, 1)
         XCTAssertEqual(feed.startCalled, 0)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - WorldCupActionType.removeHomepageCard
@@ -153,7 +158,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockWorldCupStore.lastSetIsHomepageSectionEnabledValue, false)
         XCTAssertEqual(actionType, .didUpdate)
         XCTAssertFalse(dispatched.shouldShowHomepageWorldCupSection)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - HomepageMiddlewareActionType.didEnterBackground
@@ -171,7 +177,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(feed.stopCalled, 1)
         XCTAssertEqual(feed.startCalled, 0)
         XCTAssertTrue(mockStore.dispatchedActions.isEmpty)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didBecomeActive_whenMilestone2_startsFeed() throws {
@@ -186,7 +193,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.worldCupProvider(appState, action)
 
         XCTAssertEqual(feed.startCalled, 1)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didBecomeActive_whenFeatureDisabledAfterMilestone2_dispatchesHiddenSectionWithoutStartingFeed() throws {
@@ -243,7 +251,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(dispatched.matches.count, 1)
         XCTAssertEqual(apiClient.matchesFetchCount, 1)
         XCTAssertEqual(apiClient.liveFetchCount, 1)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_selectTeam_withNilCountryId_clearsTeam() throws {
@@ -264,7 +273,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockWorldCupStore.setSelectedTeamCalled, 1)
         XCTAssertNil(mockWorldCupStore.lastSetSelectedTeamCountryId)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - WorldCupActionType.retryMatchesFetch
@@ -291,7 +301,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertNil(dispatched.apiError)
         XCTAssertEqual(apiClient.matchesFetchCount, 1)
         XCTAssertEqual(apiClient.liveFetchCount, 1)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_retryMatchesFetch_whenFetchFails_dispatchesDidUpdateWithApiError() throws {
@@ -318,7 +329,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let dispatched = try XCTUnwrap(latestWorldCupAction())
         XCTAssertTrue(dispatched.matches.isEmpty)
         XCTAssertNotNil(dispatched.apiError)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Live endpoint
@@ -359,7 +371,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let dispatched = try XCTUnwrap(latestWorldCupAction())
         XCTAssertEqual(dispatched.matches.count, 1)
         XCTAssertTrue(dispatched.matches.first?.isLive ?? false)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_homepageInitialize_whenLiveEndpointEmpty_cardIsNotLive_evenWhenCurrentPopulated() throws {
@@ -392,7 +405,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let dispatched = try XCTUnwrap(latestWorldCupAction())
         XCTAssertEqual(dispatched.matches.count, 1)
         XCTAssertFalse(dispatched.matches.first?.isLive ?? true)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     /// Merino keeps recently-final matches in the `/live` response for a tail
@@ -426,7 +440,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let dispatched = try XCTUnwrap(latestWorldCupAction())
         XCTAssertEqual(dispatched.matches.count, 1)
         XCTAssertFalse(dispatched.matches.first?.isLive ?? true)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_homepageInitialize_whenLiveEndpointFails_stillReturnsMatchesAsNotLive() throws {
@@ -456,7 +471,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertNil(dispatched.apiError)
         XCTAssertEqual(dispatched.matches.count, 1)
         XCTAssertFalse(dispatched.matches.first?.isLive ?? true)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     /// Smart-polling gate: when `/matches` shows nothing in its play window
@@ -479,7 +495,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(apiClient.matchesFetchCount, 1)
         XCTAssertEqual(apiClient.liveFetchCount, 0)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Flattened grouping (no team selected)
@@ -520,7 +537,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(dispatched.matches[0].featuredMatch.isEmpty)
         XCTAssertEqual(dispatched.matches[1].upcomingMatches.count, 1)
         XCTAssertTrue(dispatched.matches[1].featuredMatch.isEmpty)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - M3 elimination branching
@@ -571,7 +589,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(apiClient.fetchTeamsCount, 1)
         XCTAssertNil(apiClient.lastTeamsTeam, "teams call should be unfiltered")
         XCTAssertNil(apiClient.lastMatchesTeam, "matches call should be unfiltered")
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_homepageInitialize_whenSelectedTeamAdvancesToKnockouts_addsKnockoutCard() throws {
@@ -619,7 +638,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
                        String.WorldCup.HomepageWidget.RoundPhase.Round32Label)
         // Lands on the latest stage (R32, index 1), not the group card.
         XCTAssertEqual(dispatched.defaultMatchIndex, 1)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_homepageInitialize_whenSelectedTeamEliminated_fallsBackToFlattenedAllTeams() throws {
@@ -660,7 +680,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
                        String.WorldCup.HomepageWidget.RoundPhase.Round16Label)
         XCTAssertEqual(dispatched.matches[1].phaseTitle,
                        String.WorldCup.HomepageWidget.RoundPhase.QuarterFinalsLabel)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_homepageInitialize_whenSelectedTeamNotInRoster_defaultsToSingleTeamCard() throws {
@@ -694,7 +715,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let dispatched = try XCTUnwrap(latestWorldCupAction())
         XCTAssertEqual(dispatched.matches.count, 1)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - WorldCupActionType.worldCupDidStart
@@ -721,7 +743,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(actionType, .didUpdate)
         XCTAssertTrue(dispatched.hasWorldCupStarted)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Unhandled actions
@@ -738,7 +761,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         XCTAssertEqual(mockWorldCupStore.setIsHomepageSectionEnabledCalled, 0)
         XCTAssertEqual(mockWorldCupStore.setSelectedTeamCalled, 0)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Dev server timeline
@@ -778,7 +802,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(card.featuredMatch.first?.awayCode, "GER")
         XCTAssertEqual(card.upcomingMatches.map(\.homeCode), ["BRA"])
         XCTAssertEqual(card.upcomingMatches.first?.awayCode, "ARG")
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_initialize_acceptsFractionalSecondsInServerNow() throws {
@@ -828,7 +853,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(card.featuredMatch.map(\.homeCode), ["BRA"])
         XCTAssertEqual(card.featuredMatch.first?.awayCode, "ARG")
         XCTAssertEqual(card.upcomingMatches.first?.awayCode, "GER")
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_initialize_whenDevTimelineDisabled_ignoresResponseNow() throws {
@@ -861,7 +887,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let card = try XCTUnwrap(dispatched.matches.first)
         XCTAssertEqual(card.featuredMatch.count, 1)
         XCTAssertEqual(card.upcomingMatches.count, 1)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_initialize_whenDevTimelineEnabledButServerNowMalformed_fallsBackToDate() throws {
@@ -894,7 +921,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let card = try XCTUnwrap(dispatched.matches.first)
         XCTAssertEqual(card.featuredMatch.count, 1)
         XCTAssertEqual(card.upcomingMatches.count, 1)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_initialize_noTeam_dispatchesTimerAsDefaultPage() throws {
@@ -927,7 +955,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let dispatched = try XCTUnwrap(latestWorldCupAction())
         XCTAssertEqual(dispatched.matches.count, 2)
         XCTAssertEqual(dispatched.defaultMatchIndex, 0)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Confetti
@@ -959,7 +988,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(dispatched.defaultMatchIndex, 0)
         XCTAssertTrue(dispatched.shouldShowConfetti)
         XCTAssertFalse(mockWorldCupStore.seenWinningMatchIDs.isEmpty)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didUpdate_whenWinningMatchIsNotOnDefaultCard_doesNotSetConfetti() throws {
@@ -1009,7 +1039,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(dispatched.shouldShowConfetti)
         // The win is still recorded as seen even though it didn't celebrate.
         XCTAssertFalse(mockWorldCupStore.seenWinningMatchIDs.isEmpty)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didUpdate_whenWinAlreadySeen_doesNotReCelebrateOnRefetch() throws {
@@ -1047,7 +1078,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         wait(for: [secondExpectation])
 
         XCTAssertFalse(try XCTUnwrap(latestWorldCupAction()).shouldShowConfetti)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didUpdate_whenNoTeam_andDefaultCardIsNotAFinal_doesNotSetConfetti() throws {
@@ -1078,7 +1110,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let dispatched = try XCTUnwrap(latestWorldCupAction())
         XCTAssertFalse(dispatched.shouldShowConfetti)
         XCTAssertEqual(mockWorldCupStore.setSeenWinningMatchIDsCalled, 0)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didUpdate_whenNoTeam_andDefaultCardIsFinishedFinal_setsConfettiAndPersists() throws {
@@ -1116,7 +1149,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(dispatched.defaultMatchIndex, 1)
         XCTAssertTrue(dispatched.shouldShowConfetti)
         XCTAssertFalse(mockWorldCupStore.seenWinningMatchIDs.isEmpty)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didUpdate_whenNoTeam_andDefaultCardIsFinishedBronzeFinal_setsConfetti() throws {
@@ -1151,7 +1185,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let dispatched = try XCTUnwrap(latestWorldCupAction())
         XCTAssertTrue(dispatched.shouldShowConfetti)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didUpdate_whenNoTeam_andFinalIsLiveNotEnded_doesNotSetConfetti() throws {
@@ -1189,7 +1224,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let dispatched = try XCTUnwrap(latestWorldCupAction())
         XCTAssertFalse(dispatched.shouldShowConfetti)
         XCTAssertEqual(mockWorldCupStore.setSeenWinningMatchIDsCalled, 0)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didUpdate_whenNoTeam_finalCelebratesOnceThenNotOnRefetch() throws {
@@ -1232,7 +1268,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         wait(for: [secondExpectation])
         XCTAssertFalse(try XCTUnwrap(latestWorldCupAction()).shouldShowConfetti)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_viewWillDisappear_suppressesConfettiWhileOffScreen() throws {
@@ -1264,7 +1301,8 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertFalse(try XCTUnwrap(latestWorldCupAction()).shouldShowConfetti)
         XCTAssertEqual(mockWorldCupStore.setSeenWinningMatchIDsCalled, 0)
-        subject.worldCupProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Helpers
@@ -1289,6 +1327,17 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
         let subject = WorldCupMiddleware(worldCupStore: store, feed: feed)
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    /// Our middleware providers always retain a strong reference to `self` for ease of use. Thus, `trackForMemoryLeaks` will
+    /// fail in our unit tests due to a strong circular reference to the middleware retained by its provider closures. In
+    /// practice, this is not a memory leak issue, as we permanently allocate and retain our middleware providers for the
+    /// entire app lifecycle.
+    ///
+    /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
+    /// empty closure, which does not strongly retain `self`.
+    private func releaseMiddlewareProvidersFromMemory(_ subject: WorldCupMiddleware) {
+        subject.worldCupProvider = { _, _ in }
     }
 
     /// Hands the middleware a `MockWorldCupFeed` so tests can assert on the

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/WorldCupMiddlewareTests.swift
@@ -1337,7 +1337,7 @@ final class WorldCupMiddlewareTests: XCTestCase, StoreTestUtility {
     /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: WorldCupMiddleware) {
-        subject.worldCupProvider = { _, _ in }
+        subject.worldCupProvider = emptyLegacyMiddlewareMethodFactory()
     }
 
     /// Hands the middleware a `MockWorldCupFeed` so tests can assert on the

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
@@ -78,9 +78,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, .showSummarizer)
         XCTAssertEqual(actionCalled.summarizerTrigger, .shakeGesture)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        // the summarizer provider strong retains the middleware as per redux is designed
-        // thus trackForMemoryLeaks would fail, the only way is to release the closure by assigning a new one
-        subject.summarizerProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_shakeMotionAction_withoutValidConfigurationAndShakeEnabled_dispatchesToastAction() throws {
@@ -111,7 +110,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, .showToast)
         XCTAssertEqual(actionCalled.toastType, .shakeToSummarizeNotAvailable)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        subject.summarizerProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_shakeMotionAction_withoutValidConfigurationAndShakeDisabled_doesNotDispatchToastAction() throws {
@@ -136,7 +136,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
         wait(for: [expectation], timeout: 1.0)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        subject.summarizerProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_shakeMotionAction_whenTabIsHomePage_doesNotDispatchToastAction() throws {
@@ -162,7 +163,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
         wait(for: [expectation], timeout: 1)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        subject.summarizerProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_shakeMotionAction_withoutWebView_doesNotDispatchMiddlewareAction() throws {
@@ -185,7 +187,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
         // the summarizer provider strong retains the middleware as per redux is designed
         // thus trackForMemoryLeaks would fail, the only way is to release the closure by assigning a new one
-        subject.summarizerProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - didTapReaderModeBarSummarizerButton
@@ -215,7 +218,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, .showSummarizer)
         XCTAssertEqual(actionCalled.summarizerTrigger, .readerModeBarButton)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        subject.summarizerProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - showReaderMode
@@ -244,7 +248,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(actionType, .showReaderModeBarSummarizerButton)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        subject.summarizerProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_showReaderModeAction_withInvalidConfiguration_dispatchesNotAvailableAction() throws {
@@ -272,7 +277,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(actionType, .summaryNotAvailable)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        subject.summarizerProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - didSummarizeSettingsChange
@@ -301,7 +307,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(actionType, .showReaderModeBarSummarizerButton)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        subject.summarizerProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_didSummarizeSettingsChange_withCanSummarizeFalse_dispatchesNotAvailableAction() throws {
@@ -327,7 +334,8 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(actionType, .summaryNotAvailable)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        subject.summarizerProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - makeConfiguration
@@ -446,6 +454,17 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    /// Our middleware providers always retain a strong reference to `self` for ease of use. Thus, `trackForMemoryLeaks` will
+    /// fail in our unit tests due to a strong circular reference to the middleware retained by its provider closures. In
+    /// practice, this is not a memory leak issue, as we permanently allocate and retain our middleware providers for the
+    /// entire app lifecycle.
+    ///
+    /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
+    /// empty closure, which does not strongly retain `self`.
+    private func releaseMiddlewareProvidersFromMemory(_ subject: SummarizerMiddleware) {
+        subject.summarizerProvider = { _, _ in }
     }
 
     private func setupWebViewForTabManager(isHomePage: Bool = false) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
@@ -464,7 +464,7 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
     /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: SummarizerMiddleware) {
-        subject.summarizerProvider = { _, _ in }
+        subject.summarizerProvider = emptyLegacyMiddlewareMethodFactory()
     }
 
     private func setupWebViewForTabManager(isHomePage: Bool = false) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -508,6 +508,6 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
     /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
     /// empty closure, which does not strongly retain `self`.
     private func releaseMiddlewareProvidersFromMemory(_ subject: TranslationSettingsMiddleware) {
-        subject.translationSettingsProvider = { _, _ in }
+        subject.translationSettingsProvider = emptyLegacyMiddlewareMethodFactory()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -4,6 +4,7 @@
 
 import Redux
 import Shared
+import TestKit
 import XCTest
 
 @testable import Client
@@ -61,9 +62,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(dispatchedAction.isTranslationsEnabled, true)
         XCTAssertEqual(dispatchedAction.supportedLanguages, ["en", "fr", "de"])
         XCTAssertEqual(preferredCodes, ["en", "fr"])
-        // the translationSettingsProvider strong retains the middleware as per redux is designed
-        // thus trackForMemoryLeaks would fail, the only way is to release the closure by assigning a new one
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_viewDidLoad_withTranslationsDisabled_dispatchesDisabledState() throws {
@@ -92,9 +92,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(dispatchedActionType, TranslationSettingsMiddlewareActionType.didLoadSettings)
         XCTAssertEqual(dispatchedAction.isTranslationsEnabled, false)
         XCTAssertEqual(preferredCodes, ["en"])
-        // the translationSettingsProvider strong retains the middleware as per redux is designed
-        // thus trackForMemoryLeaks would fail, the only way is to release the closure by assigning a new one
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_viewDidLoad_deviceLanguage_firstItemHasDeviceLanguageSubtitle() throws {
@@ -122,7 +121,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(preferredLanguages[0].code, "en")
         XCTAssertEqual(preferredLanguages[0].subtitleText, .Settings.Translation.PreferredLanguages.DeviceLanguage)
         XCTAssertEqual(preferredLanguages[1].code, "fr")
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_viewDidLoad_deviceLanguage_notFirst_stillHasDeviceLanguageSubtitle() throws {
@@ -149,7 +149,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(preferredLanguages[1].code, "en")
         XCTAssertEqual(preferredLanguages[1].subtitleText, .Settings.Translation.PreferredLanguages.DeviceLanguage)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_saveLanguages_deviceLanguage_notFirst_stillHasDeviceLanguageSubtitle() throws {
@@ -167,7 +168,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(preferredLanguages[1].code, "en")
         XCTAssertEqual(preferredLanguages[1].subtitleText, .Settings.Translation.PreferredLanguages.DeviceLanguage)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_viewDidLoad_readsAutoTranslatePref_whenEnabled() throws {
@@ -189,7 +191,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let dispatchedAction = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationSettingsMiddlewareAction)
         XCTAssertEqual(dispatchedAction.isAutoTranslateEnabled, true)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - toggleTranslationsEnabled
@@ -219,7 +222,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, TranslationsActionType.didTranslationSettingsChange)
         XCTAssertNil(translationsAction.translationConfiguration?.state)
         XCTAssertEqual(mockProfile.prefs.boolForKey(PrefsKeys.Settings.translationsFeature), false)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_toggleTranslationsEnabled_whenDisabled_enablesAndDispatchesUpdate() throws {
@@ -240,7 +244,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(actionType, TranslationsActionType.didTranslationSettingsChange)
         XCTAssertNil(translationsAction.translationConfiguration?.state)
         XCTAssertEqual(mockProfile.prefs.boolForKey(PrefsKeys.Settings.translationsFeature), true)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_toggleTranslationsEnabled_whenEnabled_resetsStorage() {
@@ -264,7 +269,7 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
 
-        subject.translationSettingsProvider = { _, _ in }
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_toggleTranslationsEnabled_whenDisabled_doesNotResetStorage() {
@@ -288,7 +293,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         wait(for: [expectation, resetExpectation], timeout: 2.0)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - toggleAutoTranslate
@@ -313,7 +319,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         let secondAction = try XCTUnwrap(mockStore.dispatchedActions[1] as? TranslationsAction)
         let secondActionType = try XCTUnwrap(secondAction.actionType as? TranslationsActionType)
         XCTAssertEqual(secondActionType, TranslationsActionType.didTranslationSettingsChange)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_toggleAutoTranslate_whenEnabled_disablesAndDispatches() throws {
@@ -333,7 +340,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(dispatchedActionType, TranslationSettingsMiddlewareActionType.didUpdateSettings)
         XCTAssertEqual(dispatchedAction.isAutoTranslateEnabled, false)
         XCTAssertEqual(mockProfile.prefs.boolForKey(PrefsKeys.Settings.translationAutoTranslate), false)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - saveLanguages
@@ -357,7 +365,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(dispatchedType, TranslationSettingsMiddlewareActionType.didUpdateSettings)
         XCTAssertEqual(preferredCodes, ["en", "fr"])
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_enterEditMode_doesNotDispatchViaMiddleware() {
@@ -370,7 +379,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.translationSettingsProvider(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_cancelEditMode_doesNotDispatchViaMiddleware() {
@@ -383,7 +393,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.translationSettingsProvider(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_reorderLanguages_doesNotDispatchViaMiddleware() {
@@ -397,7 +408,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.translationSettingsProvider(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_removeLanguage_doesNotDispatchViaMiddleware() {
@@ -411,7 +423,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.translationSettingsProvider(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Unrelated action
@@ -426,7 +439,8 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.translationSettingsProvider(mockStore.state, action)
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        subject.translationSettingsProvider = { _, _ in }
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - StoreTestUtility
@@ -484,5 +498,16 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    /// Our middleware providers always retain a strong reference to `self` for ease of use. Thus, `trackForMemoryLeaks` will
+    /// fail in our unit tests due to a strong circular reference to the middleware retained by its provider closures. In
+    /// practice, this is not a memory leak issue, as we permanently allocate and retain our middleware providers for the
+    /// entire app lifecycle.
+    ///
+    /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
+    /// empty closure, which does not strongly retain `self`.
+    private func releaseMiddlewareProvidersFromMemory(_ subject: TranslationSettingsMiddleware) {
+        subject.translationSettingsProvider = { _, _ in }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description

- Test changes only, no Client changes
- Adds a new TestKit helper for deallocating middleware providers to avoid retain cycles

Eventually I want to look at whether we should rework out middleware provider closures to avoid strong retain cycles of `self`. But for now, I would like to consolidate this into a helper method before I finish my work on FXIOS-16140.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

