### PR TITLE
BugFix FXIOS-16020 Dismiss library modal before settings deeplink

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -333,7 +333,7 @@ final class BrowserCoordinator: BaseCoordinator,
             handle(homepanelSection: section)
 
         case let .settings(section):
-            handleSettings(with: section)
+            show(settings: section)
 
         case let .action(routeAction):
             switch routeAction {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1098,6 +1098,32 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertTrue(presentedVC.topViewController is AppSettingsTableViewController)
     }
 
+    func testSettingsRoute_whenModalIsPresented_dismissesModalBeforeShowingSettings() throws {
+        let subject = createSubject()
+        subject.browserHasLoaded()
+        let presentedViewController = DismissSpyViewController()
+        presentedViewController.onDismiss = {
+            XCTAssertEqual(self.mockRouter.presentCalled, 0)
+        }
+        let navigationController = try XCTUnwrap(
+            mockRouter.navigationController as? MockNavigationController
+        )
+        navigationController.presentedViewController = presentedViewController
+
+        subject.handle(route: .settings(section: .appIcon))
+
+        XCTAssertEqual(presentedViewController.dismissCalled, 1)
+        let presentedNavigationController = try XCTUnwrap(
+            mockRouter.presentedViewController as? ThemedNavigationController
+        )
+        XCTAssertEqual(mockRouter.presentCalled, 1)
+        XCTAssertTrue(
+            presentedNavigationController.topViewController is UIHostingController<AppIconSelectionView>
+        )
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertNotNil(subject.childCoordinators[0] as? SettingsCoordinator)
+    }
+
     func testSettingsRoute_addSettingsCoordinator() {
         let subject = createSubject()
         subject.browserHasLoaded()
@@ -1708,5 +1734,16 @@ final class BrowserCoordinatorTests: XCTestCase,
         }
 
         return URL(string: "http://localhost:\(webServer.port)")!
+    }
+}
+
+private final class DismissSpyViewController: UIViewController {
+    var dismissCalled = 0
+    var onDismiss: (() -> Void)?
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        dismissCalled += 1
+        onDismiss?()
+        completion?()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets

  Jira ticket (https://mozilla-hub.atlassian.net/browse/FXIOS-16020)
  GitHub issue (https://github.com/mozilla-mobile/firefox-ios/issues/34182)

  ## :bulb: Description

  Fixes settings deeplinks failing while a Library panel is open.

  Settings deeplink handling now uses the existing settings presentation flow, which dismisses any active modal before presenting Settings.
  This allows routes such as settings/app-icon to work from Bookmarks, History, Downloads, and Reading List.

  Added a unit test covering dismissal of an active modal before the App Icon settings screen is presented.

  ## :pencil: Checklist

  - [x] I filled in the ticket numbers and a description of my work
  - [x] I updated the PR name to follow our PR naming guidelines
  - [ ] I ensured unit tests pass and wrote tests for new code
  - [ ] If working on UI, I checked and implemented accessibility
  - [ ] If adding telemetry, I read the data stewardship requirements
  - [ ] If adding or modifying strings, I read the localization guidelines
  - [x] If needed, I updated documentation and added comments to complex code