### PR TITLE
BugFix FXIOS-16223 [Microsurvey]: Fix truncated label in prompt alert

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -79,7 +79,7 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
     }
 
     private lazy var headerView: UIStackView = .build { stack in
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .horizontal
         stack.alignment = .top
         stack.spacing = UX.headerStackSpacing
@@ -178,7 +178,6 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
             toastView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: UX.padding.bottom),
 
             headerView.widthAnchor.constraint(equalTo: toastView.widthAnchor),
-            titleLabel.heightAnchor.constraint(equalTo: headerView.heightAnchor),
         ])
     }
 


### PR DESCRIPTION
### Summary
Fixes issue #34526 (FXIOS-16223): The main label in the microsurvey alert/toast was truncated instead of wrapping to multiple lines.

### Root cause
Two compounding UIKit layout issues in `MicrosurveyPromptView`:
1. A circular height constraint (`titleLabel.heightAnchor == headerView.heightAnchor`) forced the label to match the stack's height, preventing natural multi-line wrapping.
2. The `headerView` used `.fillProportionally` distribution, which squeezed `titleLabel` width based on its unwrapped intrinsic width, leaving insufficient space for wrapped text, especially at larger Dynamic Type sizes.

### Fix
- Changed `headerView` distribution from `.fillProportionally` to `.fill`.
- Removed the circular `titleLabel.heightAnchor == headerView.heightAnchor` constraint.
This allows the title to wrap naturally and the prompt card to grow to accommodate all content.

### Testing
- Checked compiles with Swift 6.3.3.
- Checked that logo and close button alignment remain correct.

Closes #34526
Jira: FXIOS-16223
