### PR TITLE
Add FXIOS-16297 [Google Lens] Telemetry phase 2 (System Camera and Photo Picker)

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1734,7 +1734,6 @@
 		C7CDBEFD2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CDBEFC2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift */; };
 		C7F051522D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */; };
 		C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */; };
-		A1B2C3D40000000000000002 /* GoogleLensTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */; };
 		C0D3CA000000000000000002 /* SystemCameraTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3CA000000000000000001 /* SystemCameraTelemetry.swift */; };
 		C0D3F1000000000000000002 /* SystemPhotoPickerTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1000000000000000001 /* SystemPhotoPickerTelemetry.swift */; };
 		C0D3F1000000000000000004 /* SystemPhotoPickerTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1000000000000000003 /* SystemPhotoPickerTelemetryTests.swift */; };
@@ -10750,7 +10749,6 @@
 		C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDeletionUtilityTelemetryTests.swift; sourceTree = "<group>"; };
 		C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDeletionUtilityTelemetry.swift; sourceTree = "<group>"; };
 		C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetry.swift; sourceTree = "<group>"; };
-		A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLensTelemetry.swift; sourceTree = "<group>"; };
 		C0D3CA000000000000000001 /* SystemCameraTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemCameraTelemetry.swift; sourceTree = "<group>"; };
 		C0D3F1000000000000000001 /* SystemPhotoPickerTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPhotoPickerTelemetry.swift; sourceTree = "<group>"; };
 		C0D3F1000000000000000003 /* SystemPhotoPickerTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPhotoPickerTelemetryTests.swift; sourceTree = "<group>"; };

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1734,6 +1734,10 @@
 		C7CDBEFD2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CDBEFC2CE6926900826A92 /* BookmarksFolderEmptyStateView.swift */; };
 		C7F051522D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */; };
 		C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */; };
+		A1B2C3D40000000000000002 /* GoogleLensTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */; };
+		C0D3CA000000000000000002 /* SystemCameraTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3CA000000000000000001 /* SystemCameraTelemetry.swift */; };
+		C0D3CA000000000000000004 /* SystemCameraTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3CA000000000000000003 /* SystemCameraTelemetryTests.swift */; };
+		C0D3CA000000000000000006 /* MockSystemCameraTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3CA000000000000000005 /* MockSystemCameraTelemetry.swift */; };
 		C7F051582D9F098200EC52C0 /* ContextMenuTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */; };
 		C7F051692DB2F38000EC52C0 /* ContextMenuPreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051682DB2F38000EC52C0 /* ContextMenuPreviewViewController.swift */; };
 		C7F5331A2E5799AA0089DEC7 /* ShortcutsLibraryTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F533192E5799AA0089DEC7 /* ShortcutsLibraryTelemetry.swift */; };
@@ -10743,6 +10747,10 @@
 		C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDeletionUtilityTelemetryTests.swift; sourceTree = "<group>"; };
 		C7F051512D95EACF00EC52C0 /* HistoryDeletionUtilityTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDeletionUtilityTelemetry.swift; sourceTree = "<group>"; };
 		C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetry.swift; sourceTree = "<group>"; };
+		A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLensTelemetry.swift; sourceTree = "<group>"; };
+		C0D3CA000000000000000001 /* SystemCameraTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemCameraTelemetry.swift; sourceTree = "<group>"; };
+		C0D3CA000000000000000003 /* SystemCameraTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemCameraTelemetryTests.swift; sourceTree = "<group>"; };
+		C0D3CA000000000000000005 /* MockSystemCameraTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemCameraTelemetry.swift; sourceTree = "<group>"; };
 		C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetryTests.swift; sourceTree = "<group>"; };
 		C7F051682DB2F38000EC52C0 /* ContextMenuPreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuPreviewViewController.swift; sourceTree = "<group>"; };
 		C7F533192E5799AA0089DEC7 /* ShortcutsLibraryTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsLibraryTelemetry.swift; sourceTree = "<group>"; };
@@ -14676,6 +14684,7 @@
 				8ADA19A12E7DB86400E95E5E /* NotificationManagerTelemetryTests.swift */,
 				C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */,
 				A1B2C3D40000000000000003 /* GoogleLensTelemetryTests.swift */,
+				C0D3CA000000000000000003 /* SystemCameraTelemetryTests.swift */,
 				8A87E98B2E70792F006F0239 /* FxSuggestTelemetryTests.swift */,
 				C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */,
 				0A686B3B2CDB70DC0090E146 /* MainMenuTelemetryTests.swift */,
@@ -15893,6 +15902,7 @@
 				8A9E46BC2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift */,
 				8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */,
 				5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */,
+				C0D3CA000000000000000005 /* MockSystemCameraTelemetry.swift */,
 				ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */,
 				C80C11F228B3CD3E0062922A /* MockTests */,
 				5AA75A622A46272000533F8D /* MockThemeManager.swift */,
@@ -16907,6 +16917,7 @@
 				8A0DF2C12D6D1C670066EC00 /* AutoplaySettingTelemetry.swift */,
 				C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */,
 				A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */,
+				C0D3CA000000000000000001 /* SystemCameraTelemetry.swift */,
 				3933D4F32EF3357D00C0C4E3 /* DefaultBrowserUtilityTelemetry.swift */,
 				8A732A812DE8AFCA0099F575 /* FxSuggestTelemetry.swift */,
 				8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */,
@@ -19666,6 +19677,7 @@
 				8A48807E2E68923200AD43D5 /* GleanHttpUploader.swift in Sources */,
 				C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */,
 				A1B2C3D40000000000000002 /* GoogleLensTelemetry.swift in Sources */,
+				C0D3CA000000000000000002 /* SystemCameraTelemetry.swift in Sources */,
 				0E4AF8652D764046002E4238 /* DownloadProgressManager.swift in Sources */,
 				819656192C80ECFE00E62323 /* MainMenuMiddleware.swift in Sources */,
 				E127313D28B6AD99006F39D2 /* WallpaperSettingsViewModel.swift in Sources */,
@@ -20620,6 +20632,7 @@
 				C25018E72ECC88440071506F /* BridgeTests.swift in Sources */,
 				C7F051582D9F098200EC52C0 /* ContextMenuTelemetryTests.swift in Sources */,
 				A1B2C3D40000000000000004 /* GoogleLensTelemetryTests.swift in Sources */,
+				C0D3CA000000000000000004 /* SystemCameraTelemetryTests.swift in Sources */,
 				219935F12B07DFA200E5966F /* TabDisplayPanelTests.swift in Sources */,
 				0B7B053D2D647D00007FD7AC /* TemporaryDocumentTests.swift in Sources */,
 				C714D6372E46570700FC02E6 /* ShortcutsLibraryStateTests.swift in Sources */,
@@ -20915,6 +20928,7 @@
 				8A1C0B912FCB000100AD5DB0 /* AdsClientDocumentsDirectoryMigrationTests.swift in Sources */,
 				E1EAA5F12D49470900D3039C /* ToolbarStateTests.swift in Sources */,
 				5A9A09D428B01D8700B6F51E /* MockTelemetryWrapper.swift in Sources */,
+				C0D3CA000000000000000006 /* MockSystemCameraTelemetry.swift in Sources */,
 				C80C11F028B3C9150062922A /* MockUserDefaults.swift in Sources */,
 				AA4D99432E857AF300BB039D /* MockRecentSearchProvider.swift in Sources */,
 				D8BA1790206D47830023AC00 /* DeferredTestUtils.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1736,6 +1736,9 @@
 		C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */; };
 		A1B2C3D40000000000000002 /* GoogleLensTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */; };
 		C0D3CA000000000000000002 /* SystemCameraTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3CA000000000000000001 /* SystemCameraTelemetry.swift */; };
+		C0D3F1000000000000000002 /* SystemPhotoPickerTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1000000000000000001 /* SystemPhotoPickerTelemetry.swift */; };
+		C0D3F1000000000000000004 /* SystemPhotoPickerTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1000000000000000003 /* SystemPhotoPickerTelemetryTests.swift */; };
+		C0D3F1000000000000000006 /* MockSystemPhotoPickerTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1000000000000000005 /* MockSystemPhotoPickerTelemetry.swift */; };
 		C0D3CA000000000000000004 /* SystemCameraTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3CA000000000000000003 /* SystemCameraTelemetryTests.swift */; };
 		C0D3CA000000000000000006 /* MockSystemCameraTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3CA000000000000000005 /* MockSystemCameraTelemetry.swift */; };
 		C7F051582D9F098200EC52C0 /* ContextMenuTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */; };
@@ -10749,6 +10752,9 @@
 		C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetry.swift; sourceTree = "<group>"; };
 		A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLensTelemetry.swift; sourceTree = "<group>"; };
 		C0D3CA000000000000000001 /* SystemCameraTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemCameraTelemetry.swift; sourceTree = "<group>"; };
+		C0D3F1000000000000000001 /* SystemPhotoPickerTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPhotoPickerTelemetry.swift; sourceTree = "<group>"; };
+		C0D3F1000000000000000003 /* SystemPhotoPickerTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemPhotoPickerTelemetryTests.swift; sourceTree = "<group>"; };
+		C0D3F1000000000000000005 /* MockSystemPhotoPickerTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemPhotoPickerTelemetry.swift; sourceTree = "<group>"; };
 		C0D3CA000000000000000003 /* SystemCameraTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemCameraTelemetryTests.swift; sourceTree = "<group>"; };
 		C0D3CA000000000000000005 /* MockSystemCameraTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemCameraTelemetry.swift; sourceTree = "<group>"; };
 		C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuTelemetryTests.swift; sourceTree = "<group>"; };
@@ -14685,6 +14691,7 @@
 				C7F051572D9F098200EC52C0 /* ContextMenuTelemetryTests.swift */,
 				A1B2C3D40000000000000003 /* GoogleLensTelemetryTests.swift */,
 				C0D3CA000000000000000003 /* SystemCameraTelemetryTests.swift */,
+				C0D3F1000000000000000003 /* SystemPhotoPickerTelemetryTests.swift */,
 				8A87E98B2E70792F006F0239 /* FxSuggestTelemetryTests.swift */,
 				C7F0514F2D95EA5C00EC52C0 /* HistoryDeletionUtilityTelemetryTests.swift */,
 				0A686B3B2CDB70DC0090E146 /* MainMenuTelemetryTests.swift */,
@@ -15903,6 +15910,7 @@
 				8A36AC2B2886F27F00CDC0AD /* MockTabManager.swift */,
 				5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */,
 				C0D3CA000000000000000005 /* MockSystemCameraTelemetry.swift */,
+				C0D3F1000000000000000005 /* MockSystemPhotoPickerTelemetry.swift */,
 				ED575BD22D00F9D00056BCDA /* MockTemporaryDocument.swift */,
 				C80C11F228B3CD3E0062922A /* MockTests */,
 				5AA75A622A46272000533F8D /* MockThemeManager.swift */,
@@ -16918,6 +16926,7 @@
 				C7F051552D9EF87D00EC52C0 /* ContextMenuTelemetry.swift */,
 				A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */,
 				C0D3CA000000000000000001 /* SystemCameraTelemetry.swift */,
+				C0D3F1000000000000000001 /* SystemPhotoPickerTelemetry.swift */,
 				3933D4F32EF3357D00C0C4E3 /* DefaultBrowserUtilityTelemetry.swift */,
 				8A732A812DE8AFCA0099F575 /* FxSuggestTelemetry.swift */,
 				8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */,
@@ -19678,6 +19687,7 @@
 				C7F051562D9EF87D00EC52C0 /* ContextMenuTelemetry.swift in Sources */,
 				A1B2C3D40000000000000002 /* GoogleLensTelemetry.swift in Sources */,
 				C0D3CA000000000000000002 /* SystemCameraTelemetry.swift in Sources */,
+				C0D3F1000000000000000002 /* SystemPhotoPickerTelemetry.swift in Sources */,
 				0E4AF8652D764046002E4238 /* DownloadProgressManager.swift in Sources */,
 				819656192C80ECFE00E62323 /* MainMenuMiddleware.swift in Sources */,
 				E127313D28B6AD99006F39D2 /* WallpaperSettingsViewModel.swift in Sources */,
@@ -20633,6 +20643,7 @@
 				C7F051582D9F098200EC52C0 /* ContextMenuTelemetryTests.swift in Sources */,
 				A1B2C3D40000000000000004 /* GoogleLensTelemetryTests.swift in Sources */,
 				C0D3CA000000000000000004 /* SystemCameraTelemetryTests.swift in Sources */,
+				C0D3F1000000000000000004 /* SystemPhotoPickerTelemetryTests.swift in Sources */,
 				219935F12B07DFA200E5966F /* TabDisplayPanelTests.swift in Sources */,
 				0B7B053D2D647D00007FD7AC /* TemporaryDocumentTests.swift in Sources */,
 				C714D6372E46570700FC02E6 /* ShortcutsLibraryStateTests.swift in Sources */,
@@ -20929,6 +20940,7 @@
 				E1EAA5F12D49470900D3039C /* ToolbarStateTests.swift in Sources */,
 				5A9A09D428B01D8700B6F51E /* MockTelemetryWrapper.swift in Sources */,
 				C0D3CA000000000000000006 /* MockSystemCameraTelemetry.swift in Sources */,
+				C0D3F1000000000000000006 /* MockSystemPhotoPickerTelemetry.swift in Sources */,
 				C80C11F028B3C9150062922A /* MockUserDefaults.swift in Sources */,
 				AA4D99432E857AF300BB039D /* MockRecentSearchProvider.swift in Sources */,
 				D8BA1790206D47830023AC00 /* DeferredTestUtils.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1168,7 +1168,8 @@ final class BrowserCoordinator: BaseCoordinator,
         guard !childCoordinators.contains(where: { $0 is CameraCoordinator }) else { return }
         let coordinator = CameraCoordinator(
             parentCoordinatorDelegate: self,
-            router: router
+            router: router,
+            cameraReason: .googleLens
         ) { [weak self] image in
             guard let image else { return }
             self?.searchGoogleLens(with: image, source: .camera)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1153,7 +1153,8 @@ final class BrowserCoordinator: BaseCoordinator,
         guard !childCoordinators.contains(where: { $0 is PhotoPickerCoordinator }) else { return }
         let coordinator = PhotoPickerCoordinator(
             parentCoordinatorDelegate: self,
-            router: router
+            router: router,
+            photoPickerReason: .googleLens
         ) { [weak self] results in
             self?.handleGoogleLensPhotoPick(results)
         }

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -4,6 +4,10 @@
 
 import AVFoundation
 
+enum CameraReason: String {
+    case googleLens
+}
+
 /// Presents the system camera capture UI and owns its delegate conformance.
 final class CameraCoordinator: BaseCoordinator,
                                UIImagePickerControllerDelegate,
@@ -13,6 +17,8 @@ final class CameraCoordinator: BaseCoordinator,
     private let isCameraAvailable: Bool
     private let cameraAuthorizationStatus: AVAuthorizationStatus
     private let requestCameraAccess: () async -> Bool
+    private let cameraReason: CameraReason
+    private let cameraTelemetry: SystemCameraTelemetryProtocol
 
     init(
         parentCoordinatorDelegate: ParentCoordinatorDelegate?,
@@ -22,6 +28,8 @@ final class CameraCoordinator: BaseCoordinator,
         requestCameraAccess: @escaping () async -> Bool = {
             await AVCaptureDevice.requestAccess(for: .video)
         },
+        cameraReason: CameraReason,
+        cameraTelemetry: SystemCameraTelemetryProtocol = SystemCameraTelemetry(),
         onComplete: @escaping (UIImage?) -> Void
     ) {
         self.parentCoordinatorDelegate = parentCoordinatorDelegate
@@ -29,6 +37,8 @@ final class CameraCoordinator: BaseCoordinator,
         self.isCameraAvailable = isCameraAvailable
         self.cameraAuthorizationStatus = cameraAuthorizationStatus
         self.requestCameraAccess = requestCameraAccess
+        self.cameraReason = cameraReason
+        self.cameraTelemetry = cameraTelemetry
         super.init(router: router)
     }
 
@@ -60,6 +70,7 @@ final class CameraCoordinator: BaseCoordinator,
     // MARK: - Camera permission
     func dismissCameraInterfaceIfAccessRefused() async {
         let granted = await requestCameraAccess()
+        cameraTelemetry.permissionResponded(reason: cameraReason, granted: granted)
         guard !granted else { return }
         dismissCameraInterface()
     }

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -4,6 +4,7 @@
 
 import AVFoundation
 
+/// Identifies the app flow that prompted showing the system camera interface
 enum CameraReason: String {
     case googleLens
 }

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -103,9 +103,9 @@ final class CameraCoordinator: BaseCoordinator,
         finish(with: nil)
     }
 
-    private func finish(with image: UIImage?) {
+    private func finish(with image: UIImage?, photoSelected: Bool = false) {
         if isCameraAvailable && cameraAuthorizationStatus() == .authorized {
-            cameraTelemetry.closed(reason: cameraReason)
+            cameraTelemetry.closed(reason: cameraReason, photoSelected: photoSelected)
         }
         onComplete(image)
         parentCoordinatorDelegate?.didFinish(from: self)
@@ -114,9 +114,8 @@ final class CameraCoordinator: BaseCoordinator,
     // MARK: - UIImagePickerControllerDelegate
     func imagePickerController(_ picker: UIImagePickerController,
                                didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-        cameraTelemetry.photoSelected(reason: cameraReason)
         router.dismiss(animated: true)
-        finish(with: info[.originalImage] as? UIImage)
+        finish(with: info[.originalImage] as? UIImage, photoSelected: true)
     }
 
     func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -44,7 +44,7 @@ final class CameraCoordinator: BaseCoordinator,
 
     func start() {
         guard isCameraAvailable else {
-            finish(with: nil)
+            finish(with: nil, recordCameraClosed: false)
             return
         }
 
@@ -54,6 +54,7 @@ final class CameraCoordinator: BaseCoordinator,
         router.present(picker, animated: true) { [weak self] in
             self?.finish(with: nil)
         }
+        cameraTelemetry.shown(reason: cameraReason)
 
         switch cameraAuthorizationStatus {
         case .denied, .restricted:
@@ -96,7 +97,10 @@ final class CameraCoordinator: BaseCoordinator,
         finish(with: nil)
     }
 
-    private func finish(with image: UIImage?) {
+    private func finish(with image: UIImage?, recordCameraClosed: Bool = true) {
+        if recordCameraClosed {
+            cameraTelemetry.closed(reason: cameraReason)
+        }
         onComplete(image)
         parentCoordinatorDelegate?.didFinish(from: self)
     }

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -64,7 +64,7 @@ final class CameraCoordinator: BaseCoordinator,
         case .notDetermined:
             // If not determined, presenting the interface triggers the system permission prompt.
             // Dismiss the interface if the user refuses access.
-            Task { [weak self] in await self?.dismissCameraInterfaceIfAccessRefused() }
+            Task { [weak self] in await self?.handleCameraAccessRequest() }
         case .authorized:
             cameraTelemetry.shown(reason: cameraReason)
         @unknown default:
@@ -73,7 +73,7 @@ final class CameraCoordinator: BaseCoordinator,
     }
 
     // MARK: - Camera permission
-    func dismissCameraInterfaceIfAccessRefused() async {
+    func handleCameraAccessRequest() async {
         let granted = await requestCameraAccess()
         cameraTelemetry.permissionResponded(reason: cameraReason, granted: granted)
         if granted {

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -108,6 +108,7 @@ final class CameraCoordinator: BaseCoordinator,
     // MARK: - UIImagePickerControllerDelegate
     func imagePickerController(_ picker: UIImagePickerController,
                                didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        cameraTelemetry.photoSelected(reason: cameraReason)
         router.dismiss(animated: true)
         finish(with: info[.originalImage] as? UIImage)
     }

--- a/firefox-ios/Client/Coordinators/CameraCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/CameraCoordinator.swift
@@ -16,7 +16,7 @@ final class CameraCoordinator: BaseCoordinator,
     private weak var parentCoordinatorDelegate: ParentCoordinatorDelegate?
     private let onComplete: (UIImage?) -> Void
     private let isCameraAvailable: Bool
-    private let cameraAuthorizationStatus: AVAuthorizationStatus
+    private let cameraAuthorizationStatus: () -> AVAuthorizationStatus
     private let requestCameraAccess: () async -> Bool
     private let cameraReason: CameraReason
     private let cameraTelemetry: SystemCameraTelemetryProtocol
@@ -25,7 +25,9 @@ final class CameraCoordinator: BaseCoordinator,
         parentCoordinatorDelegate: ParentCoordinatorDelegate?,
         router: Router,
         isCameraAvailable: Bool = UIImagePickerController.isSourceTypeAvailable(.camera),
-        cameraAuthorizationStatus: AVAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .video),
+        cameraAuthorizationStatus: @escaping () -> AVAuthorizationStatus = {
+            AVCaptureDevice.authorizationStatus(for: .video)
+        },
         requestCameraAccess: @escaping () async -> Bool = {
             await AVCaptureDevice.requestAccess(for: .video)
         },
@@ -45,7 +47,7 @@ final class CameraCoordinator: BaseCoordinator,
 
     func start() {
         guard isCameraAvailable else {
-            finish(with: nil, recordCameraClosed: false)
+            finish(with: nil)
             return
         }
 
@@ -55,16 +57,17 @@ final class CameraCoordinator: BaseCoordinator,
         router.present(picker, animated: true) { [weak self] in
             self?.finish(with: nil)
         }
-        cameraTelemetry.shown(reason: cameraReason)
 
-        switch cameraAuthorizationStatus {
+        switch cameraAuthorizationStatus() {
         case .denied, .restricted:
             presentCameraAccessDeniedAlert(over: picker)
         case .notDetermined:
             // If not determined, presenting the interface triggers the system permission prompt.
             // Dismiss the interface if the user refuses access.
             Task { [weak self] in await self?.dismissCameraInterfaceIfAccessRefused() }
-        default:
+        case .authorized:
+            cameraTelemetry.shown(reason: cameraReason)
+        @unknown default:
             break
         }
     }
@@ -73,8 +76,11 @@ final class CameraCoordinator: BaseCoordinator,
     func dismissCameraInterfaceIfAccessRefused() async {
         let granted = await requestCameraAccess()
         cameraTelemetry.permissionResponded(reason: cameraReason, granted: granted)
-        guard !granted else { return }
-        dismissCameraInterface()
+        if granted {
+            cameraTelemetry.shown(reason: cameraReason)
+        } else {
+            dismissCameraInterface()
+        }
     }
 
     private func presentCameraAccessDeniedAlert(over presenter: UIViewController) {
@@ -92,14 +98,13 @@ final class CameraCoordinator: BaseCoordinator,
         }
     }
 
-    /// Dismisses the camera interface and ends the flow without a captured image.
     func dismissCameraInterface() {
         router.dismiss(animated: true)
         finish(with: nil)
     }
 
-    private func finish(with image: UIImage?, recordCameraClosed: Bool = true) {
-        if recordCameraClosed {
+    private func finish(with image: UIImage?) {
+        if isCameraAvailable && cameraAuthorizationStatus() == .authorized {
             cameraTelemetry.closed(reason: cameraReason)
         }
         onComplete(image)

--- a/firefox-ios/Client/Coordinators/PhotoPickerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PhotoPickerCoordinator.swift
@@ -42,6 +42,9 @@ final class PhotoPickerCoordinator: BaseCoordinator, PHPickerViewControllerDeleg
 
     // MARK: - PHPickerViewControllerDelegate
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        if !results.isEmpty {
+            photoPickerTelemetry.photoSelected(reason: photoPickerReason)
+        }
         router.dismiss(animated: true)
         finish(with: results)
     }

--- a/firefox-ios/Client/Coordinators/PhotoPickerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PhotoPickerCoordinator.swift
@@ -4,16 +4,26 @@
 
 import PhotosUI
 
+enum PhotoPickerReason: String {
+    case googleLens
+}
+
 /// Presents the system photo library picker and owns its delegate conformance.
 final class PhotoPickerCoordinator: BaseCoordinator, PHPickerViewControllerDelegate {
     private weak var parentCoordinatorDelegate: ParentCoordinatorDelegate?
     private let onComplete: ([PHPickerResult]) -> Void
+    private let photoPickerReason: PhotoPickerReason
+    private let photoPickerTelemetry: SystemPhotoPickerTelemetryProtocol
 
     init(parentCoordinatorDelegate: ParentCoordinatorDelegate?,
          router: Router,
+         photoPickerReason: PhotoPickerReason,
+         photoPickerTelemetry: SystemPhotoPickerTelemetryProtocol = SystemPhotoPickerTelemetry(),
          onComplete: @escaping ([PHPickerResult]) -> Void) {
         self.parentCoordinatorDelegate = parentCoordinatorDelegate
         self.onComplete = onComplete
+        self.photoPickerReason = photoPickerReason
+        self.photoPickerTelemetry = photoPickerTelemetry
         super.init(router: router)
     }
 
@@ -27,6 +37,7 @@ final class PhotoPickerCoordinator: BaseCoordinator, PHPickerViewControllerDeleg
         router.present(picker, animated: true) { [weak self] in
             self?.finish(with: [])
         }
+        photoPickerTelemetry.shown(reason: photoPickerReason)
     }
 
     // MARK: - PHPickerViewControllerDelegate
@@ -36,6 +47,7 @@ final class PhotoPickerCoordinator: BaseCoordinator, PHPickerViewControllerDeleg
     }
 
     private func finish(with results: [PHPickerResult]) {
+        photoPickerTelemetry.closed(reason: photoPickerReason)
         onComplete(results)
         parentCoordinatorDelegate?.didFinish(from: self)
     }

--- a/firefox-ios/Client/Coordinators/PhotoPickerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PhotoPickerCoordinator.swift
@@ -43,15 +43,12 @@ final class PhotoPickerCoordinator: BaseCoordinator, PHPickerViewControllerDeleg
 
     // MARK: - PHPickerViewControllerDelegate
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-        if !results.isEmpty {
-            photoPickerTelemetry.photoSelected(reason: photoPickerReason)
-        }
         router.dismiss(animated: true)
         finish(with: results)
     }
 
     private func finish(with results: [PHPickerResult]) {
-        photoPickerTelemetry.closed(reason: photoPickerReason)
+        photoPickerTelemetry.closed(reason: photoPickerReason, photoSelected: !results.isEmpty)
         onComplete(results)
         parentCoordinatorDelegate?.didFinish(from: self)
     }

--- a/firefox-ios/Client/Coordinators/PhotoPickerCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/PhotoPickerCoordinator.swift
@@ -4,6 +4,7 @@
 
 import PhotosUI
 
+/// Identifies the app flow that prompted showing the system photo picker interface
 enum PhotoPickerReason: String {
     case googleLens
 }

--- a/firefox-ios/Client/Glean/gleanProbes.xcfilelist
+++ b/firefox-ios/Client/Glean/gleanProbes.xcfilelist
@@ -23,6 +23,7 @@ $(PROJECT_DIR)/Client/Glean/probes/search.yaml
 $(PROJECT_DIR)/Client/Glean/probes/settings.yaml
 $(PROJECT_DIR)/Client/Glean/probes/share_sheet.yaml
 $(PROJECT_DIR)/Client/Glean/probes/share.open_in_firefox_extension.yaml
+$(PROJECT_DIR)/Client/Glean/probes/system.camera.yaml
 $(PROJECT_DIR)/Client/Glean/probes/tabs_panel.yaml
 $(PROJECT_DIR)/Client/Glean/probes/terms_of_use.yaml
 $(PROJECT_DIR)/Client/Glean/probes/toolbar.yaml

--- a/firefox-ios/Client/Glean/gleanProbes.xcfilelist
+++ b/firefox-ios/Client/Glean/gleanProbes.xcfilelist
@@ -24,6 +24,7 @@ $(PROJECT_DIR)/Client/Glean/probes/settings.yaml
 $(PROJECT_DIR)/Client/Glean/probes/share_sheet.yaml
 $(PROJECT_DIR)/Client/Glean/probes/share.open_in_firefox_extension.yaml
 $(PROJECT_DIR)/Client/Glean/probes/system.camera.yaml
+$(PROJECT_DIR)/Client/Glean/probes/system.photo_picker.yaml
 $(PROJECT_DIR)/Client/Glean/probes/tabs_panel.yaml
 $(PROJECT_DIR)/Client/Glean/probes/terms_of_use.yaml
 $(PROJECT_DIR)/Client/Glean/probes/toolbar.yaml

--- a/firefox-ios/Client/Glean/probes/system.camera.yaml
+++ b/firefox-ios/Client/Glean/probes/system.camera.yaml
@@ -56,6 +56,19 @@ system.camera:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+  photo_selected:
+    type: event
+    description: |
+      Recorded when the user selects Use Photo from the system camera interface.
+    extra_keys:
+      reason: *camera_reason_extra
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
   shown:
     type: event
     description: |

--- a/firefox-ios/Client/Glean/probes/system.camera.yaml
+++ b/firefox-ios/Client/Glean/probes/system.camera.yaml
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the metrics that are recorded by the Glean SDK. They are
+# automatically converted to Swift code at build time using the `glean_parser`
+# PyPI package.
+
+# This file is organized (roughly) alphabetically by metric names
+# for easy navigation
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+$tags:
+  - Camera
+  - System
+
+###############################################################################
+# Documentation
+###############################################################################
+
+system.camera:
+  permission_responded:
+    type: event
+    description: |
+      Recorded when the user responds to the system camera permission request.
+    extra_keys:
+      reason:
+        type: string
+        description: |
+          The reason the system camera permission request was initiated.
+          Options are listed in the CameraReason enumeration.
+      granted:
+        type: boolean
+        description: |
+          Whether the user granted camera access in response to the system
+          permission request.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never

--- a/firefox-ios/Client/Glean/probes/system.camera.yaml
+++ b/firefox-ios/Client/Glean/probes/system.camera.yaml
@@ -34,7 +34,7 @@ system.camera:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -52,7 +52,7 @@ system.camera:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -65,7 +65,7 @@ system.camera:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -78,7 +78,7 @@ system.camera:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/system.camera.yaml
+++ b/firefox-ios/Client/Glean/probes/system.camera.yaml
@@ -31,6 +31,10 @@ system.camera:
         description: |
           The reason associated with the system camera interaction.
           Options are listed in the CameraReason enumeration.
+      photo_selected:
+        type: boolean
+        description: |
+          Whether the user selected a photo before the camera interface closed.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:
@@ -49,19 +53,6 @@ system.camera:
         description: |
           Whether the user granted camera access in response to the system
           permission request.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: never
-  photo_selected:
-    type: event
-    description: |
-      Recorded when the user selects Use Photo from the system camera interface.
-    extra_keys:
-      reason: *camera_reason_extra
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:

--- a/firefox-ios/Client/Glean/probes/system.camera.yaml
+++ b/firefox-ios/Client/Glean/probes/system.camera.yaml
@@ -21,21 +21,47 @@ $tags:
 ###############################################################################
 
 system.camera:
+  closed:
+    type: event
+    description: |
+      Recorded when the system camera interface is closed.
+    extra_keys:
+      reason: &camera_reason_extra
+        type: string
+        description: |
+          The reason associated with the system camera interaction.
+          Options are listed in the CameraReason enumeration.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
   permission_responded:
     type: event
     description: |
       Recorded when the user responds to the system camera permission request.
     extra_keys:
-      reason:
-        type: string
-        description: |
-          The reason the system camera permission request was initiated.
-          Options are listed in the CameraReason enumeration.
+      reason: *camera_reason_extra
       granted:
         type: boolean
         description: |
           Whether the user granted camera access in response to the system
           permission request.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  shown:
+    type: event
+    description: |
+      Recorded when the system camera interface is shown.
+    extra_keys:
+      reason: *camera_reason_extra
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:

--- a/firefox-ios/Client/Glean/probes/system.photo_picker.yaml
+++ b/firefox-ios/Client/Glean/probes/system.photo_picker.yaml
@@ -34,7 +34,7 @@ system.photo_picker:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -47,7 +47,7 @@ system.photo_picker:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -60,7 +60,7 @@ system.photo_picker:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/system.photo_picker.yaml
+++ b/firefox-ios/Client/Glean/probes/system.photo_picker.yaml
@@ -1,0 +1,53 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the metrics that are recorded by the Glean SDK. They are
+# automatically converted to Swift code at build time using the `glean_parser`
+# PyPI package.
+
+# This file is organized (roughly) alphabetically by metric names
+# for easy navigation
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+$tags:
+  - PhotoPicker
+  - System
+
+###############################################################################
+# Documentation
+###############################################################################
+
+system.photo_picker:
+  closed:
+    type: event
+    description: |
+      Recorded when the system photo picker interface is closed.
+    extra_keys:
+      reason: &photo_picker_reason_extra
+        type: string
+        description: |
+          The reason associated with the system photo picker interaction.
+          Options are listed in the PhotoPickerReason enumeration.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  shown:
+    type: event
+    description: |
+      Recorded when the system photo picker interface is shown.
+    extra_keys:
+      reason: *photo_picker_reason_extra
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never

--- a/firefox-ios/Client/Glean/probes/system.photo_picker.yaml
+++ b/firefox-ios/Client/Glean/probes/system.photo_picker.yaml
@@ -31,19 +31,10 @@ system.photo_picker:
         description: |
           The reason associated with the system photo picker interaction.
           Options are listed in the PhotoPickerReason enumeration.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: never
-  photo_selected:
-    type: event
-    description: |
-      Recorded when the user selects a photo from the system photo picker.
-    extra_keys:
-      reason: *photo_picker_reason_extra
+      photo_selected:
+        type: boolean
+        description: |
+          Whether the user selected a photo before the photo picker closed.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
     data_reviews:

--- a/firefox-ios/Client/Glean/probes/system.photo_picker.yaml
+++ b/firefox-ios/Client/Glean/probes/system.photo_picker.yaml
@@ -38,6 +38,19 @@ system.photo_picker:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+  photo_selected:
+    type: event
+    description: |
+      Recorded when the user selects a photo from the system photo picker.
+    extra_keys:
+      reason: *photo_picker_reason_extra
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+    data_reviews:
+      - TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
   shown:
     type: event
     description: |

--- a/firefox-ios/Client/Glean/tags.yaml
+++ b/firefox-ios/Client/Glean/tags.yaml
@@ -81,6 +81,9 @@ Passwords:
 PasswordGenerator:
   description: Corresponds to the generation of strong passwords for logins and autofill.
 
+PhotoPicker:
+  description: Corresponds to features that use the system photo picker.
+
 QuickAnswers:
   description: Corresponds to the AI-powered Quick Answers feature that returns answers to spoken questions.
 

--- a/firefox-ios/Client/Glean/tags.yaml
+++ b/firefox-ios/Client/Glean/tags.yaml
@@ -39,6 +39,9 @@ Autofill:
 BookmarksPanel:
   description: Corresponds to the library screen's bookmarks panel where the user can view and manage their bookmarks.
 
+Camera:
+  description: Corresponds to features that use the device camera.
+
 ContextMenu:
   description: Corresponds to any context menu in the app.
 
@@ -113,6 +116,9 @@ ShortcutsLibrary:
 
 Summarizer:
   description: Corresponds to the AI-powered feature that generates and displays concise summaries of webpage content.
+
+System:
+  description: Corresponds to interactions with iOS system functionality.
 
 TabsPanel:
   description: Corresponds to all things related to the tab panel.

--- a/firefox-ios/Client/Telemetry/SystemCameraTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SystemCameraTelemetry.swift
@@ -5,6 +5,8 @@
 import Glean
 
 protocol SystemCameraTelemetryProtocol {
+    func shown(reason: CameraReason)
+    func closed(reason: CameraReason)
     func permissionResponded(reason: CameraReason, granted: Bool)
 }
 
@@ -13,6 +15,16 @@ struct SystemCameraTelemetry: SystemCameraTelemetryProtocol {
 
     init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
         self.gleanWrapper = gleanWrapper
+    }
+
+    func shown(reason: CameraReason) {
+        let extra = GleanMetrics.SystemCamera.ShownExtra(reason: reason.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.SystemCamera.shown, extras: extra)
+    }
+
+    func closed(reason: CameraReason) {
+        let extra = GleanMetrics.SystemCamera.ClosedExtra(reason: reason.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.SystemCamera.closed, extras: extra)
     }
 
     func permissionResponded(reason: CameraReason, granted: Bool) {

--- a/firefox-ios/Client/Telemetry/SystemCameraTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SystemCameraTelemetry.swift
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+
+protocol SystemCameraTelemetryProtocol {
+    func permissionResponded(reason: CameraReason, granted: Bool)
+}
+
+struct SystemCameraTelemetry: SystemCameraTelemetryProtocol {
+    private let gleanWrapper: GleanWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
+    func permissionResponded(reason: CameraReason, granted: Bool) {
+        let extra = GleanMetrics.SystemCamera.PermissionRespondedExtra(
+            granted: granted,
+            reason: reason.rawValue
+        )
+        gleanWrapper.recordEvent(for: GleanMetrics.SystemCamera.permissionResponded, extras: extra)
+    }
+}

--- a/firefox-ios/Client/Telemetry/SystemCameraTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SystemCameraTelemetry.swift
@@ -6,9 +6,8 @@ import Glean
 
 protocol SystemCameraTelemetryProtocol {
     func shown(reason: CameraReason)
-    func closed(reason: CameraReason)
+    func closed(reason: CameraReason, photoSelected: Bool)
     func permissionResponded(reason: CameraReason, granted: Bool)
-    func photoSelected(reason: CameraReason)
 }
 
 struct SystemCameraTelemetry: SystemCameraTelemetryProtocol {
@@ -23,8 +22,11 @@ struct SystemCameraTelemetry: SystemCameraTelemetryProtocol {
         gleanWrapper.recordEvent(for: GleanMetrics.SystemCamera.shown, extras: extra)
     }
 
-    func closed(reason: CameraReason) {
-        let extra = GleanMetrics.SystemCamera.ClosedExtra(reason: reason.rawValue)
+    func closed(reason: CameraReason, photoSelected: Bool) {
+        let extra = GleanMetrics.SystemCamera.ClosedExtra(
+            photoSelected: photoSelected,
+            reason: reason.rawValue
+        )
         gleanWrapper.recordEvent(for: GleanMetrics.SystemCamera.closed, extras: extra)
     }
 
@@ -34,10 +36,5 @@ struct SystemCameraTelemetry: SystemCameraTelemetryProtocol {
             reason: reason.rawValue
         )
         gleanWrapper.recordEvent(for: GleanMetrics.SystemCamera.permissionResponded, extras: extra)
-    }
-
-    func photoSelected(reason: CameraReason) {
-        let extra = GleanMetrics.SystemCamera.PhotoSelectedExtra(reason: reason.rawValue)
-        gleanWrapper.recordEvent(for: GleanMetrics.SystemCamera.photoSelected, extras: extra)
     }
 }

--- a/firefox-ios/Client/Telemetry/SystemCameraTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SystemCameraTelemetry.swift
@@ -8,6 +8,7 @@ protocol SystemCameraTelemetryProtocol {
     func shown(reason: CameraReason)
     func closed(reason: CameraReason)
     func permissionResponded(reason: CameraReason, granted: Bool)
+    func photoSelected(reason: CameraReason)
 }
 
 struct SystemCameraTelemetry: SystemCameraTelemetryProtocol {
@@ -33,5 +34,10 @@ struct SystemCameraTelemetry: SystemCameraTelemetryProtocol {
             reason: reason.rawValue
         )
         gleanWrapper.recordEvent(for: GleanMetrics.SystemCamera.permissionResponded, extras: extra)
+    }
+
+    func photoSelected(reason: CameraReason) {
+        let extra = GleanMetrics.SystemCamera.PhotoSelectedExtra(reason: reason.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.SystemCamera.photoSelected, extras: extra)
     }
 }

--- a/firefox-ios/Client/Telemetry/SystemPhotoPickerTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SystemPhotoPickerTelemetry.swift
@@ -7,6 +7,7 @@ import Glean
 protocol SystemPhotoPickerTelemetryProtocol {
     func shown(reason: PhotoPickerReason)
     func closed(reason: PhotoPickerReason)
+    func photoSelected(reason: PhotoPickerReason)
 }
 
 struct SystemPhotoPickerTelemetry: SystemPhotoPickerTelemetryProtocol {
@@ -24,5 +25,10 @@ struct SystemPhotoPickerTelemetry: SystemPhotoPickerTelemetryProtocol {
     func closed(reason: PhotoPickerReason) {
         let extra = GleanMetrics.SystemPhotoPicker.ClosedExtra(reason: reason.rawValue)
         gleanWrapper.recordEvent(for: GleanMetrics.SystemPhotoPicker.closed, extras: extra)
+    }
+
+    func photoSelected(reason: PhotoPickerReason) {
+        let extra = GleanMetrics.SystemPhotoPicker.PhotoSelectedExtra(reason: reason.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.SystemPhotoPicker.photoSelected, extras: extra)
     }
 }

--- a/firefox-ios/Client/Telemetry/SystemPhotoPickerTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SystemPhotoPickerTelemetry.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+
+protocol SystemPhotoPickerTelemetryProtocol {
+    func shown(reason: PhotoPickerReason)
+    func closed(reason: PhotoPickerReason)
+}
+
+struct SystemPhotoPickerTelemetry: SystemPhotoPickerTelemetryProtocol {
+    private let gleanWrapper: GleanWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
+    func shown(reason: PhotoPickerReason) {
+        let extra = GleanMetrics.SystemPhotoPicker.ShownExtra(reason: reason.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.SystemPhotoPicker.shown, extras: extra)
+    }
+
+    func closed(reason: PhotoPickerReason) {
+        let extra = GleanMetrics.SystemPhotoPicker.ClosedExtra(reason: reason.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.SystemPhotoPicker.closed, extras: extra)
+    }
+}

--- a/firefox-ios/Client/Telemetry/SystemPhotoPickerTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SystemPhotoPickerTelemetry.swift
@@ -6,8 +6,7 @@ import Glean
 
 protocol SystemPhotoPickerTelemetryProtocol {
     func shown(reason: PhotoPickerReason)
-    func closed(reason: PhotoPickerReason)
-    func photoSelected(reason: PhotoPickerReason)
+    func closed(reason: PhotoPickerReason, photoSelected: Bool)
 }
 
 struct SystemPhotoPickerTelemetry: SystemPhotoPickerTelemetryProtocol {
@@ -22,13 +21,11 @@ struct SystemPhotoPickerTelemetry: SystemPhotoPickerTelemetryProtocol {
         gleanWrapper.recordEvent(for: GleanMetrics.SystemPhotoPicker.shown, extras: extra)
     }
 
-    func closed(reason: PhotoPickerReason) {
-        let extra = GleanMetrics.SystemPhotoPicker.ClosedExtra(reason: reason.rawValue)
+    func closed(reason: PhotoPickerReason, photoSelected: Bool) {
+        let extra = GleanMetrics.SystemPhotoPicker.ClosedExtra(
+            photoSelected: photoSelected,
+            reason: reason.rawValue
+        )
         gleanWrapper.recordEvent(for: GleanMetrics.SystemPhotoPicker.closed, extras: extra)
-    }
-
-    func photoSelected(reason: PhotoPickerReason) {
-        let extra = GleanMetrics.SystemPhotoPicker.PhotoSelectedExtra(reason: reason.rawValue)
-        gleanWrapper.recordEvent(for: GleanMetrics.SystemPhotoPicker.photoSelected, extras: extra)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -443,7 +443,8 @@ final class BrowserCoordinatorTests: XCTestCase,
     func testShowGoogleLensCamera_whenCameraCoordinatorAlreadyPresent_doesNotAddDuplicate() {
         let subject = createSubject()
         let existing = CameraCoordinator(parentCoordinatorDelegate: subject,
-                                         router: mockRouter) { _ in }
+                                         router: mockRouter,
+                                         cameraReason: .googleLens) { _ in }
         subject.add(child: existing)
 
         subject.showGoogleLensCamera()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -50,7 +50,8 @@ final class CameraCoordinatorTests: XCTestCase {
     func test_didFinishPicking_withImage_callsCompletionAndNotifiesParent() {
         let expectedImage = UIImage()
         var completionImage: UIImage?
-        let subject = createSubject(onComplete: { completionImage = $0 })
+        let cameraTelemetry = MockSystemCameraTelemetry()
+        let subject = createSubject(cameraTelemetry: cameraTelemetry, onComplete: { completionImage = $0 })
         let picker = UIImagePickerController()
 
         subject.imagePickerController(picker, didFinishPickingMediaWithInfo: [.originalImage: expectedImage])
@@ -58,6 +59,8 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertIdentical(completionImage, expectedImage)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
         XCTAssertEqual(router.dismissCalled, 1)
+        XCTAssertEqual(cameraTelemetry.photoSelectedCalled, 1)
+        XCTAssertEqual(cameraTelemetry.savedPhotoSelectedReason, .googleLens)
     }
 
     func test_didFinishPicking_withoutImage_callsCompletionWithNil() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -49,6 +49,7 @@ final class CameraCoordinatorTests: XCTestCase {
 
     func test_start_whenPermissionNotDetermined_doesNotRecordShownBeforeResponse() async {
         let requestStarted = expectation(description: "Camera access request started")
+        let requestFinished = expectation(description: "Camera access request finished")
         var accessContinuation: CheckedContinuation<Bool, Never>?
         let cameraTelemetry = MockSystemCameraTelemetry()
         let requestCameraAccess: () async -> Bool = {
@@ -59,7 +60,8 @@ final class CameraCoordinatorTests: XCTestCase {
         }
         let subject = createSubject(cameraAuthorizationStatus: .notDetermined,
                                     requestCameraAccess: requestCameraAccess,
-                                    cameraTelemetry: cameraTelemetry)
+                                    cameraTelemetry: cameraTelemetry,
+                                    onComplete: { _ in requestFinished.fulfill() })
 
         subject.start()
         await fulfillment(of: [requestStarted], timeout: 1)
@@ -68,7 +70,8 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(cameraTelemetry.closedCalled, 0)
 
         accessContinuation?.resume(returning: false)
-        await Task.yield()
+        await fulfillment(of: [requestFinished], timeout: 1)
+        releasePresentedCamera()
     }
 
     func test_didFinishPicking_withImage_callsCompletionAndNotifiesParent() {
@@ -126,6 +129,7 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(cameraTelemetry.closedCalled, 1)
         XCTAssertEqual(cameraTelemetry.savedClosedReason, .googleLens)
         XCTAssertEqual(cameraTelemetry.savedClosedPhotoSelected, false)
+        releasePresentedCamera()
     }
 
     func test_dismissCameraInterface_whenPermissionDenied_doesNotRecordCameraLifecycle() {
@@ -138,6 +142,7 @@ final class CameraCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(cameraTelemetry.shownCalled, 0)
         XCTAssertEqual(cameraTelemetry.closedCalled, 0)
+        releasePresentedCamera()
     }
 
     func test_dismissCameraInterfaceIfAccessRefused_whenRefused_dismissesAndFinishesWithNil() async {
@@ -208,6 +213,11 @@ final class CameraCoordinatorTests: XCTestCase {
     }
 
     // MARK: - Helper Methods
+    private func releasePresentedCamera() {
+        (router.presentedViewController as? UIImagePickerController)?.delegate = nil
+        router.presentedViewController = nil
+    }
+
     private func createSubject(isCameraAvailable: Bool = true,
                                cameraAuthorizationStatus: AVAuthorizationStatus = .authorized,
                                requestCameraAccess: @escaping () async -> Bool = { false },

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -29,7 +29,10 @@ final class CameraCoordinatorTests: XCTestCase {
     func test_start_whenCameraUnavailable_finishesWithNilAndNotifiesParent() {
         var completionCalled = 0
         var completionImage: UIImage?
-        let subject = createSubject(isCameraAvailable: false, onComplete: { image in
+        let cameraTelemetry = MockSystemCameraTelemetry()
+        let subject = createSubject(isCameraAvailable: false,
+                                    cameraTelemetry: cameraTelemetry,
+                                    onComplete: { image in
             completionCalled += 1
             completionImage = image
         })
@@ -40,6 +43,8 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(completionCalled, 1)
         XCTAssertNil(completionImage)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+        XCTAssertEqual(cameraTelemetry.shownCalled, 0)
+        XCTAssertEqual(cameraTelemetry.closedCalled, 0)
     }
 
     func test_didFinishPicking_withImage_callsCompletionAndNotifiesParent() {
@@ -75,10 +80,12 @@ final class CameraCoordinatorTests: XCTestCase {
     func test_dismissCameraInterface_dismissesAndFinishesWithNil() {
         var completionCalled = 0
         var completionImage: UIImage?
-        let subject = createSubject(onComplete: { image in
+        let cameraTelemetry = MockSystemCameraTelemetry()
+        let subject = createSubject(cameraTelemetry: cameraTelemetry, onComplete: { image in
             completionCalled += 1
             completionImage = image
         })
+        subject.start()
 
         subject.dismissCameraInterface()
 
@@ -86,6 +93,10 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(completionCalled, 1)
         XCTAssertNil(completionImage)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+        XCTAssertEqual(cameraTelemetry.shownCalled, 1)
+        XCTAssertEqual(cameraTelemetry.savedShownReason, .googleLens)
+        XCTAssertEqual(cameraTelemetry.closedCalled, 1)
+        XCTAssertEqual(cameraTelemetry.savedClosedReason, .googleLens)
     }
 
     func test_dismissCameraInterfaceIfAccessRefused_whenRefused_dismissesAndFinishesWithNil() async {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -83,8 +83,9 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertIdentical(completionImage, expectedImage)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
         XCTAssertEqual(router.dismissCalled, 1)
-        XCTAssertEqual(cameraTelemetry.photoSelectedCalled, 1)
-        XCTAssertEqual(cameraTelemetry.savedPhotoSelectedReason, .googleLens)
+        XCTAssertEqual(cameraTelemetry.closedCalled, 1)
+        XCTAssertEqual(cameraTelemetry.savedClosedReason, .googleLens)
+        XCTAssertEqual(cameraTelemetry.savedClosedPhotoSelected, true)
     }
 
     func test_didFinishPicking_withoutImage_callsCompletionWithNil() {
@@ -124,6 +125,7 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(cameraTelemetry.savedShownReason, .googleLens)
         XCTAssertEqual(cameraTelemetry.closedCalled, 1)
         XCTAssertEqual(cameraTelemetry.savedClosedReason, .googleLens)
+        XCTAssertEqual(cameraTelemetry.savedClosedPhotoSelected, false)
     }
 
     func test_dismissCameraInterface_whenPermissionDenied_doesNotRecordCameraLifecycle() {
@@ -185,6 +187,7 @@ final class CameraCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(cameraTelemetry.closedCalled, 1)
         XCTAssertEqual(cameraTelemetry.savedClosedReason, .googleLens)
+        XCTAssertEqual(cameraTelemetry.savedClosedPhotoSelected, false)
     }
 
     func test_didCancel_callsCompletionWithNilAndNotifiesParent() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -62,7 +62,7 @@ final class CameraCoordinatorTests: XCTestCase {
                                     cameraTelemetry: cameraTelemetry)
 
         let permissionTask = Task {
-            await subject.dismissCameraInterfaceIfAccessRefused()
+            await subject.handleCameraAccessRequest()
         }
         await fulfillment(of: [requestStarted], timeout: 1)
 
@@ -150,7 +150,7 @@ final class CameraCoordinatorTests: XCTestCase {
             completionImage = image
         })
 
-        await subject.dismissCameraInterfaceIfAccessRefused()
+        await subject.handleCameraAccessRequest()
 
         XCTAssertEqual(router.dismissCalled, 1)
         XCTAssertEqual(completionCalled, 1)
@@ -170,7 +170,7 @@ final class CameraCoordinatorTests: XCTestCase {
                                     cameraTelemetry: cameraTelemetry,
                                     onComplete: { _ in completionCalled += 1 })
 
-        await subject.dismissCameraInterfaceIfAccessRefused()
+        await subject.handleCameraAccessRequest()
 
         XCTAssertEqual(router.dismissCalled, 0)
         XCTAssertEqual(completionCalled, 0)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -91,7 +91,9 @@ final class CameraCoordinatorTests: XCTestCase {
     func test_dismissCameraInterfaceIfAccessRefused_whenRefused_dismissesAndFinishesWithNil() async {
         var completionCalled = 0
         var completionImage: UIImage?
+        let cameraTelemetry = MockSystemCameraTelemetry()
         let subject = createSubject(requestCameraAccess: { false },
+                                    cameraTelemetry: cameraTelemetry,
                                     onComplete: { image in
             completionCalled += 1
             completionImage = image
@@ -103,11 +105,16 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(completionCalled, 1)
         XCTAssertNil(completionImage)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+        XCTAssertEqual(cameraTelemetry.permissionRespondedCalled, 1)
+        XCTAssertEqual(cameraTelemetry.savedReason, .googleLens)
+        XCTAssertEqual(cameraTelemetry.savedGranted, false)
     }
 
     func test_dismissCameraInterfaceIfAccessRefused_whenGranted_keepsInterfacePresented() async {
         var completionCalled = 0
+        let cameraTelemetry = MockSystemCameraTelemetry()
         let subject = createSubject(requestCameraAccess: { true },
+                                    cameraTelemetry: cameraTelemetry,
                                     onComplete: { _ in completionCalled += 1 })
 
         await subject.dismissCameraInterfaceIfAccessRefused()
@@ -115,6 +122,9 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.dismissCalled, 0)
         XCTAssertEqual(completionCalled, 0)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 0)
+        XCTAssertEqual(cameraTelemetry.permissionRespondedCalled, 1)
+        XCTAssertEqual(cameraTelemetry.savedReason, .googleLens)
+        XCTAssertEqual(cameraTelemetry.savedGranted, true)
     }
 
     func test_didCancel_callsCompletionWithNilAndNotifiesParent() {
@@ -138,6 +148,7 @@ final class CameraCoordinatorTests: XCTestCase {
     private func createSubject(isCameraAvailable: Bool = true,
                                cameraAuthorizationStatus: AVAuthorizationStatus = .authorized,
                                requestCameraAccess: @escaping () async -> Bool = { false },
+                               cameraTelemetry: SystemCameraTelemetryProtocol = MockSystemCameraTelemetry(),
                                onComplete: @escaping (UIImage?) -> Void = { _ in },
                                file: StaticString = #filePath,
                                line: UInt = #line) -> CameraCoordinator {
@@ -146,6 +157,8 @@ final class CameraCoordinatorTests: XCTestCase {
                                         isCameraAvailable: isCameraAvailable,
                                         cameraAuthorizationStatus: cameraAuthorizationStatus,
                                         requestCameraAccess: requestCameraAccess,
+                                        cameraReason: .googleLens,
+                                        cameraTelemetry: cameraTelemetry,
                                         onComplete: onComplete)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -47,6 +47,30 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(cameraTelemetry.closedCalled, 0)
     }
 
+    func test_start_whenPermissionNotDetermined_doesNotRecordShownBeforeResponse() async {
+        let requestStarted = expectation(description: "Camera access request started")
+        var accessContinuation: CheckedContinuation<Bool, Never>?
+        let cameraTelemetry = MockSystemCameraTelemetry()
+        let requestCameraAccess: () async -> Bool = {
+            await withCheckedContinuation { continuation in
+                accessContinuation = continuation
+                requestStarted.fulfill()
+            }
+        }
+        let subject = createSubject(cameraAuthorizationStatus: .notDetermined,
+                                    requestCameraAccess: requestCameraAccess,
+                                    cameraTelemetry: cameraTelemetry)
+
+        subject.start()
+        await fulfillment(of: [requestStarted], timeout: 1)
+
+        XCTAssertEqual(cameraTelemetry.shownCalled, 0)
+        XCTAssertEqual(cameraTelemetry.closedCalled, 0)
+
+        accessContinuation?.resume(returning: false)
+        await Task.yield()
+    }
+
     func test_didFinishPicking_withImage_callsCompletionAndNotifiesParent() {
         let expectedImage = UIImage()
         var completionImage: UIImage?
@@ -102,11 +126,24 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(cameraTelemetry.savedClosedReason, .googleLens)
     }
 
+    func test_dismissCameraInterface_whenPermissionDenied_doesNotRecordCameraLifecycle() {
+        let cameraTelemetry = MockSystemCameraTelemetry()
+        let subject = createSubject(cameraAuthorizationStatus: .denied,
+                                    cameraTelemetry: cameraTelemetry)
+        subject.start()
+
+        subject.dismissCameraInterface()
+
+        XCTAssertEqual(cameraTelemetry.shownCalled, 0)
+        XCTAssertEqual(cameraTelemetry.closedCalled, 0)
+    }
+
     func test_dismissCameraInterfaceIfAccessRefused_whenRefused_dismissesAndFinishesWithNil() async {
         var completionCalled = 0
         var completionImage: UIImage?
         let cameraTelemetry = MockSystemCameraTelemetry()
-        let subject = createSubject(requestCameraAccess: { false },
+        let subject = createSubject(cameraAuthorizationStatus: .notDetermined,
+                                    requestCameraAccess: { false },
                                     cameraTelemetry: cameraTelemetry,
                                     onComplete: { image in
             completionCalled += 1
@@ -122,6 +159,8 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(cameraTelemetry.permissionRespondedCalled, 1)
         XCTAssertEqual(cameraTelemetry.savedReason, .googleLens)
         XCTAssertEqual(cameraTelemetry.savedGranted, false)
+        XCTAssertEqual(cameraTelemetry.shownCalled, 0)
+        XCTAssertEqual(cameraTelemetry.closedCalled, 0)
     }
 
     func test_dismissCameraInterfaceIfAccessRefused_whenGranted_keepsInterfacePresented() async {
@@ -139,6 +178,13 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(cameraTelemetry.permissionRespondedCalled, 1)
         XCTAssertEqual(cameraTelemetry.savedReason, .googleLens)
         XCTAssertEqual(cameraTelemetry.savedGranted, true)
+        XCTAssertEqual(cameraTelemetry.shownCalled, 1)
+        XCTAssertEqual(cameraTelemetry.savedShownReason, .googleLens)
+
+        subject.dismissCameraInterface()
+
+        XCTAssertEqual(cameraTelemetry.closedCalled, 1)
+        XCTAssertEqual(cameraTelemetry.savedClosedReason, .googleLens)
     }
 
     func test_didCancel_callsCompletionWithNilAndNotifiesParent() {
@@ -169,7 +215,7 @@ final class CameraCoordinatorTests: XCTestCase {
         let subject = CameraCoordinator(parentCoordinatorDelegate: parentCoordinator,
                                         router: router,
                                         isCameraAvailable: isCameraAvailable,
-                                        cameraAuthorizationStatus: cameraAuthorizationStatus,
+                                        cameraAuthorizationStatus: { cameraAuthorizationStatus },
                                         requestCameraAccess: requestCameraAccess,
                                         cameraReason: .googleLens,
                                         cameraTelemetry: cameraTelemetry,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -136,13 +136,11 @@ final class CameraCoordinatorTests: XCTestCase {
         let cameraTelemetry = MockSystemCameraTelemetry()
         let subject = createSubject(cameraAuthorizationStatus: .denied,
                                     cameraTelemetry: cameraTelemetry)
-        subject.start()
 
         subject.dismissCameraInterface()
 
         XCTAssertEqual(cameraTelemetry.shownCalled, 0)
         XCTAssertEqual(cameraTelemetry.closedCalled, 0)
-        releasePresentedCamera()
     }
 
     func test_dismissCameraInterfaceIfAccessRefused_whenRefused_dismissesAndFinishesWithNil() async {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/CameraCoordinatorTests.swift
@@ -47,9 +47,8 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(cameraTelemetry.closedCalled, 0)
     }
 
-    func test_start_whenPermissionNotDetermined_doesNotRecordShownBeforeResponse() async {
+    func test_dismissCameraInterfaceIfAccessRefused_beforeResponse_doesNotRecordShown() async {
         let requestStarted = expectation(description: "Camera access request started")
-        let requestFinished = expectation(description: "Camera access request finished")
         var accessContinuation: CheckedContinuation<Bool, Never>?
         let cameraTelemetry = MockSystemCameraTelemetry()
         let requestCameraAccess: () async -> Bool = {
@@ -60,18 +59,18 @@ final class CameraCoordinatorTests: XCTestCase {
         }
         let subject = createSubject(cameraAuthorizationStatus: .notDetermined,
                                     requestCameraAccess: requestCameraAccess,
-                                    cameraTelemetry: cameraTelemetry,
-                                    onComplete: { _ in requestFinished.fulfill() })
+                                    cameraTelemetry: cameraTelemetry)
 
-        subject.start()
+        let permissionTask = Task {
+            await subject.dismissCameraInterfaceIfAccessRefused()
+        }
         await fulfillment(of: [requestStarted], timeout: 1)
 
         XCTAssertEqual(cameraTelemetry.shownCalled, 0)
         XCTAssertEqual(cameraTelemetry.closedCalled, 0)
 
         accessContinuation?.resume(returning: false)
-        await fulfillment(of: [requestFinished], timeout: 1)
-        releasePresentedCamera()
+        await permissionTask.value
     }
 
     func test_didFinishPicking_withImage_callsCompletionAndNotifiesParent() {
@@ -116,7 +115,6 @@ final class CameraCoordinatorTests: XCTestCase {
             completionCalled += 1
             completionImage = image
         })
-        subject.start()
 
         subject.dismissCameraInterface()
 
@@ -124,12 +122,9 @@ final class CameraCoordinatorTests: XCTestCase {
         XCTAssertEqual(completionCalled, 1)
         XCTAssertNil(completionImage)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
-        XCTAssertEqual(cameraTelemetry.shownCalled, 1)
-        XCTAssertEqual(cameraTelemetry.savedShownReason, .googleLens)
         XCTAssertEqual(cameraTelemetry.closedCalled, 1)
         XCTAssertEqual(cameraTelemetry.savedClosedReason, .googleLens)
         XCTAssertEqual(cameraTelemetry.savedClosedPhotoSelected, false)
-        releasePresentedCamera()
     }
 
     func test_dismissCameraInterface_whenPermissionDenied_doesNotRecordCameraLifecycle() {
@@ -211,11 +206,6 @@ final class CameraCoordinatorTests: XCTestCase {
     }
 
     // MARK: - Helper Methods
-    private func releasePresentedCamera() {
-        (router.presentedViewController as? UIImagePickerController)?.delegate = nil
-        router.presentedViewController = nil
-    }
-
     private func createSubject(isCameraAvailable: Bool = true,
                                cameraAuthorizationStatus: AVAuthorizationStatus = .authorized,
                                requestCameraAccess: @escaping () async -> Bool = { false },

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/PhotoPickerCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/PhotoPickerCoordinatorTests.swift
@@ -26,17 +26,22 @@ final class PhotoPickerCoordinatorTests: XCTestCase {
     }
 
     func test_start_presentsPhotoPicker() {
-        let subject = createSubject()
+        let photoPickerTelemetry = MockSystemPhotoPickerTelemetry()
+        let subject = createSubject(photoPickerTelemetry: photoPickerTelemetry)
 
         subject.start()
 
         XCTAssertEqual(router.presentCalled, 1)
         XCTAssertTrue(router.presentedViewController is PHPickerViewController)
+        XCTAssertEqual(photoPickerTelemetry.shownCalled, 1)
+        XCTAssertEqual(photoPickerTelemetry.savedShownReason, .googleLens)
     }
 
     func test_didFinishPicking_callsCompletionAndNotifiesParent() {
         var completionCalled = 0
-        let subject = createSubject(onComplete: { _ in completionCalled += 1 })
+        let photoPickerTelemetry = MockSystemPhotoPickerTelemetry()
+        let subject = createSubject(photoPickerTelemetry: photoPickerTelemetry,
+                                    onComplete: { _ in completionCalled += 1 })
         let picker = PHPickerViewController(configuration: PHPickerConfiguration(photoLibrary: .shared()))
 
         subject.picker(picker, didFinishPicking: [])
@@ -44,25 +49,34 @@ final class PhotoPickerCoordinatorTests: XCTestCase {
         XCTAssertEqual(completionCalled, 1)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
         XCTAssertEqual(router.dismissCalled, 1)
+        XCTAssertEqual(photoPickerTelemetry.closedCalled, 1)
+        XCTAssertEqual(photoPickerTelemetry.savedClosedReason, .googleLens)
     }
 
     func test_interactiveDismissal_callsCompletionAndNotifiesParent() {
         var completionResults: [PHPickerResult]?
-        let subject = createSubject(onComplete: { completionResults = $0 })
+        let photoPickerTelemetry = MockSystemPhotoPickerTelemetry()
+        let subject = createSubject(photoPickerTelemetry: photoPickerTelemetry,
+                                    onComplete: { completionResults = $0 })
 
         subject.start()
         router.savedCompletion?()
 
         XCTAssertEqual(completionResults?.count, 0)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+        XCTAssertEqual(photoPickerTelemetry.closedCalled, 1)
+        XCTAssertEqual(photoPickerTelemetry.savedClosedReason, .googleLens)
     }
 
     // MARK: - Helper Methods
-    private func createSubject(onComplete: @escaping ([PHPickerResult]) -> Void = { _ in },
+    private func createSubject(photoPickerTelemetry: SystemPhotoPickerTelemetryProtocol = MockSystemPhotoPickerTelemetry(),
+                               onComplete: @escaping ([PHPickerResult]) -> Void = { _ in },
                                file: StaticString = #filePath,
                                line: UInt = #line) -> PhotoPickerCoordinator {
         let subject = PhotoPickerCoordinator(parentCoordinatorDelegate: parentCoordinator,
                                              router: router,
+                                             photoPickerReason: .googleLens,
+                                             photoPickerTelemetry: photoPickerTelemetry,
                                              onComplete: onComplete)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/PhotoPickerCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/PhotoPickerCoordinatorTests.swift
@@ -37,7 +37,7 @@ final class PhotoPickerCoordinatorTests: XCTestCase {
         XCTAssertEqual(photoPickerTelemetry.savedShownReason, .googleLens)
     }
 
-    func test_didFinishPicking_withoutResults_doesNotRecordPhotoSelected() {
+    func test_didFinishPicking_withoutResults_recordsPhotoSelectedFalse() {
         var completionCalled = 0
         let photoPickerTelemetry = MockSystemPhotoPickerTelemetry()
         let subject = createSubject(photoPickerTelemetry: photoPickerTelemetry,
@@ -51,7 +51,7 @@ final class PhotoPickerCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.dismissCalled, 1)
         XCTAssertEqual(photoPickerTelemetry.closedCalled, 1)
         XCTAssertEqual(photoPickerTelemetry.savedClosedReason, .googleLens)
-        XCTAssertEqual(photoPickerTelemetry.photoSelectedCalled, 0)
+        XCTAssertEqual(photoPickerTelemetry.savedClosedPhotoSelected, false)
     }
 
     func test_interactiveDismissal_callsCompletionAndNotifiesParent() {
@@ -67,6 +67,7 @@ final class PhotoPickerCoordinatorTests: XCTestCase {
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
         XCTAssertEqual(photoPickerTelemetry.closedCalled, 1)
         XCTAssertEqual(photoPickerTelemetry.savedClosedReason, .googleLens)
+        XCTAssertEqual(photoPickerTelemetry.savedClosedPhotoSelected, false)
     }
 
     // MARK: - Helper Methods

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/PhotoPickerCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/PhotoPickerCoordinatorTests.swift
@@ -37,7 +37,7 @@ final class PhotoPickerCoordinatorTests: XCTestCase {
         XCTAssertEqual(photoPickerTelemetry.savedShownReason, .googleLens)
     }
 
-    func test_didFinishPicking_callsCompletionAndNotifiesParent() {
+    func test_didFinishPicking_withoutResults_doesNotRecordPhotoSelected() {
         var completionCalled = 0
         let photoPickerTelemetry = MockSystemPhotoPickerTelemetry()
         let subject = createSubject(photoPickerTelemetry: photoPickerTelemetry,
@@ -51,6 +51,7 @@ final class PhotoPickerCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.dismissCalled, 1)
         XCTAssertEqual(photoPickerTelemetry.closedCalled, 1)
         XCTAssertEqual(photoPickerTelemetry.savedClosedReason, .googleLens)
+        XCTAssertEqual(photoPickerTelemetry.photoSelectedCalled, 0)
     }
 
     func test_interactiveDismissal_callsCompletionAndNotifiesParent() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemCameraTelemetry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemCameraTelemetry.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+final class MockSystemCameraTelemetry: SystemCameraTelemetryProtocol {
+    private(set) var permissionRespondedCalled = 0
+    private(set) var savedReason: CameraReason?
+    private(set) var savedGranted: Bool?
+
+    func permissionResponded(reason: CameraReason, granted: Bool) {
+        permissionRespondedCalled += 1
+        savedReason = reason
+        savedGranted = granted
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemCameraTelemetry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemCameraTelemetry.swift
@@ -5,9 +5,23 @@
 @testable import Client
 
 final class MockSystemCameraTelemetry: SystemCameraTelemetryProtocol {
+    private(set) var shownCalled = 0
+    private(set) var closedCalled = 0
     private(set) var permissionRespondedCalled = 0
+    private(set) var savedShownReason: CameraReason?
+    private(set) var savedClosedReason: CameraReason?
     private(set) var savedReason: CameraReason?
     private(set) var savedGranted: Bool?
+
+    func shown(reason: CameraReason) {
+        shownCalled += 1
+        savedShownReason = reason
+    }
+
+    func closed(reason: CameraReason) {
+        closedCalled += 1
+        savedClosedReason = reason
+    }
 
     func permissionResponded(reason: CameraReason, granted: Bool) {
         permissionRespondedCalled += 1

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemCameraTelemetry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemCameraTelemetry.swift
@@ -8,11 +8,10 @@ final class MockSystemCameraTelemetry: SystemCameraTelemetryProtocol {
     private(set) var shownCalled = 0
     private(set) var closedCalled = 0
     private(set) var permissionRespondedCalled = 0
-    private(set) var photoSelectedCalled = 0
     private(set) var savedShownReason: CameraReason?
     private(set) var savedClosedReason: CameraReason?
+    private(set) var savedClosedPhotoSelected: Bool?
     private(set) var savedReason: CameraReason?
-    private(set) var savedPhotoSelectedReason: CameraReason?
     private(set) var savedGranted: Bool?
 
     func shown(reason: CameraReason) {
@@ -20,19 +19,15 @@ final class MockSystemCameraTelemetry: SystemCameraTelemetryProtocol {
         savedShownReason = reason
     }
 
-    func closed(reason: CameraReason) {
+    func closed(reason: CameraReason, photoSelected: Bool) {
         closedCalled += 1
         savedClosedReason = reason
+        savedClosedPhotoSelected = photoSelected
     }
 
     func permissionResponded(reason: CameraReason, granted: Bool) {
         permissionRespondedCalled += 1
         savedReason = reason
         savedGranted = granted
-    }
-
-    func photoSelected(reason: CameraReason) {
-        photoSelectedCalled += 1
-        savedPhotoSelectedReason = reason
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemCameraTelemetry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemCameraTelemetry.swift
@@ -8,9 +8,11 @@ final class MockSystemCameraTelemetry: SystemCameraTelemetryProtocol {
     private(set) var shownCalled = 0
     private(set) var closedCalled = 0
     private(set) var permissionRespondedCalled = 0
+    private(set) var photoSelectedCalled = 0
     private(set) var savedShownReason: CameraReason?
     private(set) var savedClosedReason: CameraReason?
     private(set) var savedReason: CameraReason?
+    private(set) var savedPhotoSelectedReason: CameraReason?
     private(set) var savedGranted: Bool?
 
     func shown(reason: CameraReason) {
@@ -27,5 +29,10 @@ final class MockSystemCameraTelemetry: SystemCameraTelemetryProtocol {
         permissionRespondedCalled += 1
         savedReason = reason
         savedGranted = granted
+    }
+
+    func photoSelected(reason: CameraReason) {
+        photoSelectedCalled += 1
+        savedPhotoSelectedReason = reason
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemPhotoPickerTelemetry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemPhotoPickerTelemetry.swift
@@ -7,23 +7,18 @@
 final class MockSystemPhotoPickerTelemetry: SystemPhotoPickerTelemetryProtocol {
     private(set) var shownCalled = 0
     private(set) var closedCalled = 0
-    private(set) var photoSelectedCalled = 0
     private(set) var savedShownReason: PhotoPickerReason?
     private(set) var savedClosedReason: PhotoPickerReason?
-    private(set) var savedPhotoSelectedReason: PhotoPickerReason?
+    private(set) var savedClosedPhotoSelected: Bool?
 
     func shown(reason: PhotoPickerReason) {
         shownCalled += 1
         savedShownReason = reason
     }
 
-    func closed(reason: PhotoPickerReason) {
+    func closed(reason: PhotoPickerReason, photoSelected: Bool) {
         closedCalled += 1
         savedClosedReason = reason
-    }
-
-    func photoSelected(reason: PhotoPickerReason) {
-        photoSelectedCalled += 1
-        savedPhotoSelectedReason = reason
+        savedClosedPhotoSelected = photoSelected
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemPhotoPickerTelemetry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemPhotoPickerTelemetry.swift
@@ -7,8 +7,10 @@
 final class MockSystemPhotoPickerTelemetry: SystemPhotoPickerTelemetryProtocol {
     private(set) var shownCalled = 0
     private(set) var closedCalled = 0
+    private(set) var photoSelectedCalled = 0
     private(set) var savedShownReason: PhotoPickerReason?
     private(set) var savedClosedReason: PhotoPickerReason?
+    private(set) var savedPhotoSelectedReason: PhotoPickerReason?
 
     func shown(reason: PhotoPickerReason) {
         shownCalled += 1
@@ -18,5 +20,10 @@ final class MockSystemPhotoPickerTelemetry: SystemPhotoPickerTelemetryProtocol {
     func closed(reason: PhotoPickerReason) {
         closedCalled += 1
         savedClosedReason = reason
+    }
+
+    func photoSelected(reason: PhotoPickerReason) {
+        photoSelectedCalled += 1
+        savedPhotoSelectedReason = reason
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemPhotoPickerTelemetry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSystemPhotoPickerTelemetry.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+final class MockSystemPhotoPickerTelemetry: SystemPhotoPickerTelemetryProtocol {
+    private(set) var shownCalled = 0
+    private(set) var closedCalled = 0
+    private(set) var savedShownReason: PhotoPickerReason?
+    private(set) var savedClosedReason: PhotoPickerReason?
+
+    func shown(reason: PhotoPickerReason) {
+        shownCalled += 1
+        savedShownReason = reason
+    }
+
+    func closed(reason: PhotoPickerReason) {
+        closedCalled += 1
+        savedClosedReason = reason
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemCameraTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemCameraTelemetryTests.swift
@@ -34,16 +34,17 @@ final class SystemCameraTelemetryTests: XCTestCase {
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
-    func testClosed_recordsEventAndReason() throws {
+    func testClosed_recordsEventAndExtras() throws {
         typealias EventExtrasType = GleanMetrics.SystemCamera.ClosedExtra
         let event = GleanMetrics.SystemCamera.closed
         let subject = SystemCameraTelemetry(gleanWrapper: gleanWrapper)
 
-        subject.closed(reason: .googleLens)
+        subject.closed(reason: .googleLens, photoSelected: true)
 
         let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
         let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
         XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.photoSelected, true)
         XCTAssertEqual(savedExtras.reason, CameraReason.googleLens.rawValue)
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
@@ -62,20 +63,6 @@ final class SystemCameraTelemetryTests: XCTestCase {
         subject.permissionResponded(reason: .googleLens, granted: false)
 
         try assertPermissionRespondedEvent(granted: false)
-    }
-
-    func testPhotoSelected_recordsEventAndReason() throws {
-        typealias EventExtrasType = GleanMetrics.SystemCamera.PhotoSelectedExtra
-        let event = GleanMetrics.SystemCamera.photoSelected
-        let subject = SystemCameraTelemetry(gleanWrapper: gleanWrapper)
-
-        subject.photoSelected(reason: .googleLens)
-
-        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
-        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.reason, CameraReason.googleLens.rawValue)
-        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
     private func assertPermissionRespondedEvent(granted: Bool,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemCameraTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemCameraTelemetryTests.swift
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import XCTest
+
+@testable import Client
+
+final class SystemCameraTelemetryTests: XCTestCase {
+    private var gleanWrapper: MockGleanWrapper!
+
+    override func setUp() {
+        super.setUp()
+        gleanWrapper = MockGleanWrapper()
+    }
+
+    override func tearDown() {
+        gleanWrapper = nil
+        super.tearDown()
+    }
+
+    func testPermissionResponded_whenGranted_recordsEventAndExtras() throws {
+        let subject = SystemCameraTelemetry(gleanWrapper: gleanWrapper)
+
+        subject.permissionResponded(reason: .googleLens, granted: true)
+
+        try assertPermissionRespondedEvent(granted: true)
+    }
+
+    func testPermissionResponded_whenDenied_recordsEventAndExtras() throws {
+        let subject = SystemCameraTelemetry(gleanWrapper: gleanWrapper)
+
+        subject.permissionResponded(reason: .googleLens, granted: false)
+
+        try assertPermissionRespondedEvent(granted: false)
+    }
+
+    private func assertPermissionRespondedEvent(granted: Bool,
+                                                file: StaticString = #filePath,
+                                                line: UInt = #line) throws {
+        typealias EventExtrasType = GleanMetrics.SystemCamera.PermissionRespondedExtra
+        let event = GleanMetrics.SystemCamera.permissionResponded
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType,
+                                        file: file,
+                                        line: line)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>,
+                                        file: file,
+                                        line: line)
+
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1, file: file, line: line)
+        XCTAssertEqual(savedExtras.granted, granted, file: file, line: line)
+        XCTAssertEqual(savedExtras.reason, CameraReason.googleLens.rawValue, file: file, line: line)
+        XCTAssert(savedMetric === event,
+                  "Received \(savedMetric) instead of \(event)",
+                  file: file,
+                  line: line)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemCameraTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemCameraTelemetryTests.swift
@@ -20,6 +20,34 @@ final class SystemCameraTelemetryTests: XCTestCase {
         super.tearDown()
     }
 
+    func testShown_recordsEventAndReason() throws {
+        typealias EventExtrasType = GleanMetrics.SystemCamera.ShownExtra
+        let event = GleanMetrics.SystemCamera.shown
+        let subject = SystemCameraTelemetry(gleanWrapper: gleanWrapper)
+
+        subject.shown(reason: .googleLens)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.reason, CameraReason.googleLens.rawValue)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
+    func testClosed_recordsEventAndReason() throws {
+        typealias EventExtrasType = GleanMetrics.SystemCamera.ClosedExtra
+        let event = GleanMetrics.SystemCamera.closed
+        let subject = SystemCameraTelemetry(gleanWrapper: gleanWrapper)
+
+        subject.closed(reason: .googleLens)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.reason, CameraReason.googleLens.rawValue)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
     func testPermissionResponded_whenGranted_recordsEventAndExtras() throws {
         let subject = SystemCameraTelemetry(gleanWrapper: gleanWrapper)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemCameraTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemCameraTelemetryTests.swift
@@ -64,6 +64,20 @@ final class SystemCameraTelemetryTests: XCTestCase {
         try assertPermissionRespondedEvent(granted: false)
     }
 
+    func testPhotoSelected_recordsEventAndReason() throws {
+        typealias EventExtrasType = GleanMetrics.SystemCamera.PhotoSelectedExtra
+        let event = GleanMetrics.SystemCamera.photoSelected
+        let subject = SystemCameraTelemetry(gleanWrapper: gleanWrapper)
+
+        subject.photoSelected(reason: .googleLens)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.reason, CameraReason.googleLens.rawValue)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
     private func assertPermissionRespondedEvent(granted: Bool,
                                                 file: StaticString = #filePath,
                                                 line: UInt = #line) throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemPhotoPickerTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemPhotoPickerTelemetryTests.swift
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Glean
+import XCTest
+
+@testable import Client
+
+final class SystemPhotoPickerTelemetryTests: XCTestCase {
+    private var gleanWrapper: MockGleanWrapper!
+
+    override func setUp() {
+        super.setUp()
+        gleanWrapper = MockGleanWrapper()
+    }
+
+    override func tearDown() {
+        gleanWrapper = nil
+        super.tearDown()
+    }
+
+    func testShown_recordsEventAndReason() throws {
+        typealias EventExtrasType = GleanMetrics.SystemPhotoPicker.ShownExtra
+        let event = GleanMetrics.SystemPhotoPicker.shown
+        let subject = SystemPhotoPickerTelemetry(gleanWrapper: gleanWrapper)
+
+        subject.shown(reason: .googleLens)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.reason, PhotoPickerReason.googleLens.rawValue)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
+    func testClosed_recordsEventAndReason() throws {
+        typealias EventExtrasType = GleanMetrics.SystemPhotoPicker.ClosedExtra
+        let event = GleanMetrics.SystemPhotoPicker.closed
+        let subject = SystemPhotoPickerTelemetry(gleanWrapper: gleanWrapper)
+
+        subject.closed(reason: .googleLens)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.reason, PhotoPickerReason.googleLens.rawValue)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemPhotoPickerTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemPhotoPickerTelemetryTests.swift
@@ -34,30 +34,17 @@ final class SystemPhotoPickerTelemetryTests: XCTestCase {
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
 
-    func testClosed_recordsEventAndReason() throws {
+    func testClosed_recordsEventAndExtras() throws {
         typealias EventExtrasType = GleanMetrics.SystemPhotoPicker.ClosedExtra
         let event = GleanMetrics.SystemPhotoPicker.closed
         let subject = SystemPhotoPickerTelemetry(gleanWrapper: gleanWrapper)
 
-        subject.closed(reason: .googleLens)
+        subject.closed(reason: .googleLens, photoSelected: true)
 
         let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
         let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
         XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.reason, PhotoPickerReason.googleLens.rawValue)
-        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
-    }
-
-    func testPhotoSelected_recordsEventAndReason() throws {
-        typealias EventExtrasType = GleanMetrics.SystemPhotoPicker.PhotoSelectedExtra
-        let event = GleanMetrics.SystemPhotoPicker.photoSelected
-        let subject = SystemPhotoPickerTelemetry(gleanWrapper: gleanWrapper)
-
-        subject.photoSelected(reason: .googleLens)
-
-        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
-        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.photoSelected, true)
         XCTAssertEqual(savedExtras.reason, PhotoPickerReason.googleLens.rawValue)
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemPhotoPickerTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/SystemPhotoPickerTelemetryTests.swift
@@ -47,4 +47,18 @@ final class SystemPhotoPickerTelemetryTests: XCTestCase {
         XCTAssertEqual(savedExtras.reason, PhotoPickerReason.googleLens.rawValue)
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
     }
+
+    func testPhotoSelected_recordsEventAndReason() throws {
+        typealias EventExtrasType = GleanMetrics.SystemPhotoPicker.PhotoSelectedExtra
+        let event = GleanMetrics.SystemPhotoPicker.photoSelected
+        let subject = SystemPhotoPickerTelemetry(gleanWrapper: gleanWrapper)
+
+        subject.photoSelected(reason: .googleLens)
+
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first as? EventExtrasType)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first as? EventMetricType<EventExtrasType>)
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.reason, PhotoPickerReason.googleLens.rawValue)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16297)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34655)

## :bulb: Description
- Add telemetry for system camera permission and camera/photo-picker shown, closed, and photo selected events

| Probe Name | Extra Keys | Trigger |
| ------------- | ------------- | ------------- |
| system.camera.permission_responded | `reason`: `googleLens` <br><br> `granted`: boolean | Recorded when the user responds to the system camera permission request. |
| system.camera.shown | `reason`: `googleLens` | Recorded when the system camera interface is shown. |
| system.camera.closed | `reason`: `googleLens` <br><br> `photo_selected`: boolean | Recorded when the system camera interface is closed. |
| system.photo_picker.shown | `reason`: `googleLens` | Recorded when the system photo picker interface is shown. |
| system.photo_picker.closed | `reason`: `googleLens` <br><br> `photo_selected`: boolean | Recorded when the system photo picker interface is closed. |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

