### PR TITLE
Add FXIOS-16273 [Danger] Add Danger detection for `UIScreen.main.scale`

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -569,6 +569,7 @@ class CodeUsageDetector {
         case cspHeader
         case userInterfaceIdiom
         case screenBounds
+        case screenScale
 
         var bundledHeader: String {
             switch self {
@@ -605,6 +606,12 @@ class CodeUsageDetector {
                 adaptive environment, your scene may not span the full screen. Use the view's or window's bounds, \
                 size classes, or trait-based layout instead.
                 """
+            case .screenScale:
+                return """
+                ### ⚠️ `UIScreen.main.scale` usage detected
+                Per Apple's WWDC 26 "Modernize your UIKit app" guidance, avoid using `UIScreen.main.scale`. \
+                Use the trait collection's `displayScale` instead.
+                """
             }
         }
 
@@ -632,6 +639,8 @@ class CodeUsageDetector {
                 return "userInterfaceIdiom"
             case .screenBounds:
                 return "UIScreen.main.bounds"
+            case .screenScale:
+                return "UIScreen.main.scale"
             }
         }
 
@@ -657,7 +666,7 @@ class CodeUsageDetector {
         // Decide if we want to `warn` instead of `fail` on the pull request.
         var shouldWarn: Bool {
             switch self {
-            case .deferred, .notifiable, .userInterfaceIdiom, .screenBounds:
+            case .deferred, .notifiable, .userInterfaceIdiom, .screenBounds, .screenScale:
                 return true
             default:
                 return false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16273)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34595)

## :bulb: Description
Add the Danger rule for `UIScreen.main.scale`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

