### PR TITLE
Add FXIOS-16291 [Content Blocker] Integrate into tab lifecyle

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1693,6 +1693,7 @@
 		C2EA23542FA1B8AE004B6340 /* WorldCupTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EA23552FA1B8AE004B6340 /* WorldCupTelemetry.swift */; };
 		C2EA23542FA1B8AE004B6341 /* WorldCupResetDismissedSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EA23552FA1B8AE004B6341 /* WorldCupResetDismissedSetting.swift */; };
 		C2EBB68F2E8181F20029E82C /* DismissableNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EBB68E2E8181EF0029E82C /* DismissableNavigationViewController.swift */; };
+		C2F2C19B30044C9600F9B916 /* MockAdBlockerListFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F2C19A30044C8700F9B916 /* MockAdBlockerListFetcher.swift */; };
 		C2F335342ECE33720071588A /* translations-engine.worker.js in Resources */ = {isa = PBXBuildFile; fileRef = C2F335322ECE33720071588A /* translations-engine.worker.js */; };
 		C2F335352ECE33720071588A /* TranslationsEngine.js in Resources */ = {isa = PBXBuildFile; fileRef = C2F335332ECE33720071588A /* TranslationsEngine.js */; };
 		C2F335372ECE339F0071588A /* TranslationsEngine.html in Resources */ = {isa = PBXBuildFile; fileRef = C2F335362ECE339F0071588A /* TranslationsEngine.html */; };
@@ -10665,6 +10666,7 @@
 		C2EA23552FA1B8AE004B6340 /* WorldCupTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupTelemetry.swift; sourceTree = "<group>"; };
 		C2EA23552FA1B8AE004B6341 /* WorldCupResetDismissedSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorldCupResetDismissedSetting.swift; sourceTree = "<group>"; };
 		C2EBB68E2E8181EF0029E82C /* DismissableNavigationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissableNavigationViewController.swift; sourceTree = "<group>"; };
+		C2F2C19A30044C8700F9B916 /* MockAdBlockerListFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAdBlockerListFetcher.swift; sourceTree = "<group>"; };
 		C2F335322ECE33720071588A /* translations-engine.worker.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "translations-engine.worker.js"; sourceTree = "<group>"; };
 		C2F335332ECE33720071588A /* TranslationsEngine.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = TranslationsEngine.js; sourceTree = "<group>"; };
 		C2F335362ECE339F0071588A /* TranslationsEngine.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = TranslationsEngine.html; path = Client/Frontend/UserContent/UserScripts/TranslationsEngine/TranslationsEngine.html; sourceTree = "<group>"; };
@@ -17231,6 +17233,7 @@
 		F84B21D61A090F8100AAB793 /* ClientTests */ = {
 			isa = PBXGroup;
 			children = (
+				C2F2C19A30044C8700F9B916 /* MockAdBlockerListFetcher.swift */,
 				ECD8E56D2FF7ED75002092C6 /* WaybackTests.swift */,
 				EEB965152FBCCE7B00D6C232 /* ReaderTests */,
 				C24A0D2E2F3A7E7200BF08B7 /* KeyChainAppAttestKeyIDStoreTests.swift */,
@@ -20599,6 +20602,7 @@
 				8A4880802E68AF8400AD43D5 /* GleanHttpUploaderTests.swift in Sources */,
 				8CA4E80F2D22D2C7007207C1 /* GleanUsageReportingLifecycleObserverTest.swift in Sources */,
 				8AE80BAF2891960300BC12EA /* MockTraitCollection.swift in Sources */,
+				C2F2C19B30044C9600F9B916 /* MockAdBlockerListFetcher.swift in Sources */,
 				8A55E8042BFBA9BE006DBD85 /* MicrosurveyCoordinatorTests.swift in Sources */,
 				8A832A9729DCBD3C0025D5DD /* LaunchTypeTests.swift in Sources */,
 				219AEECE2E5E524300BF5F6F /* MockTabProviderProtocol.swift in Sources */,

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASAdBlockerListFetcher.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASAdBlockerListFetcher.swift
@@ -18,7 +18,7 @@ protocol AdBlockerListFetcherProtocol: Sendable {
 /// TODO(FXIOS-16233): Migrate the existing ETP lists to also use the AS implementation of RS.
 final class ASAdBlockerListFetcher: AdBlockerListFetcherProtocol {
     /// Identifier of the ad-blocker record within the `tracking-protection-lists-ios` collection.
-    static let adBlockerRecordID = "ad-block.json"
+    static let adBlockerRecordID = "ad-block"
 
     /// Dedicated queue for the blocking Remote Settings FFI calls. `getRecords(syncIfEmpty:)` and
     /// `getAttachment(record:)` are synchronous Rust calls that can sync over the network and hit

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -118,6 +118,7 @@ class ContentBlocker {
     var blockImagesRule: WKContentRuleList?
     var setupCompleted = false
     let logger: Logger
+    var adBlockerListFetcher: AdBlockerListFetcherProtocol = ASAdBlockerListFetcher()
 
     static let shared = ContentBlocker()
 
@@ -280,6 +281,8 @@ extension ContentBlocker {
     }
 
     func removeAllRulesInStore(completion: @escaping () -> Void) {
+        // Drop the ad-blocker list's cached hash so `reloadAdBlockerList` recompiles it after a wipe.
+        UserDefaults.standard.removeObject(forKey: ASAdBlockerListFetcher.adBlockerRecordID)
         let dispatchGroup = DispatchGroup()
         let logger = self.logger
         ruleStore?.getAvailableContentRuleListIdentifiers { [weak self] available in
@@ -439,6 +442,45 @@ extension ContentBlocker {
             logger.log("Nil rule set for BlockList.", level: .warning, category: .adblock)
             assertionFailure()
             return
+        }
+    }
+
+    func reloadAdBlockerList() async {
+        guard let encoded = await fetchAdBlockerRuleJSON() else {
+            logger.log("Skipping ad-blocker list, none available.", level: .info, category: .adblock)
+            return
+        }
+        await compileAdBlockerList(encoded)
+    }
+
+    private func fetchAdBlockerRuleJSON() async -> String? {
+        guard let json = await adBlockerListFetcher.fetchAdBlockerListJSON(),
+              let range = json.range(of: "]", options: .backwards) else {
+            return nil
+        }
+        return json.replacingCharacters(in: range, with: safelistAsJSON() + "]")
+    }
+
+    private func compileAdBlockerList(_ encoded: String) async {
+        let identifier = ASAdBlockerListFetcher.adBlockerRecordID
+        // If the hash of the encoded list matches the cached hash, we can skip compilation and setup.
+        let hash = calculateHash(for: Data(encoded.utf8))
+        if let hash, hash == UserDefaults.standard.string(forKey: identifier) { 
+            return 
+        }
+
+        guard let ruleStore else { return }
+        do {
+            let rule = try await ruleStore.compileContentRuleList(
+                forIdentifier: identifier,
+                encodedContentRuleList: encoded
+            )
+            if rule != nil {
+                UserDefaults.standard.set(hash, forKey: identifier)
+            }
+        } catch {
+            logger.log("Ad-blocker list compile failed: \(error.localizedDescription)",
+                        level: .warning, category: .adblock)
         }
     }
 }

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -465,8 +465,8 @@ extension ContentBlocker {
         let identifier = ASAdBlockerListFetcher.adBlockerRecordID
         // If the hash of the encoded list matches the cached hash, we can skip compilation and setup.
         let hash = calculateHash(for: Data(encoded.utf8))
-        if let hash, hash == UserDefaults.standard.string(forKey: identifier) { 
-            return 
+        if let hash, hash == UserDefaults.standard.string(forKey: identifier) {
+            return
         }
 
         guard let ruleStore else { return }
@@ -480,7 +480,8 @@ extension ContentBlocker {
             }
         } catch {
             logger.log("Ad-blocker list compile failed: \(error.localizedDescription)",
-                        level: .warning, category: .adblock)
+                       level: .warning,
+                       category: .adblock)
         }
     }
 }

--- a/firefox-ios/Client/ContentBlocker/TabContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/TabContentBlocker.swift
@@ -87,7 +87,7 @@ class TabContentBlocker: Notifiable {
         switch notification.name {
         case .contentBlockerTabSetupRequired:
             ensureMainThread {
-                self.notifiedTabSetupRequired
+                self.notifiedTabSetupRequired()
             }
         default:
             return

--- a/firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
+++ b/firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
@@ -64,8 +64,20 @@ extension BlockingStrength {
 
 /// Firefox-specific implementation of tab content blocking.
 @MainActor
-final class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
+final class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript, FeatureFlaggable {
     let userPrefs: Prefs
+
+    private var isAdBlockingEnabled: Bool {
+        return featureFlagsProvider.isEnabled(.adBlocker) && (userPrefs.boolForKey(PrefsKeys.BlockAds) ?? false)
+    }
+
+    private func currentRules() -> [String] {
+        var rules = isEnabled ? BlocklistFileName.listsForMode(strict: blockingStrengthPref == .strict) : []
+        if isAdBlockingEnabled {
+            rules.append(ASAdBlockerListFetcher.adBlockerRecordID)
+        }
+        return rules
+    }
 
     class func name() -> String {
         return "TrackingProtectionStats"
@@ -104,11 +116,11 @@ final class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
 
     func setupForTab(completion: (() -> Void)? = nil) {
         guard let tab = tab else { return }
-        let rules = BlocklistFileName.listsForMode(strict: blockingStrengthPref == .strict)
+        let rules = currentRules()
         logger.log("Setup tracking protection for tab: \(tab)", level: .info, category: .adblock)
         ContentBlocker.shared.setupTrackingProtection(
             forTab: tab,
-            isEnabled: isEnabled,
+            isEnabled: isEnabled || isAdBlockingEnabled,
             rules: rules,
             completion: completion
         )
@@ -122,7 +134,7 @@ final class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript {
     }
 
     override func currentlyEnabledLists() -> [String] {
-        return BlocklistFileName.listsForMode(strict: blockingStrengthPref == .strict)
+        return currentRules()
     }
 
     override func notifyContentBlockingChanged() {

--- a/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
@@ -83,7 +83,17 @@ class BrowsingSettingsViewController: SettingsTableViewController, FeatureFlagga
                     theme: theme,
                     prefKey: PrefsKeys.BlockAds,
                     defaultValue: false,
-                    titleText: .Settings.Browsing.BlockAds
+                    titleText: .Settings.Browsing.BlockAds,
+                    settingDidChange: { isEnabled in
+                        if isEnabled {
+                            Task {
+                                await ContentBlocker.shared.reloadAdBlockerList()
+                                ContentBlocker.shared.prefsChanged()
+                            }
+                        } else {
+                            ContentBlocker.shared.prefsChanged()
+                        }
+                    }
                 ))
             }
             contentSection += [

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -3,25 +3,171 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import WebKit
+import Common
+import Shared
 @testable import Client
 
+@MainActor
 final class ContentBlockerTests: XCTestCase {
+    private var featureFlags: MockNimbusFeatureFlags!
+    private var profile: MockProfile!
+    private var originalFetcher: AdBlockerListFetcherProtocol!
+
     override func setUp() async throws {
         try await super.setUp()
+        featureFlags = MockNimbusFeatureFlags()
+        profile = MockProfile()
+        DependencyHelperMock().bootstrapDependencies(injectedFeatureFlagProvider: featureFlags)
+        originalFetcher = ContentBlocker.shared.adBlockerListFetcher
 
         // Ensure all rules are removed from the global store prior to each test
         let expectation = XCTestExpectation()
-        await ContentBlocker.shared.removeAllRulesInStore {
+        ContentBlocker.shared.removeAllRulesInStore {
             expectation.fulfill()
         }
         await fulfillment(of: [expectation])
     }
 
+    override func tearDown() async throws {
+        UserDefaults.standard.removeObject(forKey: ASAdBlockerListFetcher.adBlockerRecordID)
+        ContentBlocker.shared.adBlockerListFetcher = originalFetcher
+        DependencyHelperMock().reset()
+        featureFlags = nil
+        profile = nil
+        originalFetcher = nil
+        try await super.tearDown()
+    }
+
     func testCompileListsNotInStore_callsCompletionHandlerSuccessfully() async {
         let expectation = XCTestExpectation()
-        await ContentBlocker.shared.compileListsNotInStore {
+        ContentBlocker.shared.compileListsNotInStore {
             expectation.fulfill()
         }
         await fulfillment(of: [expectation], timeout: 2)
     }
+
+    func testReloadAdBlockerList_fetchesList() async {
+        let mock = MockAdBlockerListFetcher(jsonToReturn: Self.validRuleJSON)
+        ContentBlocker.shared.adBlockerListFetcher = mock
+
+        await ContentBlocker.shared.reloadAdBlockerList()
+
+        XCTAssertEqual(mock.fetchCallCount, 1)
+    }
+
+    func testReloadAdBlockerList_whenNoListAvailable_completes() async {
+        let mock = MockAdBlockerListFetcher(jsonToReturn: nil)
+        ContentBlocker.shared.adBlockerListFetcher = mock
+
+        await ContentBlocker.shared.reloadAdBlockerList()
+
+        XCTAssertEqual(mock.fetchCallCount, 1)
+    }
+
+    func testCurrentlyEnabledLists_whenAdBlockerFlagAndPrefOn_includesAdBlockerRule() {
+        featureFlags.enabledFlags = [.adBlocker]
+        profile.prefs.setBool(true, forKey: PrefsKeys.BlockAds)
+        let subject = FirefoxTabContentBlocker(tab: MockContentBlockerTab(), prefs: profile.prefs)
+
+        XCTAssertTrue(subject.currentlyEnabledLists().contains(ASAdBlockerListFetcher.adBlockerRecordID))
+    }
+
+    func testCurrentlyEnabledLists_whenBlockAdsPrefOff_excludesAdBlockerRule() {
+        featureFlags.enabledFlags = [.adBlocker]
+        profile.prefs.setBool(false, forKey: PrefsKeys.BlockAds)
+        let subject = FirefoxTabContentBlocker(tab: MockContentBlockerTab(), prefs: profile.prefs)
+
+        XCTAssertFalse(subject.currentlyEnabledLists().contains(ASAdBlockerListFetcher.adBlockerRecordID))
+    }
+
+    func testCurrentlyEnabledLists_whenAdBlockerFlagOff_excludesAdBlockerRule() {
+        featureFlags.enabledFlags = []
+        profile.prefs.setBool(true, forKey: PrefsKeys.BlockAds)
+        let subject = FirefoxTabContentBlocker(tab: MockContentBlockerTab(), prefs: profile.prefs)
+
+        XCTAssertFalse(subject.currentlyEnabledLists().contains(ASAdBlockerListFetcher.adBlockerRecordID))
+    }
+
+    func testCurrentlyEnabledLists_adBlockingAppliesEvenWhenTrackingProtectionOff() {
+        featureFlags.enabledFlags = [.adBlocker]
+        profile.prefs.setBool(false, forKey: ContentBlockingConfig.Prefs.EnabledKey)
+        profile.prefs.setBool(true, forKey: PrefsKeys.BlockAds)
+        let subject = FirefoxTabContentBlocker(tab: MockContentBlockerTab(), prefs: profile.prefs)
+
+        XCTAssertEqual(subject.currentlyEnabledLists(), [ASAdBlockerListFetcher.adBlockerRecordID])
+    }
+
+    func testReloadAdBlockerList_secondCallWithSameJSON_skipsRecompile() async {
+        let mock = MockAdBlockerListFetcher(jsonToReturn: Self.validRuleJSON)
+        ContentBlocker.shared.adBlockerListFetcher = mock
+        let hashKey = ASAdBlockerListFetcher.adBlockerRecordID
+
+        await ContentBlocker.shared.reloadAdBlockerList()
+        let hashAfterFirst = UserDefaults.standard.string(forKey: hashKey)
+        XCTAssertNotNil(hashAfterFirst, "Hash should be stored after successful compile")
+
+        await ContentBlocker.shared.reloadAdBlockerList()
+        XCTAssertEqual(mock.fetchCallCount, 2, "Fetcher is called both times")
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: hashKey),
+            hashAfterFirst,
+            "Hash unchanged — compile was skipped"
+        )
+    }
+
+    func testReloadAdBlockerList_afterRemoveAllRules_recompilesEvenWithSameJSON() async {
+        let mock = MockAdBlockerListFetcher(jsonToReturn: Self.validRuleJSON)
+        ContentBlocker.shared.adBlockerListFetcher = mock
+        let hashKey = ASAdBlockerListFetcher.adBlockerRecordID
+
+        await ContentBlocker.shared.reloadAdBlockerList()
+        XCTAssertNotNil(UserDefaults.standard.string(forKey: hashKey))
+
+        let wipe = XCTestExpectation(description: "wipe rules")
+        await ContentBlocker.shared.removeAllRulesInStore { wipe.fulfill() }
+        await fulfillment(of: [wipe], timeout: 5)
+
+        XCTAssertNil(
+            UserDefaults.standard.string(forKey: hashKey),
+            "removeAllRulesInStore should clear the cached hash"
+        )
+
+        await ContentBlocker.shared.reloadAdBlockerList()
+        XCTAssertNotNil(
+            UserDefaults.standard.string(forKey: hashKey),
+            "Hash should be stored again after recompile"
+        )
+    }
+
+    func testReloadAdBlockerList_differentJSON_recompiles() async {
+        let mock = MockAdBlockerListFetcher(jsonToReturn: Self.validRuleJSON)
+        ContentBlocker.shared.adBlockerListFetcher = mock
+        let hashKey = ASAdBlockerListFetcher.adBlockerRecordID
+
+        await ContentBlocker.shared.reloadAdBlockerList()
+        let hashAfterFirst = UserDefaults.standard.string(forKey: hashKey)
+        XCTAssertNotNil(hashAfterFirst)
+
+        mock.jsonToReturn = Self.differentRuleJSON
+
+        await ContentBlocker.shared.reloadAdBlockerList()
+        let hashAfterSecond = UserDefaults.standard.string(forKey: hashKey)
+        XCTAssertNotNil(hashAfterSecond)
+        XCTAssertNotEqual(hashAfterFirst, hashAfterSecond, "Different JSON should produce a new hash")
+    }
+
+    private static let validRuleJSON = """
+    [{"trigger":{"url-filter":".*ads.*"},"action":{"type":"block"}}]
+    """
+
+    private static let differentRuleJSON = """
+    [{"trigger":{"url-filter":".*tracker.*"},"action":{"type":"block"}}]
+    """
+}
+
+private final class MockContentBlockerTab: ContentBlockerTab {
+    func currentURL() -> URL? { return nil }
+    func currentWebView() -> WKWebView? { return nil }
+    func imageContentBlockingEnabled() -> Bool { return false }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -125,7 +125,7 @@ final class ContentBlockerTests: XCTestCase {
         XCTAssertNotNil(UserDefaults.standard.string(forKey: hashKey))
 
         let wipe = XCTestExpectation(description: "wipe rules")
-        await ContentBlocker.shared.removeAllRulesInStore { wipe.fulfill() }
+        ContentBlocker.shared.removeAllRulesInStore { wipe.fulfill() }
         await fulfillment(of: [wipe], timeout: 5)
 
         XCTAssertNil(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MockAdBlockerListFetcher.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MockAdBlockerListFetcher.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+@testable import Client
+
+final class MockAdBlockerListFetcher: AdBlockerListFetcherProtocol, @unchecked Sendable {
+    var jsonToReturn: String?
+    private(set) var fetchCallCount = 0
+
+    init(jsonToReturn: String?) {
+        self.jsonToReturn = jsonToReturn
+    }
+
+    func fetchAdBlockerListJSON() async -> String? {
+        fetchCallCount += 1
+        return jsonToReturn
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16291)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34632)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Integrates content blocker into tab lifecycle.
- Adds tests.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

