### PR TITLE
Bugfix FXIOS-15144 [Settings] Navigation toolbar settings UI are cut off in landscape mode

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSettingsView.swift
@@ -43,22 +43,24 @@ struct AddressBarSettingsView: View, UserFeaturePreferenceProvider {
     }
 
     var body: some View {
-        VStack {
-            GenericSectionView(theme: currentTheme,
-                               title: .Settings.AddressBar.AddressBarSectionTitle,
-                               identifier: AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting) {
-                AddressBarSelectionView(
-                    theme: currentTheme,
-                    selectedAddressBarPosition: addressBarPosition,
-                    onSelected: viewModel.saveSearchBarPosition)
-                .modifier(SectionStyle(theme: currentTheme, cornerRadius: UX.cornerRadius))
-            }
+        ScrollView {
+            VStack {
+                GenericSectionView(theme: currentTheme,
+                                   title: .Settings.AddressBar.AddressBarSectionTitle,
+                                   identifier: AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting) {
+                    AddressBarSelectionView(
+                        theme: currentTheme,
+                        selectedAddressBarPosition: addressBarPosition,
+                        onSelected: viewModel.saveSearchBarPosition)
+                    .modifier(SectionStyle(theme: currentTheme, cornerRadius: UX.cornerRadius))
+                }
 
-            NavigationToolbarSection(theme: currentTheme,
-                                     selectedOption: selectedMiddleButtonType,
-                                     onChange: updateMiddleNavigationToolbarButton,
-                                     cornerRadius: UX.cornerRadius)
-            Spacer()
+                NavigationToolbarSection(theme: currentTheme,
+                                         selectedOption: selectedMiddleButtonType,
+                                         onChange: updateMiddleNavigationToolbarButton,
+                                         cornerRadius: UX.cornerRadius)
+                Spacer()
+            }
         }
         .modifier(PaddingStyle(theme: currentTheme, spacing: UX.spacing))
         .background(viewBackground)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15144)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32594)

## :bulb: Description
- Wraps view in scroll view to fix bug in landscape and small screens

## :movie_camera: Demos

https://github.com/user-attachments/assets/1ad48128-d32a-498c-8434-fe4821399a1e



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

