### PR TITLE
Add FXIOS-16272 [Danger] Add danger rule for screen bounds

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -568,6 +568,7 @@ class CodeUsageDetector {
         case unsafe
         case cspHeader
         case userInterfaceIdiom
+        case screenBounds
 
         var bundledHeader: String {
             switch self {
@@ -597,6 +598,13 @@ class CodeUsageDetector {
                 decisions. iPhone apps running on iPad or in iPhone Mirroring on Mac still report the phone idiom. \
                 Prefer size classes or trait-based layout instead.
                 """
+            case .screenBounds:
+                return """
+                ### ⚠️ `UIScreen.main.bounds` usage detected
+                Per Apple's WWDC 26 "Modernize your UIKit app" guidance, avoid using `UIScreen.main.bounds`. In an \
+                adaptive environment, your scene may not span the full screen. Use the view's or window's bounds, \
+                size classes, or trait-based layout instead.
+                """
             }
         }
 
@@ -622,6 +630,8 @@ class CodeUsageDetector {
                 return "Content-Security-Policy"
             case .userInterfaceIdiom:
                 return "userInterfaceIdiom"
+            case .screenBounds:
+                return "UIScreen.main.bounds"
             }
         }
 
@@ -647,7 +657,7 @@ class CodeUsageDetector {
         // Decide if we want to `warn` instead of `fail` on the pull request.
         var shouldWarn: Bool {
             switch self {
-            case .deferred, .notifiable, .userInterfaceIdiom:
+            case .deferred, .notifiable, .userInterfaceIdiom, .screenBounds:
                 return true
             default:
                 return false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16272)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34595)

## :bulb: Description
Add Danger rule for screen bounds

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

