### PR TITLE
[MTE-5643] - enable share menu tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -296,7 +296,6 @@
         "SettingsTests\/testImageOnOff_tabTrayExperimentOn()",
         "SettingsTests\/testSettingsOptionSubtitles()",
         "SettingsTests\/testSettingsOptionSubtitles_TAE()",
-        "ShareMenuTests",
         "SiteLoadTest",
         "SyncUITests\/testAccountManagementPage()",
         "TabTraySearchTabsTests\/testSearchTabs()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
@@ -4,17 +4,14 @@
 
 import Foundation
 import XCTest
+import Common
 
 let pdfUrl = "https://storage.googleapis.com/mobile_test_assets/public/lorem_ipsum.pdf"
 
-class ShareMenuTests: BaseTestCase {
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        throw XCTSkip("Skipping all ShareMenuTests. The option is not available on the new menu")
-    }
-
+class ShareMenuTests: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2863631
     func testShareNormalWebsiteTabViaReminders() {
+        app.launch()
         // Couldn't find a way to tap on reminders on iOS 16
         if #available(iOS 17, *) {
             reachShareMenuLayoutAndSelectOption(option: "Reminders")
@@ -23,43 +20,53 @@ class ShareMenuTests: BaseTestCase {
                 [
                     app.navigationBars["Reminders"],
                     app.links["http://" + url_3]
-                ]
+                ],
+                timeout: TIMEOUT_LONG
             )
         }
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864049
     func testShareNormalWebsitePrint() {
+        app.launch()
         reachShareMenuLayoutAndSelectOption(option: "Print")
         validatePrintLayout()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864047
     func testShareNormalWebsiteSendLinkToDevice() {
+        app.launch()
         reachShareMenuLayoutAndSelectOption(option: "Send Link to Device")
         // If not signed in, the browser prompts you to sign in
         waitForElementsToExist(
             [
                 app.staticTexts[sendLinkMsg1],
                 app.staticTexts[sendLinkMsg2]
-            ]
+            ],
+            timeout: TIMEOUT_LONG
         )
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864048
     func testShareNormalWebsiteMarkup() {
+        app.launch()
         reachShareMenuLayoutAndSelectOption(option: "Markup")
         validateMarkupTool()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864046
     func testShareNormalWebsiteCopyUrl() {
+        app.launch()
         reachShareMenuLayoutAndSelectOption(option: "Copy")
         openNewTabAndValidateURLisPaste(url: url_3)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864073
     func testShareWebsiteReaderModeReminders() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launchArguments.append(LaunchArguments.SkipAppleIntelligence)
+        app.launch()
         if #available(iOS 17, *) {
             reachReaderModeShareMenuLayoutAndSelectOption(option: "Reminders")
             // The URL of the website is added in a new reminder
@@ -67,89 +74,139 @@ class ShareMenuTests: BaseTestCase {
                 [
                     app.navigationBars["Reminders"],
                     app.links.elementContainingText(TestPages.mozillaBook)
-                ]
+                ],
+                timeout: TIMEOUT_LONG
             )
         }
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864082
     func testShareWebsiteReaderModePrint() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launchArguments.append(LaunchArguments.SkipAppleIntelligence)
+        app.launch()
         reachReaderModeShareMenuLayoutAndSelectOption(option: "Print")
         validatePrintLayout()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864079
     func testShareWebsiteReaderModeCopy() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launchArguments.append(LaunchArguments.SkipAppleIntelligence)
+        app.launch()
         reachReaderModeShareMenuLayoutAndSelectOption(option: "Copy")
         openNewTabAndValidateURLisPaste(url: TestPages.mozillaBook)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864080
     func testShareWebsiteReaderModeSendLink() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launchArguments.append(LaunchArguments.SkipAppleIntelligence)
+        app.launch()
         reachReaderModeShareMenuLayoutAndSelectOption(option: "Send Link to Device")
         // If not signed in, the browser prompts you to sign in
         waitForElementsToExist(
             [
                 app.staticTexts[sendLinkMsg1],
                 app.staticTexts[sendLinkMsg2]
-            ]
+            ],
+            timeout: TIMEOUT_LONG
         )
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864081
     func testShareWebsiteReaderModeMarkup() {
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
+        app.launchArguments.append(LaunchArguments.SkipAppleIntelligence)
+        app.launch()
         reachReaderModeShareMenuLayoutAndSelectOption(option: "Markup")
         validateMarkupTool()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864065
     func testSharePdfFilePrint() {
+        app.launch()
         reachShareMenuLayoutAndSelectOption(option: "Print", url: pdfUrl)
         validatePrintLayout()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864064
     func testSharePdfFileMarkup() {
+        app.launch()
         reachShareMenuLayoutAndSelectOption(option: "Markup", url: pdfUrl)
         validateMarkupTool()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864066
     func testSharePdfFileSaveToFile() {
+        app.launch()
         if #available(iOS 17, *) {
             reachShareMenuLayoutAndSelectOption(option: "Save to Files", url: pdfUrl)
-            if !iPad() {
-                mozWaitForElementToExist(app.staticTexts["On My iPhone"])
-            } else {
-                mozWaitForElementToExist(app.staticTexts["On My iPad"])
+            let saveButton = app.buttons["Save"]
+            var attempts = 2
+            while !saveButton.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) && attempts > 0 {
+                let saveToFilesCell = app.collectionViews.cells["Save to Files"]
+                guard saveToFilesCell.exists else { break }
+                saveToFilesCell.tapOnApp()
+                attempts -= 1
             }
-            app.buttons["Save"].waitAndTap()
+            mozWaitForElementToExist(saveButton, timeout: TIMEOUT_LONG)
+            saveButton.waitAndTap()
             waitForTabsButton()
         }
     }
 
     private func validatePrintLayout() {
-        // The Print dialog appears
+        // The Print dialog appears. It can take a little longer to load, so wait longer.
         waitForElementsToExist(
             [
                 app.staticTexts["Printer"],
                 app.staticTexts["Paper Size"]
-            ]
+            ],
+            timeout: TIMEOUT_LONG
         )
         if #available(iOS 16, *) {
-            mozWaitForElementToExist(app.staticTexts["Layout"])
+            mozWaitForElementToExist(app.staticTexts["Layout"], timeout: TIMEOUT_LONG)
         }
         if #available(iOS 17, *) {
-            mozWaitForElementToExist(app.staticTexts["Options"])
+            mozWaitForElementToExist(app.staticTexts["Options"], timeout: TIMEOUT_LONG)
         } else {
-            mozWaitForElementToExist(app.staticTexts["Print Options"])
+            mozWaitForElementToExist(app.staticTexts["Print Options"], timeout: TIMEOUT_LONG)
         }
     }
 
     private func validateMarkupTool() {
-        // The Markup tool opens
-        mozWaitForElementToExist(app.switches["Markup"])
-        mozWaitForElementToExist(app.buttons["Done"])
+        // The Markup tool opens. It can take a little longer to load, so wait longer.
+        if #available(iOS 26, *) {
+            if !iPad() {
+                // The navbar overflow label varies ("More" -> "View More", MTE-5253) and the
+                // palette sometimes opens without one; only tap the label that's actually present.
+                if !app.buttons["Markup"].mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) {
+                    let overflow = app.navigationBars.buttons["More"].exists
+                        ? app.navigationBars.buttons["More"]
+                        : app.navigationBars.buttons["View More"]
+                    if overflow.exists {
+                        overflow.waitAndTap()
+                    }
+                }
+                mozWaitForElementToExist(app.buttons["Markup"], timeout: TIMEOUT_LONG)
+                mozWaitForElementToExist(app.buttons["Close"], timeout: TIMEOUT_LONG)
+                mozWaitForElementToExist(app.otherElements["Drawing-Palette"], timeout: TIMEOUT_LONG)
+            } else {
+                // On iPad the Markup palette renders inline with no navbar overflow button;
+                // the Markup control is a switch, not a button.
+                mozWaitForElementToExist(app.switches["Markup"], timeout: TIMEOUT_LONG)
+                mozWaitForElementToExist(app.buttons["close"], timeout: TIMEOUT_LONG)
+            }
+        } else {
+            if !app.switches["Markup"].mozWaitForElementToExist(timeout: TIMEOUT_LONG, failOnTimeout: false) {
+                mozWaitForElementToExist(app.buttons["Markup"], timeout: TIMEOUT_LONG)
+            }
+        }
     }
 
     private func reachReaderModeShareMenuLayoutAndSelectOption(option: String) {
@@ -158,29 +215,34 @@ class ShareMenuTests: BaseTestCase {
         navigator.nowAt(BrowserTab)
         mozWaitForElementToNotExist(app.staticTexts["Fennec pasted from XCUITests-Runner"])
         app.buttons["Reader View"].waitAndTap()
-        // navigator.goto(ToolsBrowserTabMenu)
-        // Tap the Share button in the menu
+        // Open the main menu and tap the Share option
         navigator.performAction(Action.ShareBrowserTabMenuOption)
-        if #available(iOS 16, *) {
-            mozWaitForElementToExist(app.collectionViews.cells[option])
-            app.collectionViews.cells[option].tapOnApp()
-        } else {
-            app.buttons[option].waitAndTap()
-        }
+        selectShareSheetOption(option)
     }
 
     private func reachShareMenuLayoutAndSelectOption(option: String, url: String = url_3) {
+        if !iPad() {
+            navigator.nowAt(HomePanelsScreen)
+            navigator.goto(URLBarOpen)
+        }
         // Open a website in the browser
         navigator.openURL(url)
         waitUntilPageLoad()
-        // navigator.goto(ToolsBrowserTabMenu)
-        // Tap the Share button in the menu
+        // Open the main menu and tap the Share option
         navigator.performAction(Action.ShareBrowserTabMenuOption)
+        selectShareSheetOption(option)
+    }
+
+    private func selectShareSheetOption(_ option: String) {
+        if #available(iOS 26, *) {
+            let optionCell = app.collectionViews.cells[option]
+            if !optionCell.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) {
+                app.scrollViews.cells["View More"].waitAndTap(timeout: 10)
+            }
+        }
         if #available(iOS 16, *) {
             mozWaitForElementToExist(app.collectionViews.cells[option])
-            app.collectionViews.cells[option].waitAndTap()
-            // Workaround needed for iOS 17 to make sure the element is getting tapped and to avoid using sleeps
-            app.collectionViews.cells[option].tapIfExists()
+            app.collectionViews.cells[option].tapOnApp()
         } else {
             app.buttons[option].waitAndTap()
         }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -182,13 +182,15 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
         // The Markup tool opens
         if #available(iOS 26, *) {
             if !iPad() {
-                // iOS 26.3 renamed this navbar overflow button "More" -> "View More" (same rename
-                // as the share sheet, see MTE-5253). Tap whichever label is present.
-                let moreButton = app.navigationBars.buttons["More"]
-                if moreButton.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) {
-                    moreButton.waitAndTap()
-                } else {
-                    app.navigationBars.buttons["View More"].waitAndTap()
+                // The navbar overflow label varies ("More" -> "View More", MTE-5253) and the
+                // palette sometimes opens without one; only tap the label that's actually present.
+                if !app.buttons["Markup"].mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) {
+                    let overflow = app.navigationBars.buttons["More"].exists
+                        ? app.navigationBars.buttons["More"]
+                        : app.navigationBars.buttons["View More"]
+                    if overflow.exists {
+                        overflow.waitAndTap()
+                    }
                 }
                 mozWaitForElementToExist(app.buttons["Markup"])
                 mozWaitForElementToExist(app.buttons["Close"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabMenuNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabMenuNavigation.swift
@@ -24,6 +24,10 @@ func registerTabMenuNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIAppl
         screenState.tap(
             app.tables.cells[AccessibilityIdentifiers.MainMenu.print],
             to: PrintPage)
+        // Share
+        screenState.tap(
+            app.tables.cells[AccessibilityIdentifiers.MainMenu.share],
+            forAction: Action.ShareBrowserTabMenuOption)
         // Turn on night mode
         screenState.dismissOnUse = true
         screenState.backAction = cancelBackAction(for: app)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5643

## :bulb: Description
Re-enables the previously fully-skipped ShareMenuTests suite (removed the blanket XCTSkip in setUpWithError and the "ShareMenuTests" entry from FullFunctionalTestPlan.xctestplan).

Changes:
- Converted ShareMenuTests from BaseTestCase to FeatureFlaggedTestBase and moved app.launch() into each test so per-test launch arguments can be set. Reader-mode tests now disable the Apple/hosted summarizer feature flags and skip Apple Intelligence so the share flow is reachable.
- Added a shared selectShareSheetOption(_:) helper and handled the iOS 26 share sheet, which hides options behind a View More cell.
- Made validateMarkupTool() and validatePrintLayout() iOS 26-aware (navbar overflow label varies "More" → "View More", iPad renders the Markup palette inline as a switch) and bumped waits to TIMEOUT_LONG since these dialogs load slowly.
- Hardened testSharePdfFileSaveToFile with a retry loop that re-taps "Save to Files" until the Save button appears.
- Registered a Share graph edge for Action.ShareBrowserTabMenuOption in registerTabMenuNavigation.
- Aligned ShareToolbarTests Markup validation with the same overflow-label handling.

The intent of this PR is to reenable the tests, the conversion to TAE must be done in a different task, because this requires a lot more changes.
