### PR TITLE
[MTE-5687] - Skip UI tests on firefox schema

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PhotonActionSheetTests.swift
@@ -73,7 +73,11 @@ class PhotonActionSheetTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323203
-    func testShareSheetSendToDevice() {
+    func testShareSheetSendToDevice() throws {
+        try XCTSkipIf(
+            isFirefoxBeta || isFirefox,
+            "Skipping test because Firefox and FirefoxBeta are not yet supported"
+        )
         openNewShareSheet()
         var attempts = 2
         let sendToDeviceButton = app.staticTexts["Send to Device"]
@@ -92,7 +96,11 @@ class PhotonActionSheetTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323204
-    func testShareSheetOpenAndCancel() {
+    func testShareSheetOpenAndCancel() throws {
+        try XCTSkipIf(
+            isFirefoxBeta || isFirefox,
+            "Skipping test because Firefox and FirefoxBeta are not yet supported"
+        )
         openNewShareSheet()
         app.buttons["Cancel"].waitAndTap()
         // User is back to the BrowserTab where the sharesheet was launched

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
@@ -70,7 +70,12 @@ final class TranslationsTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3379185
-    func testTranslationSettingsDoesNotAppear_translationExperimentOff() {
+    func testTranslationSettingsDoesNotAppear_translationExperimentOff() throws {
+        try XCTSkipIf(
+            isFirefoxBeta || isFirefox,
+            "Skipping test because on Firefox and FirefoxBeta addLaunchArgument cannot override the " +
+            "default experiment value, so the translations feature cannot be forced off"
+        )
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "translations-feature")
         app.launch()
         openSettingsFromToolbarMenu()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5687

## :bulb: Description
Skip XCUI tests that can't pass on the Firefox scheme. Added XCTSkipIf guards to testShareSheetOpenAndCancel, testShareSheetSendToDevice, and testTranslationSettingsDoesNotAppear_translationExperimentOff.
Skipping the first 2 because the test flow can't complete on the Firefox/FirefoxBeta schemes: openNewShareSheet() opens the iOS share sheet and taps the app's own share destination to bring up Firefox's custom ShareView (with Cancel / Send to Device). On Fennec that works, but on Firefox the ShareTo extension doesn't present its view — verified on the simulator, the tap registers but nothing opens, so the test times out. Same limitation already documented on the sibling testSharePageWithShareSheetOptions ("Firefox and FirefoxBeta are not yet supported").
Skipping testTranslationSettingsDoesNotAppear_translationExperimentOff because on Firefox and FirefoxBeta addLaunchArgument cannot override the default experiment value, so the translations feature cannot be forced off.