### PR TITLE
Add FXIOS-16385 [Tracker Blocker] added accessibility identifiers to shield and text in tracker blocker UI

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -305,6 +305,11 @@ struct AccessibilityIdentifiers {
             static let favIconImage = "SyncedTabFavIconImage"
             static let descriptionLabel = "SyncedTabDescriptionLabel"
         }
+
+        struct TrackerBlockerModule {
+            static let shieldIcon = "TrackerBlockerModule.shieldIcon"
+            static let titleLabel = "TrackerBlockerModule.titleLabel"
+        }
     }
 
     struct GeneralizedIdentifiers {

--- a/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerModuleCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerModuleCell.swift
@@ -25,6 +25,7 @@ final class TrackerBlockerModuleCell: UICollectionViewCell, ReusableCell, ThemeA
         icon.adjustsImageSizeForAccessibilityContentSizeCategory = true
         icon.image = UIImage(named: StandardImageIdentifiers.Large.shieldCheckmark)?
             .withRenderingMode(.alwaysTemplate)
+        icon.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.TrackerBlockerModule.shieldIcon
     }
 
     private lazy var titleLabel: UILabel = .build { label in
@@ -32,6 +33,7 @@ final class TrackerBlockerModuleCell: UICollectionViewCell, ReusableCell, ThemeA
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.text = .Menu.EnhancedTrackingProtection.trackersBlockedLabel
+        label.accessibilityIdentifier = AccessibilityIdentifiers.FirefoxHomepage.TrackerBlockerModule.titleLabel
     }
 
     // MARK: - Init


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16385)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34776)

## :bulb: Description
The initial iteration of the tracker blocker UI did not have accessibility identifiers for the shield icon and the title label. This change updates the AccessibilityIdentifiers.FirefoxHomepage struct and adds identifiers to both components.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

