### PR TITLE
Bugfix FXIOS-16263 [Quick Answers] Display footer in settings screen

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -793,6 +793,7 @@ struct AccessibilityIdentifiers {
 
         struct QuickAnswers {
             static let title = "Settings.QuickAnswers.Title"
+            static let learnMoreButton = "Settings.QuickAnswers.LearnMoreButton"
         }
 
         struct BlockImages {

--- a/firefox-ios/Client/Coordinators/QuickAnswersCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/QuickAnswersCoordinator.swift
@@ -18,6 +18,8 @@ final class QuickAnswersCoordinator: BaseCoordinator, QuickAnswersNavigationHand
     private var shouldAnimateTransition: Bool {
         return !UIAccessibility.isReduceMotionEnabled
     }
+    /// The SUMO link for quick answer.
+    static let learnMoreURL = SupportUtils.URLForTopic("quick-answers-mobile")
 
     init(
         parentCoordinatorDelegate: ParentCoordinatorDelegate?,
@@ -46,7 +48,7 @@ final class QuickAnswersCoordinator: BaseCoordinator, QuickAnswersNavigationHand
             themeManager: themeManager,
             telemetry: DefaultQuickAnswersTelemetry(),
             configFetcher: DefaultQuickAnswersConfigFetcher(model: nimbusModel()),
-            learnMoreURL: SupportUtils.URLForTopic("quick-answers-mobile"),
+            learnMoreURL: Self.learnMoreURL,
         )
         router.present(controller, animated: shouldAnimateTransition)
     }

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -490,7 +490,6 @@ final class SettingsCoordinator: BaseCoordinator,
             prefs: profile.prefs,
             windowUUID: windowUUID
         )
-        viewController.settingsDelegate = self
         router.push(viewController)
     }
 

--- a/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SettingsCoordinator.swift
@@ -490,6 +490,7 @@ final class SettingsCoordinator: BaseCoordinator,
             prefs: profile.prefs,
             windowUUID: windowUUID
         )
+        viewController.settingsDelegate = self
         router.push(viewController)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/QuickAnswers/QuickAnswersSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/QuickAnswers/QuickAnswersSettingsViewController.swift
@@ -4,9 +4,15 @@
 
 import Common
 import Shared
+import ComponentLibrary
 
 final class QuickAnswersSettingsViewController: SettingsTableViewController, UserFeaturePreferenceProvider {
+    private struct UX {
+        static let buttonContentInsets = NSDirectionalEdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0)
+    }
     let prefs: Prefs
+    private lazy var linkButton: LinkButton = .build()
+
     init(prefs: Prefs, windowUUID: WindowUUID) {
         self.prefs = prefs
         super.init(style: .grouped, windowUUID: windowUUID)
@@ -46,6 +52,49 @@ final class QuickAnswersSettingsViewController: SettingsTableViewController, Use
                 )
             )
         }
-        return SettingSection(children: [enableFeatureSwitch])
+        // TODO: - FXIOS-14720 Add Strings
+        let footer = "Ask out loud and get short answers. We don’t store your voice, questions, or answers."
+        return SettingSection(
+            footerTitle: NSAttributedString(string: footer),
+            children: [enableFeatureSwitch]
+        )
+    }
+
+    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard let defaultFooter = super.tableView(
+            tableView,
+            viewForFooterInSection: section
+        ) as? ThemedTableSectionHeaderFooterView else { return nil }
+
+        let linkButtonViewModel = LinkButtonViewModel(
+            // TODO: - FXIOS-14720 Add Strings
+            title: "Learn more",
+            a11yIdentifier: AccessibilityIdentifiers.Settings.QuickAnswers.learnMoreButton,
+            font: FXFontStyles.Regular.caption1.scaledFont(),
+            contentInsets: UX.buttonContentInsets
+        )
+        linkButton.configure(viewModel: linkButtonViewModel)
+        linkButton.addTarget(self, action: #selector(learnMoreTapped), for: .touchUpInside)
+        defaultFooter.stackView.addArrangedSubview(linkButton)
+
+        return defaultFooter
+    }
+
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    @objc
+    private func learnMoreTapped() {
+        let controller = SettingsContentViewController(windowUUID: windowUUID)
+        controller.url = QuickAnswersCoordinator.learnMoreURL
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
+    // MARK: - ThemeApplicable
+
+    override func applyTheme() {
+        super.applyTheme()
+        linkButton.applyTheme(theme: theme)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/QuickAnswers/QuickAnswersSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/QuickAnswers/QuickAnswersSettingsViewControllerTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import ComponentLibrary
 import Shared
 import XCTest
 
@@ -68,10 +69,10 @@ final class QuickAnswersSettingsViewControllerTests: XCTestCase {
         XCTAssertNil(section.title)
     }
 
-    func test_generateSettings_sectionHasNoFooter() throws {
+    func test_generateSettings_sectionHasFooter() throws {
         let subject = createSubject()
         let section = try XCTUnwrap(subject.generateSettings().first)
-        XCTAssertNil(section.footerTitle)
+        XCTAssertNotNil(section.footerTitle)
     }
 
     // MARK: - Preference Integration
@@ -93,6 +94,17 @@ final class QuickAnswersSettingsViewControllerTests: XCTestCase {
 
         let displayValue = profile.prefs.boolForKey(boolSetting.prefKey ?? "")
         XCTAssertEqual(displayValue, false)
+    }
+
+    func test_viewForFooterInSection_addsLearnMoreLinkButton() throws {
+        let subject = createSubject()
+        subject.loadViewIfNeeded()
+        subject.settings = subject.generateSettings()
+        let footer = try XCTUnwrap(
+            subject.tableView(subject.tableView, viewForFooterInSection: 0) as? ThemedTableSectionHeaderFooterView
+        )
+        let hasLinkButton = footer.stackView.arrangedSubviews.contains { $0 is LinkButton }
+        XCTAssertTrue(hasLinkButton)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16263)

## :bulb: Description
Adds a footer below the Quick Answers toggle describing the feature, with a tappable "Learn more" link that opens the support article.

## :movie_camera: Demos

<img width="500" height="1086" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-13 at 11 04 34" src="https://github.com/user-attachments/assets/74cae973-0c74-4fda-93a3-00d8712b5791" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telem0request a data review
- [x] If adding or modifying strings, I read the [guidelinesRFmozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review f needed, I updated documentation and added comments to complex code
