### PR TITLE
Bugfix FXIOS-16324 - App hangs when scheduled sync calls getCurrentDeviceId() on the main thread

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/FxAClient/FxAccountManager.swift
@@ -220,11 +220,20 @@ open class FxAccountManager: @unchecked Sendable {
     /// Get the device ID registered for this account.
     /// The device is registered synchronously during `finishAuthentication`, so this is available
     /// immediately after login without waiting for `DeviceConstellation.refreshState()`.
-    public func getCurrentDeviceId() -> Result<String, Error> {
-        do {
-            return try .success(requireAccount().getCurrentDeviceId())
-        } catch {
-            return .failure(error)
+    ///
+    /// This makes a blocking FFI call that acquires the account's internal mutex, so the work is
+    /// dispatched off the calling thread to avoid hanging the caller (e.g. the main thread) when
+    /// another thread is holding that mutex.
+    public func getCurrentDeviceId(
+        completionHandler: @escaping @MainActor @Sendable (Result<String, Error>) -> Void
+    ) {
+        DispatchQueue.global().async {
+            do {
+                let deviceID = try self.requireAccount().getCurrentDeviceId()
+                DispatchQueue.main.async { completionHandler(.success(deviceID)) }
+            } catch {
+                DispatchQueue.main.async { completionHandler(.failure(error)) }
+            }
         }
     }
 

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -590,15 +590,20 @@ public class RustSyncManager: NSObject, SyncManager, @unchecked Sendable {
         let deferred = Deferred<Maybe<SyncResult>>()
 
         logger.log("Syncing \(engines)", level: .info, category: .sync)
-        if let accountManager = RustFirefoxAccounts.shared.accountManager {
-            // Prefer accountState over deviceConstellation for the current
-            // device ID to avoid a possible server round-trip.
-            guard case .success(let deviceId) = accountManager.getCurrentDeviceId() else {
+        guard let accountManager = RustFirefoxAccounts.shared.accountManager else {
+            return deferred
+        }
+
+        // Prefer accountState over deviceConstellation for the current
+        // device ID to avoid a possible server round-trip. This runs off the
+        // main thread so the blocking FFI call can't hang the UI.
+        accountManager.getCurrentDeviceId { deviceIDResult in
+            guard case .success(let deviceId) = deviceIDResult else {
                 self.logger.log("Device Id could not be retrieved",
                                 level: .warning,
                                 category: .sync)
                 deferred.fill(Maybe(failure: DeviceIdError()))
-                return deferred
+                return
             }
 
             accountManager.getAccessToken(scope: OAuthScope.oldSync) { result in

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -597,6 +597,7 @@ public class RustSyncManager: NSObject, SyncManager, @unchecked Sendable {
         // Prefer accountState over deviceConstellation for the current
         // device ID to avoid a possible server round-trip. This runs off the
         // main thread so the blocking FFI call can't hang the UI.
+        // swiftlint:disable closure_body_length
         accountManager.getCurrentDeviceId { deviceIDResult in
             guard case .success(let deviceId) = deviceIDResult else {
                 self.logger.log("Device Id could not be retrieved",
@@ -644,6 +645,7 @@ public class RustSyncManager: NSObject, SyncManager, @unchecked Sendable {
                 }
             }
         }
+        // swiftlint:enable closure_body_length
         return deferred
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16324)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34702)

Also related to this issue: (https://github.com/mozilla-mobile/firefox-ios/issues/34615)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

### Root cause: 

`FxAccountManager.getCurrentDeviceId()` was a synchronous method that makes a blocking FFI call into the Rust `fxa_client`. Although that call does no network I/O, the fxa-client protects its account object with a single internal mutex, so the call blocks whenever another thread is mid-operation. `syncRustEngines` called it directly, with no queue hop, unlike the sibling `getAccessToken/getTokenServerEndpointURL` calls, which already dispatch their Rust work off the caller's thread. Because the sync timer fires on the main run loop, the main thread would block on the mutex and freeze the UI.

This was introduced in [#32716 (SYNC-4917, 2026-04-17)](https://github.com/mozilla-mobile/firefox-ios/commit/b434ae259bb229f81adb7c6308854bd351c261b2#diff-d5642d0c646420be33100f8afcf55c61e0564dc5c25f9f567936248017610e2bR599), which migrated FxA to the app-services state machine.

### Fix:

Refactor `getCurrentDeviceId()` to follow the same pattern as `getAccessToken`, take a completion handler and run the blocking FFI call on a background `DispatchQueue`, returning the result on the main actor. `RustSyncManager.syncRustEngines` is updated to use the completion-handler form. The control flow and outcomes are unchanged, only the device-ID retrieval (and therefore the Deferred's fill) is now asynchronous instead of blocking the caller.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

