### PR TITLE
Bugfix FXIOS-16337 [World Cup] Fix failing HomePageSettingViewControllerTests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
@@ -11,6 +11,7 @@ import Shared
 final class HomePageSettingViewControllerTests: XCTestCase {
     private var profile: MockProfile!
     private var wallpaperManager: WallpaperManagerMock!
+    private var worldCupStore: MockWorldCupStore!
     private var delegate: MockSettingsDelegate!
     private var mockNimbusLayer: MockNimbusFeatureFlagLayer!
 
@@ -29,6 +30,7 @@ final class HomePageSettingViewControllerTests: XCTestCase {
 
         delegate = MockSettingsDelegate()
         wallpaperManager = WallpaperManagerMock()
+        worldCupStore = MockWorldCupStore()
     }
 
     override func tearDown() async throws {
@@ -164,7 +166,8 @@ final class HomePageSettingViewControllerTests: XCTestCase {
         let subject = HomePageSettingViewController(prefs: profile.prefs,
                                                     wallpaperManager: wallpaperManager,
                                                     settingsDelegate: delegate,
-                                                    tabManager: MockTabManager())
+                                                    tabManager: MockTabManager(),
+                                                    worldCupStore: worldCupStore)
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
@@ -132,9 +132,9 @@ final class HomePageSettingViewControllerTests: XCTestCase {
     }
 
     func testHomepageSettings_generateSettings_worldCupSectionDefaultValue_whenFFEnabled_isTrue() throws {
-        setFeatureFlag(.worldCupWidget, isEnabled: true)
         let subject = createSubject()
         subject.profile = profile
+        worldCupStore.isFeatureEnabled = true
 
         let settingsList = subject.generateSettings()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
@@ -153,6 +153,26 @@ final class HomePageSettingViewControllerTests: XCTestCase {
         XCTAssertTrue(worldCupSectionSettingValue)
     }
 
+    func testHomepageSettings_generateSettings_withWorldCupDisabled_hidesSetting() throws {
+        let subject = createSubject()
+        subject.profile = profile
+        worldCupStore.isFeatureEnabled = false
+
+        let settingsList = subject.generateSettings()
+
+        let customizeFirefoxHomeSettingsList = settingsList.first(
+            where: {
+                $0.title?.string == .Settings.Homepage.CustomizeFirefoxHome.Title
+            })
+
+        let worldCupSectionSetting = customizeFirefoxHomeSettingsList?.children.first(
+            where: {
+                ($0 as? BoolSetting)?.prefKey == PrefsKeys.HomepageSettings.WorldCupSection
+            }) as? BoolSetting
+
+        XCTAssertNil(worldCupSectionSetting)
+    }
+
     // MARK: - Helper
     private func setFeatureFlag(_ flag: FeatureFlagID, isEnabled: Bool) {
         if isEnabled {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16337)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/16337)

## :bulb: Description
Fixes the failing HomePageSettingViewControllerTests due to the World Cup ending and adds a new test. Both tests are now using a mock for the world cup store.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

