### PR TITLE
Localize NO-TICKET Revert NSCameraUsageDescription strings

### DIFF
--- a/firefox-ios/Client/ab.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/ab.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Абларҭа ҿыц";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox акамера ахархәоит QR-кодқәа рыҭыхразы, насгьы афотосахьақәеи авидеоқәеи рҭыхразы.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox иаҭахуп Face ID еиқәырханы иҟоу алогинқәеи ишәарҭоу акартақәеи рахь анеиразы.";

--- a/firefox-ios/Client/af.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/af.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Nuwe oortjie";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Hierdie laat mens foto’s neem en oplaai.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "Webwerwe wat u besoek kan dalk u ligging vra.";

--- a/firefox-ios/Client/an.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/an.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Nueva pestanya";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox usa a tuya camara ta escanear QRs y fer fotos y video.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox necesita Face ID pa acceder a os tuyos logins guardaus.";

--- a/firefox-ios/Client/anp.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/anp.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "नया टैब";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "इ से तोय आपनो विडियो ले आरू अपलोड कैर सकै छै.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "फायरफॉक्स तोहर पासवर्ड और भुगतान देखे खातिर फेस आईडी चाहे.";

--- a/firefox-ios/Client/ast.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/ast.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Llingüeta nueva";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox usa la cámara pa escaniar códigos QR y facer semeyes y vídeos.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox rique Face ID p'acceder a les contraseñes ya a los métodos de pagu guardaos.";

--- a/firefox-ios/Client/az.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/az.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Yeni Vərəq";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Bu sizə şəkil çəkmə və yükləmə imkanı verir.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "Daxil olduğunuz saytlar sizin yerinizi soruşa bilərlər.";

--- a/firefox-ios/Client/be.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/be.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Новая картка";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox выкарыстоўвае камеру, каб сканаваць QR-коды, здымаць фота і відэа.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox патрабуе Face ID для доступу да захаваных пароляў і спосабаў аплаты.";

--- a/firefox-ios/Client/bn.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/bn.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "নতুন ট্যাব";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox আপনার ক্যামেরা ব্যবহার করবে QR কোড স্ক্যান করার জন্য এবং ছবি তোলা ও ভিডিও করার জন্য।";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "আপনার সংরক্ষিত পাসওয়ার্ড ও পেমেন্টের মাধ্যম অ্যাক্সেস করতে Firefox এর ফেস আইডি প্রয়োজন।";

--- a/firefox-ios/Client/br.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/br.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Ivinell nevez";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Gant se e c’hallit kemer ha pellgas luc’hskeudennoù.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Face ID a zo rekis evit ma c’hallfe kaout Firefox ho kerioù-tremen enrollet hag ho toareoù paeañ.";

--- a/firefox-ios/Client/bs.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/bs.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Novi tab";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox koristi vašu kameru za skeniranje QR kodova i snimanje fotografija i video zapisa.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox zahtijeva Face ID za pristup vašim sačuvanim lozinkama i načinima plaćanja.";

--- a/firefox-ios/Client/da.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/da.lproj/InfoPlist.strings
@@ -8,7 +8,7 @@
 "New Tab" = "Nyt faneblad";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox bruger dit kamera til at skanne QR-koder, tage billeder og optage video.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox kræver Face ID for at få adgang til dine gemte adgangskoder og betalingsmetoder.";

--- a/firefox-ios/Client/es-ES.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/es-ES.lproj/InfoPlist.strings
@@ -8,7 +8,7 @@
 "New Tab" = "Nueva pestaña";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox usa tu cámara para escanear códigos QR y realizar fotos y videos.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox requiere Face ID para acceder a tus contraseñas y métodos de pago guardados.";

--- a/firefox-ios/Client/es.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/es.lproj/InfoPlist.strings
@@ -8,7 +8,7 @@
 "New Tab" = "Nueva pestaña";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox usa tu cámara para escanear códigos QR y realizar fotos y videos.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox requiere Face ID para acceder a tus contraseñas y métodos de pago guardados.";

--- a/firefox-ios/Client/et.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/et.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Uus kaart";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox kasutab sinu kaamerat QR-koodide skannimiseks ning fotode ja videote tegemiseks.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox vajab salvestatud paroolidele ja makseviisidele ligipääsuks Face-ID'd.";

--- a/firefox-ios/Client/fa.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/fa.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "زبانه‌ جدید";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "فایرفاکس از دوربین شما برای پردازش کد QR یا گرفتن عکس یا ویدیو شما استفاده می‌کند.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "وب سایت‌هایی که شما بازدید میکنید ممکن است مکان شما را درخواست کنند.";

--- a/firefox-ios/Client/ga.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/ga.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Cluaisín Nua";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Ligeann seo duit pictiúir a thógáil agus a uaslódáil.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "D'fhéadfadh suíomhanna a dtugann tú cuairt orthu do láthair a iarraidh.";

--- a/firefox-ios/Client/gd.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/gd.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Taba ùr";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Bheir seo comas dhut dealbhan a thogail is a luchdadh suas.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Feumaidh Firefox Face ID mus fhaigh e cothrom air na faclan-faire is dòighean pàighidh a shàbhail thu.";

--- a/firefox-ios/Client/gl.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/gl.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Nova lapela";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Isto permítelle facer fotos e subilas.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox require Face ID para acceder aos teus contrasinais e aos métodos de pago gardados.";

--- a/firefox-ios/Client/gu-IN.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/gu-IN.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "નવું ટેબ";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "આ તમને ફોટા લેવા અને અપલોડ કરવા દે છે.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "તમે મુલાકાત લો છો તે વેબસાઇટ્સ તમારા સ્થાનની વિનંતી કરી શકે છે.";

--- a/firefox-ios/Client/hi-IN.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/hi-IN.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "नया टैब";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "यह आपको तस्वीरें लेने और अपलोड करने देता है।";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "आपके द्वारा देखे गए वेबसाइट आपके स्थान का अनुरोध कर सकते हैं।";

--- a/firefox-ios/Client/hr.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/hr.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Nova kartica";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox koristi tvoju kameru za snimanje QR kodova, fotografija i videa.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox zahtijeva Face ID za pristup tvojim spremljenim lozinkama i načinima plaćanja.";

--- a/firefox-ios/Client/id.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/id.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Tab Baru";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox menggunakan kamera Anda untuk memindai kode QR dan mengambil foto dan video.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox memerlukan Face ID untuk mengakses kata sandi dan metode pembayaran Anda yang tersimpan.";

--- a/firefox-ios/Client/jv.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/jv.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Tab Anyar";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Ngidinké sampéyan njepret lan ngunggah poto.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "Situs kang sampéyan tiliki njaluk lokasi sampéyan.";

--- a/firefox-ios/Client/kab.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/kab.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Iccer amaynut";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Ayagi ad k-isireg tuṭṭfa d usali n tvidyutin.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox yesra Face ID i unekcum ɣer wawalen-ik·im uffiren d tarrayin n uxelleṣ yettwawgelhen.";

--- a/firefox-ios/Client/kn.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/kn.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "ಹೊಸ ಟ್ಯಾಬ್‍";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "ಇದು ನಿಮ್ಮನ್ನು ಫೋಟೊ ತೆಗೆಯಲು ಮತ್ತು ಅಪ್ಲೋಡ್ ಮಾಡಲು ಬಿಡುತ್ತದೆ.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "‍ನೀವು ಭೇಟಿ ನೀಡುವ ಜಾಲತಾಣಗಳು ನಿಮ್ಮ ಸ್ಥಳ ಮಾಹಿತಿಯನ್ನು ಕೇಳಬಹುದು.";

--- a/firefox-ios/Client/lo.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/lo.lproj/InfoPlist.strings
@@ -8,7 +8,7 @@
 "New Tab" = "ແທັບໃຫມ່";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "ສິ່ງນີ້ຈະເຮັດໃຫ້ທ່ານຖ່າຍ ແລະ ອັບໂຫລດຮູບພາບໄດ້.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox ຕ້ອງການ Face ID ເພື່ອເຂົ້າເຖິງລະຫັດຜ່ານທີ່ບັນທຶກໄວ້ ແລະ ວິທີການຊໍາລະເງິນຂອງທ່ານ.";

--- a/firefox-ios/Client/lt.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/lt.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Nauja kortelė";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "„Firefox“ naudoja jūsų kamerą QR kodų nuskaitymui, nuotraukų darymui, ir vaizdo įrašams.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "Svetainės gali teirautis jūsų buvimo vietos.";

--- a/firefox-ios/Client/lv.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/lv.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Jauna cilne";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Šis ļauj uzņemt un augšupielādēt foto.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "Lapas, ko apmeklējat var prasīt jūsu atrašanās vietu.";

--- a/firefox-ios/Client/mr.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/mr.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "नवीन टॅब";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "हे आपल्याला फोटो घेऊ व अपलोड करू देते.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "आपण भेट देता त्या वेबसाइट आपल्या स्थानाची विनंती करू शकतात.";

--- a/firefox-ios/Client/ms.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/ms.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Tab Baru";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Ciri ini membolehkan anda mengambil dan memuat naik foto.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "Laman web yang anda lawati mungkin meminta lokasi anda.";

--- a/firefox-ios/Client/my.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/my.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "တပ်ဗ်အသစ်";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "ဓါတ်ပုံရိုက်ခြင်းနှင့် တင်ပို့ခြင်းတို့ကို ဆောင်ရွက်နိုင်စေသည်။";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox သည် သင်၏သိမ်းဆည်းထားသော စကားဝှက်များနှင့် ငွေပေးချေမှုနည်းလမ်းများကို အသုံးပြုရန်အတွက် Face ID လိုအပ်သည်။";

--- a/firefox-ios/Client/ne-NP.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/ne-NP.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "नयाँ ट्याब";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox ले QR कोडहरू स्क्यान गर्न र फोटो र भिडियो खिच्न तपाईंको क्यामरा प्रयोग गर्दछ।";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "तपाईंले भ्रमण गर्ने वेबसाइटहरूले तपाईंको स्थान अनुरोध गर्न सक्छन् ।";

--- a/firefox-ios/Client/oc.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/oc.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Onglet novèl";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Aquò vos permet de prendre e d’enviar de fotos.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "Los sites que visitatz pòdon demandar ont sètz.";

--- a/firefox-ios/Client/or.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/or.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "ନୂତନ ଟ୍ୟାବ";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "ଏହା ଆପଣକୁ ଫଟୋ ଉଠାଇବା ଓ ଅପଲୋଡ଼ କରିବାର ସୁଯୋଗ ଦେବ ।";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "ଆପଣ ଦେଖୁଥିବା ୱେବସାଇଟସବୁ ଆପଣଙ୍କ ଅବସ୍ଥିତି ମାଗିପାରନ୍ତି ।";

--- a/firefox-ios/Client/sat-Olck.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/sat-Olck.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "ᱱᱟᱶᱟ ᱴᱮᱵ";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "ᱱᱚᱶᱟ ᱛᱮ ᱟᱢ ᱪᱤᱛᱟᱹᱨ ᱨᱟᱠᱟᱵ ᱟᱨ ᱞᱟᱫᱮ ᱫᱟᱰᱮᱭᱟᱜᱼᱟᱢ ᱾";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "ᱟᱢᱟᱜ ᱥᱟᱧᱪᱟᱣ ᱨᱩᱠᱷᱭᱟᱹ ᱞᱳᱜᱤᱱ ᱨᱮ ᱵᱚᱞᱚᱱ ᱞᱟᱹᱜᱤᱱ Firefox ᱟᱢᱟᱜ ᱢᱮᱫᱦᱟᱸ ID ᱞᱟᱹᱠᱛᱤᱜ ᱠᱟᱱᱟᱭ ᱾";

--- a/firefox-ios/Client/scn.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/scn.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Nova scheda";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox usa a fotucàmmira pi scanziunari i còdici QR e fari fotu e vidiu.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox abbisogna dû Face ID p’accèdiri ê to chiavi e i furmi di pagamentu sarbati.";

--- a/firefox-ios/Client/ses.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/ses.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Kanji taaga";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Woo ga naŋ war ma biyey zaa k'i zijandi.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "Interneti nungey kaŋ war g'i naaru ga hin ka war gorodogoo hãa.";

--- a/firefox-ios/Client/si.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/si.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "නව පටිත්ත";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "QR කේත සුපිරික්සීමට, ඡායාරූප සහ දෘශ්‍යක ගැනීමට ෆයර්ෆොක්ස් රූගතය භාවිතා කරයි.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "ෆයර්ෆොක්ස් සඳහා ඔබගේ සුරැකි පිවිසුම් හා සංකේතිත පත් වෙත ප්‍රවේශයට මුහුණේ හැඳු. වුවමනාය.";

--- a/firefox-ios/Client/sq.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/sq.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Skedë e Re";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox-i përdor kamerën tuaj për të skanuar kode QR dhe për të bërë foto dhe video.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox-i lyp Face ID që të hyjë në fjalëkalimet dhe metoda pagesash tuajat të ruajtura.";

--- a/firefox-ios/Client/su.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/su.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Tab Anyar";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox maké kaméra anjeun pikeun nyekén kode QR jeung moto sarta vidéo.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "Firefox butuh Face ID pikeun ngaksés sandi kedap nu disimpen jeung cara mayar.";

--- a/firefox-ios/Client/ta.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/ta.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "புதிய கீற்று";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "படங்களை எடுத்து பதிவேற்றச் செய்கிறது.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "வலைதள பக்கங்கள் உங்கள் இடத்தை கேட்கலாம்.";

--- a/firefox-ios/Client/te.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/te.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "కొత్త ట్యాబు";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "ఇది మీకు ఫోటోలను తీసుకొని అప్లోడ్ చేయడానికి అనుమతిస్తుంది.";
 
 /* Privacy - Face ID Usage Description */
 "NSFaceIDUsageDescription" = "మీరు భద్రపరచిన సంకేతపదాలను, చెల్లింపు పద్ధతులను చూడడానికి Firefoxకి ఫేస్ ID అవసరం.";

--- a/firefox-ios/Client/ur.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/ur.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "نیا ٹیب";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "Firefox QR کوڈز کو اسکین کرنے اور تصاویر اور ویڈیو لینے کیلئے آپ کے کیمرہ کا استعمال کرتا ہے۔";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "جن ویب سائٹ کا آُپ دورہ کریں شاید وہ آُپ سے محل وقوع کی درخواست کر سکتی ہیں۔";

--- a/firefox-ios/Client/uz.lproj/InfoPlist.strings
+++ b/firefox-ios/Client/uz.lproj/InfoPlist.strings
@@ -5,7 +5,7 @@
 "New Tab" = "Yangi ichki oyna";
 
 /* Privacy - Camera Usage Description */
-"NSCameraUsageDescription" = "Firefox can use your camera to scan QR codes or take photos and video.";
+"NSCameraUsageDescription" = "U rasmga tushirish va internetga yuklashda yordam beradi.";
 
 /* Privacy - Location When In Use Usage Description */
 "NSLocationWhenInUseUsageDescription" = "Ziyaret ettiğiniz web siteleri konumunuzu isteyebilir.";


### PR DESCRIPTION
## :bulb: Description
- Continuing reversions of untranslated `NSCameraUsageDescription` strings from #34418 (see [thread from last weeks import](https://github.com/mozilla-mobile/firefox-ios/pull/34342#discussion_r3437474003) for more info).
  - TL;DR (from @ih-codes): the InfoPlist.strings are translated differently than the strings in Strings.swift 😔 So we can't update a string without losing all translations.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

