### PR TITLE
Add FXIOS-16313 [Google Lens] Telemetry phase 3 (Timing Distributions)

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -4,6 +4,7 @@
 
 import Common
 import Foundation
+import Glean
 import PhotosUI
 import SwiftUI
 import UIKit
@@ -1184,8 +1185,12 @@ final class BrowserCoordinator: BaseCoordinator,
                                             actionType: GeneralBrowserActionType.leaveOverlay))
     }
 
-    func searchGoogleLens(with image: UIImage, source: GoogleLensTelemetry.Source) {
+    func searchGoogleLens(with image: UIImage, source: GoogleLensTelemetry.Source, searchTimerId: GleanTimerId? = nil) {
+        let googleLensTelemetry = GoogleLensTelemetry(gleanWrapper: glean)
         guard let tab = tabManager.selectedTab else {
+            if let searchTimerId {
+                googleLensTelemetry.cancelSearchTimer(source: source, timerId: searchTimerId)
+            }
             logger.log("Google Lens: no selected tab to load the upload request",
                        level: .warning,
                        category: .coordinator)
@@ -1196,15 +1201,17 @@ final class BrowserCoordinator: BaseCoordinator,
         guard let request = googleLensService.makeUploadRequest(for: image,
                                                                 viewportSize: viewportSize,
                                                                 entryPoint: entryPoint) else {
+            if let searchTimerId {
+                googleLensTelemetry.cancelSearchTimer(source: source, timerId: searchTimerId)
+            }
             logger.log("Google Lens: failed to build upload request (image could not be processed)",
                        level: .warning,
                        category: .coordinator)
             return
         }
-        let googleLensTelemetry = GoogleLensTelemetry(gleanWrapper: glean)
-        let timerId = source == .contextMenu ? nil : googleLensTelemetry.startToolbarButtonSearch()
+        let timerId = searchTimerId ?? googleLensTelemetry.startSearchTimer(source: source)
         browserViewController.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: source,
-                                                                                      toolbarButtonSearchTimerId: timerId)
+                                                                                      searchTimerId: timerId)
         _ = tab.loadRequest(request)
     }
     private func handleGoogleLensPhotoPick(_ results: [PHPickerResult]) {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -91,7 +91,9 @@ final class BrowserCoordinator: BaseCoordinator,
         self.windowManager = windowManager
         self.touExperimentsTracking = ToUExperimentsTracking(prefs: profile.prefs)
         self.homepageTabStateStore = homepageTabStateStore
-        self.browserViewController = BrowserViewController(profile: profile, tabManager: tabManager)
+        self.browserViewController = BrowserViewController(profile: profile,
+                                                           tabManager: tabManager,
+                                                           gleanWrapper: glean)
         self.applicationHelper = applicationHelper
         self.glean = glean
         self.worldCupStore = worldCupStore
@@ -1199,7 +1201,10 @@ final class BrowserCoordinator: BaseCoordinator,
                        category: .coordinator)
             return
         }
-        browserViewController.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: source)
+        let googleLensTelemetry = GoogleLensTelemetry(gleanWrapper: glean)
+        let timerId = source == .contextMenu ? nil : googleLensTelemetry.startToolbarButtonSearch()
+        browserViewController.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: source,
+                                                                                      toolbarButtonSearchTimerId: timerId)
         _ = tab.loadRequest(request)
     }
     private func handleGoogleLensPhotoPick(_ results: [PHPickerResult]) {

--- a/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserNavigationHandler.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Glean
 import Storage
 import UIKit
 import WebKit
@@ -133,7 +134,9 @@ protocol BrowserNavigationHandler: AnyObject, QRCodeNavigationHandler {
     func showGoogleLensCamera()
 
     @MainActor
-    func searchGoogleLens(with image: UIImage, source: GoogleLensTelemetry.Source)
+    func searchGoogleLens(with image: UIImage,
+                          source: GoogleLensTelemetry.Source,
+                          searchTimerId: GleanTimerId?)
 
     @MainActor
     func showQuickAnswers(transitionType: QuickAnswersTransitionType)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -445,9 +445,12 @@ extension BrowserViewController: WKUIDelegate {
     /// once its results page finishes loading or fails, then clears the tracked state.
     private func recordGoogleLensSearchCompletedIfNeeded(for tab: Tab?, succeeded: Bool) {
         guard let tab, let search = googleLensSearches.removeValue(forKey: tab.tabUUID) else { return }
-        GoogleLensTelemetry().searchCompleted(source: search.source,
-                                              succeeded: succeeded,
-                                              httpStatusCode: search.httpStatusCode)
+        if let timerId = search.toolbarButtonSearchTimerId {
+            googleLensTelemetry.stopToolbarButtonSearch(timerId: timerId)
+        }
+        googleLensTelemetry.searchCompleted(source: search.source,
+                                            succeeded: succeeded,
+                                            httpStatusCode: search.httpStatusCode)
     }
 
     func assignWebView(_ webView: WKWebView?) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -433,20 +433,29 @@ extension BrowserViewController: WKUIDelegate {
     }
 
     private func searchGoogleLens(forImageURL url: URL) {
-        getImageData(url) { [weak self] data in
-            guard let image = UIImage(data: data) else { return }
-            ensureMainThread {
-                self?.navigationHandler?.searchGoogleLens(with: image, source: .contextMenu)
+        let telemetry = googleLensTelemetry
+        let source: GoogleLensTelemetry.Source = .contextMenu
+        let timerId = telemetry.startSearchTimer(source: source)
+        getImageData(url,
+                     success: { [weak self] data in
+            guard let image = UIImage(data: data), let navigationHandler = self?.navigationHandler else {
+                telemetry.cancelSearchTimer(source: source, timerId: timerId)
+                return
             }
-        }
+            navigationHandler.searchGoogleLens(with: image,
+                                               source: source,
+                                               searchTimerId: timerId)
+        }, failure: {
+            telemetry.cancelSearchTimer(source: source, timerId: timerId)
+        })
     }
 
     /// Reports the completion of an in-flight Google Lens image search (see `googleLensSearches`)
     /// once its results page finishes loading or fails, then clears the tracked state.
     private func recordGoogleLensSearchCompletedIfNeeded(for tab: Tab?, succeeded: Bool) {
         guard let tab, let search = googleLensSearches.removeValue(forKey: tab.tabUUID) else { return }
-        if let timerId = search.toolbarButtonSearchTimerId {
-            googleLensTelemetry.stopToolbarButtonSearch(timerId: timerId)
+        if let timerId = search.searchTimerId {
+            googleLensTelemetry.stopSearchTimer(source: search.source, timerId: timerId)
         }
         googleLensTelemetry.searchCompleted(source: search.source,
                                             succeeded: succeeded,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5056,6 +5056,12 @@ extension BrowserViewController: UIAdaptivePresentationControllerDelegate {
 extension BrowserViewController {
     /// Used to get the context menu save image in the context menu, shown from long press on webview links
     func getImageData(_ url: URL, success: @escaping @MainActor @Sendable (Data) -> Void) {
+        getImageData(url, success: success, failure: {})
+    }
+
+    func getImageData(_ url: URL,
+                      success: @escaping @MainActor @Sendable (Data) -> Void,
+                      failure: @escaping @MainActor @Sendable () -> Void) {
         makeURLSession(
             userAgent: UserAgent.fxaUserAgent,
             configuration: URLSessionConfiguration.defaultMPTCP).dataTask(with: url
@@ -5064,6 +5070,10 @@ extension BrowserViewController {
                let data = data {
                 ensureMainThread {
                     success(data)
+                }
+            } else {
+                ensureMainThread {
+                    failure()
                 }
             }
         }.resume()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -362,6 +362,7 @@ class BrowserViewController: UIViewController,
     let profile: Profile
     let tabManager: TabManager
     var googleLensSearches = [TabUUID: GoogleLensSearchState]()
+    let googleLensTelemetry: GoogleLensTelemetry
     let crashTracker: CrashTracker
     let ratingPromptManager: RatingPromptManager
     private(set) var browserViewControllerState: BrowserViewControllerState?
@@ -449,6 +450,7 @@ class BrowserViewController: UIViewController,
         self.documentLogger = documentLogger
         self.appAuthenticator = appAuthenticator
         self.searchEnginesManager = searchEnginesManager
+        self.googleLensTelemetry = GoogleLensTelemetry(gleanWrapper: gleanWrapper)
         self.bookmarksSaver = DefaultBookmarksSaver(profile: profile)
         self.bookmarksHandler = profile.places
         self.zoomManager = ZoomPageManager(windowUUID: tabManager.windowUUID)

--- a/firefox-ios/Client/Glean/probes/google_lens.yaml
+++ b/firefox-ios/Client/Glean/probes/google_lens.yaml
@@ -54,9 +54,9 @@ google_lens:
       Starts when the request for fetching results starts.
       Ends when the user sees the results or an error.
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16313
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
+      - TBD
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -68,9 +68,9 @@ google_lens:
       Starts when the user selects the Google Lens context menu action.
       Ends when the user sees the results or an error.
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16313
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
+      - TBD
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/google_lens.yaml
+++ b/firefox-ios/Client/Glean/probes/google_lens.yaml
@@ -60,3 +60,17 @@ google_lens:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+  webpage_image_search_time:
+    type: timing_distribution
+    description: |
+      Records the total time for generating Google Lens results and showing
+      them to the user after a search initiated from a webpage image context menu.
+      Starts when the user selects the Google Lens context menu action.
+      Ends when the user sees the results or an error.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never

--- a/firefox-ios/Client/Glean/probes/google_lens.yaml
+++ b/firefox-ios/Client/Glean/probes/google_lens.yaml
@@ -56,7 +56,7 @@ google_lens:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16313
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34719
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -70,7 +70,7 @@ google_lens:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16313
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34719
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/google_lens.yaml
+++ b/firefox-ios/Client/Glean/probes/google_lens.yaml
@@ -46,3 +46,17 @@ google_lens:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+  toolbar_button_search_time:
+    type: timing_distribution
+    description: |
+      Records the total time for generating Google Lens results and showing
+      them to the user after a search initiated from the toolbar button.
+      Starts when the request for fetching results starts.
+      Ends when the user sees the results or an error.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16297
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/34671
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never

--- a/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
@@ -7,19 +7,19 @@ import Glean
 
 struct GoogleLensSearchState {
     let source: GoogleLensTelemetry.Source
-    let toolbarButtonSearchTimerId: GleanTimerId?
+    let searchTimerId: GleanTimerId?
     var httpStatusCode: Int?
 
     init(source: GoogleLensTelemetry.Source,
-         toolbarButtonSearchTimerId: GleanTimerId? = nil,
+         searchTimerId: GleanTimerId? = nil,
          httpStatusCode: Int? = nil) {
         self.source = source
-        self.toolbarButtonSearchTimerId = toolbarButtonSearchTimerId
+        self.searchTimerId = searchTimerId
         self.httpStatusCode = httpStatusCode
     }
 }
 
-struct GoogleLensTelemetry {
+struct GoogleLensTelemetry: Sendable {
     enum Source: String {
         case camera
         case photoPicker
@@ -45,12 +45,26 @@ struct GoogleLensTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.GoogleLens.searchCompleted, extras: extra)
     }
 
-    func startToolbarButtonSearch() -> GleanTimerId {
-        return gleanWrapper.startTiming(for: GleanMetrics.GoogleLens.toolbarButtonSearchTime)
+    func startSearchTimer(source: Source) -> GleanTimerId {
+        return gleanWrapper.startTiming(for: searchTimeMetric(for: source))
     }
 
-    func stopToolbarButtonSearch(timerId: GleanTimerId) {
-        gleanWrapper.stopAndAccumulateTiming(for: GleanMetrics.GoogleLens.toolbarButtonSearchTime,
+    func cancelSearchTimer(source: Source, timerId: GleanTimerId) {
+        gleanWrapper.cancelTiming(for: searchTimeMetric(for: source),
+                                  timerId: timerId)
+    }
+
+    func stopSearchTimer(source: Source, timerId: GleanTimerId) {
+        gleanWrapper.stopAndAccumulateTiming(for: searchTimeMetric(for: source),
                                              timerId: timerId)
+    }
+
+    private func searchTimeMetric(for source: Source) -> TimingDistributionMetricType {
+        switch source {
+        case .camera, .photoPicker:
+            return GleanMetrics.GoogleLens.toolbarButtonSearchTime
+        case .contextMenu:
+            return GleanMetrics.GoogleLens.webpageImageSearchTime
+        }
     }
 }

--- a/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/GoogleLensTelemetry.swift
@@ -7,10 +7,14 @@ import Glean
 
 struct GoogleLensSearchState {
     let source: GoogleLensTelemetry.Source
+    let toolbarButtonSearchTimerId: GleanTimerId?
     var httpStatusCode: Int?
 
-    init(source: GoogleLensTelemetry.Source, httpStatusCode: Int? = nil) {
+    init(source: GoogleLensTelemetry.Source,
+         toolbarButtonSearchTimerId: GleanTimerId? = nil,
+         httpStatusCode: Int? = nil) {
         self.source = source
+        self.toolbarButtonSearchTimerId = toolbarButtonSearchTimerId
         self.httpStatusCode = httpStatusCode
     }
 }
@@ -39,5 +43,14 @@ struct GoogleLensTelemetry {
             succeeded: succeeded
         )
         gleanWrapper.recordEvent(for: GleanMetrics.GoogleLens.searchCompleted, extras: extra)
+    }
+
+    func startToolbarButtonSearch() -> GleanTimerId {
+        return gleanWrapper.startTiming(for: GleanMetrics.GoogleLens.toolbarButtonSearchTime)
+    }
+
+    func stopToolbarButtonSearch(timerId: GleanTimerId) {
+        gleanWrapper.stopAndAccumulateTiming(for: GleanMetrics.GoogleLens.toolbarButtonSearchTime,
+                                             timerId: timerId)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -464,21 +464,23 @@ final class BrowserCoordinatorTests: XCTestCase,
 
         let search = try XCTUnwrap(subject.browserViewController.googleLensSearches[tab.tabUUID])
         XCTAssertEqual(glean.startTimingCalled, 1)
-        XCTAssertNotNil(search.toolbarButtonSearchTimerId)
+        XCTAssertNotNil(search.searchTimerId)
     }
 
-    func testSearchGoogleLens_fromWebImageContextMenu_doesNotStartSearchTimer() throws {
+    func testSearchGoogleLens_fromWebImageContextMenu_usesExistingSearchTimer() throws {
         let tab = MockTab(profile: profile, windowUUID: windowUUID)
         tab.webView = MockTabWebView(tab: tab)
         tabManager.tabs = [tab]
         tabManager.selectedTab = tab
         let subject = createSubject(googleLensService: MockGoogleLensService())
 
-        subject.searchGoogleLens(with: UIImage(), source: .contextMenu)
+        subject.searchGoogleLens(with: UIImage(),
+                                 source: .contextMenu,
+                                 searchTimerId: glean.savedTimerId)
 
         let search = try XCTUnwrap(subject.browserViewController.googleLensSearches[tab.tabUUID])
         XCTAssertEqual(glean.startTimingCalled, 0)
-        XCTAssertNil(search.toolbarButtonSearchTimerId)
+        XCTAssertNotNil(search.searchTimerId)
     }
 
     func testShowQRCode_presentsQRCodeNavigationController() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -453,6 +453,34 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertTrue(subject.childCoordinators.first is CameraCoordinator)
     }
 
+    func testSearchGoogleLens_fromToolbarButton_startsSearchTimer() throws {
+        let tab = MockTab(profile: profile, windowUUID: windowUUID)
+        tab.webView = MockTabWebView(tab: tab)
+        tabManager.tabs = [tab]
+        tabManager.selectedTab = tab
+        let subject = createSubject(googleLensService: MockGoogleLensService())
+
+        subject.searchGoogleLens(with: UIImage(), source: .camera)
+
+        let search = try XCTUnwrap(subject.browserViewController.googleLensSearches[tab.tabUUID])
+        XCTAssertEqual(glean.startTimingCalled, 1)
+        XCTAssertNotNil(search.toolbarButtonSearchTimerId)
+    }
+
+    func testSearchGoogleLens_fromWebImageContextMenu_doesNotStartSearchTimer() throws {
+        let tab = MockTab(profile: profile, windowUUID: windowUUID)
+        tab.webView = MockTabWebView(tab: tab)
+        tabManager.tabs = [tab]
+        tabManager.selectedTab = tab
+        let subject = createSubject(googleLensService: MockGoogleLensService())
+
+        subject.searchGoogleLens(with: UIImage(), source: .contextMenu)
+
+        let search = try XCTUnwrap(subject.browserViewController.googleLensSearches[tab.tabUUID])
+        XCTAssertEqual(glean.startTimingCalled, 0)
+        XCTAssertNil(search.toolbarButtonSearchTimerId)
+    }
+
     func testShowQRCode_presentsQRCodeNavigationController() {
         let subject = createSubject()
         let delegate = MockQRCodeViewControllerDelegate()
@@ -1673,7 +1701,8 @@ final class BrowserCoordinatorTests: XCTestCase,
     }
 
     // MARK: - Helpers
-    private func createSubject(file: StaticString = #filePath,
+    private func createSubject(googleLensService: GoogleLensServicing = GoogleLensService(),
+                               file: StaticString = #filePath,
                                line: UInt = #line) -> BrowserCoordinator {
         let subject = BrowserCoordinator(router: mockRouter,
                                          screenshotService: screenshotService,
@@ -1682,7 +1711,8 @@ final class BrowserCoordinatorTests: XCTestCase,
                                          profile: profile,
                                          glean: glean,
                                          applicationHelper: applicationHelper,
-                                         worldCupStore: mockWorldCupStore)
+                                         worldCupStore: mockWorldCupStore,
+                                         googleLensService: googleLensService)
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
     }
@@ -1735,6 +1765,14 @@ final class BrowserCoordinatorTests: XCTestCase,
         }
 
         return URL(string: "http://localhost:\(webServer.port)")!
+    }
+}
+
+private struct MockGoogleLensService: GoogleLensServicing {
+    func makeUploadRequest(for image: UIImage,
+                           viewportSize: CGSize,
+                           entryPoint: GoogleLensUploadEntryPoint) -> URLRequest? {
+        return URLRequest(url: URL(string: "https://lens.google.com/upload")!)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockBrowserCoordinator.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Glean
 import Storage
 import WebKit
 import SummarizeKit
@@ -59,6 +60,7 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
     var showGoogleLensCameraCalled = 0
     var searchGoogleLensCalled = 0
     var searchGoogleLensSource: GoogleLensTelemetry.Source?
+    var searchGoogleLensTimerId: GleanTimerId?
 
     func show(settings: Client.Route.SettingsSection, onDismiss: (() -> Void)?) {
         showSettingsCalled += 1
@@ -194,9 +196,12 @@ class MockBrowserCoordinator: BrowserNavigationHandler,
         showGoogleLensCameraCalled += 1
     }
 
-    func searchGoogleLens(with image: UIImage, source: GoogleLensTelemetry.Source) {
+    func searchGoogleLens(with image: UIImage,
+                          source: GoogleLensTelemetry.Source,
+                          searchTimerId: GleanTimerId?) {
         searchGoogleLensCalled += 1
         searchGoogleLensSource = source
+        searchGoogleLensTimerId = searchTimerId
     }
 
     // MARK: - BrowserDelegate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -399,12 +399,11 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
     }
 
     @MainActor
-    private func createSubject() -> BrowserViewController {
-        let subject = BrowserViewController(
-            profile: profile,
-            tabManager: tabManager,
-            userInitiatedQueue: MockDispatchQueue()
-        )
+    private func createSubject(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) -> BrowserViewController {
+        let subject = BrowserViewController(profile: profile,
+                                            tabManager: tabManager,
+                                            gleanWrapper: gleanWrapper,
+                                            userInitiatedQueue: MockDispatchQueue())
         trackForMemoryLeaks(subject)
         return subject
     }
@@ -506,24 +505,29 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
 
     @MainActor
     func testWebViewDidFinish_clearsPendingGoogleLensSearch() {
-        let subject = createSubject()
+        let gleanWrapper = MockGleanWrapper()
+        let subject = createSubject(gleanWrapper: gleanWrapper)
         let tab = createTab()
         tabManager.tabs = [tab]
         tabManager.selectedTab = tab
-        subject.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: .camera)
+        subject.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: .camera,
+                                                                       toolbarButtonSearchTimerId: gleanWrapper.savedTimerId)
 
         subject.webView(tab.webView!, didFinish: nil)
 
         XCTAssertNil(subject.googleLensSearches[tab.tabUUID],
                      "Finishing navigation should report and clear the pending Google Lens search")
+        XCTAssertEqual(gleanWrapper.stopAndAccumulateCalled, 1)
     }
 
     @MainActor
     func testWebViewDidFailProvisionalNavigation_clearsPendingGoogleLensSearch() {
-        let subject = createSubject()
+        let gleanWrapper = MockGleanWrapper()
+        let subject = createSubject(gleanWrapper: gleanWrapper)
         let tab = createTab()
         tabManager.tabs = [tab]
-        subject.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: .contextMenu)
+        subject.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: .photoPicker,
+                                                                       toolbarButtonSearchTimerId: gleanWrapper.savedTimerId)
 
         // Code 102 ("Frame load interrupted") makes the delegate return early right after the
         // Google Lens reporting, keeping the test free of error-page side effects.
@@ -533,6 +537,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
 
         XCTAssertNil(subject.googleLensSearches[tab.tabUUID],
                      "A failed navigation should report and clear the pending Google Lens search")
+        XCTAssertEqual(gleanWrapper.stopAndAccumulateCalled, 1)
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 import Common
+import Glean
 import WebKit
 import Shared
 
@@ -511,7 +512,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         tabManager.tabs = [tab]
         tabManager.selectedTab = tab
         subject.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: .camera,
-                                                                       toolbarButtonSearchTimerId: gleanWrapper.savedTimerId)
+                                                                        searchTimerId: gleanWrapper.savedTimerId)
 
         subject.webView(tab.webView!, didFinish: nil)
 
@@ -527,7 +528,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         let tab = createTab()
         tabManager.tabs = [tab]
         subject.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: .photoPicker,
-                                                                       toolbarButtonSearchTimerId: gleanWrapper.savedTimerId)
+                                                                        searchTimerId: gleanWrapper.savedTimerId)
 
         // Code 102 ("Frame load interrupted") makes the delegate return early right after the
         // Google Lens reporting, keeping the test free of error-page side effects.
@@ -538,6 +539,42 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         XCTAssertNil(subject.googleLensSearches[tab.tabUUID],
                      "A failed navigation should report and clear the pending Google Lens search")
         XCTAssertEqual(gleanWrapper.stopAndAccumulateCalled, 1)
+    }
+
+    @MainActor
+    func testWebViewDidFinish_withWebpageImageSearch_stopsSearchTimer() {
+        let gleanWrapper = MockGleanWrapper()
+        let subject = createSubject(gleanWrapper: gleanWrapper)
+        let tab = createTab()
+        tabManager.tabs = [tab]
+        tabManager.selectedTab = tab
+        subject.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: .contextMenu,
+                                                                        searchTimerId: gleanWrapper.savedTimerId)
+
+        subject.webView(tab.webView!, didFinish: nil)
+
+        let savedMetrics = gleanWrapper.savedEvents.compactMap { $0 as? TimingDistributionMetricType }
+        XCTAssertEqual(gleanWrapper.stopAndAccumulateCalled, 1)
+        XCTAssertTrue(savedMetrics.contains { $0 === GleanMetrics.GoogleLens.webpageImageSearchTime })
+    }
+
+    @MainActor
+    func testWebViewDidFail_withWebpageImageSearch_stopsSearchTimer() {
+        let gleanWrapper = MockGleanWrapper()
+        let subject = createSubject(gleanWrapper: gleanWrapper)
+        let tab = createTab()
+        tabManager.tabs = [tab]
+        tabManager.selectedTab = tab
+        subject.googleLensSearches[tab.tabUUID] = GoogleLensSearchState(source: .contextMenu,
+                                                                        searchTimerId: gleanWrapper.savedTimerId)
+
+        subject.webView(tab.webView!,
+                        didFailProvisionalNavigation: nil,
+                        withError: NSError(domain: "WebKitErrorDomain", code: 102))
+
+        let savedMetrics = gleanWrapper.savedEvents.compactMap { $0 as? TimingDistributionMetricType }
+        XCTAssertEqual(gleanWrapper.stopAndAccumulateCalled, 1)
+        XCTAssertTrue(savedMetrics.contains { $0 === GleanMetrics.GoogleLens.webpageImageSearchTime })
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/GoogleLensTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/GoogleLensTelemetryTests.swift
@@ -61,4 +61,17 @@ final class GoogleLensTelemetryTests: XCTestCase {
         XCTAssertEqual(savedExtras.succeeded, false)
         XCTAssertNil(savedExtras.httpStatus)
     }
+
+    func testToolbarButtonSearchTime_whenStartedThenStopped_accumulatesTiming() throws {
+        let metric = GleanMetrics.GoogleLens.toolbarButtonSearchTime
+
+        let timerId = try XCTUnwrap(subject?.startToolbarButtonSearch())
+        subject?.stopToolbarButtonSearch(timerId: timerId)
+
+        let savedMetrics = gleanWrapper.savedEvents.compactMap { $0 as? TimingDistributionMetricType }
+        XCTAssertEqual(gleanWrapper.startTimingCalled, 1)
+        XCTAssertEqual(gleanWrapper.stopAndAccumulateCalled, 1)
+        XCTAssertEqual(savedMetrics.count, 2)
+        XCTAssertTrue(savedMetrics.allSatisfy { $0 === metric })
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/GoogleLensTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/GoogleLensTelemetryTests.swift
@@ -65,12 +65,38 @@ final class GoogleLensTelemetryTests: XCTestCase {
     func testToolbarButtonSearchTime_whenStartedThenStopped_accumulatesTiming() throws {
         let metric = GleanMetrics.GoogleLens.toolbarButtonSearchTime
 
-        let timerId = try XCTUnwrap(subject?.startToolbarButtonSearch())
-        subject?.stopToolbarButtonSearch(timerId: timerId)
+        let timerId = try XCTUnwrap(subject?.startSearchTimer(source: .camera))
+        subject?.stopSearchTimer(source: .camera, timerId: timerId)
 
         let savedMetrics = gleanWrapper.savedEvents.compactMap { $0 as? TimingDistributionMetricType }
         XCTAssertEqual(gleanWrapper.startTimingCalled, 1)
         XCTAssertEqual(gleanWrapper.stopAndAccumulateCalled, 1)
+        XCTAssertEqual(savedMetrics.count, 2)
+        XCTAssertTrue(savedMetrics.allSatisfy { $0 === metric })
+    }
+
+    func testWebpageImageSearchTime_whenStartedThenStopped_accumulatesTiming() throws {
+        let metric = GleanMetrics.GoogleLens.webpageImageSearchTime
+
+        let timerId = try XCTUnwrap(subject?.startSearchTimer(source: .contextMenu))
+        subject?.stopSearchTimer(source: .contextMenu, timerId: timerId)
+
+        let savedMetrics = gleanWrapper.savedEvents.compactMap { $0 as? TimingDistributionMetricType }
+        XCTAssertEqual(gleanWrapper.startTimingCalled, 1)
+        XCTAssertEqual(gleanWrapper.stopAndAccumulateCalled, 1)
+        XCTAssertEqual(savedMetrics.count, 2)
+        XCTAssertTrue(savedMetrics.allSatisfy { $0 === metric })
+    }
+
+    func testWebpageImageSearchTime_whenCanceled_cancelsTiming() throws {
+        let metric = GleanMetrics.GoogleLens.webpageImageSearchTime
+
+        let timerId = try XCTUnwrap(subject?.startSearchTimer(source: .contextMenu))
+        subject?.cancelSearchTimer(source: .contextMenu, timerId: timerId)
+
+        let savedMetrics = gleanWrapper.savedEvents.compactMap { $0 as? TimingDistributionMetricType }
+        XCTAssertEqual(gleanWrapper.startTimingCalled, 1)
+        XCTAssertEqual(gleanWrapper.cancelTimingCalled, 1)
         XCTAssertEqual(savedMetrics.count, 2)
         XCTAssertTrue(savedMetrics.allSatisfy { $0 === metric })
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16313)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34708)

## :bulb: Description
- Add timing distribution probes to measure how long Google Lens toolbar and webpage image searches take to complete

| Probe Name  | Trigger |
| -------------- | ------------- |
| google_lens.toolbar_button_search_time | Records the total time for generating Google Lens results and showing them to the user after a search initiated from the toolbar button. Starts when the request for fetching results starts. Ends when the user sees the results or an error. |
| google_lens.webpage_image_search_time | Records the total time for generating Google Lens results and showing them to the user after a search initiated from a webpage image context menu. Starts when the user selects the Google Lens context menu action. Ends when the user sees the results or an error. |

### 📝 Technical Notes:
- Toolbar timing starts when the Lens upload request begins
- Webpage image timing starts at context-menu selection and includes image fetching (since we upload web images by bytes, not URL)
- Both stop on results/error navigation and are canceled if navigation never begins.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

