### PR TITLE
[MTE-5684] - Improve flaky 18.6 tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -511,9 +511,24 @@ class BaseTestCase: XCTestCase {
         urlBar.pressWithRetry(duration: 2.0, element: pasteAction)
         mozWaitForElementToExist(app.tables["Context Menu"])
         pasteAction.waitAndTap()
-        springboard.buttons["Allow Paste"].tapIfExists(timeout: 1.5)
         mozWaitForElementToExist(urlBar)
-        mozWaitForValueContains(urlBar, value: url)
+        waitForPastedValue(in: urlBar, contains: url)
+    }
+
+    /// Waits for `element` to contain `url` after a paste, dismissing the "Allow Paste"
+    /// prompt whenever it shows, since a single check can miss its variable CI delay.
+    func waitForPastedValue(in element: XCUIElement, contains url: String, timeout: TimeInterval = TIMEOUT_LONG) {
+        let allowPaste = springboard.buttons["Allow Paste"]
+        let startTime = Date()
+        while true {
+            if allowPaste.exists { allowPaste.tap() }
+            if let value = element.value as? String, value.contains(url) { return }
+            if Date().timeIntervalSince(startTime) > timeout {
+                XCTFail("Timed out waiting for element \(element) to contain value \(url)")
+                return
+            }
+            usleep(10000)
+        }
     }
 
     func waitForElementsToExist(_ elements: [XCUIElement], timeout: TimeInterval = TIMEOUT, message: String? = nil) {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5684

## :bulb: Description
 New waitForPastedValue helper polls for the pasted value while dismissing the "Allow Paste" prompt whenever it appears (not a single 1.5s check), fixing the intermittent AddressToolbar.address timeout in the copy-URL Share tests. Verified on iOS 18.6.

