### PR TITLE
Add FXIOS-16271 [Danger] Add userInterfaceIdiom detection

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -567,6 +567,7 @@ class CodeUsageDetector {
         case notifiable
         case unsafe
         case cspHeader
+        case userInterfaceIdiom
 
         var bundledHeader: String {
             switch self {
@@ -589,6 +590,13 @@ class CodeUsageDetector {
                 return "### 🔒 Security: CSP `unsafe-` detected\nPlease request a security review."
             case .cspHeader:
                 return "### 🔒 Security: `Content-Security-Policy` change detected\nPlease request a security review."
+            case .userInterfaceIdiom:
+                return """
+                ### ⚠️ `userInterfaceIdiom` usage detected
+                Per Apple's WWDC 26 "Modernize your UIKit app" guidance, avoid checking `userInterfaceIdiom` for layout \
+                decisions. iPhone apps running on iPad or in iPhone Mirroring on Mac still report the phone idiom. \
+                Prefer size classes or trait-based layout instead.
+                """
             }
         }
 
@@ -612,6 +620,8 @@ class CodeUsageDetector {
                 return "unsafe-"
             case .cspHeader:
                 return "Content-Security-Policy"
+            case .userInterfaceIdiom:
+                return "userInterfaceIdiom"
             }
         }
 
@@ -637,7 +647,7 @@ class CodeUsageDetector {
         // Decide if we want to `warn` instead of `fail` on the pull request.
         var shouldWarn: Bool {
             switch self {
-            case .deferred, .notifiable:
+            case .deferred, .notifiable, .userInterfaceIdiom:
                 return true
             default:
                 return false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16271)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34593)

## :bulb: Description
Warn on userInterfaceIdiom with Danger

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

