### PR TITLE
Remove - RMST-473 Removing remote-settings v2 switches

### DIFF
--- a/BrowserKit/Sources/Shared/RemoteSettingsEnvironment.swift
+++ b/BrowserKit/Sources/Shared/RemoteSettingsEnvironment.swift
@@ -5,9 +5,6 @@
 /// NOTE: It would much cleaner to use RemoteSettingsServer if it had a public initializer.
 /// TODO(FXIOS-13189): Add public initializer from rawValue to RemoteSettingsServer.
 public enum RemoteSettingsEnvironment: String {
-    case prodV2
-    case stageV2
-    case devV2
     case prod
     case stage
     case dev

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -56,7 +56,7 @@ final class ASSearchEngineSelector: ASSearchEngineSelectorProtocol {
             let remoteSettingsEnvironmentKey =
                 profile.prefs.stringForKey(PrefsKeys.RemoteSettings.remoteSettingsEnvironment) ?? ""
             let remoteSettingsEnv = RemoteSettingsEnvironment(rawValue: remoteSettingsEnvironmentKey) ?? .prod
-            let isProd = remoteSettingsEnv == .prod || remoteSettingsEnv == .prodV2
+            let isProd = remoteSettingsEnv == .prod
             if !isProd {
                 _ = try? profile.remoteSettingsService.sync()
             }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeRSServerSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/ChangeRSServerSetting.swift
@@ -23,23 +23,13 @@ class ChangeRSServerSetting: HiddenSetting {
         Current: \(currentEnvRaw.capitalized)
 
         Changes take effect on the next app launch.
+
+        To switch to Staging and reset ordering prefs for Consolidated Search, choose the SEC Reset option.
         """
         let alert = UIAlertController(title: "Remote Settings Server",
                                       message: message,
                                       preferredStyle: .alert)
 
-        alert.addAction(UIAlertAction(title: "Production V2", style: .default, handler: { [weak self] _ in
-            guard let self else { return }
-            self.prefs.setString(RemoteSettingsEnvironment.prodV2.rawValue, forKey: self.prefsKey)
-        }))
-        alert.addAction(UIAlertAction(title: "Staging V2", style: .default, handler: { [weak self] _ in
-            guard let self else { return }
-            self.prefs.setString(RemoteSettingsEnvironment.stageV2.rawValue, forKey: self.prefsKey)
-        }))
-        alert.addAction(UIAlertAction(title: "Dev V2", style: .default, handler: { [weak self] _ in
-            guard let self else { return }
-            self.prefs.setString(RemoteSettingsEnvironment.devV2.rawValue, forKey: self.prefsKey)
-        }))
         alert.addAction(UIAlertAction(title: "Production", style: .default, handler: { [weak self] _ in
             guard let self else { return }
             self.prefs.removeObjectForKey(self.prefsKey)

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -831,9 +831,6 @@ extension RemoteSettingsEnvironment {
         case .prod: return .prod
         case .stage: return .stage
         case .dev: return .dev
-        case .prodV2: return .prodV2
-        case .stageV2: return .stageV2
-        case .devV2: return .devV2
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[RMST-473](https://mozilla-hub.atlassian.net/browse/RMST-473)
[Bug 2057029](https://bugzilla.mozilla.org/show_bug.cgi?id=2057029)

## :bulb: Description
The v2 services will be the default and only supported versions going forward.
This should be merged with or before [PR 7492](https://github.com/mozilla/application-services/pull/7492) in application-services client to prevent breaking builds.
This ticket is mostly a revert of #34038 , which added the ability for dev users to switch to v2 for testing.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code



[RMST-473]: https://mozilla-hub.atlassian.net/browse/RMST-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ