### PR TITLE
Bugfix FXIOS-16276 Restore web context menu telemetry broken by tab-leak fix

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -16,8 +16,11 @@ class WebContextMenuActionsProvider {
     }
 
     private var actions = [UIAction]()
-    private var taskId = UIBackgroundTaskIdentifier(rawValue: 0)
     private let menuType: MenuType
+
+    private var telemetryOrigin: ContextMenuTelemetry.OriginExtra {
+        menuType == .image ? .imageLink : .webLink
+    }
 
     init(menuType: MenuType) {
         self.menuType = menuType
@@ -29,42 +32,45 @@ class WebContextMenuActionsProvider {
 
     @MainActor
     func addOpenInNewTab(url: URL, currentTab: Tab, addTab: @escaping @MainActor (URL, Bool, Tab) -> Void) {
+        let origin = telemetryOrigin
         actions.append(
             UIAction(
                 title: .ContextMenuOpenInNewTab,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.plus),
                 identifier: UIAction.Identifier(rawValue: "linkContextMenu.openInNewTab")
-            ) { [weak self, weak currentTab] _ in
+            ) { [weak currentTab] _ in
                 guard let currentTab else { return }
                 addTab(url, false, currentTab)
-                self?.recordOptionSelectedTelemetry(option: .openInNewTab)
+                Self.recordOptionSelectedTelemetry(option: .openInNewTab, originExtra: origin)
             })
     }
 
     @MainActor
     func addOpenInNewPrivateTab(url: URL, currentTab: Tab, addTab: @escaping @MainActor (URL, Bool, Tab) -> Void) {
+        let origin = telemetryOrigin
         actions.append(
             UIAction(
                 title: .ContextMenuOpenInNewPrivateTab,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.privateMode),
                 identifier: UIAction.Identifier("linkContextMenu.openInNewPrivateTab")
-            ) { [weak self, weak currentTab] _ in
+            ) { [weak currentTab] _ in
                 guard let currentTab else { return }
                 addTab(url, true, currentTab)
-                self?.recordOptionSelectedTelemetry(option: .openInNewPrivateTab)
+                Self.recordOptionSelectedTelemetry(option: .openInNewPrivateTab, originExtra: origin)
             })
     }
 
     @MainActor
     func addBookmarkLink(url: URL, title: String?, addBookmark: @escaping (String, String?, Site?) -> Void) {
+        let origin = telemetryOrigin
         actions.append(
             UIAction(
                 title: .ContextMenuBookmarkLink,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.bookmark),
                 identifier: UIAction.Identifier("linkContextMenu.bookmarkLink")
-            ) { [weak self] _ in
+            ) { _ in
                 addBookmark(url.absoluteString, title, nil)
-                self?.recordOptionSelectedTelemetry(option: .bookmarkLink)
+                Self.recordOptionSelectedTelemetry(option: .bookmarkLink, originExtra: origin)
                 BookmarksTelemetry().addBookmark(eventLabel: .pageActionMenu)
             }
         )
@@ -79,14 +85,15 @@ class WebContextMenuActionsProvider {
             String?,
             Site?
         ) -> Void) {
+        let origin = telemetryOrigin
         actions.append(
             UIAction(
                 title: .RemoveBookmarkContextMenuTitle,
                 image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.cross),
                 identifier: UIAction.Identifier("linkContextMenu.removeBookmarkLink")
-            ) { [weak self] _ in
+            ) { _ in
                 removeBookmark(urlString, title, nil)
-                self?.recordOptionSelectedTelemetry(option: .removeBookmark)
+                Self.recordOptionSelectedTelemetry(option: .removeBookmark, originExtra: origin)
                 BookmarksTelemetry().deleteBookmark(eventLabel: .pageActionMenu)
             }
         )
@@ -94,13 +101,14 @@ class WebContextMenuActionsProvider {
 
     @MainActor
     func addDownload(url: URL, currentTab: Tab, assignWebView: @escaping (WKWebView?) -> Void) {
+        let origin = telemetryOrigin
         actions.append(UIAction(
             title: .ContextMenuDownloadLink,
             image: UIImage.templateImageNamed(
                 StandardImageIdentifiers.Large.download
             ),
             identifier: UIAction.Identifier("linkContextMenu.download")
-        ) { [weak self, weak currentTab] _ in
+        ) { [weak currentTab] _ in
             ensureMainThread {
                 guard let currentTab else { return }
                 // This checks if download is a blob, if yes, begin blob download process
@@ -111,7 +119,7 @@ class WebContextMenuActionsProvider {
                     assignWebView(currentTab.webView)
                     let request = URLRequest(url: url)
                     currentTab.webView?.load(request)
-                    self?.recordOptionSelectedTelemetry(option: .downloadLink)
+                    Self.recordOptionSelectedTelemetry(option: .downloadLink, originExtra: origin)
                 }
             }
         })
@@ -119,13 +127,14 @@ class WebContextMenuActionsProvider {
 
     @MainActor
     func addCopyLink(url: URL) {
+        let origin = telemetryOrigin
         actions.append(UIAction(
             title: .ContextMenuCopyLink,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.link),
             identifier: UIAction.Identifier("linkContextMenu.copyLink")
-        ) { [weak self] _ in
+        ) { _ in
             UIPasteboard.general.url = url
-            self?.recordOptionSelectedTelemetry(option: .copyLink)
+            Self.recordOptionSelectedTelemetry(option: .copyLink, originExtra: origin)
         })
     }
 
@@ -136,11 +145,12 @@ class WebContextMenuActionsProvider {
                   view: UIView,
                   navigationHandler: BrowserNavigationHandler?,
                   contentContainer: ContentContainer) {
+        let origin = telemetryOrigin
         actions.append(UIAction(
             title: .ContextMenuShareLink,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.shareApple),
             identifier: UIAction.Identifier("linkContextMenu.share")
-        ) { [weak self] _ in
+        ) { _ in
             guard let tab = tabManager[webView],
                   let helper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper
             else { return }
@@ -157,7 +167,7 @@ class WebContextMenuActionsProvider {
                 toastContainer: contentContainer,
                 popoverArrowDirection: .unknown
             )
-            self?.recordOptionSelectedTelemetry(option: .shareLink)
+            Self.recordOptionSelectedTelemetry(option: .shareLink, originExtra: origin)
         })
     }
 
@@ -165,10 +175,11 @@ class WebContextMenuActionsProvider {
     func addSaveImage(url: URL,
                       getImageData: @escaping (URL, @escaping @MainActor @Sendable (Data) -> Void) -> Void,
                       writeToPhotoAlbum: @escaping @MainActor (UIImage) -> Void) {
+        let origin = telemetryOrigin
         actions.append(UIAction(
             title: .ContextMenuSaveImage,
             identifier: UIAction.Identifier("linkContextMenu.saveImage")
-        ) { [weak self] _ in
+        ) { _ in
             getImageData(url) { data in
                 if url.pathExtension.lowercased() == "gif" {
                     PHPhotoLibrary.shared().performChanges {
@@ -182,48 +193,54 @@ class WebContextMenuActionsProvider {
                     }
                 }
             }
-            self?.recordOptionSelectedTelemetry(option: .saveImage)
+            Self.recordOptionSelectedTelemetry(option: .saveImage, originExtra: origin)
         })
     }
 
     @MainActor
     func addSearchWithGoogleLens(url: URL, searchGoogleLens: @escaping @MainActor (URL) -> Void) {
+        let origin = telemetryOrigin
         actions.append(UIAction(
             title: .ContextMenuGoogleLens,
             image: UIImage.templateImageNamed(StandardImageIdentifiers.Medium.logoGoogleLens),
             identifier: UIAction.Identifier("linkContextMenu.googleLens")
-        ) { [weak self] _ in
+        ) { _ in
             searchGoogleLens(url)
-            self?.recordOptionSelectedTelemetry(option: .googleLens)
+            Self.recordOptionSelectedTelemetry(option: .googleLens, originExtra: origin)
         })
     }
 
     @MainActor
     func addCopyImage(url: URL) {
+        let origin = telemetryOrigin
+        // The handler captures values only, never `self`. The provider is deallocated as soon as the menu is built,
+        // so capturing `self` would drop the telemetry and abort the copy once the handler runs
         actions.append(UIAction(
             title: .ContextMenuCopyImage,
             identifier: UIAction.Identifier("linkContextMenu.copyImage")
-        ) { [weak self] _ in
-            guard let self else { return }
+        ) { _ in
             // put the actual image on the clipboard
             // do this asynchronously just in case we're in a low bandwidth situation
             let pasteboard = UIPasteboard.general
             pasteboard.url = url as URL
             let changeCount = pasteboard.changeCount
             let application = UIApplication.shared
-            self.taskId = application.beginBackgroundTask(expirationHandler: { [weak self] in
-                guard let taskId = self?.taskId else { return }
-                application.endBackgroundTask(taskId)
+
+            // Held in a reference so the same identifier is shared between the expiration
+            // handler and the network completion without capturing the (short-lived) provider.
+            let backgroundTask = BackgroundTaskHolder()
+            backgroundTask.id = application.beginBackgroundTask(expirationHandler: {
+                application.endBackgroundTask(backgroundTask.id)
+                backgroundTask.id = .invalid
             })
 
             makeURLSession(
                 userAgent: UserAgent.fxaUserAgent,
                 configuration: URLSessionConfiguration.defaultMPTCP
-            ).dataTask(with: url) { [weak self] (data, response, error) in
+            ).dataTask(with: url) { (data, response, error) in
                 ensureMainThread {
-                    guard let taskId = self?.taskId else { return }
                     guard validatedHTTPResponse(response, statusCode: 200..<300) != nil else {
-                        application.endBackgroundTask(taskId)
+                        application.endBackgroundTask(backgroundTask.id)
                         return
                     }
 
@@ -236,27 +253,33 @@ class WebContextMenuActionsProvider {
                         pasteboard.addImageWithData(imageData, forURL: url)
                     }
 
-                    application.endBackgroundTask(taskId)
+                    application.endBackgroundTask(backgroundTask.id)
                 }
             }.resume()
-            self.recordOptionSelectedTelemetry(option: .copyImage)
+            Self.recordOptionSelectedTelemetry(option: .copyImage, originExtra: origin)
         })
     }
 
     @MainActor
     func addCopyImageLink(url: URL) {
+        let origin = telemetryOrigin
         actions.append(UIAction(
             title: .ContextMenuCopyImageLink,
             identifier: UIAction.Identifier("linkContextMenu.copyImageLink")
-        ) { [weak self] _ in
+        ) { _ in
             UIPasteboard.general.url = url as URL
-            self?.recordOptionSelectedTelemetry(option: .copyImageLink)
+            Self.recordOptionSelectedTelemetry(option: .copyImageLink, originExtra: origin)
         })
     }
 
-    private func recordOptionSelectedTelemetry(option: ContextMenuTelemetry.OptionExtra) {
-        let originExtra = menuType == .image ? ContextMenuTelemetry.OriginExtra.imageLink
-                                             : ContextMenuTelemetry.OriginExtra.webLink
+    private static func recordOptionSelectedTelemetry(option: ContextMenuTelemetry.OptionExtra,
+                                                      originExtra: ContextMenuTelemetry.OriginExtra) {
         ContextMenuTelemetry().optionSelected(option: option, origin: originExtra)
     }
+}
+
+/// Holds a background task identifier by reference so it can be shared between the
+/// `beginBackgroundTask` expiration handler and the network completion handler.
+private final class BackgroundTaskHolder: @unchecked Sendable {
+    var id: UIBackgroundTaskIdentifier = .invalid
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -226,15 +226,17 @@ class WebContextMenuActionsProvider {
             let changeCount = pasteboard.changeCount
             let application = UIApplication.shared
 
-            var taskId = UIBackgroundTaskIdentifier.invalid
-            taskId = application.beginBackgroundTask(expirationHandler: {
-                application.endBackgroundTask(taskId)
+            // Confined to the main actor so the same identifier can be shared with the (@Sendable)
+            // expiration handler, and captured by value into the network completion below.
+            let backgroundTask = BackgroundTaskHolder()
+            backgroundTask.id = application.beginBackgroundTask(expirationHandler: {
+                application.endBackgroundTask(backgroundTask.id)
             })
 
             makeURLSession(
                 userAgent: UserAgent.fxaUserAgent,
                 configuration: URLSessionConfiguration.defaultMPTCP
-            ).dataTask(with: url) { [taskId] (data, response, error) in
+            ).dataTask(with: url) { [taskId = backgroundTask.id] (data, response, error) in
                 ensureMainThread {
                     guard validatedHTTPResponse(response, statusCode: 200..<300) != nil else {
                         application.endBackgroundTask(taskId)
@@ -273,4 +275,9 @@ class WebContextMenuActionsProvider {
                                                       originExtra: ContextMenuTelemetry.OriginExtra) {
         ContextMenuTelemetry().optionSelected(option: option, origin: originExtra)
     }
+}
+
+@MainActor
+private final class BackgroundTaskHolder {
+    var id: UIBackgroundTaskIdentifier = .invalid
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -226,21 +226,18 @@ class WebContextMenuActionsProvider {
             let changeCount = pasteboard.changeCount
             let application = UIApplication.shared
 
-            // Held in a reference so the same identifier is shared between the expiration
-            // handler and the network completion without capturing the (short-lived) provider.
-            let backgroundTask = BackgroundTaskHolder()
-            backgroundTask.id = application.beginBackgroundTask(expirationHandler: {
-                application.endBackgroundTask(backgroundTask.id)
-                backgroundTask.id = .invalid
+            var taskId = UIBackgroundTaskIdentifier.invalid
+            taskId = application.beginBackgroundTask(expirationHandler: {
+                application.endBackgroundTask(taskId)
             })
 
             makeURLSession(
                 userAgent: UserAgent.fxaUserAgent,
                 configuration: URLSessionConfiguration.defaultMPTCP
-            ).dataTask(with: url) { (data, response, error) in
+            ).dataTask(with: url) { [taskId] (data, response, error) in
                 ensureMainThread {
                     guard validatedHTTPResponse(response, statusCode: 200..<300) != nil else {
-                        application.endBackgroundTask(backgroundTask.id)
+                        application.endBackgroundTask(taskId)
                         return
                     }
 
@@ -253,7 +250,7 @@ class WebContextMenuActionsProvider {
                         pasteboard.addImageWithData(imageData, forURL: url)
                     }
 
-                    application.endBackgroundTask(backgroundTask.id)
+                    application.endBackgroundTask(taskId)
                 }
             }.resume()
             Self.recordOptionSelectedTelemetry(option: .copyImage, originExtra: origin)
@@ -276,10 +273,4 @@ class WebContextMenuActionsProvider {
                                                       originExtra: ContextMenuTelemetry.OriginExtra) {
         ContextMenuTelemetry().optionSelected(option: option, origin: originExtra)
     }
-}
-
-/// Holds a background task identifier by reference so it can be shared between the
-/// `beginBackgroundTask` expiration handler and the network completion handler.
-private final class BackgroundTaskHolder: @unchecked Sendable {
-    var id: UIBackgroundTaskIdentifier = .invalid
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16276)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34602)

## :bulb: Description
Fixes the web/image context menu telemetry (`context_menu.option_selected`) that stopped being recorded, and restores the Copy Image action, without reintroducing the tab retention that [33734](https://github.com/mozilla-mobile/firefox-ios/pull/33734) fixed.


[33734](https://github.com/mozilla-mobile/firefox-ios/pull/33734)  added `[weak self]` to every UIAction handler in `WebContextMenuActionsProvider` to avoid retaining tabs. But self here is the provider, which is a local object in createActions(...) and is deallocated as soon as the menu is built, before any option is ever tapped. So by the time a handler runs, self is nil:

Fix

Capture values instead of self in the handlers:

- `recordOptionSelectedTelemetry` is now static and takes the origin; each handler resolves origin up front (from menuType) and captures it by value. Self. captures nothing, so telemetry fires regardless of the provider's lifetime and there's no retain cycle.
- Kept `[weak currentTab] `in the three tab-capturing handlers, so tab retention stays fixed.
- addCopyImage: removed the guard let self, and moved the background-task identifier off the provider into a small reference box (`BackgroundTaskHolder`) shared between the expiration and network-completion handlers. Removed the now-unused taskId property.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

