### PR TITLE
MTE-5648 - Fix translation failing test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
@@ -24,6 +24,7 @@ final class ToolbarScreen {
     private var translateButton: XCUIElement { sel.TRANSLATE_BUTTON.element(in: app) }
     private var translateLoadingButton: XCUIElement { sel.TRANSLATE_LOADING_BUTTON.element(in: app) }
     private var translateActiveButton: XCUIElement { sel.TRANSLATE_ACTIVE_BUTTON.element(in: app) }
+    private var translateLanguageEnglishOption: XCUIElement { sel.TRANSLATE_LANGUAGE_ENGLISH_OPTION.element(in: app) }
 
     func assertSettingsButtonExists(timeout: TimeInterval = TIMEOUT) {
         let settingsButton = sel.SETTINGS_MENU_BUTTON.element(in: app)
@@ -182,6 +183,15 @@ final class ToolbarScreen {
             translateLoadingButton.waitAndTap()
         case .active:
             translateActiveButton.waitAndTap()
+        }
+    }
+
+    /// Selects English in the translation language picker action sheet when it is shown.
+    /// The picker only appears when the language picker feature is enabled and multiple
+    /// target languages are available, so this is a no-op when the sheet doesn't show.
+    func selectTranslationLanguageIfPresented(timeout: TimeInterval = TIMEOUT) {
+        if translateLanguageEnglishOption.mozWaitForElementToExist(timeout: timeout, failOnTimeout: false) {
+            translateLanguageEnglishOption.waitAndTap()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/ToolbarSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/ToolbarSelectors.swift
@@ -17,6 +17,7 @@ protocol ToolbarSelectorsSet {
     var TRANSLATE_BUTTON: Selector { get }
     var TRANSLATE_LOADING_BUTTON: Selector { get }
     var TRANSLATE_ACTIVE_BUTTON: Selector { get }
+    var TRANSLATE_LANGUAGE_ENGLISH_OPTION: Selector { get }
     var all: [Selector] { get }
 }
 
@@ -34,6 +35,7 @@ struct ToolbarSelectors: ToolbarSelectorsSet {
         static let translateButton = AccessibilityIdentifiers.Toolbar.translateButton
         static let translateLoadingButton = AccessibilityIdentifiers.Toolbar.translateLoadingButton
         static let translateActiveButton = AccessibilityIdentifiers.Toolbar.translateActiveButton
+        static let translateLanguageEnglishOption = "English"
     }
 
     let SETTINGS_MENU_BUTTON = Selector.buttonId(
@@ -108,6 +110,13 @@ struct ToolbarSelectors: ToolbarSelectorsSet {
         groups: ["browser", "toolbar", "translation"]
     )
 
+    // Language option in the translation language picker action sheet, matched by its title.
+    let TRANSLATE_LANGUAGE_ENGLISH_OPTION = Selector.buttonId(
+        IDs.translateLanguageEnglishOption,
+        description: "English option in the translation language picker",
+        groups: ["translation"]
+    )
+
     var all: [Selector] { [
         SETTINGS_MENU_BUTTON,
         TABS_BUTTON,
@@ -120,6 +129,7 @@ struct ToolbarSelectors: ToolbarSelectorsSet {
         HOME_BUTTON,
         TRANSLATE_BUTTON,
         TRANSLATE_LOADING_BUTTON,
-        TRANSLATE_ACTIVE_BUTTON
+        TRANSLATE_ACTIVE_BUTTON,
+        TRANSLATE_LANGUAGE_ENGLISH_OPTION
     ] }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
@@ -35,6 +35,9 @@ final class TranslationsTests: FeatureFlaggedTestBase {
         toolBarScreen.assertTranslateButtonExists(with: .inactive)
         toolBarScreen.tapTranslateButton(with: .inactive)
 
+        // A language picker may appear before translating; select English if it does
+        toolBarScreen.selectTranslationLanguageIfPresented()
+
         // Check that translation icon switches to loading (spinner) and eventually active mode (blue button)
         toolBarScreen.assertTranslateButtonExists(with: .loading)
         toolBarScreen.assertTranslateButtonExists(with: .active)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5648

## :bulb: Description
Handled the translation language picker action sheet that can appear after tapping the inactive translate button in testTranslationFlow_withDifferentStates_translationExperimentOn:

- ToolbarSelectors.swift — added a TRANSLATE_LANGUAGE_ENGLISH_OPTION selector matching the sheet's "English" button.
- ToolbarScreen.swift — added selectTranslationLanguageIfPresented(), which taps English only if the sheet shows (using failOnTimeout: false), so it's a no-op when the popup doesn't appear.
- TranslationTests.swift — called it right after tapTranslateButton(with: .inactive).
