### PR TITLE
[MTE-5689] - remove firefox app icon test from smoke plan

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -389,6 +389,7 @@
         "NavigationTest\/testDownloadLink()",
         "NavigationTest\/testLongPressLinkOptions_TAE()",
         "NavigationTest\/testLongPressOnAddressBar()",
+        "NavigationTest\/testLongTapFirefoxIconAppIcon()",
         "NavigationTest\/testLongTapFirefoxIconNewPrivateTab()",
         "NavigationTest\/testLongTapFirefoxIconNewTab()",
         "NavigationTest\/testLongTapFirefoxIconOpenLastBookmark()",


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5689

## :bulb: Description
testLongTapFirefoxIconAppIcon is functional only, removing it from the smoke test plan

