### PR TITLE
Refactor FXIOS-15349 [Technical Debt] [Redux] Use @Copyable macro for TabPeekState

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -8,6 +8,7 @@ import Common
 
 @Copyable
 struct TabPeekState: ScreenState {
+    let windowUUID: WindowUUID
     let showAddToBookmarks: Bool
     let showRemoveBookmark: Bool
     let showSendToDevice: Bool
@@ -15,7 +16,6 @@ struct TabPeekState: ScreenState {
     let showCloseTab: Bool
     let previewAccessibilityLabel: String
     let screenshot: UIImage
-    let windowUUID: WindowUUID
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let tabPeekState = appState.componentState(

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -3,8 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Redux
+import ModifiedCopy
 import Common
 
+@Copyable
 struct TabPeekState: ScreenState {
     let showAddToBookmarks: Bool
     let showRemoveBookmark: Bool
@@ -62,13 +64,13 @@ struct TabPeekState: ScreenState {
         switch action.actionType {
         case TabPeekActionType.loadTabPeek:
             guard let tabPeekModel = action.tabPeekModel else { return state }
-            return TabPeekState(windowUUID: state.windowUUID,
-                                showAddToBookmarks: tabPeekModel.canTabBeSaved,
-                                showRemoveBookmark: tabPeekModel.canTabBeRemoved,
-                                showSendToDevice: tabPeekModel.isSyncEnabled && tabPeekModel.canTabBeSaved,
-                                showCopyURL: tabPeekModel.canCopyURL,
-                                previewAccessibilityLabel: tabPeekModel.accessiblityLabel,
-                                screenshot: tabPeekModel.screenshot)
+            return state
+                .copy(showAddToBookmarks: tabPeekModel.canTabBeSaved)
+                .copy(showRemoveBookmark: tabPeekModel.canTabBeRemoved)
+                .copy(showSendToDevice: tabPeekModel.isSyncEnabled && tabPeekModel.canTabBeSaved)
+                .copy(showCopyURL: tabPeekModel.canCopyURL)
+                .copy(previewAccessibilityLabel: tabPeekModel.accessiblityLabel)
+                .copy(screenshot: tabPeekModel.screenshot)
         default:
             return state
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15349)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32936)

## :bulb: Description
Migrates `TabPeekState` (Redux state) to use the `@Copyable` macro from the `ModifiedCopy` package, replacing the reducer's manual full-struct reconstruction with chained `.copy(property:)` calls. This follows the same pattern already used by other Redux states in the codebase (e.g. `SearchBarState`, `HomepageState`).

Pure technical-debt refactor — no behavior change, no public API change. `showCloseTab` is intentionally left out of the `.copy()` chain since the existing reducer never updates it (always stays at its default `true`); confirmed via `TabPeekState(` grep that no call site ever constructs it with a non-default value, so this is behavior-identical to before.

`TabPeekStateTests.swift` is unmodified.

## :movie_camera: Demos
N/A — no UI or behavior change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [ ] I ensured unit tests pass and wrote tests for new code — **note:** could not run `xcodebuild test` locally (no iOS Simulator runtimes installed in this environment); relying on CI to verify `TabPeekStateTests` (5 existing tests) still pass unmodified
- [ ] N/A — no UI changes
- [ ] N/A — no telemetry changes
- [ ] N/A — no string changes
- [ ] N/A — no documentation changes needed