### PR TITLE
Refactor FXIOS-16336 - [UTests] - Adjust world cup test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
@@ -129,7 +129,7 @@ final class HomePageSettingViewControllerTests: XCTestCase {
         XCTAssertTrue(trackerBlockerModuleSettingValue)
     }
 
-    func testHomepageSettings_generateSettings_worldCupSectionDefaultValue_whenFFEnabled_isTrue() throws {
+    func testHomepageSettings_generateSettings_worldCupSection_whenTournamentEnded_isHidden() throws {
         setFeatureFlag(.worldCupWidget, isEnabled: true)
         let subject = createSubject()
         subject.profile = profile
@@ -146,9 +146,7 @@ final class HomePageSettingViewControllerTests: XCTestCase {
                 ($0 as? BoolSetting)?.prefKey == PrefsKeys.HomepageSettings.WorldCupSection
             }) as? BoolSetting
 
-        let worldCupSectionSettingValue = try XCTUnwrap(worldCupSectionSetting?.getDefaultValue())
-
-        XCTAssertTrue(worldCupSectionSettingValue)
+        XCTAssertNil(worldCupSectionSetting)
     }
 
     // MARK: - Helper


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16336)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34732)
## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

# 🥳 🇪🇸
- Adjusted the world cup test that was failing because of the ending of world cup. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

