### PR TITLE
[MTE-5690] - improve translation test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -22,6 +22,8 @@ func path(forTestPage page: String) -> String {
 // Extended timeout values for mozWaitForElementToExist and mozWaitForElementToNotExist
 let TIMEOUT: TimeInterval = 10
 let TIMEOUT_LONG: TimeInterval = 20
+// Translation is network-bound and can take up to ~1 min to complete
+let TRANSLATION_TIMEOUT: TimeInterval = 90
 let MAX_SWIPE = 5
 
 @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
@@ -195,15 +195,23 @@ final class ToolbarScreen {
         }
     }
 
-    func assertTranslateButtonExists(with mode: TranslationButtonType) {
+    func assertTranslateButtonExists(with mode: TranslationButtonType, timeout: TimeInterval = TIMEOUT) {
         switch mode {
         case .inactive:
-            BaseTestCase().mozWaitForElementToExist(translateButton)
+            BaseTestCase().mozWaitForElementToExist(translateButton, timeout: timeout)
         case .loading:
-            BaseTestCase().mozWaitForElementToExist(translateLoadingButton)
+            BaseTestCase().mozWaitForElementToExist(translateLoadingButton, timeout: timeout)
         case .active:
-            BaseTestCase().mozWaitForElementToExist(translateActiveButton)
+            BaseTestCase().mozWaitForElementToExist(translateActiveButton, timeout: timeout)
         }
+    }
+
+    /// Gates on the loading spinner disappearing (translation done) before asserting the active
+    /// button, since translation is network-bound and can take much longer than a normal UI wait.
+    func waitForTranslateButtonToBecomeActive() {
+        let base = BaseTestCase()
+        base.mozWaitForElementToNotExist(translateLoadingButton, timeout: TRANSLATION_TIMEOUT)
+        base.mozWaitForElementToExist(translateActiveButton)
     }
 
     func assertTranslateButtonDoesNotExist(with mode: TranslationButtonType) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
@@ -40,7 +40,7 @@ final class TranslationsTests: FeatureFlaggedTestBase {
 
         // Check that translation icon switches to loading (spinner) and eventually active mode (blue button)
         toolBarScreen.assertTranslateButtonExists(with: .loading)
-        toolBarScreen.assertTranslateButtonExists(with: .active)
+        toolBarScreen.waitForTranslateButtonToBecomeActive()
         browserScreen.assertWebPageText(with: "Example domain")
 
         toolBarScreen.tapTranslateButton(with: .active)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5690

## :bulb: Description
- BaseTestCase.swift — added TRANSLATION_TIMEOUT = 90 constant.
- ToolbarScreen.swift — added waitForTranslateButtonToBecomeActive(), which waits for the loading spinner to disappear (translation done) then asserts the active button. Also made assertTranslateButtonExists take an optional timeout param.
- TranslationTests.swift:43 — replaced the fixed-timeout .active assertion with the new helper so the test waits on the actual translation completion instead of a fixed duration.

