### PR TITLE
Bugfix FXIOS-15847 [Homepage] Serve last known sponsored tiles while revalidating in the background

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesManager.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesManager.swift
@@ -120,7 +120,8 @@ final class TopSitesManager: TopSitesManagerInterface, UserFeaturePreferenceProv
                 continuation: continuation
             )
 
-            unifiedAdsProvider.fetchTiles { [weak self] result in
+            Task { [weak self, unifiedAdsProvider] in
+                let result = await unifiedAdsProvider.fetchTiles()
                 timeoutTask.cancel()
                 Self.resumeSponsoredTilesFetch(
                     result,

--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
@@ -10,9 +10,14 @@ import Shared
 typealias UnifiedTileResult = Swift.Result<[UnifiedTile], Error>
 
 protocol UnifiedAdsProviderInterface: Sendable {
-    /// Fetch unififed ads tiles
+    /// Fetch unified ads tiles.
+    ///
+    /// When tiles were fetched recently (see `UnifiedAdsProvider.maxTileStaleness`), the
+    /// completion is called synchronously with the last known tiles and a refresh runs in
+    /// the background for the next caller. Otherwise the blocking ads client request runs
+    /// on a dedicated queue and the completion is called from that queue.
     /// - Parameters:
-    ///   - timestamp: The timestamp to retrieve from cache, useful for tests. Default is Date.now()
+    ///   - timestamp: The timestamp to validate the cache against, useful for tests. Default is Date.now()
     ///   - completion: Returns an array of Tiles, can be empty
     func fetchTiles(timestamp: Shared.Timestamp, completion: @escaping @Sendable (UnifiedTileResult) -> Void)
 }
@@ -23,9 +28,22 @@ extension UnifiedAdsProviderInterface {
     }
 }
 
-final class UnifiedAdsProvider: UnifiedAdsProviderInterface, Sendable {
+final class UnifiedAdsProvider: UnifiedAdsProviderInterface, @unchecked Sendable {
     private let adsClient: MozAdsClient
     private let logger: Logger
+    private let fetchQueue: DispatchQueueInterface
+
+    /// How long the last successfully fetched tiles may keep being served while they get
+    /// refreshed in the background. The ads client refreshes its own cache every 30 minutes
+    /// with a network request that can block the homepage's top sites section on slow
+    /// networks (see FXIOS-15847), so serving the last known tiles for up to an hour keeps
+    /// that section instant without letting stale ads live for longer than one extra cycle.
+    static let maxTileStaleness: Timestamp = OneHourInMilliseconds
+
+    private let cacheLock = NSLock()
+    private var lastKnownTiles: [UnifiedTile]?
+    private var lastFetchTimestamp: Timestamp = 0
+    private var isRevalidating = false
 
     enum Error: Swift.Error {
         case noDataAvailable
@@ -43,10 +61,15 @@ final class UnifiedAdsProvider: UnifiedAdsProviderInterface, Sendable {
 
     init(
         adsClientFactory: MozAdsClientFactory = DefaultMozAdsClientFactory(),
-        logger: Logger = DefaultLogger.shared
+        logger: Logger = DefaultLogger.shared,
+        fetchQueue: DispatchQueueInterface = DispatchQueue(
+            label: "org.mozilla.ios.unified-ads-fetch",
+            qos: .userInitiated
+        )
     ) {
         self.adsClient = adsClientFactory.createClient()
         self.logger = logger
+        self.fetchQueue = fetchQueue
     }
 
     private struct AdPlacement: Codable {
@@ -61,6 +84,25 @@ final class UnifiedAdsProvider: UnifiedAdsProviderInterface, Sendable {
 
     func fetchTiles(timestamp: Shared.Timestamp = Date.now(),
                     completion: @escaping @Sendable (UnifiedTileResult) -> Void) {
+        if let lastKnownTiles = lastKnownTiles(at: timestamp) {
+            logger.log("Serving last known tiles while revalidating in the background",
+                       level: .debug,
+                       category: .homepage)
+            completion(.success(lastKnownTiles))
+            revalidateLastKnownTiles(timestamp: timestamp)
+            return
+        }
+
+        fetchQueue.async { [self] in
+            completion(requestTiles(timestamp: timestamp))
+        }
+    }
+
+    /// Runs the blocking ads client request and caches the tiles on success. The dedicated
+    /// `fetchQueue` keeps a slow request from tying up a Swift Concurrency cooperative
+    /// thread, and caching here means results that arrive after the top sites section
+    /// stopped waiting for them still get served on the next homepage build.
+    private func requestTiles(timestamp: Shared.Timestamp) -> UnifiedTileResult {
         logger.log("Fetching tiles with ads client", level: .debug, category: .homepage)
         let mozAdRequests = TileOrder.placementOrder.map {
             MozAdsPlacementRequest(iabContent: nil, placementId: $0)
@@ -76,10 +118,47 @@ final class UnifiedAdsProvider: UnifiedAdsProviderInterface, Sendable {
             }
 
             logger.log("Ads client request successful", level: .info, category: .homepage)
-            completion(.success(unifiedTiles))
+            storeLastKnownTiles(unifiedTiles, fetchedAt: timestamp)
+            return .success(unifiedTiles)
         } catch let error {
             logger.log("Ads client request failed: \(error)", level: .warning, category: .homepage)
-            completion(.failure(Error.noDataAvailable))
+            return .failure(Error.noDataAvailable)
+        }
+    }
+
+    private func lastKnownTiles(at timestamp: Shared.Timestamp) -> [UnifiedTile]? {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        guard let lastKnownTiles,
+              timestamp >= lastFetchTimestamp,
+              timestamp - lastFetchTimestamp <= Self.maxTileStaleness
+        else { return nil }
+        return lastKnownTiles
+    }
+
+    private func storeLastKnownTiles(_ tiles: [UnifiedTile], fetchedAt timestamp: Shared.Timestamp) {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        lastKnownTiles = tiles
+        lastFetchTimestamp = timestamp
+    }
+
+    /// Refreshes the last known tiles off the calling thread. A failed refresh keeps the
+    /// previous tiles so they can be served until `maxTileStaleness` runs out.
+    private func revalidateLastKnownTiles(timestamp: Shared.Timestamp) {
+        cacheLock.lock()
+        guard !isRevalidating else {
+            cacheLock.unlock()
+            return
+        }
+        isRevalidating = true
+        cacheLock.unlock()
+
+        fetchQueue.async { [self] in
+            _ = requestTiles(timestamp: timestamp)
+            cacheLock.lock()
+            isRevalidating = false
+            cacheLock.unlock()
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
@@ -12,23 +12,29 @@ typealias UnifiedTileResult = Swift.Result<[UnifiedTile], Error>
 protocol UnifiedAdsProviderInterface: Sendable {
     /// Fetch unified ads tiles.
     ///
-    /// When tiles were fetched recently (see `UnifiedAdsProvider.maxTileStaleness`), the
-    /// completion is called synchronously with the last known tiles and a refresh runs in
-    /// the background for the next caller. Otherwise the blocking ads client request runs
-    /// on a dedicated queue and the completion is called from that queue.
-    /// - Parameters:
-    ///   - timestamp: The timestamp to validate the cache against, useful for tests. Default is Date.now()
-    ///   - completion: Returns an array of Tiles, can be empty
-    func fetchTiles(timestamp: Shared.Timestamp, completion: @escaping @Sendable (UnifiedTileResult) -> Void)
+    /// When tiles were fetched recently (see `UnifiedAdsProvider.maxTileStaleness`), the last
+    /// known tiles are returned immediately and a refresh runs in the background for the next
+    /// caller. Otherwise the blocking ads client request runs on a dedicated queue, off the
+    /// Swift Concurrency cooperative pool, and its result is returned once it completes.
+    /// - Parameter timestamp: The timestamp to validate the cache against, useful for tests.
+    ///   Defaults to `Date.now()`.
+    /// - Returns: An array of tiles, which can be empty, or an error when no tiles are available.
+    func fetchTiles(timestamp: Shared.Timestamp) async -> UnifiedTileResult
 }
 
 extension UnifiedAdsProviderInterface {
-    func fetchTiles(timestamp: Shared.Timestamp = Date.now(), completion: @escaping @Sendable (UnifiedTileResult) -> Void) {
-        fetchTiles(timestamp: timestamp, completion: completion)
+    func fetchTiles(timestamp: Shared.Timestamp = Date.now()) async -> UnifiedTileResult {
+        await fetchTiles(timestamp: timestamp)
     }
 }
 
-final class UnifiedAdsProvider: UnifiedAdsProviderInterface, @unchecked Sendable {
+/// Serves sponsored tiles for the homepage, keeping the last known tiles in memory so the top
+/// sites section stays instant while the ads client's cache is revalidated in the background.
+///
+/// The cache is protected by actor isolation rather than a lock, and the blocking ads client
+/// request is bridged onto a dedicated queue so it never ties up a Swift Concurrency
+/// cooperative thread (see FXIOS-16156 / FXIOS-16307).
+actor UnifiedAdsProvider: UnifiedAdsProviderInterface {
     private let adsClient: MozAdsClient
     private let logger: Logger
     private let fetchQueue: DispatchQueueInterface
@@ -40,10 +46,9 @@ final class UnifiedAdsProvider: UnifiedAdsProviderInterface, @unchecked Sendable
     /// that section instant without letting stale ads live for longer than one extra cycle.
     static let maxTileStaleness: Timestamp = OneHourInMilliseconds
 
-    private let cacheLock = NSLock()
     private var lastKnownTiles: [UnifiedTile]?
     private var lastFetchTimestamp: Timestamp = 0
-    private var isRevalidating = false
+    private var revalidationTask: Task<Void, Never>?
 
     enum Error: Swift.Error {
         case noDataAvailable
@@ -82,53 +87,42 @@ final class UnifiedAdsProvider: UnifiedAdsProviderInterface, @unchecked Sendable
         let placements: [AdPlacement]
     }
 
-    func fetchTiles(timestamp: Shared.Timestamp = Date.now(),
-                    completion: @escaping @Sendable (UnifiedTileResult) -> Void) {
-        if let lastKnownTiles = lastKnownTiles(at: timestamp) {
+    func fetchTiles(timestamp: Shared.Timestamp = Date.now()) async -> UnifiedTileResult {
+        if let lastKnownTiles = validLastKnownTiles(at: timestamp) {
             logger.log("Serving last known tiles while revalidating in the background",
                        level: .debug,
                        category: .homepage)
-            completion(.success(lastKnownTiles))
             revalidateLastKnownTiles(timestamp: timestamp)
-            return
+            return .success(lastKnownTiles)
         }
 
-        fetchQueue.async { [self] in
-            completion(requestTiles(timestamp: timestamp))
-        }
+        return await requestTiles(timestamp: timestamp)
     }
 
-    /// Runs the blocking ads client request and caches the tiles on success. The dedicated
-    /// `fetchQueue` keeps a slow request from tying up a Swift Concurrency cooperative
-    /// thread, and caching here means results that arrive after the top sites section
-    /// stopped waiting for them still get served on the next homepage build.
-    private func requestTiles(timestamp: Shared.Timestamp) -> UnifiedTileResult {
-        logger.log("Fetching tiles with ads client", level: .debug, category: .homepage)
-        let mozAdRequests = TileOrder.placementOrder.map {
-            MozAdsPlacementRequest(iabContent: nil, placementId: $0)
+    /// Runs the blocking ads client request off the actor and caches the tiles on success.
+    /// Caching here means results that arrive after the top sites section stopped waiting for
+    /// them still get served on the next homepage build.
+    private func requestTiles(timestamp: Shared.Timestamp) async -> UnifiedTileResult {
+        let result = await performRequest()
+        if case .success(let tiles) = result {
+            lastKnownTiles = tiles
+            lastFetchTimestamp = timestamp
         }
-        do {
-            let mozAdsTiles = try adsClient.requestTileAds(
-                mozAdRequests: mozAdRequests,
-                options: nil
-            )
-            let unifiedTiles: [UnifiedTile] = TileOrder.placementOrder.compactMap { placement in
-                guard let mozAdsTile = mozAdsTiles[placement] else { return nil }
-                return UnifiedTile.from(name: placement, mozAdsTile: mozAdsTile)
+        return result
+    }
+
+    /// Bridges the blocking `requestTileAds` FFI call onto the dedicated `fetchQueue` so it
+    /// never occupies the actor's executor or a Swift Concurrency cooperative thread.
+    private func performRequest() async -> UnifiedTileResult {
+        let request = BlockingTileRequest(adsClient: adsClient, logger: logger)
+        return await withCheckedContinuation { continuation in
+            fetchQueue.async {
+                continuation.resume(returning: request.run())
             }
-
-            logger.log("Ads client request successful", level: .info, category: .homepage)
-            storeLastKnownTiles(unifiedTiles, fetchedAt: timestamp)
-            return .success(unifiedTiles)
-        } catch let error {
-            logger.log("Ads client request failed: \(error)", level: .warning, category: .homepage)
-            return .failure(Error.noDataAvailable)
         }
     }
 
-    private func lastKnownTiles(at timestamp: Shared.Timestamp) -> [UnifiedTile]? {
-        cacheLock.lock()
-        defer { cacheLock.unlock() }
+    private func validLastKnownTiles(at timestamp: Shared.Timestamp) -> [UnifiedTile]? {
         guard let lastKnownTiles,
               timestamp >= lastFetchTimestamp,
               timestamp - lastFetchTimestamp <= Self.maxTileStaleness
@@ -136,29 +130,55 @@ final class UnifiedAdsProvider: UnifiedAdsProviderInterface, @unchecked Sendable
         return lastKnownTiles
     }
 
-    private func storeLastKnownTiles(_ tiles: [UnifiedTile], fetchedAt timestamp: Shared.Timestamp) {
-        cacheLock.lock()
-        defer { cacheLock.unlock() }
-        lastKnownTiles = tiles
-        lastFetchTimestamp = timestamp
+    /// Refreshes the last known tiles in the background. A failed refresh keeps the previous
+    /// tiles so they can be served until `maxTileStaleness` runs out. Concurrent revalidations
+    /// coalesce into the one already in flight.
+    private func revalidateLastKnownTiles(timestamp: Shared.Timestamp) {
+        guard revalidationTask == nil else { return }
+        revalidationTask = Task { [weak self] in
+            _ = await self?.requestTiles(timestamp: timestamp)
+            await self?.finishRevalidation()
+        }
     }
 
-    /// Refreshes the last known tiles off the calling thread. A failed refresh keeps the
-    /// previous tiles so they can be served until `maxTileStaleness` runs out.
-    private func revalidateLastKnownTiles(timestamp: Shared.Timestamp) {
-        cacheLock.lock()
-        guard !isRevalidating else {
-            cacheLock.unlock()
-            return
-        }
-        isRevalidating = true
-        cacheLock.unlock()
+    private func finishRevalidation() {
+        revalidationTask = nil
+    }
 
-        fetchQueue.async { [self] in
-            _ = requestTiles(timestamp: timestamp)
-            cacheLock.lock()
-            isRevalidating = false
-            cacheLock.unlock()
+    /// Awaits the in-flight background revalidation, if any. Intended for tests that need to
+    /// observe the refreshed cache deterministically.
+    func awaitPendingRevalidation() async {
+        await revalidationTask?.value
+    }
+}
+
+/// Wraps the Rust-backed ads client so its blocking request can run off the actor. The client
+/// is thread-safe, which this box asserts, keeping `@unchecked Sendable` narrowly scoped here
+/// instead of applied to the whole provider.
+private struct BlockingTileRequest: @unchecked Sendable {
+    let adsClient: MozAdsClient
+    let logger: Logger
+
+    func run() -> UnifiedTileResult {
+        logger.log("Fetching tiles with ads client", level: .debug, category: .homepage)
+        let mozAdRequests = UnifiedAdsProvider.TileOrder.placementOrder.map {
+            MozAdsPlacementRequest(iabContent: nil, placementId: $0)
+        }
+        do {
+            let mozAdsTiles = try adsClient.requestTileAds(
+                mozAdRequests: mozAdRequests,
+                options: nil
+            )
+            let unifiedTiles: [UnifiedTile] = UnifiedAdsProvider.TileOrder.placementOrder.compactMap { placement in
+                guard let mozAdsTile = mozAdsTiles[placement] else { return nil }
+                return UnifiedTile.from(name: placement, mozAdsTile: mozAdsTile)
+            }
+
+            logger.log("Ads client request successful", level: .info, category: .homepage)
+            return .success(unifiedTiles)
+        } catch let error {
+            logger.log("Ads client request failed: \(error)", level: .warning, category: .homepage)
+            return .failure(UnifiedAdsProvider.Error.noDataAvailable)
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsProviderTests.swift
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 import MozillaAppServices
+import Shared
 import XCTest
 
 @testable import Client
@@ -15,6 +17,7 @@ class MockMozAdsClient: MozAdsClient, @unchecked Sendable {
 
     var recordClickCalledWith: String?
     var recordImpressionCalledWith: String?
+    var requestTileAdsCalledCount = 0
 
     init() {
         super.init(noHandle: MozAdsClient.NoHandle())
@@ -55,14 +58,49 @@ class MockMozAdsClient: MozAdsClient, @unchecked Sendable {
         mozAdRequests: [MozAdsPlacementRequest],
         options: MozAdsRequestOptions?
     ) throws -> [String: MozillaAppServices.MozAdsTile] {
+        requestTileAdsCalledCount += 1
         if let error = mockError { throw error }
         return mockAdsTiles ?? [:]
+    }
+}
+
+/// Collects dispatched work so tests can control when the provider's fetch queue runs,
+/// simulating requests that are still in flight.
+private final class PendingWorkDispatchQueue: DispatchQueueInterface, @unchecked Sendable {
+    private(set) var pendingWork: [() -> Void] = []
+
+    func runAllPendingWork() {
+        let work = pendingWork
+        pendingWork = []
+        work.forEach { $0() }
+    }
+
+    func async(group: DispatchGroup?,
+               qos: DispatchQoS,
+               flags: DispatchWorkItemFlags,
+               execute work: @escaping @Sendable @convention(block) () -> Void) {
+        pendingWork.append(work)
+    }
+
+    func asyncAfter(deadline: DispatchTime,
+                    qos: DispatchQoS,
+                    flags: DispatchWorkItemFlags,
+                    execute work: @escaping @Sendable @convention(block) () -> Void) {
+        pendingWork.append(work)
+    }
+
+    func asyncAfter(deadline: DispatchTime, execute: DispatchWorkItem) {
+        pendingWork.append { execute.perform() }
     }
 }
 
 @MainActor
 class UnifiedAdsProviderTests: XCTestCase {
     private var mockAdsClient: MockMozAdsClient!
+
+    private let baseTimestamp: Timestamp = 1_735_000_000_000
+    private let oneMinute: Timestamp = OneMinuteInMilliseconds
+    private let maxStaleness: Timestamp = UnifiedAdsProvider.maxTileStaleness
 
     override func setUp() async throws {
         try await super.setUp()
@@ -78,148 +116,254 @@ class UnifiedAdsProviderTests: XCTestCase {
     }
 
     func testFetchTiles_whenSuccessful_thenReturnsTiles() {
-        let adTile1 = MozAdsTile(
-            blockKey: "12345",
-            callbacks: MozAdsCallbacks(
-                click: "https://www.test2.com",
-                impression: "https://www.test3.com",
-                report: nil
-            ),
-            format: "tile",
-            imageUrl: "https://www.test4.com",
-            name: "newtab_mobile_tile_1",
-            url: "https://www.test1.com"
-        )
-
-        let adTile2 = MozAdsTile(
-            blockKey: "6789",
-            callbacks: MozAdsCallbacks(
-                click: "https://www.test6.com",
-                impression: "https://www.test7.com",
-                report: nil
-            ),
-            format: "tile",
-            imageUrl: "https://www.test8.com",
-            name: "newtab_mobile_tile_2",
-            url: "https://www.test5.com"
-        )
-
         mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": adTile1,
-            "newtab_mobile_tile_2": adTile2
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.test1.com"),
+            "newtab_mobile_tile_2": createAdTile(name: "newtab_mobile_tile_2", url: "https://www.test5.com")
         ]
 
         let subject = createSubject()
 
-        subject.fetchTiles { result in
-            switch result {
-            case let .success(tiles):
-                XCTAssertEqual(tiles.count, 2)
-                XCTAssertEqual(tiles[0].url, "https://www.test1.com")
-                XCTAssertEqual(tiles[1].url, "https://www.test5.com")
-            default:
-                XCTFail("Expected success, got \(result) instead")
-            }
-        }
+        fetchTilesAndExpect(tileURLs: ["https://www.test1.com", "https://www.test5.com"],
+                            from: subject,
+                            timestamp: baseTimestamp)
     }
 
     func testFetchTiles_whenInvertedOrder_thenReturnsProperTileOrder() {
-        let adTile1 = MozAdsTile(
-            blockKey: "12345",
-            callbacks: MozAdsCallbacks(
-                click: "https://www.test2.com",
-                impression: "https://www.test3.com",
-                report: nil
-            ),
-            format: "tile",
-            imageUrl: "https://www.test4.com",
-            name: "newtab_mobile_tile_1",
-            url: "https://www.test1.com"
-        )
-
-        let adTile2 = MozAdsTile(
-            blockKey: "6789",
-            callbacks: MozAdsCallbacks(
-                click: "https://www.test6.com",
-                impression: "https://www.test7.com",
-                report: nil
-            ),
-            format: "tile",
-            imageUrl: "https://www.test8.com",
-            name: "newtab_mobile_tile_2",
-            url: "https://www.test5.com"
-        )
-
         // Insert position2 before position1 to verify the order does not depend
         // on the dictionary's iteration order.
         mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_2": adTile2,
-            "newtab_mobile_tile_1": adTile1
+            "newtab_mobile_tile_2": createAdTile(name: "newtab_mobile_tile_2", url: "https://www.test5.com"),
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.test1.com")
         ]
 
         let subject = createSubject()
 
-        subject.fetchTiles { result in
-            switch result {
-            case let .success(tiles):
-                XCTAssertEqual(tiles.count, 2)
-                XCTAssertEqual(tiles[0].url, "https://www.test1.com")
-                XCTAssertEqual(tiles[1].url, "https://www.test5.com")
-            default:
-                XCTFail("Expected success, got \(result) instead")
-            }
-        }
+        fetchTilesAndExpect(tileURLs: ["https://www.test1.com", "https://www.test5.com"],
+                            from: subject,
+                            timestamp: baseTimestamp)
     }
 
     func testFetchTiles_whenOnlyFirstPlacement_thenReturnsSingleTile() {
-        let adTile1 = MozAdsTile(
-            blockKey: "12345",
-            callbacks: MozAdsCallbacks(
-                click: "https://www.test2.com",
-                impression: "https://www.test3.com",
-                report: nil
-            ),
-            format: "tile",
-            imageUrl: "https://www.test4.com",
-            name: "newtab_mobile_tile_1",
-            url: "https://www.test1.com"
-        )
-
-        mockAdsClient.mockAdsTiles = ["newtab_mobile_tile_1": adTile1]
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.test1.com")
+        ]
 
         let subject = createSubject()
 
-        subject.fetchTiles { result in
-            switch result {
-            case let .success(tiles):
-                XCTAssertEqual(tiles.count, 1)
-                XCTAssertEqual(tiles[0].url, "https://www.test1.com")
-            default:
-                XCTFail("Expected success, got \(result) instead")
-            }
-        }
+        fetchTilesAndExpect(tileURLs: ["https://www.test1.com"], from: subject, timestamp: baseTimestamp)
     }
 
-    func testFetchTiles_whenError_thenFailsWithError() {
+    func testFetchTiles_whenErrorAndNoLastKnownTiles_thenFailsWithError() {
         mockAdsClient.mockError = NSError(domain: "test", code: 1)
 
         let subject = createSubject()
+        let expectation = expectation(description: "fetchTiles completion is called")
 
-        subject.fetchTiles { result in
+        subject.fetchTiles(timestamp: baseTimestamp) { result in
             switch result {
             case let .failure(error as UnifiedAdsProvider.Error):
                 XCTAssertEqual(error, UnifiedAdsProvider.Error.noDataAvailable)
             default:
                 XCTFail("Expected failure, got \(result) instead")
             }
+            expectation.fulfill()
         }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - Serving last known tiles
+
+    func testFetchTiles_withinStalenessWindow_servesLastKnownTilesAndRevalidates() {
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
+        ]
+
+        let subject = createSubject()
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
+
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.refreshed.com")
+        ]
+
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
+                            from: subject,
+                            timestamp: baseTimestamp + 30 * oneMinute)
+        XCTAssertEqual(mockAdsClient.requestTileAdsCalledCount, 2, "Expected a background revalidation request")
+    }
+
+    func testFetchTiles_afterRevalidation_servesRefreshedTiles() {
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
+        ]
+
+        let subject = createSubject()
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
+
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.refreshed.com")
+        ]
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
+                            from: subject,
+                            timestamp: baseTimestamp + 30 * oneMinute)
+
+        fetchTilesAndExpect(tileURLs: ["https://www.refreshed.com"],
+                            from: subject,
+                            timestamp: baseTimestamp + 31 * oneMinute)
+    }
+
+    func testFetchTiles_atExactStalenessBound_servesLastKnownTiles() {
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
+        ]
+
+        let subject = createSubject()
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
+
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.refreshed.com")
+        ]
+
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
+                            from: subject,
+                            timestamp: baseTimestamp + maxStaleness)
+    }
+
+    func testFetchTiles_beyondStalenessWindow_fetchesFromAdsClient() {
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
+        ]
+
+        let subject = createSubject()
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
+
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.refreshed.com")
+        ]
+
+        fetchTilesAndExpect(tileURLs: ["https://www.refreshed.com"],
+                            from: subject,
+                            timestamp: baseTimestamp + maxStaleness + 1)
+        XCTAssertEqual(mockAdsClient.requestTileAdsCalledCount, 2)
+    }
+
+    func testFetchTiles_whenRevalidationFails_keepsServingLastKnownTiles() {
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
+        ]
+
+        let subject = createSubject()
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
+
+        mockAdsClient.mockError = NSError(domain: "test", code: 1)
+
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
+                            from: subject,
+                            timestamp: baseTimestamp + 30 * oneMinute)
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
+                            from: subject,
+                            timestamp: baseTimestamp + 31 * oneMinute)
+        XCTAssertEqual(mockAdsClient.requestTileAdsCalledCount, 3, "Expected one revalidation per served fetch")
+    }
+
+    func testFetchTiles_whenEmptySuccess_cachesEmptyTiles() {
+        mockAdsClient.mockAdsTiles = [:]
+
+        let subject = createSubject()
+        fetchTilesAndExpect(tileURLs: [], from: subject, timestamp: baseTimestamp)
+
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.refreshed.com")
+        ]
+
+        fetchTilesAndExpect(tileURLs: [], from: subject, timestamp: baseTimestamp + oneMinute)
+        fetchTilesAndExpect(tileURLs: ["https://www.refreshed.com"],
+                            from: subject,
+                            timestamp: baseTimestamp + 2 * oneMinute)
+    }
+
+    func testFetchTiles_whileRevalidationInFlight_doesNotStartSecondRevalidation() {
+        let pendingQueue = PendingWorkDispatchQueue()
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
+        ]
+
+        let subject = createSubject(fetchQueue: pendingQueue)
+        subject.fetchTiles(timestamp: baseTimestamp) { _ in }
+        pendingQueue.runAllPendingWork()
+
+        subject.fetchTiles(timestamp: baseTimestamp + 30 * oneMinute) { _ in }
+        subject.fetchTiles(timestamp: baseTimestamp + 31 * oneMinute) { _ in }
+
+        XCTAssertEqual(pendingQueue.pendingWork.count, 1, "Expected the in-flight revalidation to be reused")
+
+        pendingQueue.runAllPendingWork()
+        XCTAssertEqual(mockAdsClient.requestTileAdsCalledCount, 2)
+    }
+
+    func testFetchTiles_resultArrivingAfterCallerStoppedWaiting_isServedOnNextFetch() {
+        let pendingQueue = PendingWorkDispatchQueue()
+        mockAdsClient.mockAdsTiles = [
+            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
+        ]
+
+        let subject = createSubject(fetchQueue: pendingQueue)
+        subject.fetchTiles(timestamp: baseTimestamp) { _ in }
+
+        // The slow request completes only after the caller stopped waiting for it.
+        pendingQueue.runAllPendingWork()
+
+        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
+                            from: subject,
+                            timestamp: baseTimestamp + oneMinute)
+        XCTAssertFalse(pendingQueue.pendingWork.isEmpty, "Expected a background revalidation to be enqueued")
+        pendingQueue.runAllPendingWork()
     }
 
     // MARK: - Helper functions
 
-    func createSubject(file: StaticString = #filePath, line: UInt = #line) -> UnifiedAdsProvider {
+    private func fetchTilesAndExpect(
+        tileURLs expectedTileURLs: [String],
+        from subject: UnifiedAdsProvider,
+        timestamp: Timestamp,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let expectation = expectation(description: "fetchTiles completion is called")
+        subject.fetchTiles(timestamp: timestamp) { result in
+            switch result {
+            case let .success(tiles):
+                XCTAssertEqual(tiles.map(\.url), expectedTileURLs, file: file, line: line)
+            case .failure:
+                XCTFail("Expected success, got \(result) instead", file: file, line: line)
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    private func createAdTile(name: String, url: String) -> MozAdsTile {
+        return MozAdsTile(
+            blockKey: "12345",
+            callbacks: MozAdsCallbacks(
+                click: "\(url)/click",
+                impression: "\(url)/impression",
+                report: nil
+            ),
+            format: "tile",
+            imageUrl: "\(url)/image",
+            name: name,
+            url: url
+        )
+    }
+
+    func createSubject(
+        fetchQueue: DispatchQueueInterface = MockDispatchQueue(),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> UnifiedAdsProvider {
         let factory = MockMozAdsClientFactory(mockClient: mockAdsClient)
-        let subject = UnifiedAdsProvider(adsClientFactory: factory)
+        let subject = UnifiedAdsProvider(adsClientFactory: factory, fetchQueue: fetchQueue)
 
         trackForMemoryLeaks(subject, file: file, line: line)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/UnifiedAds/UnifiedAdsProviderTests.swift
@@ -67,30 +67,62 @@ class MockMozAdsClient: MozAdsClient, @unchecked Sendable {
 /// Collects dispatched work so tests can control when the provider's fetch queue runs,
 /// simulating requests that are still in flight.
 private final class PendingWorkDispatchQueue: DispatchQueueInterface, @unchecked Sendable {
-    private(set) var pendingWork: [() -> Void] = []
+    private let lock = NSLock()
+    private var enqueuedWork: [() -> Void] = []
+    private var enqueueWaiters: [CheckedContinuation<Void, Never>] = []
+
+    var pendingWork: [() -> Void] {
+        lock.lock()
+        defer { lock.unlock() }
+        return enqueuedWork
+    }
 
     func runAllPendingWork() {
-        let work = pendingWork
-        pendingWork = []
+        lock.lock()
+        let work = enqueuedWork
+        enqueuedWork = []
+        lock.unlock()
+
         work.forEach { $0() }
+    }
+
+    /// Suspends until at least one work item has been enqueued, so tests can deterministically
+    /// wait for the provider's background request to reach the queue.
+    func waitForPendingWork() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if !enqueuedWork.isEmpty {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                enqueueWaiters.append(continuation)
+                lock.unlock()
+            }
+        }
     }
 
     func async(group: DispatchGroup?,
                qos: DispatchQoS,
                flags: DispatchWorkItemFlags,
                execute work: @escaping @Sendable @convention(block) () -> Void) {
-        pendingWork.append(work)
+        lock.lock()
+        enqueuedWork.append(work)
+        let waiters = enqueueWaiters
+        enqueueWaiters = []
+        lock.unlock()
+
+        waiters.forEach { $0.resume() }
     }
 
     func asyncAfter(deadline: DispatchTime,
                     qos: DispatchQoS,
                     flags: DispatchWorkItemFlags,
                     execute work: @escaping @Sendable @convention(block) () -> Void) {
-        pendingWork.append(work)
+        async(group: nil, qos: qos, flags: flags, execute: work)
     }
 
     func asyncAfter(deadline: DispatchTime, execute: DispatchWorkItem) {
-        pendingWork.append { execute.perform() }
+        async(group: nil, qos: .unspecified, flags: []) { execute.perform() }
     }
 }
 
@@ -115,7 +147,7 @@ class UnifiedAdsProviderTests: XCTestCase {
         try await super.tearDown()
     }
 
-    func testFetchTiles_whenSuccessful_thenReturnsTiles() {
+    func testFetchTiles_whenSuccessful_thenReturnsTiles() async {
         mockAdsClient.mockAdsTiles = [
             "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.test1.com"),
             "newtab_mobile_tile_2": createAdTile(name: "newtab_mobile_tile_2", url: "https://www.test5.com")
@@ -123,12 +155,12 @@ class UnifiedAdsProviderTests: XCTestCase {
 
         let subject = createSubject()
 
-        fetchTilesAndExpect(tileURLs: ["https://www.test1.com", "https://www.test5.com"],
-                            from: subject,
-                            timestamp: baseTimestamp)
+        await fetchAndExpect(tileURLs: ["https://www.test1.com", "https://www.test5.com"],
+                             from: subject,
+                             timestamp: baseTimestamp)
     }
 
-    func testFetchTiles_whenInvertedOrder_thenReturnsProperTileOrder() {
+    func testFetchTiles_whenInvertedOrder_thenReturnsProperTileOrder() async {
         // Insert position2 before position1 to verify the order does not depend
         // on the dictionary's iteration order.
         mockAdsClient.mockAdsTiles = [
@@ -138,208 +170,200 @@ class UnifiedAdsProviderTests: XCTestCase {
 
         let subject = createSubject()
 
-        fetchTilesAndExpect(tileURLs: ["https://www.test1.com", "https://www.test5.com"],
-                            from: subject,
-                            timestamp: baseTimestamp)
+        await fetchAndExpect(tileURLs: ["https://www.test1.com", "https://www.test5.com"],
+                             from: subject,
+                             timestamp: baseTimestamp)
     }
 
-    func testFetchTiles_whenOnlyFirstPlacement_thenReturnsSingleTile() {
+    func testFetchTiles_whenOnlyFirstPlacement_thenReturnsSingleTile() async {
         mockAdsClient.mockAdsTiles = [
             "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.test1.com")
         ]
 
         let subject = createSubject()
 
-        fetchTilesAndExpect(tileURLs: ["https://www.test1.com"], from: subject, timestamp: baseTimestamp)
+        await fetchAndExpect(tileURLs: ["https://www.test1.com"], from: subject, timestamp: baseTimestamp)
     }
 
-    func testFetchTiles_whenErrorAndNoLastKnownTiles_thenFailsWithError() {
+    func testFetchTiles_whenErrorAndNoLastKnownTiles_thenFailsWithError() async {
         mockAdsClient.mockError = NSError(domain: "test", code: 1)
 
         let subject = createSubject()
-        let expectation = expectation(description: "fetchTiles completion is called")
+        let result = await subject.fetchTiles(timestamp: baseTimestamp)
 
-        subject.fetchTiles(timestamp: baseTimestamp) { result in
-            switch result {
-            case let .failure(error as UnifiedAdsProvider.Error):
-                XCTAssertEqual(error, UnifiedAdsProvider.Error.noDataAvailable)
-            default:
-                XCTFail("Expected failure, got \(result) instead")
-            }
-            expectation.fulfill()
+        switch result {
+        case let .failure(error as UnifiedAdsProvider.Error):
+            XCTAssertEqual(error, UnifiedAdsProvider.Error.noDataAvailable)
+        default:
+            XCTFail("Expected failure, got \(result) instead")
         }
-
-        waitForExpectations(timeout: 1)
     }
 
     // MARK: - Serving last known tiles
 
-    func testFetchTiles_withinStalenessWindow_servesLastKnownTilesAndRevalidates() {
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
-        ]
+    func testFetchTiles_withinStalenessWindow_servesLastKnownTilesAndRevalidates() async {
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.first.com")
 
         let subject = createSubject()
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
+        await fetchAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
 
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.refreshed.com")
-        ]
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.refreshed.com")
 
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
-                            from: subject,
-                            timestamp: baseTimestamp + 30 * oneMinute)
+        await fetchAndExpect(tileURLs: ["https://www.first.com"],
+                             from: subject,
+                             timestamp: baseTimestamp + 30 * oneMinute)
+        await subject.awaitPendingRevalidation()
         XCTAssertEqual(mockAdsClient.requestTileAdsCalledCount, 2, "Expected a background revalidation request")
     }
 
-    func testFetchTiles_afterRevalidation_servesRefreshedTiles() {
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
-        ]
+    func testFetchTiles_afterRevalidation_servesRefreshedTiles() async {
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.first.com")
 
         let subject = createSubject()
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
+        await fetchAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
 
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.refreshed.com")
-        ]
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
-                            from: subject,
-                            timestamp: baseTimestamp + 30 * oneMinute)
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.refreshed.com")
+        await fetchAndExpect(tileURLs: ["https://www.first.com"],
+                             from: subject,
+                             timestamp: baseTimestamp + 30 * oneMinute)
+        await subject.awaitPendingRevalidation()
 
-        fetchTilesAndExpect(tileURLs: ["https://www.refreshed.com"],
-                            from: subject,
-                            timestamp: baseTimestamp + 31 * oneMinute)
+        await fetchAndExpect(tileURLs: ["https://www.refreshed.com"],
+                             from: subject,
+                             timestamp: baseTimestamp + 31 * oneMinute)
+        await subject.awaitPendingRevalidation()
     }
 
-    func testFetchTiles_atExactStalenessBound_servesLastKnownTiles() {
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
-        ]
+    func testFetchTiles_atExactStalenessBound_servesLastKnownTiles() async {
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.first.com")
 
         let subject = createSubject()
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
+        await fetchAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
 
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.refreshed.com")
-        ]
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.refreshed.com")
 
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
-                            from: subject,
-                            timestamp: baseTimestamp + maxStaleness)
+        await fetchAndExpect(tileURLs: ["https://www.first.com"],
+                             from: subject,
+                             timestamp: baseTimestamp + maxStaleness)
+        await subject.awaitPendingRevalidation()
     }
 
-    func testFetchTiles_beyondStalenessWindow_fetchesFromAdsClient() {
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
-        ]
+    func testFetchTiles_beyondStalenessWindow_fetchesFromAdsClient() async {
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.first.com")
 
         let subject = createSubject()
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
+        await fetchAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
 
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.refreshed.com")
-        ]
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.refreshed.com")
 
-        fetchTilesAndExpect(tileURLs: ["https://www.refreshed.com"],
-                            from: subject,
-                            timestamp: baseTimestamp + maxStaleness + 1)
+        await fetchAndExpect(tileURLs: ["https://www.refreshed.com"],
+                             from: subject,
+                             timestamp: baseTimestamp + maxStaleness + 1)
         XCTAssertEqual(mockAdsClient.requestTileAdsCalledCount, 2)
     }
 
-    func testFetchTiles_whenRevalidationFails_keepsServingLastKnownTiles() {
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
-        ]
+    func testFetchTiles_whenRevalidationFails_keepsServingLastKnownTiles() async {
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.first.com")
 
         let subject = createSubject()
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
+        await fetchAndExpect(tileURLs: ["https://www.first.com"], from: subject, timestamp: baseTimestamp)
 
         mockAdsClient.mockError = NSError(domain: "test", code: 1)
 
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
-                            from: subject,
-                            timestamp: baseTimestamp + 30 * oneMinute)
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
-                            from: subject,
-                            timestamp: baseTimestamp + 31 * oneMinute)
+        await fetchAndExpect(tileURLs: ["https://www.first.com"],
+                             from: subject,
+                             timestamp: baseTimestamp + 30 * oneMinute)
+        await subject.awaitPendingRevalidation()
+
+        await fetchAndExpect(tileURLs: ["https://www.first.com"],
+                             from: subject,
+                             timestamp: baseTimestamp + 31 * oneMinute)
+        await subject.awaitPendingRevalidation()
         XCTAssertEqual(mockAdsClient.requestTileAdsCalledCount, 3, "Expected one revalidation per served fetch")
     }
 
-    func testFetchTiles_whenEmptySuccess_cachesEmptyTiles() {
+    func testFetchTiles_whenEmptySuccess_cachesEmptyTiles() async {
         mockAdsClient.mockAdsTiles = [:]
 
         let subject = createSubject()
-        fetchTilesAndExpect(tileURLs: [], from: subject, timestamp: baseTimestamp)
+        await fetchAndExpect(tileURLs: [], from: subject, timestamp: baseTimestamp)
 
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.refreshed.com")
-        ]
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.refreshed.com")
 
-        fetchTilesAndExpect(tileURLs: [], from: subject, timestamp: baseTimestamp + oneMinute)
-        fetchTilesAndExpect(tileURLs: ["https://www.refreshed.com"],
-                            from: subject,
-                            timestamp: baseTimestamp + 2 * oneMinute)
+        await fetchAndExpect(tileURLs: [], from: subject, timestamp: baseTimestamp + oneMinute)
+        await subject.awaitPendingRevalidation()
+        await fetchAndExpect(tileURLs: ["https://www.refreshed.com"],
+                             from: subject,
+                             timestamp: baseTimestamp + 2 * oneMinute)
+        await subject.awaitPendingRevalidation()
     }
 
-    func testFetchTiles_whileRevalidationInFlight_doesNotStartSecondRevalidation() {
+    func testFetchTiles_whileRevalidationInFlight_doesNotStartSecondRevalidation() async {
         let pendingQueue = PendingWorkDispatchQueue()
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
-        ]
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.first.com")
 
         let subject = createSubject(fetchQueue: pendingQueue)
-        subject.fetchTiles(timestamp: baseTimestamp) { _ in }
+
+        // Warm the cache with a cold fetch whose blocking work we run explicitly.
+        let coldFetch = Task { await subject.fetchTiles(timestamp: baseTimestamp) }
+        await pendingQueue.waitForPendingWork()
         pendingQueue.runAllPendingWork()
+        _ = await coldFetch.value
 
-        subject.fetchTiles(timestamp: baseTimestamp + 30 * oneMinute) { _ in }
-        subject.fetchTiles(timestamp: baseTimestamp + 31 * oneMinute) { _ in }
+        // The first warm fetch starts a revalidation; the second must reuse the in-flight one.
+        _ = await subject.fetchTiles(timestamp: baseTimestamp + 30 * oneMinute)
+        _ = await subject.fetchTiles(timestamp: baseTimestamp + 31 * oneMinute)
 
+        await pendingQueue.waitForPendingWork()
         XCTAssertEqual(pendingQueue.pendingWork.count, 1, "Expected the in-flight revalidation to be reused")
 
         pendingQueue.runAllPendingWork()
+        await subject.awaitPendingRevalidation()
         XCTAssertEqual(mockAdsClient.requestTileAdsCalledCount, 2)
     }
 
-    func testFetchTiles_resultArrivingAfterCallerStoppedWaiting_isServedOnNextFetch() {
+    func testFetchTiles_resultArrivingAfterCallerStoppedWaiting_isServedOnNextFetch() async {
         let pendingQueue = PendingWorkDispatchQueue()
-        mockAdsClient.mockAdsTiles = [
-            "newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: "https://www.first.com")
-        ]
+        mockAdsClient.mockAdsTiles = tiles(url: "https://www.first.com")
 
         let subject = createSubject(fetchQueue: pendingQueue)
-        subject.fetchTiles(timestamp: baseTimestamp) { _ in }
 
-        // The slow request completes only after the caller stopped waiting for it.
+        // The caller stops waiting for the result; the slow request only completes afterwards.
+        let coldFetch = Task { _ = await subject.fetchTiles(timestamp: baseTimestamp) }
+        await pendingQueue.waitForPendingWork()
         pendingQueue.runAllPendingWork()
+        _ = await coldFetch.value
 
-        fetchTilesAndExpect(tileURLs: ["https://www.first.com"],
-                            from: subject,
-                            timestamp: baseTimestamp + oneMinute)
+        await fetchAndExpect(tileURLs: ["https://www.first.com"],
+                             from: subject,
+                             timestamp: baseTimestamp + oneMinute)
+
+        await pendingQueue.waitForPendingWork()
         XCTAssertFalse(pendingQueue.pendingWork.isEmpty, "Expected a background revalidation to be enqueued")
         pendingQueue.runAllPendingWork()
+        await subject.awaitPendingRevalidation()
     }
 
     // MARK: - Helper functions
 
-    private func fetchTilesAndExpect(
+    private func fetchAndExpect(
         tileURLs expectedTileURLs: [String],
         from subject: UnifiedAdsProvider,
         timestamp: Timestamp,
         file: StaticString = #filePath,
         line: UInt = #line
-    ) {
-        let expectation = expectation(description: "fetchTiles completion is called")
-        subject.fetchTiles(timestamp: timestamp) { result in
-            switch result {
-            case let .success(tiles):
-                XCTAssertEqual(tiles.map(\.url), expectedTileURLs, file: file, line: line)
-            case .failure:
-                XCTFail("Expected success, got \(result) instead", file: file, line: line)
-            }
-            expectation.fulfill()
+    ) async {
+        let result = await subject.fetchTiles(timestamp: timestamp)
+        switch result {
+        case let .success(tiles):
+            XCTAssertEqual(tiles.map(\.url), expectedTileURLs, file: file, line: line)
+        case .failure:
+            XCTFail("Expected success, got \(result) instead", file: file, line: line)
         }
-        waitForExpectations(timeout: 1)
+    }
+
+    private func tiles(url: String) -> [String: MozAdsTile] {
+        return ["newtab_mobile_tile_1": createAdTile(name: "newtab_mobile_tile_1", url: url)]
     }
 
     private func createAdTile(name: String, url: String) -> MozAdsTile {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUnifiedAdsProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUnifiedAdsProvider.swift
@@ -7,20 +7,18 @@
 import Shared
 
 final class MockUnifiedAdsProvider: UnifiedAdsProviderInterface, @unchecked Sendable {
-    private var result: UnifiedTileResult?
+    private let result: UnifiedTileResult?
 
     init(result: UnifiedTileResult?) {
         self.result = result
     }
 
-    func fetchTiles(timestamp: Timestamp, completion: @escaping @Sendable (UnifiedTileResult) -> Void) {
-        guard let result else { return }
-
-        switch result {
-        case .success(let unifiedTiles):
-            completion(.success(unifiedTiles))
-        case .failure(let error):
-            completion(.failure(error))
+    func fetchTiles(timestamp: Timestamp) async -> UnifiedTileResult {
+        guard let result else {
+            // Simulates a provider that never returns, so the caller must rely on its own timeout.
+            try? await Task.sleep(nanoseconds: .max)
+            return .success([])
         }
+        return result
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15847)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33899)

## :bulb: Description

This implements the sponsored-shortcuts part of #33899 — "Use stale sponsored shortcuts … while refreshing the cache in the background" — scoped entirely to `UnifiedAdsProvider`, so it does not change how or when the homepage renders.

**Why the shortcuts section stalls on slow networks**

- `MozAdsClient.requestTileAds` is a blocking FFI call, and the ads client's HTTP cache hard-expires entries (default 30 minutes): [`delete_expired_entries()` runs before every lookup](https://github.com/mozilla/application-services/blob/main/components/ads-client/src/http_cache.rs), so once the TTL passes the client must go to the network — the previous response is unreadable at that point.
- `TopSitesMiddleware.getTopSitesDataAndUpdateState` dispatches a single `retrievedUpdatedSites` action that awaits both `getOtherSites()` (local, milliseconds) and `fetchSponsoredSites()`. With an expired ad cache on a slow network, the entire shortcuts section (pinned + history + Google tile — all local data) waits on the sponsored request until the 3-second timeout added in FXIOS-16077.
- When that timeout fires, two more things go wrong: the late result is discarded, so that homepage build shows no sponsored tiles at all; and the blocking call keeps occupying a Swift Concurrency cooperative-pool thread until the request actually finishes, since `fetchTiles` ran it synchronously on the calling task's thread (the same class of problem as FXIOS-16156 / FXIOS-16307).
- The legacy provider could serve its cached POST response via `URLCache` within `maxCacheAge` (30 min) without touching the network. That ability was lost in the Rust ads client migration (FXIOS-14580; legacy path removed with the flag in FXIOS-15992) — the `timestamp` parameter on `fetchTiles` has been vestigial since then.

**What this PR changes (all inside `UnifiedAdsProvider`)**

1. The blocking `requestTileAds` call now runs on a dedicated dispatch queue instead of the caller's thread, mirroring `DefaultUnifiedAdsCallbackTelemetry` (FXIOS-15787) and the merino WC fetcher fix (FXIOS-16156).
2. The provider keeps the last successfully fetched tiles in memory and, while they are at most `maxTileStaleness` (1 hour) old, completes immediately with them and revalidates in the background. After the first successful fetch of a session, a homepage build never waits on the ad network again. Concurrent revalidations are coalesced.
3. Results arriving after the caller stopped waiting (timeout) are cached, so the next homepage build gets tiles instantly instead of fetching again.

**Scope / behavior notes**

- Tiles still only change when the homepage naturally rebuilds (`initialize` / `didBecomeActive` / `topSitesUpdated`), so this does not introduce the mid-view content shifting that #33899 flags as needing design input.
- Cold start on an expired cache behaves exactly as today (single fetch, 3s cap); the in-memory cache intentionally does not persist.
- The Merino stories half of #33899 is untouched and could be a follow-up.
- I saw the Jira note that the Ads team is exploring an async/lazy-load AdsClient. This is deliberately a thin, self-contained layer over the existing client that is trivial to delete when that lands — happy to adjust or park this if you'd rather fold it into that work.

**Testing**

`UnifiedAdsProviderTests` covers every branch of the new behavior deterministically (no sleeps, timestamps injected): serving within / at / beyond the staleness bound, revalidation updating the cache, failed revalidation keeping the previous tiles, empty responses being cached, revalidation coalescing while one is in flight, and a late-arriving result being served on the next fetch. Existing tests were updated for the queue-based completion with explicit expectations. SwiftLint passes on the changed files; unit tests run in CI.

## :movie_camera: Demos

No visual changes — the shortcuts section simply appears without waiting on the ads request when tiles were fetched within the last hour.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
