### PR TITLE
Bugfix FXIOS-16234 [Settings] Break BoolSetting retain cycle leaking AppSettingsTableViewController

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -436,7 +436,8 @@ class AppSettingsTableViewController: SettingsTableViewController,
                     defaultValue: true,
                     titleText: .AppSettingsClosePrivateTabsTitle,
                     statusText: .AppSettingsClosePrivateTabsDescription
-                ) { _ in
+                ) { [weak self] _ in
+                    guard let self else { return }
                     let action = TabTrayAction(windowUUID: self.windowUUID,
                                                actionType: TabTrayActionType.closePrivateTabsSettingToggled)
                     store.dispatch(action)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AppSettingsTableViewControllerTests.swift
@@ -131,6 +131,14 @@ class AppSettingsTableViewControllerTests: XCTestCase {
         XCTAssertNotNil(subject.parentCoordinator)
     }
 
+    func testGenerateSettings_whenRetainedBySubject_subjectDeallocates() {
+        let subject = createSubject()
+
+        subject.settings = subject.generateSettings()
+
+        XCTAssertFalse(subject.settings.isEmpty)
+    }
+
     // MARK: - Helper
     private func createSubject() -> AppSettingsTableViewController {
         let subject = AppSettingsTableViewController(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16234)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34554)

Fixes #34554

## :bulb: Description

Every visit to the main Settings screen leaked the `AppSettingsTableViewController` and everything it retains (including all its `Setting` objects), because of this cycle:

`AppSettingsTableViewController` → `settings` → `SettingSection` → `BoolSetting` ("Close Private Tabs") → `settingDidChange` closure → strong `self`

The fix captures `self` weakly in that closure, matching the pattern already used for `sendDailyUsagePingSettings.settingDidChange` in the same file. Behavior is unchanged: the closure can only fire from the setting's switch, which lives in the controller's own table view, so `self` is always present when it runs.

**Why existing tests didn't catch it:** `createSubject()` in `AppSettingsTableViewControllerTests` already calls `trackForMemoryLeaks(subject)`, but no test ever populated `subject.settings`, so the cycle was never created under test. The new test assigns `subject.settings = subject.generateSettings()` — exactly what `viewWillAppear` does — which fails the leak assertion without the fix and passes with it.

**Related finding (not included here):** `HomePageSettingViewController.WallpaperSettings` declares `var settings: SettingsTableViewController` as a strong reference, which creates the same species of cycle for the Homepage settings screen (sibling settings like `AccountSetting`/`HiddenSettings` use `unowned`). Happy to fix that in a follow-up if you agree it should be `unowned`/`weak`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code — regression test included; relying on CI for the authoritative run (local Xcode 26.0.1 cannot build current `main`, which requires 26.5)
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — n/a
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review — n/a
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n — n/a
- [ ] If needed, I updated documentation and added comments to complex code — n/a
