### PR TITLE
Add FXIOS-15942 [HNT] Persist tracker block stats

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -10,6 +10,12 @@ public struct PrefsKeys {
     public static let KeyEnableChinaSyncService = "useChinaSyncService"
     public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
 
+    // Long-term blocked-tracker stats (non-private), bucketed by ISO week and category.
+    // The current week is stored separately from completed weeks so the hot-path
+    // write only ever touches a small, fixed-size value.
+    public static let TrackerBlockStatsCurrentWeek = "trackerBlockStatsCurrentWeek"
+    public static let TrackerBlockStatsArchive = "trackerBlockStatsArchive"
+
     // Global sync state for rust sync manager
     public static let RustSyncManagerPersistedState = "rustSyncManagerPersistedStateKey"
     public static let LoginsHaveBeenVerified = "loginsHaveBeenVerified"

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -460,6 +460,10 @@
 		367C100A7ABD4B4585D029D5 /* AutoTranslatePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137DDFADC6034016BE36E02B /* AutoTranslatePromptView.swift */; };
 		39012F281F8ED262002E3D31 /* ScreenGraphTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39012F271F8ED262002E3D31 /* ScreenGraphTest.swift */; };
 		391B4FFF1F9767F50094F841 /* FxScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */; };
+		391C28173007C3C500833828 /* TrackerBlockStatsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391C28163007C3C500833828 /* TrackerBlockStatsModels.swift */; };
+		391C28193007C3CB00833828 /* TrackerBlockStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391C28183007C3CB00833828 /* TrackerBlockStatsStore.swift */; };
+		391C281C3007C3D700833828 /* TrackerBlockStatsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391C281A3007C3D700833828 /* TrackerBlockStatsStoreTests.swift */; };
+		391C281D3007C3D700833828 /* TrackingProtectionPageStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391C281B3007C3D700833828 /* TrackingProtectionPageStatsTests.swift */; };
 		39230FDC2FEC53BA00AD5FAB /* WebServerLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39230FDB2FEC53BA00AD5FAB /* WebServerLifecycleTests.swift */; };
 		39236E721FCC600200A38F1B /* TabEventHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */; };
 		392D791A2F8FCE1A00B10BDC /* FeatureFlagID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392D79192F8FCE0E00B10BDC /* FeatureFlagID.swift */; };
@@ -3503,6 +3507,10 @@
 		3905274B1C874D35007E0BB7 /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
 		3905B4D41E8E7A6B0027D953 /* FxAPushMessageHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAPushMessageHandler.swift; sourceTree = "<group>"; };
 		39104C4F9A5CFDE66911D82B /* hy-AM */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hy-AM"; path = "hy-AM.lproj/Search.strings"; sourceTree = "<group>"; };
+		391C28163007C3C500833828 /* TrackerBlockStatsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerBlockStatsModels.swift; sourceTree = "<group>"; };
+		391C28183007C3CB00833828 /* TrackerBlockStatsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerBlockStatsStore.swift; sourceTree = "<group>"; };
+		391C281A3007C3D700833828 /* TrackerBlockStatsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerBlockStatsStoreTests.swift; sourceTree = "<group>"; };
+		391C281B3007C3D700833828 /* TrackingProtectionPageStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionPageStatsTests.swift; sourceTree = "<group>"; };
 		39230FDB2FEC53BA00AD5FAB /* WebServerLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServerLifecycleTests.swift; sourceTree = "<group>"; };
 		39236E711FCC600200A38F1B /* TabEventHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabEventHandlerTests.swift; sourceTree = "<group>"; };
 		392D79192F8FCE0E00B10BDC /* FeatureFlagID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagID.swift; sourceTree = "<group>"; };
@@ -13186,6 +13194,15 @@
 			path = TrackerBlockerModule;
 			sourceTree = "<group>";
 		};
+		391C28153007C38D00833828 /* TrackerBlockStats */ = {
+			isa = PBXGroup;
+			children = (
+				391C28163007C3C500833828 /* TrackerBlockStatsModels.swift */,
+				391C28183007C3CB00833828 /* TrackerBlockStatsStore.swift */,
+			);
+			path = TrackerBlockStats;
+			sourceTree = "<group>";
+		};
 		392ED7D51D0AEEEE009D9B62 /* Accessors */ = {
 			isa = PBXGroup;
 			children = (
@@ -14810,6 +14827,7 @@
 		8AD984F12AF1554F00B9FDA4 /* ContentBlocker */ = {
 			isa = PBXGroup;
 			children = (
+				391C28153007C38D00833828 /* TrackerBlockStats */,
 				EBB894F8219398E500EB91A0 /* ContentBlocker.swift */,
 				EBB894F9219398E500EB91A0 /* ContentBlocker+Safelist.swift */,
 				EBB894F7219398E500EB91A0 /* TabContentBlocker.swift */,
@@ -17312,6 +17330,8 @@
 				CA7BD564248185B500A0A61B /* BreachAlertsTests.swift */,
 				8A28C627291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift */,
 				F84B21D91A090F8100AAB793 /* ClientTests.swift */,
+				391C281A3007C3D700833828 /* TrackerBlockStatsStoreTests.swift */,
+				391C281B3007C3D700833828 /* TrackingProtectionPageStatsTests.swift */,
 				8A86DAD7277298DE00D7BFFF /* ClosedTabsStoreTests.swift */,
 				C2200A692B7D148C00DC062A /* ContentBlockerTests.swift */,
 				ADB10C102D900000001AB003 /* ASAdBlockerListFetcherTests.swift */,
@@ -19742,6 +19762,7 @@
 				61C92A012DEF39F9004ACF49 /* TabConfigurationProvider.swift in Sources */,
 				0B62EFD21AD63CD100ACB9CD /* Clearables.swift in Sources */,
 				0AFF7F6C2C7C7BBA00265214 /* CertificatesCell.swift in Sources */,
+				391C28173007C3C500833828 /* TrackerBlockStatsModels.swift in Sources */,
 				8AAEBA062BF51141000C02B5 /* MicrosurveyMiddleware.swift in Sources */,
 				431C0CA925C890E500395CE4 /* DefaultBrowserOnboardingViewModel.swift in Sources */,
 				2140E4632E71FC250054173A /* RecordVisitObservationManager.swift in Sources */,
@@ -20176,6 +20197,7 @@
 				8A13FA8B2AD82E6D007527AB /* ApplicationStateProvider.swift in Sources */,
 				E13C072B2C2184C80087E404 /* AddressBarState.swift in Sources */,
 				C7F051522D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift in Sources */,
+				391C28193007C3CB00833828 /* TrackerBlockStatsStore.swift in Sources */,
 				C25018DF2ECC75A40071506F /* Bridge.swift in Sources */,
 				4347B39A298DA5BB0045F677 /* CreditCardInputViewModel.swift in Sources */,
 				6025B10D267B6C5400F59F6B /* LoginRecordExtension.swift in Sources */,
@@ -20918,6 +20940,8 @@
 				0A80C4262F3CD45900DB85AE /* MockLAContext.swift in Sources */,
 				C8C3FEA129F973C40038E3BA /* MockBrowserViewController.swift in Sources */,
 				8C2FB1ED2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift in Sources */,
+				391C281C3007C3D700833828 /* TrackerBlockStatsStoreTests.swift in Sources */,
+				391C281D3007C3D700833828 /* TrackingProtectionPageStatsTests.swift in Sources */,
 				8A93F86B29D39BDA004159D9 /* BaseCoordinatorTests.swift in Sources */,
 				8AF3B15A2AF99B86009BB262 /* HistoryPanelTests.swift in Sources */,
 				814A62462B587A3E00608195 /* DefaultThemeManagerTests.swift in Sources */,

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -28,6 +28,25 @@ enum BlocklistCategory: CaseIterable {
             return .fingerprinting
         }
     }
+
+    /// A stable string identifier used to persist per-category stats. Unlike the
+    /// enum case order, this value is guaranteed not to change, so serialized
+    /// stats remain readable even if the enum is reordered or extended.
+    var storageKey: String {
+        switch self {
+        case .advertising: return "advertising"
+        case .analytics: return "analytics"
+        case .social: return "social"
+        case .cryptomining: return "cryptomining"
+        case .fingerprinting: return "fingerprinting"
+        }
+    }
+
+    init?(storageKey: String) {
+        guard let match = BlocklistCategory.allCases.first(where: { $0.storageKey == storageKey })
+        else { return nil }
+        self = match
+    }
 }
 
 enum BlocklistFileName: String, CaseIterable {

--- a/firefox-ios/Client/ContentBlocker/TabContentBlocker+ContentScript.swift
+++ b/firefox-ios/Client/ContentBlocker/TabContentBlocker+ContentScript.swift
@@ -38,7 +38,14 @@ extension TabContentBlocker {
                 DispatchQueue.main.async {
                     guard let listItem = listItem else { return }
 
-                    self.stats = self.stats.create(matchingBlocklist: listItem, host: url.host ?? "")
+                    let result = self.stats.adding(matchingBlocklist: listItem, host: url.host ?? "")
+                    self.stats = result.stats
+
+                    // Record long-term stats once per newly-blocked host, excluding
+                    // private browsing so those sessions are never persisted.
+                    if result.inserted, self.tab?.isPrivate == false {
+                        self.statsRecorder?.record(category: listItem, count: 1, date: Date())
+                    }
 
                     guard let windowUUID = self.tab?.currentWebView()?.currentWindowUUID else { return }
                     store.dispatch(

--- a/firefox-ios/Client/ContentBlocker/TabContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/TabContentBlocker.swift
@@ -12,6 +12,8 @@ extension Notification.Name {
 
 protocol ContentBlockerTab: AnyObject {
     @MainActor
+    var isPrivate: Bool { get }
+    @MainActor
     func currentURL() -> URL?
     @MainActor
     func currentWebView() -> WKWebView?
@@ -55,6 +57,10 @@ class TabContentBlocker: Notifiable {
     }
 
     var stats = TPPageStats()
+
+    /// Persists blocked-tracker stats long term. Set by subclasses that have
+    /// access to prefs; left nil when long-term recording is not desired.
+    var statsRecorder: TrackerBlockStatsStore?
 
     init(tab: ContentBlockerTab, logger: Logger = DefaultLogger.shared) {
         self.tab = tab

--- a/firefox-ios/Client/ContentBlocker/TrackerBlockStats/TrackerBlockStatsModels.swift
+++ b/firefox-ios/Client/ContentBlocker/TrackerBlockStats/TrackerBlockStatsModels.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Blocked-tracker counts for a single ISO-8601 week, keyed by category.
+/// `year` is the ISO year-for-week-of-year (which can differ from the calendar
+/// year around January), and `week` is the ISO week-of-year (1...53).
+struct TrackerBlockStatsBucket: Codable, Equatable {
+    let year: Int
+    let week: Int
+    /// Category storage key (`BlocklistCategory.storageKey`) to blocked count.
+    var counts: [String: Int]
+
+    var total: Int {
+        return counts.values.reduce(0, +)
+    }
+}
+
+/// The full persisted stats payload: an append-only list of weekly buckets.
+/// Lifetime figures are derived by summing across all buckets, so there is no
+/// separate running total to keep in sync.
+struct TrackerBlockStatsData: Codable, Equatable {
+    var buckets: [TrackerBlockStatsBucket]
+
+    init(buckets: [TrackerBlockStatsBucket] = []) {
+        self.buckets = buckets
+    }
+}

--- a/firefox-ios/Client/ContentBlocker/TrackerBlockStats/TrackerBlockStatsStore.swift
+++ b/firefox-ios/Client/ContentBlocker/TrackerBlockStats/TrackerBlockStatsStore.swift
@@ -1,0 +1,158 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+/// Persists blocked-tracker counts long term, bucketed by ISO-8601 calendar
+/// week and by category. Lifetime figures are derived by summing all buckets.
+protocol TrackerBlockStatsStore {
+    func record(category: BlocklistCategory, count: Int, date: Date)
+    func lifetimeTotal() -> Int
+    func lifetimeByCategory() -> [BlocklistCategory: Int]
+    func weeklyTotal(for date: Date) -> Int
+    func weeklyByCategory(for date: Date) -> [BlocklistCategory: Int]
+    func reset()
+}
+
+/// Prefs-backed store that keeps the in-progress week separate from completed
+/// weeks. `record` runs on a hot path (once per newly-blocked host), so it only
+/// ever decodes/encodes the small, fixed-size current-week value. Completed
+/// weeks are folded into the archive on a week rollover, an operation that
+/// happens at most once per week, not per insert.
+final class DefaultTrackerBlockStatsStoreUtility: TrackerBlockStatsStore {
+    private let prefs: Prefs
+    private let calendar: Calendar
+    private let currentWeekKey: String
+    private let archiveKey: String
+
+    init(
+        prefs: Prefs,
+        calendar: Calendar = Calendar(identifier: .iso8601),
+        currentWeekKey: String = PrefsKeys.TrackerBlockStatsCurrentWeek,
+        archiveKey: String = PrefsKeys.TrackerBlockStatsArchive
+    ) {
+        self.prefs = prefs
+        self.calendar = calendar
+        self.currentWeekKey = currentWeekKey
+        self.archiveKey = archiveKey
+    }
+
+    // MARK: - TrackerBlockStatsStore
+
+    func record(category: BlocklistCategory, count: Int, date: Date) {
+        guard count > 0 else { return }
+        let (year, week) = isoYearWeek(for: date)
+
+        var current = loadCurrentWeek()
+        // A new week has started: retire the completed week into the archive.
+        if let existing = current, existing.year != year || existing.week != week {
+            archive(existing)
+            current = nil
+        }
+
+        var bucket = current ?? TrackerBlockStatsBucket(year: year, week: week, counts: [:])
+        bucket.counts[category.storageKey, default: 0] += count
+        saveCurrentWeek(bucket)
+    }
+
+    func lifetimeTotal() -> Int {
+        let archived = loadArchive().buckets.reduce(0) { $0 + $1.total }
+        return archived + (loadCurrentWeek()?.total ?? 0)
+    }
+
+    func lifetimeByCategory() -> [BlocklistCategory: Int] {
+        var buckets = loadArchive().buckets
+        if let current = loadCurrentWeek() { buckets.append(current) }
+        return aggregate(buckets: buckets)
+    }
+
+    func weeklyTotal(for date: Date) -> Int {
+        return bucket(for: date)?.total ?? 0
+    }
+
+    func weeklyByCategory(for date: Date) -> [BlocklistCategory: Int] {
+        guard let bucket = bucket(for: date) else { return [:] }
+        return aggregate(buckets: [bucket])
+    }
+
+    func reset() {
+        prefs.removeObjectForKey(currentWeekKey)
+        prefs.removeObjectForKey(archiveKey)
+    }
+
+    // MARK: - Helpers
+
+    private func isoYearWeek(for date: Date) -> (year: Int, week: Int) {
+        let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
+        return (components.yearForWeekOfYear ?? 0, components.weekOfYear ?? 0)
+    }
+
+    private func bucket(for date: Date) -> TrackerBlockStatsBucket? {
+        let (year, week) = isoYearWeek(for: date)
+        if let current = loadCurrentWeek(), current.year == year, current.week == week {
+            return current
+        }
+        return loadArchive().buckets.first { $0.year == year && $0.week == week }
+    }
+
+    private func archive(_ bucket: TrackerBlockStatsBucket) {
+        guard bucket.total > 0 else { return }
+        var data = loadArchive()
+        if let index = data.buckets.firstIndex(where: { $0.year == bucket.year && $0.week == bucket.week }) {
+            for (key, count) in bucket.counts {
+                data.buckets[index].counts[key, default: 0] += count
+            }
+        } else {
+            data.buckets.append(bucket)
+        }
+        saveArchive(data)
+    }
+
+    private func aggregate(buckets: [TrackerBlockStatsBucket]) -> [BlocklistCategory: Int] {
+        var result = [BlocklistCategory: Int]()
+        for bucket in buckets {
+            for (storageKey, count) in bucket.counts {
+                guard let category = BlocklistCategory(storageKey: storageKey) else { continue }
+                result[category, default: 0] += count
+            }
+        }
+        return result
+    }
+
+    // MARK: - Persistence
+
+    private func loadCurrentWeek() -> TrackerBlockStatsBucket? {
+        return decode(TrackerBlockStatsBucket.self, forKey: currentWeekKey)
+    }
+
+    private func saveCurrentWeek(_ bucket: TrackerBlockStatsBucket) {
+        encode(bucket, forKey: currentWeekKey)
+    }
+
+    private func loadArchive() -> TrackerBlockStatsData {
+        return decode(TrackerBlockStatsData.self, forKey: archiveKey) ?? TrackerBlockStatsData()
+    }
+
+    private func saveArchive(_ data: TrackerBlockStatsData) {
+        encode(data, forKey: archiveKey)
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
+        guard let json = prefs.stringForKey(key),
+              let data = json.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(type, from: data)
+        else {
+            return nil
+        }
+        return decoded
+    }
+
+    private func encode<T: Encodable>(_ value: T, forKey key: String) {
+        guard let encoded = try? JSONEncoder().encode(value),
+              let json = String(data: encoded, encoding: .utf8)
+        else { return }
+        prefs.setString(json, forKey: key)
+    }
+}

--- a/firefox-ios/Client/ContentBlocker/TrackingProtectionPageStats.swift
+++ b/firefox-ios/Client/ContentBlocker/TrackingProtectionPageStats.swift
@@ -18,22 +18,29 @@ struct TPPageStats {
     }
 
     private init(
-        domains: [BlocklistCategory: Set<String>],
-        blocklistName: BlocklistCategory,
-        host: String
+        domains: [BlocklistCategory: Set<String>]
     ) {
         self.domains = domains
-        if self.domains[blocklistName] == nil {
-            self.domains[blocklistName] = Set<String>()
-        }
-       self.domains[blocklistName]?.insert(host)
     }
 
     func create(
         matchingBlocklist blocklistName: BlocklistCategory,
         host: String
     ) -> TPPageStats {
-        return TPPageStats(domains: domains, blocklistName: blocklistName, host: host)
+        return adding(matchingBlocklist: blocklistName, host: host).stats
+    }
+
+    /// Returns updated stats with `host` added to `blocklistName`, along with
+    /// whether the host was newly inserted (i.e. not already counted for that
+    /// category on this page). Callers use `inserted` to record each blocked
+    /// tracker exactly once per page view, avoiding double counting.
+    func adding(
+        matchingBlocklist blocklistName: BlocklistCategory,
+        host: String
+    ) -> (stats: TPPageStats, inserted: Bool) {
+        var domains = self.domains
+        let (inserted, _) = domains[blocklistName, default: Set<String>()].insert(host)
+        return (TPPageStats(domains: domains), inserted)
     }
 
     func getTrackersBlockedForCategory(_ category: BlocklistCategory) -> Int {

--- a/firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
+++ b/firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift
@@ -108,9 +108,14 @@ final class FirefoxTabContentBlocker: TabContentBlocker, TabContentScript, Featu
         return userPrefs.stringForKey(ContentBlockingConfig.Prefs.StrengthKey).flatMap(BlockingStrength.init) ?? .basic
     }
 
-    init(tab: ContentBlockerTab, prefs: Prefs) {
+    init(
+        tab: ContentBlockerTab,
+        prefs: Prefs,
+        statsRecorder: TrackerBlockStatsStore? = nil
+    ) {
         userPrefs = prefs
         super.init(tab: tab)
+        self.statsRecorder = statsRecorder ?? DefaultTrackerBlockStatsStoreUtility(prefs: prefs)
         setupForTab()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -167,6 +167,7 @@ final class ContentBlockerTests: XCTestCase {
 }
 
 private final class MockContentBlockerTab: ContentBlockerTab {
+    var isPrivate = false
     func currentURL() -> URL? { return nil }
     func currentWebView() -> WKWebView? { return nil }
     func imageContentBlockingEnabled() -> Bool { return false }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackerBlockStatsStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackerBlockStatsStoreTests.swift
@@ -1,0 +1,214 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Shared
+@testable import Client
+
+final class TrackerBlockStatsStoreTests: XCTestCase {
+    private var prefs: MockProfilePrefs!
+    private var calendar: Calendar!
+
+    override func setUp() {
+        super.setUp()
+        prefs = MockProfilePrefs()
+        calendar = Calendar(identifier: .iso8601)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+    }
+
+    override func tearDown() {
+        prefs = nil
+        calendar = nil
+        super.tearDown()
+    }
+
+    // MARK: - Recording within a week
+
+    func testRecord_accumulatesWithinSameISOWeek() {
+        let subject = createSubject()
+        let monday = makeDate(year: 2024, month: 6, day: 10)
+        let friday = makeDate(year: 2024, month: 6, day: 14)
+
+        subject.record(category: .advertising, count: 2, date: monday)
+        subject.record(category: .advertising, count: 3, date: friday)
+
+        XCTAssertEqual(subject.lifetimeTotal(), 5)
+        XCTAssertEqual(subject.weeklyTotal(for: monday), 5)
+    }
+
+    func testRecord_attributesPerCategory() {
+        let subject = createSubject()
+        let date = makeDate(year: 2024, month: 6, day: 10)
+
+        subject.record(category: .advertising, count: 2, date: date)
+        subject.record(category: .analytics, count: 4, date: date)
+        subject.record(category: .social, count: 1, date: date)
+
+        XCTAssertEqual(subject.lifetimeByCategory()[.advertising], 2)
+        XCTAssertEqual(subject.lifetimeByCategory()[.analytics], 4)
+        XCTAssertEqual(subject.lifetimeByCategory()[.social], 1)
+        XCTAssertNil(subject.lifetimeByCategory()[.cryptomining])
+        XCTAssertEqual(subject.lifetimeTotal(), 7)
+    }
+
+    func testRecord_ignoresNonPositiveCounts() {
+        let subject = createSubject()
+        let date = makeDate(year: 2024, month: 6, day: 10)
+
+        subject.record(category: .advertising, count: 0, date: date)
+        subject.record(category: .advertising, count: -5, date: date)
+
+        XCTAssertEqual(subject.lifetimeTotal(), 0)
+        XCTAssertTrue(subject.lifetimeByCategory().isEmpty)
+    }
+
+    // MARK: - Week boundaries
+
+    func testRecord_crossingWeekBoundaryCreatesSeparateBuckets() {
+        let subject = createSubject()
+        let week24 = makeDate(year: 2024, month: 6, day: 14)
+        let week25 = makeDate(year: 2024, month: 6, day: 17)
+
+        subject.record(category: .advertising, count: 3, date: week24)
+        subject.record(category: .advertising, count: 8, date: week25)
+
+        XCTAssertEqual(subject.lifetimeTotal(), 11, "Lifetime is the sum of both weeks")
+        XCTAssertEqual(subject.weeklyTotal(for: week24), 3, "Weekly reflects only its own week")
+        XCTAssertEqual(subject.weeklyTotal(for: week25), 8)
+    }
+
+    func testRecord_acrossISOYearRolloverCreatesSeparateBuckets() {
+        let subject = createSubject()
+        // 2020-12-31 falls in ISO week 53 of 2020; 2021-01-04 is ISO week 1 of 2021.
+        let lastWeekOf2020 = makeDate(year: 2020, month: 12, day: 31)
+        let firstWeekOf2021 = makeDate(year: 2021, month: 1, day: 4)
+
+        subject.record(category: .analytics, count: 6, date: lastWeekOf2020)
+        subject.record(category: .analytics, count: 9, date: firstWeekOf2021)
+
+        XCTAssertEqual(subject.lifetimeTotal(), 15)
+        XCTAssertEqual(subject.weeklyTotal(for: lastWeekOf2020), 6)
+        XCTAssertEqual(subject.weeklyTotal(for: firstWeekOf2021), 9)
+    }
+
+    // MARK: - Weekly by category
+
+    func testWeeklyByCategory_returnsOnlyCurrentWeek() {
+        let subject = createSubject()
+        let thisWeek = makeDate(year: 2024, month: 6, day: 10)
+        let nextWeek = makeDate(year: 2024, month: 6, day: 17)
+
+        subject.record(category: .advertising, count: 2, date: thisWeek)
+        subject.record(category: .social, count: 5, date: nextWeek)
+
+        XCTAssertEqual(subject.weeklyByCategory(for: thisWeek), [.advertising: 2])
+        XCTAssertEqual(subject.weeklyByCategory(for: nextWeek), [.social: 5])
+    }
+
+    func testWeeklyTotal_returnsZeroForWeekWithoutData() {
+        let subject = createSubject()
+        subject.record(category: .advertising, count: 2, date: makeDate(year: 2024, month: 6, day: 10))
+
+        let untouchedWeek = makeDate(year: 2024, month: 1, day: 1)
+        XCTAssertEqual(subject.weeklyTotal(for: untouchedWeek), 0)
+        XCTAssertTrue(subject.weeklyByCategory(for: untouchedWeek).isEmpty)
+    }
+
+    // MARK: - Reset
+
+    func testReset_clearsAllStats() {
+        let subject = createSubject()
+        let date = makeDate(year: 2024, month: 6, day: 10)
+        subject.record(category: .advertising, count: 2, date: date)
+
+        subject.reset()
+
+        XCTAssertEqual(subject.lifetimeTotal(), 0)
+        XCTAssertEqual(subject.weeklyTotal(for: date), 0)
+        XCTAssertTrue(subject.lifetimeByCategory().isEmpty)
+    }
+
+    // MARK: - Persistence
+
+    func testRecordedStats_persistAcrossStoreInstances() {
+        let date = makeDate(year: 2024, month: 6, day: 10)
+        let first = createSubject()
+        first.record(category: .advertising, count: 4, date: date)
+
+        // A brand-new store backed by the same prefs must read the same data.
+        let second = createSubject()
+
+        XCTAssertEqual(second.lifetimeTotal(), 4)
+        XCTAssertEqual(second.weeklyTotal(for: date), 4)
+        XCTAssertEqual(second.lifetimeByCategory()[.advertising], 4)
+    }
+
+    // MARK: - Current-week / archive separation
+
+    func testCurrentWeekBlob_staysSingleBucketAcrossManyWeeks() {
+        let subject = createSubject()
+        // Record one hit per week across ~15 weeks (day values overflow the month
+        // and are normalized by the calendar into successive weeks).
+        for day in stride(from: 1, through: 99, by: 7) {
+            subject.record(category: .advertising, count: 1, date: makeDate(year: 2024, month: 1, day: day))
+        }
+
+        // The hot-path value must never accumulate history: it holds exactly one bucket.
+        let current = decodeCurrentWeek()
+        XCTAssertNotNil(current)
+        XCTAssertEqual(current?.counts.values.reduce(0, +), 1, "Current week holds only the most recent week")
+
+        // All completed weeks live in the archive instead.
+        XCTAssertGreaterThan(decodeArchive().buckets.count, 1)
+    }
+
+    func testLifetimeAndWeekly_correctAfterWeekRollovers() {
+        let subject = createSubject()
+        let week1 = makeDate(year: 2024, month: 6, day: 3)
+        let week2 = makeDate(year: 2024, month: 6, day: 10)
+        let week3 = makeDate(year: 2024, month: 6, day: 17)
+
+        subject.record(category: .advertising, count: 2, date: week1)
+        subject.record(category: .analytics, count: 5, date: week2)
+        subject.record(category: .advertising, count: 3, date: week3)
+
+        XCTAssertEqual(subject.lifetimeTotal(), 10)
+        XCTAssertEqual(subject.weeklyTotal(for: week1), 2, "An archived week is still queryable")
+        XCTAssertEqual(subject.weeklyTotal(for: week2), 5)
+        XCTAssertEqual(subject.weeklyTotal(for: week3), 3, "Current in-progress week")
+        XCTAssertEqual(subject.lifetimeByCategory()[.advertising], 5)
+        XCTAssertEqual(subject.lifetimeByCategory()[.analytics], 5)
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> DefaultTrackerBlockStatsStoreUtility {
+        return DefaultTrackerBlockStatsStoreUtility(prefs: prefs, calendar: calendar)
+    }
+
+    private func decodeCurrentWeek() -> TrackerBlockStatsBucket? {
+        return decode(TrackerBlockStatsBucket.self, forKey: PrefsKeys.TrackerBlockStatsCurrentWeek)
+    }
+
+    private func decodeArchive() -> TrackerBlockStatsData {
+        return decode(TrackerBlockStatsData.self, forKey: PrefsKeys.TrackerBlockStatsArchive) ?? TrackerBlockStatsData()
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
+        guard let json = prefs.stringForKey(key), let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = 12
+        guard let date = calendar.date(from: components) else {
+            fatalError("Invalid test date \(year)-\(month)-\(day)")
+        }
+        return date
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionPageStatsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionPageStatsTests.swift
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class TrackingProtectionPageStatsTests: XCTestCase {
+    func testAdding_firstHostForCategory_reportsInserted() {
+        let stats = TPPageStats()
+
+        let result = stats.adding(matchingBlocklist: .advertising, host: "tracker.example")
+
+        XCTAssertTrue(result.inserted)
+        XCTAssertEqual(result.stats.getTrackersBlockedForCategory(.advertising), 1)
+        XCTAssertEqual(result.stats.total, 1)
+    }
+
+    func testAdding_duplicateHostInSameCategory_reportsNotInserted() {
+        let stats = TPPageStats()
+            .adding(matchingBlocklist: .advertising, host: "tracker.example").stats
+
+        let result = stats.adding(matchingBlocklist: .advertising, host: "tracker.example")
+
+        XCTAssertFalse(result.inserted, "A host already counted for the category is not re-inserted")
+        XCTAssertEqual(result.stats.getTrackersBlockedForCategory(.advertising), 1)
+        XCTAssertEqual(result.stats.total, 1)
+    }
+
+    func testAdding_sameHostDifferentCategories_reportsInsertedForEach() {
+        let first = TPPageStats().adding(matchingBlocklist: .advertising, host: "tracker.example")
+        let second = first.stats.adding(matchingBlocklist: .analytics, host: "tracker.example")
+
+        XCTAssertTrue(first.inserted)
+        XCTAssertTrue(second.inserted)
+        XCTAssertEqual(second.stats.getTrackersBlockedForCategory(.advertising), 1)
+        XCTAssertEqual(second.stats.getTrackersBlockedForCategory(.analytics), 1)
+        XCTAssertEqual(second.stats.total, 2)
+    }
+
+    func testAdding_distinctHostsSameCategory_eachInserted() {
+        let first = TPPageStats().adding(matchingBlocklist: .social, host: "a.example")
+        let second = first.stats.adding(matchingBlocklist: .social, host: "b.example")
+
+        XCTAssertTrue(first.inserted)
+        XCTAssertTrue(second.inserted)
+        XCTAssertEqual(second.stats.getTrackersBlockedForCategory(.social), 2)
+    }
+
+    func testCreate_matchesAddingStats() {
+        let created = TPPageStats().create(matchingBlocklist: .fingerprinting, host: "fp.example")
+
+        XCTAssertEqual(created.getTrackersBlockedForCategory(.fingerprinting), 1)
+        XCTAssertEqual(created.total, 1)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15942)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34533)

## :bulb: Description
Adds a utility for persisting blocked-tracker statistics long term, laying the data-layer groundwork for the upcoming homepage tracker-blocker counter. It adds a TrackerBlockStatsStore protocol and a prefs-backed DefaultTrackerBlockStatsStore that records blocked trackers bucketed by ISO-8601 calendar week and by category, exposing both weekly and lifetime totals with per-category breakdowns. Recording hooks into the existing content-blocker stats source: TPPageStats now exposes an adding(matchingBlocklist:host:) method that reports whether a host was newly inserted, so TabContentBlocker increments the long-term count exactly once per newly-blocked host per page view to avoid the double-counting that a naive "add the running total on every update" approach would cause. Private browsing is explicitly excluded from these stats.

To keep the write path performant as history accumulates, the store separates the in-progress week from completed weeks across two prefs keys: record runs on a hot path (once per blocked host, potentially many times per page) and therefore only decodes/encodes the small, fixed-size current-week value, while finished weeks are folded into the archive on a once per week rollover. Lifetime figures are derived by summing all buckets, so there is no separate running total to keep consistent.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

