### PR TITLE
Bugfix FXIOS-14729 Incorrect behavior when closing older tabs

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -327,15 +327,24 @@ final class TabManagerImplementation: NSObject,
 
         guard !tabsToRemove.isEmpty else { return }
 
-        let selectedTab = selectedTab
+        let previouslySelectedTab = selectedTab
+        let selectedTabWillBeRemoved = previouslySelectedTab.map { selectedTab in
+            tabsToRemove.contains { $0 === selectedTab }
+        } ?? false
+
         for tab in tabsToRemove {
             // Remove each tab without persisting changes
             removeTab(tab, flushToDisk: false)
         }
-        // We need to reselect the tab and adjust the selected index after tabs removal.
-        // The selected tab will not be removed with `removeNormalTabsOlderThan` since it's
-        // `lastExecutedTime` won't be less than the `cutoffDate`.
-        selectTab(selectedTab)
+
+        if normalTabs.isEmpty {
+            selectTab(addTab())
+        } else if selectedTabWillBeRemoved {
+            selectTab(mostRecentTab(inTabs: normalTabs))
+        } else {
+            selectTab(previouslySelectedTab)
+        }
+
         commitChanges()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerOlderTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerOlderTabsTests.swift
@@ -27,7 +27,9 @@ final class TabManagerOlderTabsTests: TabManagerTestsBase {
 
         tabManager.removeNormalTabsOlderThan(period: .oneWeek, currentDate: testDate)
 
-        XCTAssertEqual(tabManager.normalTabs.count, 0)
+        XCTAssertEqual(tabManager.normalTabs.count, 1)
+        XCTAssertTrue(tabManager.selectedTab?.isURLStartingPage == true)
+        XCTAssertFalse(tabs.contains { $0 === tabManager.selectedTab })
     }
 
     @MainActor
@@ -49,7 +51,9 @@ final class TabManagerOlderTabsTests: TabManagerTestsBase {
 
         tabManager.removeNormalTabsOlderThan(period: .oneDay, currentDate: testDate)
 
-        XCTAssertEqual(tabManager.normalTabs.count, 0)
+        XCTAssertEqual(tabManager.normalTabs.count, 1)
+        XCTAssertTrue(tabManager.selectedTab?.isURLStartingPage == true)
+        XCTAssertFalse(tabs.contains { $0 === tabManager.selectedTab })
     }
 
     @MainActor
@@ -82,7 +86,9 @@ final class TabManagerOlderTabsTests: TabManagerTestsBase {
 
         tabManager.removeNormalTabsOlderThan(period: .oneDay, currentDate: testDate)
 
-        XCTAssertEqual(tabManager.normalTabs.count, 0)
+        XCTAssertEqual(tabManager.normalTabs.count, 1)
+        XCTAssertTrue(tabManager.selectedTab?.isURLStartingPage == true)
+        XCTAssertFalse(tabs.contains { $0 === tabManager.selectedTab })
     }
 
     @MainActor
@@ -93,7 +99,9 @@ final class TabManagerOlderTabsTests: TabManagerTestsBase {
 
         tabManager.removeNormalTabsOlderThan(period: .oneWeek, currentDate: testDate)
 
-        XCTAssertEqual(tabManager.normalTabs.count, 0)
+        XCTAssertEqual(tabManager.normalTabs.count, 1)
+        XCTAssertTrue(tabManager.selectedTab?.isURLStartingPage == true)
+        XCTAssertFalse(tabs.contains { $0 === tabManager.selectedTab })
     }
 
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14729)
[Github Issue](https://github.com/mozilla-mobile/firefox-ios/issues/31809)

## :bulb: Description

If applied, this commit will fix the incorrect tab behavior where, when closing week-old tabs, one tab remains undeleted.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
