### PR TITLE
Bugfix FXIOS-14323 [Logins] Serialize concurrent key retrieval

### DIFF
--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -236,6 +236,9 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
 
     private var didAttemptToMoveToBackup = false
 
+    private var isRetrievingStoredKey = false
+    private var storedKeyCompletions = [@Sendable (Result<String, NSError>) -> Void]()
+
     private let logger: Logger
 
     public init(databasePath: String,
@@ -632,7 +635,26 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
     }
 
     public func getStoredKey(completion: @escaping @Sendable (Result<String, NSError>) -> Void) {
+        queue.async {
+            self.storedKeyCompletions.append(completion)
+            guard !self.isRetrievingStoredKey else { return }
+
+            self.isRetrievingStoredKey = true
+            self.retrieveStoredKey()
+        }
+    }
+
+    private func retrieveStoredKey() {
         let (key, encryptedCanaryPhrase) = rustKeychain.getLoginsKeyData()
+
+        let completion: @Sendable (Result<String, NSError>) -> Void = { result in
+            self.queue.async {
+                let completions = self.storedKeyCompletions
+                self.storedKeyCompletions.removeAll()
+                self.isRetrievingStoredKey = false
+                completions.forEach { $0(result) }
+            }
+        }
 
         switch(key, encryptedCanaryPhrase) {
         case (.some(key), .some(encryptedCanaryPhrase)):

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -236,9 +236,6 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
 
     private var didAttemptToMoveToBackup = false
 
-    private var isRetrievingStoredKey = false
-    private var storedKeyCompletions = [@Sendable (Result<String, NSError>) -> Void]()
-
     private let logger: Logger
 
     public init(databasePath: String,
@@ -635,24 +632,11 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
     }
 
     public func getStoredKey(completion: @escaping @Sendable (Result<String, NSError>) -> Void) {
-        queue.async {
-            self.storedKeyCompletions.append(completion)
-            guard !self.isRetrievingStoredKey else { return }
-
-            self.isRetrievingStoredKey = true
-            self.retrieveStoredKey()
-        }
-    }
-
-    private func retrieveStoredKey() {
         let (key, encryptedCanaryPhrase) = rustKeychain.getLoginsKeyData()
 
-        let completion: @Sendable (Result<String, NSError>) -> Void = { result in
+        let queueCompletion: @Sendable (Result<String, NSError>) -> Void = { result in
             self.queue.async {
-                let completions = self.storedKeyCompletions
-                self.storedKeyCompletions.removeAll()
-                self.isRetrievingStoredKey = false
-                completions.forEach { $0(result) }
+                completion(result)
             }
         }
 
@@ -660,15 +644,15 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
         case (.some(key), .some(encryptedCanaryPhrase)):
                 self.handleExpectedKeyAction(encryptedCanaryPhrase: encryptedCanaryPhrase,
                                              key: key,
-                                             completion: completion)
+                                             completion: queueCompletion)
         case (.some(key), .none):
-            self.handleUnexpectedKeyAction(completion: completion)
+            self.handleUnexpectedKeyAction(completion: queueCompletion)
         case (.none, .some(encryptedCanaryPhrase)):
-            self.handleMissingKeyAction(completion: completion)
+            self.handleMissingKeyAction(completion: queueCompletion)
         case (.none, .none):
-            self.handleFirstTimeCallOrClearedKeychainAction(completion: completion)
+            self.handleFirstTimeCallOrClearedKeychainAction(completion: queueCompletion)
         default:
-            self.handleIllegalStateAction(completion: completion)
+            self.handleIllegalStateAction(completion: queueCompletion)
         }
     }
 
@@ -724,7 +708,7 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
         // We didn't expect the key to be present, which either means this is a first-time
         // call or the key data has been cleared from the keychain.
 
-        self.hasSyncedLogins().upon { result in
+        self.hasSyncedLogins().uponQueue(queue) { result in
             guard result.failureValue == nil else {
                 completion(.failure(result.failureValue! as NSError))
                 return

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
@@ -157,9 +157,12 @@ class RustLoginsTests: XCTestCase, @unchecked Sendable {
     }
 
     func testDeleteMultipleLogins() {
-        // Add three logins to delete, one after another to avoid crashing (FIXME: FXIOS-14323 / Github #31023)
+        logins.rustKeychain.removeLoginsKeysForDebugMenuItem()
+
+        var addExpectations = [XCTestExpectation]()
         for i in 0..<3 {
             let expectation = XCTestExpectation(description: "Add login \(i)")
+            addExpectations.append(expectation)
             let login = RustLoginsTests.loginFactory(number: i)
 
             logins.addLogin(login: login) { result in
@@ -171,9 +174,8 @@ class RustLoginsTests: XCTestCase, @unchecked Sendable {
                     XCTFail("Add login \(i) failed")
                 }
             }
-
-            wait(for: [expectation], timeout: 2)
         }
+        wait(for: addExpectations, timeout: 2)
 
         let deleteExpectation = XCTestExpectation(description: "Deleting all entries")
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14323)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31023)

## :bulb: Description
Concurrent login writes could request the stored encryption key at the same time. The deferred key-handling path then invoked its completions outside `RustLogins`' serial queue, allowing multiple storage operations to enter the Rust layer concurrently.

This change queues stored-key requests, coalesces concurrent retrievals, and dispatches every waiting completion back onto the existing serial queue. The regression test now removes the stored key and starts three `addLogin` operations back-to-back before deleting the resulting logins, exercising the previously crashing path.

### Impact
- Prevents concurrent first-use login writes from racing in the Rust storage layer.
- Does not change UI, strings, telemetry, or persisted data formats.

### Testing
- `xcodebuild -project firefox-ios/Client.xcodeproj -scheme Storage -destination 'platform=iOS Simulator,id=405B8F13-D4A3-48BB-8020-5C066FF70E76' -derivedDataPath /tmp/firefox-ios-31023-derived -skipMacroValidation test -only-testing:StorageTests/RustLoginsTests/testDeleteMultipleLogins CODE_SIGNING_ALLOWED=NO`
- Result: 1 test passed, 0 failures.
- SwiftLint push check passed with no violations.

## :movie_camera: Demos
Not applicable; this change has no UI impact.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (not applicable; no UI changes)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review (not applicable; no telemetry changes)
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n (not applicable; no string changes)
- [x] If needed, I updated documentation and added comments to complex code (not applicable)
