### PR TITLE
Bugfix FXIOS-16307 Fix deadlock in UIDeviceDetails

### DIFF
--- a/BrowserKit/Sources/Shared/UIDeviceDetails.swift
+++ b/BrowserKit/Sources/Shared/UIDeviceDetails.swift
@@ -20,7 +20,7 @@ public struct UIDeviceDetails {
 
 /// Lazily computes a `@MainActor` value and caches it. Safe to read from any thread.
 /// The main-thread hop happens outside the lock so this utility class avoids the deadlock
-/// we had with the previous implementatino of UIDeviceDetails.
+/// we had with the previous implementation of UIDeviceDetails.
 final class MainActorCachedValue<T: Sendable>: @unchecked Sendable {
     private let lock = NSLock()
     private var cachedValue: T?

--- a/BrowserKit/Sources/Shared/UIDeviceDetails.swift
+++ b/BrowserKit/Sources/Shared/UIDeviceDetails.swift
@@ -5,47 +5,44 @@
 import UIKit
 
 /// Contains static, unchanging information about the current `UIDevice`, like the model and system version.
-///
-/// This makes it easier for code that runs on a background thread (without an asynchronous context) to use these values.
-///
-/// **Never put values in here that might change during runtime.**
 public struct UIDeviceDetails {
-    /// The model of the device.
-    public static let model = {
-        getMainThreadDataSynchronously { UIDevice.current.model }
-    }()
+    public static var model: String { cachedModel.value }
+    private static let cachedModel = MainActorCachedValue { UIDevice.current.model }
 
-    /// The style of interface to use on the current device.
-    public static let userInterfaceIdiom = {
-        getMainThreadDataSynchronously { UIDevice.current.userInterfaceIdiom }
-    }()
+    public static var userInterfaceIdiom: UIUserInterfaceIdiom { cachedUserInterfaceIdiom.value }
+    private static let cachedUserInterfaceIdiom = MainActorCachedValue { UIDevice.current.userInterfaceIdiom }
 
-    /// The current version of the operating system.
-    public static let systemVersion = {
-        getMainThreadDataSynchronously { UIDevice.current.systemVersion }
-    }()
+    public static var systemVersion: String { cachedSystemVersion.value }
+    private static let cachedSystemVersion = MainActorCachedValue { UIDevice.current.systemVersion }
 
-    /// Never instantiate this type.
     private init() {}
+}
 
-    // MARK: Helper method
+/// Lazily computes a `@MainActor` value and caches it. Safe to read from any thread.
+/// The main-thread hop happens outside the lock so this utility class avoids the deadlock
+/// we had with the previous implementatino of UIDeviceDetails.
+final class MainActorCachedValue<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cachedValue: T?
+    private let evaluate: @MainActor () -> T
 
-    /// This nonisolated function will execute the `work` closure on the main thread to return a value outside an
-    /// asynchronous or main actor context. It will synchronously suspend if necessary to wait for the MT.
-    ///
-    /// **DO NOT USE THIS METHOD ELSEWHERE IN THE CODE BASE.**
-    /// This is a workaround to access unchanging `UIDevice.current` values that Apple has needlessly main actor-isolated.
-    private static func getMainThreadDataSynchronously<T: Sendable>(
-        work: @MainActor () -> (T)
-    ) -> T {
-        if Thread.isMainThread {
-            MainActor.assumeIsolated {
-                work()
-            }
-        } else {
-            DispatchQueue.main.sync {
-                work()
-            }
-        }
+    init(_ compute: @escaping @MainActor () -> T) {
+        self.evaluate = compute
+    }
+
+    var value: T {
+        // Fast path, lock held only for the in-memory read.
+        lock.lock()
+        if let cachedValue { lock.unlock(); return cachedValue }
+        lock.unlock()
+
+        // Compute without holding the lock
+        let value = Thread.isMainThread ? MainActor.assumeIsolated { evaluate() } : DispatchQueue.main.sync { evaluate() }
+
+        // Lock only for in-memory write. Constant value so last-writer-wins is Ok.
+        lock.lock()
+        cachedValue = value
+        lock.unlock()
+        return value
     }
 }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		1D91C1912CF526EF00B24960 /* disconnect-block-analytics.json in Resources */ = {isa = PBXBuildFile; fileRef = 1D91C1792CF11EA400B24960 /* disconnect-block-analytics.json */; };
 		1D91C1922CF526EF00B24960 /* disconnect-block-advertising.json in Resources */ = {isa = PBXBuildFile; fileRef = 1D91C1772CF11EA400B24960 /* disconnect-block-advertising.json */; };
 		1D91C1932CF526EF00B24960 /* disconnect-block-social.json in Resources */ = {isa = PBXBuildFile; fileRef = 1D91C17C2CF11EA500B24960 /* disconnect-block-social.json */; };
+		1DA2442830097B2900632E67 /* MainActorCachedValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA2442730097B2200632E67 /* MainActorCachedValueTests.swift */; };
 		1DA3144E2F21777E009E48FA /* PlainToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3144D2F21777B009E48FA /* PlainToast.swift */; };
 		1DA3CE5D24EEE73100422BB2 /* OpenTabsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */; };
 		1DA3E4B22DB1C86F0065F7E7 /* ASSearchEngineUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA3E4B12DB1C86A0065F7E7 /* ASSearchEngineUtilitiesTests.swift */; };
@@ -3103,6 +3104,7 @@
 		1D91C17C2CF11EA500B24960 /* disconnect-block-social.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "disconnect-block-social.json"; path = "attachments/tracking-protection-lists-ios/disconnect-block-social.json"; sourceTree = "<group>"; };
 		1D91C17D2CF11EA500B24960 /* disconnect-block-cookies-advertising.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "disconnect-block-cookies-advertising.json"; path = "attachments/tracking-protection-lists-ios/disconnect-block-cookies-advertising.json"; sourceTree = "<group>"; };
 		1D91C1882CF1203F00B24960 /* ContentBlockingListRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockingListRecord.swift; sourceTree = "<group>"; };
+		1DA2442730097B2200632E67 /* MainActorCachedValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainActorCachedValueTests.swift; sourceTree = "<group>"; };
 		1DA24C60879E7D4B2073FD63 /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/Search.strings; sourceTree = "<group>"; };
 		1DA3144D2F21777B009E48FA /* PlainToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainToast.swift; sourceTree = "<group>"; };
 		1DA3CE5C24EEE73100422BB2 /* OpenTabsWidget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenTabsWidget.swift; sourceTree = "<group>"; };
@@ -16941,6 +16943,7 @@
 				E6F9653B1B2F1D5D0034B023 /* NSURLExtensionsTests.swift */,
 				2FEBABAE1AB3659000DB5728 /* ResultTests.swift */,
 				ED3908E63000061F00342639 /* UIDeviceDetailsTests.swift */,
+				1DA2442730097B2200632E67 /* MainActorCachedValueTests.swift */,
 				E6F9650E1B2F1CF20034B023 /* Supporting Files */,
 				E4E7EB6C1C4AED5E0094275D /* SupportUtilsTests.swift */,
 				28A6CE891AC082E200C1A2D4 /* UtilsTests.swift */,
@@ -19386,6 +19389,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1DA2442830097B2900632E67 /* MainActorCachedValueTests.swift in Sources */,
 				28532BEB1C472015000072D9 /* UtilsTests.swift in Sources */,
 				0B1C58D12CE5019A00F498F0 /* UserAgentTests.swift in Sources */,
 				28532BEA1C472008000072D9 /* DeferredTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/MainActorCachedValueTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/MainActorCachedValueTests.swift
@@ -31,8 +31,33 @@ final class MainActorCachedValueTests: XCTestCase {
         testCounter(counter, expectedValue: 1)
     }
 
+    func testMainActorCachedValue_multipleAsyncCalls_onlyEvluateOnMainThread() {
+        let expectation = XCTestExpectation(description: "Completed")
+        expectation.expectedFulfillmentCount = 5
+        let evaluation: @MainActor @Sendable () -> String = {
+            XCTAssert(Thread.isMainThread)
+            return "value"
+        }
+
+        let cachedValue = MainActorCachedValue(evaluation)
+
+        let callCount = 5
+        for x in 0..<callCount {
+            // Alternate dispatches between background and main queue
+            // We expect everything to ultimately resolve on MT
+            let queue = x % 2 == 0 ? DispatchQueue.global() : DispatchQueue.main
+            queue.async {
+                XCTAssertEqual(cachedValue.value, "value")
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     func testMainActorCachedValue_multipleAsyncCalls_doNotDeadlock() {
         let expectation = XCTestExpectation(description: "Completed")
+        expectation.expectedFulfillmentCount = 5
         let delay: TimeInterval = 0.25
         let evaluation: @MainActor @Sendable () -> String = {
             // For this test, delay evaluation to coerce
@@ -44,17 +69,10 @@ final class MainActorCachedValueTests: XCTestCase {
         let cachedValue = MainActorCachedValue(evaluation)
 
         let callCount = 5
-        let lock = NSLock()
-        nonisolated(unsafe) var resolved = 0
         for _ in 0..<callCount {
             DispatchQueue.global().async {
                 XCTAssertEqual(cachedValue.value, "value")
-                lock.lock()
-                resolved += 1
-                if resolved == callCount {
-                    expectation.fulfill()
-                }
-                lock.unlock()
+                expectation.fulfill()
             }
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/MainActorCachedValueTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/MainActorCachedValueTests.swift
@@ -8,12 +8,12 @@ import XCTest
 final class MainActorCachedValueTests: XCTestCase {
     @MainActor private final class Counter { var value = 0 }
 
+    @MainActor
     private func testCounter(_ counter: Counter, expectedValue: Int) {
-        MainActor.assumeIsolated {
-            XCTAssertEqual(counter.value, expectedValue)
-        }
+        XCTAssertEqual(counter.value, expectedValue)
     }
 
+    @MainActor
     func testMainActorCachedValue_repeatedCalls_onlyEvaluateValueOnce() {
         let counter = Counter()
 

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/MainActorCachedValueTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/MainActorCachedValueTests.swift
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Shared
+
+final class MainActorCachedValueTests: XCTestCase {
+    @MainActor private final class Counter { var value = 0 }
+
+    private func testCounter(_ counter: Counter, expectedValue: Int) {
+        MainActor.assumeIsolated {
+            XCTAssertEqual(counter.value, expectedValue)
+        }
+    }
+
+    func testMainActorCachedValue_repeatedCalls_onlyEvaluateValueOnce() {
+        let counter = Counter()
+
+        let evaluation: @MainActor @Sendable () -> String = {
+            counter.value += 1
+            return "value"
+        }
+
+        let cachedValue = MainActorCachedValue(evaluation)
+
+        testCounter(counter, expectedValue: 0)
+        XCTAssertEqual(cachedValue.value, "value")
+        testCounter(counter, expectedValue: 1)
+        XCTAssertEqual(cachedValue.value, "value")
+        testCounter(counter, expectedValue: 1)
+    }
+
+    func testMainActorCachedValue_multipleAsyncCalls_doNotDeadlock() {
+        let expectation = XCTestExpectation(description: "Completed")
+        let delay: TimeInterval = 0.25
+        let evaluation: @MainActor @Sendable () -> String = {
+            // For this test, delay evaluation to coerce
+            // multiple async evaluations to overlap
+            Thread.sleep(forTimeInterval: delay)
+            return "value"
+        }
+
+        let cachedValue = MainActorCachedValue(evaluation)
+
+        let callCount = 5
+        let lock = NSLock()
+        nonisolated(unsafe) var resolved = 0
+        for _ in 0..<callCount {
+            DispatchQueue.global().async {
+                XCTAssertEqual(cachedValue.value, "value")
+                lock.lock()
+                resolved += 1
+                if resolved == callCount {
+                    expectation.fulfill()
+                }
+                lock.unlock()
+            }
+        }
+
+        wait(for: [expectation], timeout: delay * Double(callCount + 1))
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16307)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34661)

## :bulb: Description

This fixes a race condition in our UIDeviceDetails utility. It moves that utility away from the previous `getMainThreadDataSynchronously` implementation and towards a custom caching solution that manages its own lock for the read/write. This change allows us to avoid the deadlock and still hit these properties from any thread.

### Deadlock Details

The previous deadlock (and related hangs showing up in our Xcode reports) is caused by a race condition. If thread B (background thread) attempts to access one of the static `UIDeviceDetail` properties that call `getMainThreadDataSynchronously`, it will ultimately have to call into the MT to resolve the value. The problem is if a timing issue arises where the MT also is calling into the same static property while Thread B is resolving. In this scenario, the MT becomes effectively locked on the underlying dispatch_once lock guarding the static property, because it is waiting for Thread B to resolve. But Thread B is now calling into main.sync() which stalls Thread B and prevents forward progress. When this happens, both threads are stalled and can’t move forward.

### The Key Change

This code moves us away from the previous `static let` properties which are protected by an under-the-hood dispatch_once lock. Instead we are using computed properties now that just hit the cache wrapper. That utility in turn manages its own lock but does not hold the lock when it needs to actually call main.sync(). Note: there is a possibility of race conditions still hitting these nearly-simultaneously, but in this case it is harmless because all that will happen is that it will compute the cached value more than once. But this is fine for our purposes as long as we are not deadlocking/hanging. And once cached, the "fast" cache value will be returned from then on for any thread.

### Testing Note

Because the previous deadlock was actually happening in Swift's under-the-hood dispatch_once lock, this scenario is difficult to test in automation, because it is timing-sensitive. You can create a trivial POC to replicate the deadlock, but if you want to ensure the deadlock hits 100% it requires introducing a delay _inside_ of the static property closure. But this only really matters if we're using the static let properties which, as discussed above, have been removed in this PR (we're now using computed properties that hit the backing cache value each time). It might be possible to add a unit-test-only-delay and write a test for the original deadlock in an effort to safeguard against regressions but I am not sure if that even makes sense since the current code can't deadlock in the same way. @ih-codes Wanted to make sure I solicited your feedback on this, I'm happy to dig in further re: testing.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

