### PR TITLE
BugFix FXIOS-16282 [Quick Answers] Sources section displays only one source on iPad

### DIFF
--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
@@ -12,6 +12,9 @@ protocol ResultsService: Sendable {
 }
 
 final class DefaultResultsService: ResultsService {
+    private struct Constants {
+        static let maxCitationsCount = 2
+    }
     private let client: LiteLLMClientProtocol
     private let configFetcher: QuickAnswersConfigFetcher
 
@@ -55,8 +58,8 @@ final class DefaultResultsService: ResultsService {
     }
 
     private func formatResult(from answer: String, and citations: [Citation]) -> SearchResult {
-        // limit the citations to the first 2 in the array
-        let filteredCitations = citations.prefix(2)
+        // limit the citations in the array to maximum allowed
+        let filteredCitations = citations.prefix(Constants.maxCitationsCount)
         let sources = filteredCitations.map { citation in
             SearchResult.Source(
                 title: citation.title ?? "",

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
@@ -55,8 +55,8 @@ final class DefaultResultsService: ResultsService {
     }
 
     private func formatResult(from answer: String, and citations: [Citation]) -> SearchResult {
-        // limit the citations to the first 3 in the array
-        let filteredCitations = citations.prefix(3)
+        // limit the citations to the first 2 in the array
+        let filteredCitations = citations.prefix(2)
         let sources = filteredCitations.map { citation in
             SearchResult.Source(
                 title: citation.title ?? "",

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
@@ -144,7 +144,6 @@ final class QuickAnswersSourceView: UIView,
     private var theme: Theme?
     private var contentSizeObservation: NSKeyValueObservation?
     private var onSourceTapped: ((URL) -> Void)?
-    private var lastLaidOutWidth: CGFloat = 0
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
@@ -144,6 +144,7 @@ final class QuickAnswersSourceView: UIView,
     private var theme: Theme?
     private var contentSizeObservation: NSKeyValueObservation?
     private var onSourceTapped: ((URL) -> Void)?
+    private var lastLaidOutWidth: CGFloat = 0
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -173,8 +174,8 @@ final class QuickAnswersSourceView: UIView,
             \.contentSize,
             options: [.new, .old]
         ) { [weak self] _, change in
-            guard change.newValue != change.oldValue else { return }
             DispatchQueue.main.async {
+                self?.collectionView.collectionViewLayout.invalidateLayout()
                 self?.invalidateIntrinsicContentSize()
             }
         }

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
@@ -138,11 +138,12 @@ public final class QuickAnswersViewController: UIViewController,
         applyTheme()
         listenForThemeChanges(withNotificationCenter: notificationCenter)
         registerCallbacks()
+        viewModel.startFlow()
     }
 
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        viewModel.startFlow()
+        
     }
 
     private func setupSubviews() {

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
@@ -141,11 +141,6 @@ public final class QuickAnswersViewController: UIViewController,
         viewModel.startFlow()
     }
 
-    override public func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-    }
-
     private func setupSubviews() {
         view.addSubviews(
             backgroundRecordEffect,

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
@@ -72,6 +72,7 @@ public final class QuickAnswersViewController: UIViewController,
             self?.dismiss(with: nil)
         }
     )
+    private var hasAppeared = false
 
     public convenience init(
         navigationHandler: QuickAnswersNavigationHandler?,
@@ -138,6 +139,14 @@ public final class QuickAnswersViewController: UIViewController,
         applyTheme()
         listenForThemeChanges(withNotificationCenter: notificationCenter)
         registerCallbacks()
+    }
+
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Workaround for iPad: with formSheet presentation, viewWillAppear can fire twice when the
+        // user attempts to dismiss the sheet but the dismissal fails, so guard the one-time flow start.
+        guard !hasAppeared else { return }
+        hasAppeared = true
         viewModel.startFlow()
     }
 

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewModel.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewModel.swift
@@ -40,7 +40,6 @@ final class QuickAnswersViewModel {
         do {
             self.service = try makeService(prefs, configFetcher)
         } catch {
-            // TODO: FXIOS-15570 - Possibly add telemetry to capture service failing
             self.service = nil
         }
         telemetry.quickAnswersRequested()
@@ -81,7 +80,9 @@ final class QuickAnswersViewModel {
 
     private func startRecordingVoice() {
         guard let service else {
-            emitServiceNotInitialized()
+            let error = SpeechError.serviceNotInitialized
+            telemetry.recordingCompleted(outcome: false, errorType: error.telemetryLabel)
+            onStateChange?(.speechResult(.empty(), error))
             return
         }
         searchResultTask?.cancel()
@@ -91,7 +92,6 @@ final class QuickAnswersViewModel {
         }
     }
 
-    // TODO: FXIOS-14880 - Update view model
     private func recordVoiceTask(service: QuickAnswersService) async throws {
         onStateChange?(.recordingStarted)
         telemetry.recordingStarted()
@@ -117,22 +117,10 @@ final class QuickAnswersViewModel {
         }
     }
 
-    // TODO: FXIOS-14880 - Update view model
     private func stopRecordingVoice() async throws {
-        guard let service else {
-            emitServiceNotInitialized()
-            return
-        }
-
         recordVoiceTask?.cancel()
         recordVoiceTask = nil
-        try await service.stopRecording()
-    }
-
-    private func emitServiceNotInitialized() {
-        let error = SpeechError.serviceNotInitialized
-        telemetry.recordingCompleted(outcome: false, errorType: error.telemetryLabel)
-        onStateChange?(.speechResult(.empty(), error))
+        try await service?.stopRecording()
     }
 
     private func searchVoiceResult(_ result: SpeechResult, service: QuickAnswersService) async {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16282)

## :bulb: Description
Fixes the Quick Answers response screen only rendering a single source on iPad.

- Invalidate the collection view layout when the source list's `contentSize` changes, so all source cells are laid out instead of a stale single-item size being kept.
- Limit the displayed sources to the first 2 citations.
- Guard the one-time flow start in `viewWillAppear` so the form-sheet presentation on iPad doesn't restart the flow when a dismissal attempt fails.
- Minor `QuickAnswersViewModel` cleanup.

## :movie_camera: Demos
<img width="500" height="724" alt="Simulator Screenshot - iPad (A16) - 2026-07-14 at 11 42 49" src="https://github.com/user-attachments/assets/fc7c4d8b-7eaa-4e4e-adb8-2aeb9677d320" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
