### PR TITLE
BugFix FXIOS-16280 [Quick Answers] Restore VoiceOver after performing a voice search

### DIFF
--- a/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/Abstractions.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/Abstractions.swift
@@ -48,7 +48,7 @@ protocol AudioSessionProvider: Sendable {
 protocol AudioManagerProtocol {
     func configureAudioSession() throws
     func prepareAndStartEngine() throws
-    func stopEngine()
+    func stopEngine() throws
 
     /// Starts capturing microphone audio without format conversion.
     func startCapture(

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/AudioManager.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/AudioManager.swift
@@ -33,9 +33,13 @@ final class AudioManager: AudioManagerProtocol {
         try audioEngine.start()
     }
 
-    func stopEngine() {
+    /// Stops the audio engine and deactivates the audio session, releasing audio focus so other clients
+    /// (e.g. VoiceOver) can resume. `.notifyOthersOnDeactivation` un-ducks audio ducked by the
+    /// `.duckOthers` option used on activation.
+    func stopEngine() throws {
         audioEngine.stop()
         audioEngine.audioInputNode.removeTap(onBus: 0)
+        try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
     }
 
     /// Starts capturing microphone audio without format conversion.

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/AudioManager.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/AudioManager.swift
@@ -34,8 +34,7 @@ final class AudioManager: AudioManagerProtocol {
     }
 
     /// Stops the audio engine and deactivates the audio session, releasing audio focus so other clients
-    /// (e.g. VoiceOver) can resume. `.notifyOthersOnDeactivation` un-ducks audio ducked by the
-    /// `.duckOthers` option used on activation.
+    /// can resume.
     func stopEngine() throws {
         audioEngine.stop()
         audioEngine.audioInputNode.removeTap(onBus: 0)

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/SFSpeechRecognizerEngine.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/SFSpeechRecognizerEngine.swift
@@ -86,8 +86,8 @@ final class SFSpeechRecognizerEngine: TranscriptionEngine {
         }
     }
 
-    func stop() {
-        audioManager.stopEngine()
+    func stop() throws {
+        try audioManager.stopEngine()
         request?.endAudio()
         recognitionTask?.finish()
     }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/SpeechAnalyzerEngine.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/SpeechAnalyzerEngine.swift
@@ -116,7 +116,7 @@ final class SpeechAnalyzerEngine: TranscriptionEngine {
     }
 
     func stop() async throws {
-        audioManager.stopEngine()
+        try audioManager.stopEngine()
 
         inputContinuation?.finish()
         inputContinuation = nil

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
@@ -46,6 +46,9 @@ final class QuickAnswersSourceCell: UICollectionViewCell, ReusableCell, ThemeApp
     private func setupSubviews() {
         contentView.addSubviews(thumbnailImageView, faviconImageView, titleLabel)
 
+        isAccessibilityElement = true
+        accessibilityTraits = .link
+
         NSLayoutConstraint.activate([
             thumbnailImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             thumbnailImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
@@ -85,6 +88,7 @@ final class QuickAnswersSourceCell: UICollectionViewCell, ReusableCell, ThemeApp
             )
         )
         titleLabel.text = item.title
+        accessibilityLabel = item.title
     }
 
     // MARK: - ThemeApplicable

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 import Common
 import Shared
 
+// TODO: - FXIOS-16295 improve VoiceOver by adding notification announcement before and after recording.
 public final class QuickAnswersViewController: UIViewController,
                                                UIAdaptivePresentationControllerDelegate,
                                                Themeable {
@@ -46,6 +47,8 @@ public final class QuickAnswersViewController: UIViewController,
             }),
             for: .touchUpInside
         )
+        // TODO: - FXIOS-14720 add Strings
+        $0.accessibilityLabel = "Close"
     }
     private let contentView: QuickAnswersContentView = .build()
     private let transitionAnimator: CrossDissolveTransitionAnimator?
@@ -183,6 +186,7 @@ public final class QuickAnswersViewController: UIViewController,
                     self?.contentView.configureTranscript(result.text)
                 }
             case .loadingSearchResult:
+                UIAccessibility.post(notification: .screenChanged, argument: self?.contentView)
                 self?.triggerHaptic()
                 self?.contentView.configureSearching()
             case .showSearchResult(let result, let error):

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
@@ -24,15 +24,6 @@ public final class QuickAnswersViewController: UIViewController,
         static let contentViewTopPadding: CGFloat = 32.0
         static let contentViewBottomPadding: CGFloat = 12.0
         static let contentViewHorizontalPadding: CGFloat = 24.0
-        static let privacyButtonContentInset = NSDirectionalEdgeInsets(
-            top: 8.0,
-            leading: 8.0,
-            bottom: 8.0,
-            trailing: 12.0
-        )
-        static let privacyButtonImagePadding: CGFloat = 4.0
-        static let privacyButtonCornerRadius: CGFloat = 16.0
-        static let privacyButtonImageName = "shield"
     }
 
     // MARK: - Properties

--- a/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockAudioManager.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockAudioManager.swift
@@ -6,6 +6,7 @@ import AVFoundation
 
 enum MockAudioManagerError: Error {
     case configureAudioSession
+    case stopEngine
     case prepareAndStart
     case startCapture
 }
@@ -18,6 +19,7 @@ final class MockAudioManager: AudioManagerProtocol {
     private(set) var startCaptureWithFormatCallCount = 0
 
     var shouldThrowOnConfigure = false
+    var shouldThrowOnStopEngine = false
     var shouldThrowOnStart = false
     var shouldThrowOnCapture = false
 
@@ -35,8 +37,11 @@ final class MockAudioManager: AudioManagerProtocol {
         }
     }
 
-    func stopEngine() {
+    func stopEngine() throws {
         stopEngineCallCount += 1
+        if shouldThrowOnStopEngine {
+            throw MockAudioManagerError.stopEngine
+        }
     }
 
     func startCapture(

--- a/BrowserKit/Tests/QuickAnswersKitTests/SpeechService/AudioManagerTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/SpeechService/AudioManagerTests.swift
@@ -50,13 +50,16 @@ struct AudioManagerTests {
     }
 
     @Test
-    func test_stopEngine_callsStop() {
+    func test_stopEngine_stopsEngineAndDeactivatesSession() throws {
         let subject = createSubject()
 
-        subject.stopEngine()
+        try subject.stopEngine()
 
         #expect(engine.stopCallCount == 1)
         #expect(engine.mockInputNode.removeTapCallCount == 1)
+        #expect(session.setActiveCalls.count == 1)
+        #expect(session.setActiveCalls[0].active == false)
+        #expect(session.setActiveCalls[0].options.contains(.notifyOthersOnDeactivation))
     }
 
     // MARK: - Start Capture Tests

--- a/BrowserKit/Tests/QuickAnswersKitTests/SpeechService/SFSpeechRecognizerEngineTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/SpeechService/SFSpeechRecognizerEngineTests.swift
@@ -97,11 +97,11 @@ struct SFSpeechRecognizerEngineTests {
     }
 
     @Test
-    func test_stop_callsStopEngine() {
+    func test_stop_callsStopEngine() throws {
         let authorizer = MockAuthorizer(micAuthorized: true, speechAuthorized: true)
         let subject = createSubject(authorizer: authorizer)
 
-        subject.stop()
+        try subject.stop()
 
         #expect(audioManager.stopEngineCallCount == 1)
     }


### PR DESCRIPTION
## :scroll: Tickets
### Voice over not working after recording has started
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16280)

### Voice over not working on citations
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16281)

## :bulb: Description
Fixes VoiceOver going silent across Firefox after a voice search. `stopEngine()` now deactivates the audio session with `.notifyOthersOnDeactivation`, releasing audio focus so VoiceOver can resume. 
Improve overall VoiceOver experience.

## :movie_camera: Demos

https://github.com/user-attachments/assets/4c8e6298-b3b7-48d4-ae88-f8d4c9462bce



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
