### PR TITLE
Refactor NO-TICKET [Code Cleanup] Remove unused imports, tune Periphery config

### DIFF
--- a/firefox-ios/.periphery.yml
+++ b/firefox-ios/.periphery.yml
@@ -8,7 +8,7 @@ retain_assign_only_properties: true
 retain_objc_accessible: true
 retain_unused_protocol_func_params: false
 retain_public: true
-exclude_tests: true
+retain_swift_ui_previews: true
 
 index_exclude:
 # Generated sources

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import MozillaAppServices
-import Account
 import Common
 import Shared
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Common
-import Storage
 import UIKit
 
 /// Holds section layout logic for the new homepage as part of the rebuild project

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/DeleteAppAttestKeySetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/DeleteAppAttestKeySetting.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Storage
 import MLPAKit
 
 class DeleteAppAttestKeySetting: HiddenSetting {

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -7,7 +7,6 @@
 import Common
 import Glean
 import Shared
-import Storage
 import class MozillaAppServices.NimbusGleanPings
 
 protocol TelemetryWrapperProtocol {

--- a/firefox-ios/RustFxA/RustFirefoxAccounts.swift
+++ b/firefox-ios/RustFxA/RustFirefoxAccounts.swift
@@ -5,7 +5,6 @@
 import Common
 import UIKit
 import Shared
-import Storage
 
 import class MozillaAppServices.FxAccountManager
 import class MozillaAppServices.FxAConfig


### PR DESCRIPTION
## :scroll: Tickets
NO-TICKET

## :bulb: Description
Stage 0 + Stage 1 of a Periphery-driven dead-code cleanup pass (full staged plan tracked separately, not tied to a ticket):

- **Stage 0 (tooling):** `.periphery.yml` now sets `retain_swift_ui_previews: true` instead of the deprecated `exclude_tests` key, so SwiftUI `_Previews` structs stop being false-flagged as dead code by Periphery.
- **Stage 1 (zero-risk removals):** removed 5 confirmed-unused imports, verified via a combined Periphery scan across all 10 production targets together (Client, Account, Storage, Sync, and all extensions) to rule out cross-target false positives:
  - `Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift` — `import Account`
  - `Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift` — `import Storage`
  - `Client/Frontend/Settings/Main/Debug/DeleteAppAttestKeySetting.swift` — `import Storage`
  - `Client/Telemetry/TelemetryWrapper.swift` — `import Storage`
  - `RustFxA/RustFirefoxAccounts.swift` — `import Storage`

No behavior changes. Verified with a full build-for-testing plus `Fennec` unit test and `Smoketest` runs — no new failures introduced.

## :movie_camera: Demos
N/A — mechanical import cleanup + tooling config only, no UI changes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code