### PR TITLE
BugFix FXIOS-13453 [Addresses] Fix section remains scrollable while keyboard is displayed

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -242,13 +242,13 @@ class EditAddressViewController: UIViewController,
     // MARK: - KeyboardHelperDelegate
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillShowWithState state: KeyboardState) {
         let coveredHeight = state.intersectionHeightForView(view)
-        // Adjust stackView's bottom inset when the keyboard appears
-        stackView.layoutMargins.bottom = removeButton.isHidden ? 0 : coveredHeight
+        webView?.scrollView.contentInset.bottom = coveredHeight
+        webView?.scrollView.scrollIndicatorInsets.bottom = coveredHeight
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        // Reset the bottom inset when the keyboard hides
-        stackView.layoutMargins.bottom = 0
+        webView?.scrollView.contentInset.bottom = 0
+        webView?.scrollView.scrollIndicatorInsets.bottom = 0
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes GitHub issue [#29238](https://github.com/mozilla-mobile/firefox-ios/issues/29238) and Jira ticket [FXIOS-13453](https://mozilla-hub.atlassian.net/browse/FXIOS-13453).

**Problem:** In Settings → Addresses → Add/Edit, when tapping an input field to bring up the keyboard, the form content remains freely scrollable instead of being locked/inset to avoid the keyboard (unlike the Passwords section, which behaves correctly).

**Root Cause:** `EditAddressViewController` embeds a `WKWebView` in a `UIStackView`. The `KeyboardHelperDelegate` methods only adjusted `stackView.layoutMargins.bottom`, but never touched `webView.scrollView`, which is the actual `UIScrollView` that scrolls. Additionally, a conditional gate on `removeButton.isHidden` prevented keyboard-avoidance from working in Add mode.

**Fix:** Apply `contentInset` and `scrollIndicatorInsets` directly to `webView?.scrollView` on keyboard show/hide, matching the pattern used correctly in Passwords screens (`PasswordDetailViewController`, `PasswordManagerListViewController`, `AddCredentialViewController`). Removed the `removeButton.isHidden` gate so both Add and Edit modes get keyboard-avoidance.

## Test Plan

- [ ] Run in simulator: Settings → Addresses → "+" to add a new address
- [ ] Tap an input field near the bottom of the form to bring up the keyboard
- [ ] Confirm the form no longer scrolls freely past the keyboard
- [ ] Repeat for editing an existing address (with multiple fields requiring scroll)
- [ ] Confirm removeButton remains visible and functional in edit mode
- [ ] Run existing Autofill tests to confirm no regressions

## Code Changes

- Modified `EditAddressViewController.swift`, `keyboardHelper(_:keyboardWillShowWithState:)` and `keyboardHelper(_:keyboardWillHideWithState:)` methods

---

[FXIOS-13453]: https://mozilla-hub.atlassian.net/browse/FXIOS-13453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
