### PR TITLE
Bugfix FXIOS-16312 - [Tabs] - Synced Tabs panel triggers an infinite tab-sync loop

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -21,7 +21,7 @@ protocol RemoteTabsClientAndTabsDataSourceDelegate: AnyObject {
     func remoteTabsClientAndTabsDataSourceDidSelectURL(_ url: URL, visitType: VisitType)
 }
 
-class RemoteTabsPanel: UIViewController,
+final class RemoteTabsPanel: UIViewController,
                        Themeable,
                        RemoteTabsClientAndTabsDataSourceDelegate,
                        RemoteTabsEmptyViewDelegate,
@@ -291,7 +291,7 @@ class RemoteTabsPanel: UIViewController,
             }
         case .ProfileDidFinishSyncing:
             ensureMainThread {
-                self.refreshTabs()
+                self.refreshTabs(useCache: true)
             }
         default: return
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16312)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34668)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

`RemoteTabsPanel` refreshed on `.ProfileDidFinishSyncing` by calling `refreshTabs()` without cache, which ran a full network sync via `getClientsAndTabs()`. That sync posted `.ProfileDidFinishSyncing` again, re-entering an endless sync loop (visible in logs as continuous `Syncing ["tabs"]` cycles, wasted network and battery).

The bug was introduced in this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/31632/changes#diff-d453fd5e5ba7424066536e49d0220724c86787eed2ae222025178c9be74d3b4cR307) that fixed [FXIOS-14422](https://mozilla-hub.atlassian.net/browse/FXIOS-14422).

Tested [FXIOS-14422](https://mozilla-hub.atlassian.net/browse/FXIOS-14422) and did not found any regressions.

Fixed by having the .ProfileDidFinishSyncing handler read from cache (refreshTabs(useCache: true)) instead of triggering a new sync, matching the existing close/flush handlers.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code



[FXIOS-14422]: https://mozilla-hub.atlassian.net/browse/FXIOS-14422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-14422]: https://mozilla-hub.atlassian.net/browse/FXIOS-14422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ