### PR TITLE
Bugfix FXIOS-14741 [Autofill] Show credit card controls on first focus

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1412,6 +1412,7 @@
 		96A5F736298D8EDF00234E5F /* MockSearchEngineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A5F734298D8EB900234E5F /* MockSearchEngineProvider.swift */; };
 		96A5F73829928B3700234E5F /* GeneralizedImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A5F73729928B3700234E5F /* GeneralizedImageFetcher.swift */; };
 		96AF8C1C29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AF8C1B29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift */; };
+		A7E318350000000000000002 /* AccessoryViewProviderAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E318350000000000000001 /* AccessoryViewProviderAnimationTests.swift */; };
 		96C11E9B2864C2DD00840E7C /* DependencyHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C11E9A2864C2DD00840E7C /* DependencyHelper.swift */; };
 		96D95016270238500079D39D /* MainThreadThrottler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D95015270238500079D39D /* MainThreadThrottler.swift */; };
 		96EB6C3827D821B800A9D159 /* HistoryPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EB6C3727D821B800A9D159 /* HistoryPanelViewModel.swift */; };
@@ -10170,6 +10171,7 @@
 		96A5F734298D8EB900234E5F /* MockSearchEngineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSearchEngineProvider.swift; sourceTree = "<group>"; };
 		96A5F73729928B3700234E5F /* GeneralizedImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralizedImageFetcher.swift; sourceTree = "<group>"; };
 		96AF8C1B29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardInputFieldHelperTests.swift; sourceTree = "<group>"; };
+		A7E318350000000000000001 /* AccessoryViewProviderAnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessoryViewProviderAnimationTests.swift; sourceTree = "<group>"; };
 		96B14F71BAAD012EA8852135 /* ne-NP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ne-NP"; path = "ne-NP.lproj/LoginManager.strings"; sourceTree = "<group>"; };
 		96C11E9A2864C2DD00840E7C /* DependencyHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyHelper.swift; sourceTree = "<group>"; };
 		96D95015270238500079D39D /* MainThreadThrottler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadThrottler.swift; sourceTree = "<group>"; };
@@ -13520,6 +13522,7 @@
 		43B658D729CE249D00C9EF08 /* CreditCard */ = {
 			isa = PBXGroup;
 			children = (
+				A7E318350000000000000001 /* AccessoryViewProviderAnimationTests.swift */,
 				ABEF80D82A2F283D003F52C4 /* CreditCardBottomSheetViewModelTests.swift */,
 				96AF8C1B29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift */,
 				967EDABE29D769A10089208D /* CreditCardInputFieldTests.swift */,
@@ -20781,6 +20784,7 @@
 				EC0FBD2D3006924A005CCA62 /* FolderTreeCellTests.swift in Sources */,
 				C2E4F4C62F62F959002A8524 /* MockMainMenuCoordinatorDelegate.swift in Sources */,
 				96AF8C1C29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift in Sources */,
+				A7E318350000000000000002 /* AccessoryViewProviderAnimationTests.swift in Sources */,
 				C296B6E92F5ECBF4001CD179 /* SummarizerConfigProviderTests.swift in Sources */,
 				39BF0CD72EB512CD002064F5 /* ImpressionTrackingUtilityTests.swift in Sources */,
 				21FA8FB02AE856590013B815 /* RemoteTabsCoordinatorTests.swift in Sources */,

--- a/firefox-ios/Client/AccessoryViewProvider.swift
+++ b/firefox-ios/Client/AccessoryViewProvider.swift
@@ -75,7 +75,7 @@ final class AccessoryViewProvider: UIView,
     }
 
     // MARK: - UI Elements
-    private let toolbar: UIToolbar = .build()
+    private let toolbar: UIToolbar
     private let toolbarTopHeightSpacer: UIView = .build()
 
     private lazy var previousButton: UIButton = {
@@ -197,10 +197,12 @@ final class AccessoryViewProvider: UIView,
     // MARK: - Initialization
     init(themeManager: ThemeManager = AppContainer.shared.resolve(),
          windowUUID: WindowUUID,
-         notificationCenter: NotificationCenter = NotificationCenter.default) {
+         notificationCenter: NotificationCenter = NotificationCenter.default,
+         toolbar: UIToolbar = .build()) {
         self.themeManager = themeManager
         self.windowUUID = windowUUID
         self.notificationCenter = notificationCenter
+        self.toolbar = toolbar
 
         super.init(frame: CGRect(width: UIScreen.main.bounds.width,
                                  height: UX.accessoryViewHeight))
@@ -321,7 +323,9 @@ final class AccessoryViewProvider: UIView,
 
     // MARK: - Private Methods
     private func configureToolbarItems() {
-        toolbar.setItems(toolbarItems, animated: true)
+        // Animated item changes can be deferred until the input accessory is presented again.
+        let shouldAnimate = if #available(iOS 26.0, *) { false } else { true }
+        toolbar.setItems(toolbarItems, animated: shouldAnimate)
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/AccessoryViewProviderAnimationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/AccessoryViewProviderAnimationTests.swift
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class AccessoryViewProviderAnimationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() {
+        AppContainer.shared.reset()
+        super.tearDown()
+    }
+
+    func testReloadDoesNotAnimateToolbarItemsOnIOS26() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("This regression only affects iOS 26 and later")
+        }
+
+        let toolbar = ToolbarSpy()
+        let subject = AccessoryViewProvider(windowUUID: WindowUUID(), toolbar: toolbar)
+        toolbar.reset()
+
+        subject.reloadViewFor(.creditCard)
+
+        XCTAssertEqual(toolbar.lastAnimatedValue, false)
+    }
+}
+
+private final class ToolbarSpy: UIToolbar {
+    private(set) var lastAnimatedValue: Bool?
+
+    override func setItems(_ items: [UIBarButtonItem]?, animated: Bool) {
+        lastAnimatedValue = animated
+        super.setItems(items, animated: animated)
+    }
+
+    func reset() {
+        lastAnimatedValue = nil
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14741)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31835)

## :bulb: Description

On iOS 26, updating `UIToolbar` items with animation can defer the visible input-accessory update until the user focuses another form field. This makes the credit-card autofill affordance appear only after a second tap.

This change disables animation for toolbar item updates on iOS 26 and later so the autofill controls are applied on first focus. Earlier iOS versions keep the existing animated behavior. The toolbar is injectable solely to verify the animation choice with a focused regression test.

### Impact

- Credit-card autofill controls update immediately on first focus on iOS 26+
- Existing toolbar animation behavior is unchanged on older iOS versions
- No strings, telemetry, layout, or accessibility semantics change

### Validation

- `AccessoryViewProviderAnimationTests.testReloadDoesNotAnimateToolbarItemsOnIOS26` passed on an iPadOS 26.5 simulator
- The full `ClientTests` target compiled as part of the focused test run
- Swift parser check passed for the implementation and regression test
- Xcode project `plutil` validation passed
- SwiftLint pre-push check passed
- `git diff --check` passed

## :movie_camera: Demos

The original reproduction video is attached to the linked GitHub issue. This draft needs QA confirmation on an affected iPad because the first-focus behavior is not reliably exposed through XCUI accessibility automation.

## :pencil: Checklist

- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the data stewardship requirements and will request a data review (N/A: no telemetry changes)
- [x] If adding or modifying strings, I read the guidelines and will request a string review from l10n (N/A: no string changes)
- [x] If needed, I updated documentation and added comments to complex code
