### PR TITLE
Refactor FXIOS-15646 - [CC Autofill] - Cannot select any CC from the list 

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -36,6 +36,7 @@ class CreditCardBottomSheetViewController: UIViewController,
     var notificationCenter: NotificationProtocol
     var themeManager: ThemeManager
     var themeListenerCancellable: Any?
+    private let logger: Logger
     private var viewModel: CreditCardBottomSheetViewModel
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
@@ -102,11 +103,13 @@ class CreditCardBottomSheetViewController: UIViewController,
     init(viewModel: CreditCardBottomSheetViewModel,
          windowUUID: WindowUUID,
          notificationCenter: NotificationProtocol = NotificationCenter.default,
-         themeManager: ThemeManager = AppContainer.shared.resolve()) {
+         themeManager: ThemeManager = AppContainer.shared.resolve(),
+         logger: Logger = DefaultLogger.shared) {
         self.viewModel = viewModel
         self.notificationCenter = notificationCenter
         self.themeManager = themeManager
         self.windowUUID = windowUUID
+        self.logger = logger
         super.init(nibName: nil, bundle: nil)
 
         self.viewModel.didUpdateCreditCard = { [weak self] in
@@ -379,6 +382,11 @@ class CreditCardBottomSheetViewController: UIViewController,
             bottomSheetState: .selectSavedCard,
             row: row
         ) else {
+            // A nil means the card couldn't be decrypted. The Keychain key is unavailable.
+            logger.log("Credit card autofill selection failed: unable to decrypt selected card.",
+                       level: .fatal,
+                       category: .autofill)
+            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .creditCardAutofillFailed)
             return
         }
         didSelectCreditCardToFill?(plainTextCreditCard)

--- a/firefox-ios/Storage/RustKeychain.swift
+++ b/firefox-ios/Storage/RustKeychain.swift
@@ -249,10 +249,15 @@ public final class RustKeychain: KeychainProtocol {
         var keyValue: String?
         (keyValue, _) = getCreditCardKeyData()
 
-        guard let key = keyValue else { return nil }
+        guard let keyValue else {
+            logger.log("Credit card decryption failed: encryption key unavailable from keychain.",
+                       level: .warning,
+                       category: .storage)
+            return nil
+        }
 
         do {
-            return try decryptString(key: key, ciphertext: encryptedCCNum)
+            return try decryptString(key: keyValue, ciphertext: encryptedCCNum)
         } catch let err as NSError {
             if let autofillStoreError = err as? AutofillApiError {
                 logAutofillStoreError(err: autofillStoreError,
@@ -323,9 +328,7 @@ public final class RustKeychain: KeychainProtocol {
             // data or querying for key data that hasn't been created yet in the case
             // of a first-time sync sign in for instance.
 
-            logger.log("Failed to get keychain data: \(err)",
-                       level: .debug,
-                       category: .storage)
+            logger.log("Failed to get keychain data: \(err)", level: .warning, category: .storage)
             return nil
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15646)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33516)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Tapping a saved card in the credit card autofill bottom sheet occasionally does nothing. The card number can't be decrypted, so no fields are filled. This is most likely a Keychain issue (the credit card encryption key being unavailable/not matching the stored data). It's an isolated, hard to hit case. QA were only able to reproduce it twice.

The problem was invisible to debug: the failure was only logged at `.debug`, which isn't
captured in beta/release, so there was no signal to investigate. This PR adds logging and,
for the point of failure, a `.fatal` log so it's reported to Sentry. No behavior or UI change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

