### PR TITLE
Bug fix FXIOS-16327 Revert changes to device corner radius API

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/UIViewExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/UIViewExtension.swift
@@ -85,10 +85,7 @@ extension UIView {
 
     /// Sets the corner radius to the devices current corner radius
     public func applyScreenCornerRadius() {
-        if #available(iOS 26.0, *) {
-            cornerConfiguration = UICornerConfiguration.corners(radius: .containerConcentric(minimum: 0))
-        } else {
-            layer.cornerRadius = UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat ?? 0
-        }
+        // TODO: FXIOS-14817 FXIOS-16327 Centralize a way to query device corner radius without the private api
+        layer.cornerRadius = UIScreen.main.value(forKey: "_displayCornerRadius") as? CGFloat ?? 0
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16327)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34715)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Go back to using the private API for device corner radius

## :movie_camera: Demos
<details>

<summary>Before</summary>

https://github.com/user-attachments/assets/a1b07acd-3f29-442f-8835-67642bc5460b

</details>

<details>

<summary>After</summary>

https://github.com/user-attachments/assets/93b209f6-f62c-4f61-a76e-9e9b0bdf6495

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

