### PR TITLE
Add FXIOS-16347 [Automation] Auto-assign tech leads on big PRs

### DIFF
--- a/.github/workflows/assign-tech-lead-review.yml
+++ b/.github/workflows/assign-tech-lead-review.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          retry() { n=0; until "$@"; do n=$((n+1)); [ $n -ge 3 ] && break; sleep 2; done; }
+          retry() { n=0; until "$@"; do n=$((n+1)); [ $n -ge 3 ] && return 1; sleep 2; done; }
 
           total=$(( ADDITIONS + DELETIONS ))
           echo "PR #$NUMBER: additions=$ADDITIONS, deletions=$DELETIONS, total=$total (threshold=$BIG_PR_THRESHOLD), event=$EVENT_ACTION"
@@ -45,15 +45,13 @@ jobs:
             exit 0
           fi
 
-          # Request review from the tech lead team
+          # Request review from the tech lead team. Fails the workflow if unsuccessful after retries.
           retry gh api \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2026-03-10" \
             "/repos/$GH_REPO/pulls/$NUMBER/requested_reviewers" \
-            -f "team_reviewers[]=$TEAM_SLUG" \
-            || echo "Reviewer request failed (may be team-permission or duplicate)."
+            -f "team_reviewers[]=$TEAM_SLUG"
 
-          # Add label, no-op if already present
-          retry gh pr edit "$NUMBER" -R "$GH_REPO" --add-label "$LABEL_NAME" \
-            || echo "Label add failed (label may not exist in the repo)."
+          # Add label. Fails the workflow if the label does not exist or cannot be added.
+          retry gh pr edit "$NUMBER" -R "$GH_REPO" --add-label "$LABEL_NAME"

--- a/.github/workflows/assign-tech-lead-review.yml
+++ b/.github/workflows/assign-tech-lead-review.yml
@@ -8,9 +8,10 @@ permissions: {}
 
 jobs:
   assign-tech-lead:
-    # Skip drafts, and when triggered by `labeled`, only act on our specific label.
+    # Skip drafts and bot-authored PRs, and when triggered by `labeled`, only act on our specific label.
     if: >-
       github.event.pull_request.draft == false &&
+      github.event.pull_request.user.type != 'Bot' &&
       (github.event.action != 'labeled' || github.event.label.name == 'needs-tech-lead-review')
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/assign-tech-lead-review.yml
+++ b/.github/workflows/assign-tech-lead-review.yml
@@ -1,0 +1,58 @@
+name: 'Assign Tech Lead Review'
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
+
+permissions: {}
+
+jobs:
+  assign-tech-lead:
+    # Skip drafts, and when triggered by `labeled`, only act on our specific label.
+    if: >-
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'needs-tech-lead-review')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: assign-tech-lead-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      NUMBER: ${{ github.event.pull_request.number }}
+      ADDITIONS: ${{ github.event.pull_request.additions }}
+      DELETIONS: ${{ github.event.pull_request.deletions }}
+      EVENT_ACTION: ${{ github.event.action }}
+      BIG_PR_THRESHOLD: '800'
+      TEAM_SLUG: 'firefox-ios-tech-leads'
+      LABEL_NAME: 'needs-tech-lead-review'
+
+    steps:
+      - name: Check PR size and assign reviewer + label
+        shell: bash
+        run: |
+          set -euo pipefail
+          retry() { n=0; until "$@"; do n=$((n+1)); [ $n -ge 3 ] && break; sleep 2; done; }
+
+          total=$(( ADDITIONS + DELETIONS ))
+          echo "PR #$NUMBER: additions=$ADDITIONS, deletions=$DELETIONS, total=$total (threshold=$BIG_PR_THRESHOLD), event=$EVENT_ACTION"
+
+          if [ "$EVENT_ACTION" != "labeled" ] && [ "$total" -le "$BIG_PR_THRESHOLD" ]; then
+            echo "Under threshold and not manually labeled, nothing to do."
+            exit 0
+          fi
+
+          # Request review from the tech lead team
+          retry gh api \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GH_REPO/pulls/$NUMBER/requested_reviewers" \
+            -f "team_reviewers[]=$TEAM_SLUG" \
+            || echo "Reviewer request failed (may be team-permission or duplicate)."
+
+          # Add label, no-op if already present
+          retry gh pr edit "$NUMBER" -R "$GH_REPO" --add-label "$LABEL_NAME" \
+            || echo "Label add failed (label may not exist in the repo)."

--- a/.github/workflows/assign-tech-lead-review.yml
+++ b/.github/workflows/assign-tech-lead-review.yml
@@ -49,7 +49,7 @@ jobs:
           retry gh api \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
             "/repos/$GH_REPO/pulls/$NUMBER/requested_reviewers" \
             -f "team_reviewers[]=$TEAM_SLUG" \
             || echo "Reviewer request failed (may be team-permission or duplicate)."

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -344,6 +344,9 @@ class CodeCoverageGate {
 // swiftlint:disable line_length
 // Encourage smaller PRs
 func checkBigPullRequest() {
+    // Skip size commentary and tech lead heads-up for bot-authored PRs.
+    if danger.github.pullRequest.user.login.hasSuffix("[bot]") { return }
+
     let mediumPRThreshold = 400
     let bigPRThreshold = 800
     let monsterPRThreshold = 2000

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -377,6 +377,14 @@ func checkBigPullRequest() {
         Smaller PRs are easier to review. Thanks for making life easy for reviewers! ✨
         """)
     }
+
+    if additionsAndDeletions > bigPRThreshold {
+        markdown("""
+        ### 👀 **Tech lead review**
+        Because this PR is large, the `@mozilla-mobile/firefox-ios-tech-leads` team \
+        will be auto-assigned as reviewer by GitHub Actions.
+        """)
+    }
 }
 
 // Detect and tag specific people whenever specific files are modified


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16347)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34753)

## :bulb: Description
This is a new github action aiming to detect big PRs (similar to Danger check) but will auto-assign a member of the [tech leads team](https://github.com/orgs/mozilla-mobile/teams/firefox-ios-tech-leads/members). When this work properly, we can maybe remove the Danger `checkBigPullRequest()` function since it will be redundant a bit.

Note; I tried at first adding the reviewer with Danger, but this isn't the right tool for that job.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

