### PR TITLE
Bugfix FXIOS-16380 Ensure blocker rules input JSON is lowercased

### DIFF
--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -410,7 +410,10 @@ extension ContentBlocker {
                 self?.logger.log("Will compile list: \(filename)", level: .info, category: .adblock)
                 self?.loadJsonFromBundle(forResource: filename) { jsonString in
                     ensureMainThread {
-                        var str = jsonString
+                        // Ensure JSON is lowercase only. WebKit rules expect lowercase
+                        // domains (and no other part of the JSON should be uppercase).
+                        // Introduced with FXIOS-16380.
+                        var str = jsonString.lowercased()
 
                         // Here we find the closing array bracket in the JSON string
                         // and append our safelist as a rule to the end of the JSON.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16380)

## :bulb: Description

For context, please see: https://mozilla.slack.com/archives/C05C9RET70F/p1784741228588859?thread_ts=1784566797.434269&cid=C05C9RET70F

I am still investigating what is needed to fix the source data, however this change ensures the full JSON is lowercased. To my knowledge we don't expect any part of the blocker list input to contain uppercase alpha characters. The JSON keys and keywords are all lowercase, and the domains are expected to be lowercase as well.

In addition to the fix this reverts the `Wolt` domain to match the current Disconnect data. (If we subsequently fix the domain we can consider reverting this change, or leave it in place for futureproofing.)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

