### PR TITLE
Add FXIOS-16314 [Nova] Wire Nova gradient privacy

### DIFF
--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -180,6 +180,17 @@ final class PrivateHomepageViewController: UIViewController,
         gradient.locations = [0, 0.5, 1]
     }
 
+    private func applyBackgroundGradient(to gradient: CAGradientLayer, theme: Theme) {
+        if theme.isNova {
+            gradient.colors = theme.colors.gradientPrivacy.cgColors
+            // Not using 3 stop locations, since gradientPrivacy has 2 colors
+            gradient.locations = nil
+        } else {
+            gradient.colors = theme.colors.layerHomepage.cgColors
+            gradient.locations = [0, 0.5, 1]
+        }
+    }
+
     // Constraints for trailing and leading padding on iPad (regular) should be larger than that of compact layout
     private func setupConstraintsForMultitasking() {
         let contentLayoutGuide = scrollView.contentLayoutGuide
@@ -217,7 +228,7 @@ final class PrivateHomepageViewController: UIViewController,
 
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
-        gradient.colors = theme.colors.layerHomepage.cgColors
+        applyBackgroundGradient(to: gradient, theme: theme)
         homepageHeaderCell.applyTheme(theme: theme)
         privateMessageCardCell.applyTheme(theme: theme)
     }
@@ -257,7 +268,8 @@ final class PrivateHomepageViewController: UIViewController,
             // gradient
             let renderedGradient = CAGradientLayer()
             setupGradient(renderedGradient)
-            renderedGradient.colors = themeManager.getCurrentTheme(for: windowUUID).colors.layerHomepage.cgColors
+            applyBackgroundGradient(to: renderedGradient,
+                                    theme: themeManager.getCurrentTheme(for: windowUUID))
             renderedGradient.frame = CGRect(x: 0, y: 0, width: bounds.width, height: bounds.height)
             renderedGradient.render(in: context.cgContext)
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16314)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR adds gradientPrivacy for Nova, used in private mode, as specified in Figma.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

