### PR TITLE
Bugfix FXIOS-11367 [Bookmarks] Fix accessory view overlap when exiting edit mode

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		0A44ABAC2D6DC2520034FA86 /* ThemedLearnMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A44ABAB2D6DC2410034FA86 /* ThemedLearnMoreTableViewCell.swift */; };
 		0A49784A2C53E63200B1E82A /* TrackingProtectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4978492C53E63200B1E82A /* TrackingProtectionViewController.swift */; };
 		0A5A3A142F9B776E0040C7B8 /* TabCellCustomImageViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A3A132F9B77670040C7B8 /* TabCellCustomImageViewTests.swift */; };
+		150082C6D38C48819700F800 /* OneLineTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D44C1561FC142F59A89E890 /* OneLineTableViewCellTests.swift */; };
 		0A5E6F402CF88A7900C1DFC9 /* SwitchDetailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5E6F3F2CF88A7900C1DFC9 /* SwitchDetailedView.swift */; };
 		0A686B3C2CDB70DC0090E146 /* MainMenuTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A686B3B2CDB70DC0090E146 /* MainMenuTelemetryTests.swift */; };
 		0A686B3E2CE253AB0090E146 /* PDFDocument+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A686B3D2CE253AB0090E146 /* PDFDocument+Extension.swift */; };
@@ -2828,6 +2829,7 @@
 		0A4978492C53E63200B1E82A /* TrackingProtectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingProtectionViewController.swift; sourceTree = "<group>"; };
 		0A574D09BF8D9E37D6C9C654 /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		0A5A3A132F9B77670040C7B8 /* TabCellCustomImageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCellCustomImageViewTests.swift; sourceTree = "<group>"; };
+		2D44C1561FC142F59A89E890 /* OneLineTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneLineTableViewCellTests.swift; sourceTree = "<group>"; };
 		0A5B4CE9B0996AE804491134 /* an */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = an; path = an.lproj/Shared.strings; sourceTree = "<group>"; };
 		0A5E6F3F2CF88A7900C1DFC9 /* SwitchDetailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchDetailedView.swift; sourceTree = "<group>"; };
 		0A686B3B2CDB70DC0090E146 /* MainMenuTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuTelemetryTests.swift; sourceTree = "<group>"; };
@@ -12922,6 +12924,14 @@
 			path = TabTray;
 			sourceTree = "<group>";
 		};
+		FC065E04C2B04DF289153794 /* Widgets */ = {
+			isa = PBXGroup;
+			children = (
+				2D44C1561FC142F59A89E890 /* OneLineTableViewCellTests.swift */,
+			);
+			path = Widgets;
+			sourceTree = "<group>";
+		};
 		21F422642E315DFD004FF994 /* TabScrollController */ = {
 			isa = PBXGroup;
 			children = (
@@ -17468,6 +17478,7 @@
 				8AED868428CA7B1200351A50 /* TabManagement */,
 				D525DFB225FBE5E000B18763 /* TabTests.swift */,
 				21D8EA942ABE0511003FF16E /* TabTray */,
+				FC065E04C2B04DF289153794 /* Widgets */,
 				8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */,
 				1D8956202FFD58E40041B982 /* TabErrorTelemetryHelperTests.swift */,
 				8AC225632B6D3F9600CDA7FD /* Telemetry */,
@@ -21146,6 +21157,7 @@
 				617D8ABF2FC8D27300E1C7A5 /* ConversionEventTrackerTests.swift in Sources */,
 				617D8AC02FC8D27300E1C7A5 /* ConversionActivityLoggerTests.swift in Sources */,
 				0A5A3A142F9B776E0040C7B8 /* TabCellCustomImageViewTests.swift in Sources */,
+				150082C6D38C48819700F800 /* OneLineTableViewCellTests.swift in Sources */,
 				8A36BE2C29EDE16C00AC1C5C /* ContentContainerTests.swift in Sources */,
 				C23F08542FB37A72009113BC /* WorldCupStoreTests.swift in Sources */,
 				401F68A52D84726700786D0C /* RemoteTabsPanelTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -94,7 +94,7 @@ class OneLineTableViewCell: UITableViewCell,
         updateReorderControl()
 
         // Position the accessory at the trailing edge of the cell, accounting for safe area and padding
-        if let accessoryView {
+        if !isEditing, let accessoryView {
             if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
                 accessoryView.frame.origin.x = UX.accessoryViewTrailingPadding + safeAreaInsets.left
             } else {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Widgets/OneLineTableViewCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Widgets/OneLineTableViewCellTests.swift
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+@MainActor
+final class OneLineTableViewCellTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        await DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() async throws {
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    // MARK: - layoutSubviews
+
+    func testLayoutSubviews_nonEditingMode_accessoryViewPositionedAtTrailingEdge() {
+        let subject = createSubject()
+        subject.frame = CGRect(x: 0, y: 0, width: 375, height: 44)
+        subject.configure(viewModel: createViewModel(withAccessory: true))
+
+        subject.layoutSubviews()
+
+        guard let accessoryView = subject.accessoryView else {
+            XCTFail("Expected accessoryView to be set")
+            return
+        }
+        let expectedX = subject.frame.width
+            - accessoryView.frame.width
+            - OneLineTableViewCell.UX.accessoryViewTrailingPadding
+            - subject.safeAreaInsets.right
+        XCTAssertEqual(
+            accessoryView.frame.origin.x,
+            expectedX,
+            accuracy: 0.5,
+            "In non-editing mode the accessory view should be positioned at the trailing edge"
+        )
+    }
+
+    func testLayoutSubviews_editingMode_accessoryViewNotRepositioned() {
+        let subject = createSubject()
+        subject.frame = CGRect(x: 0, y: 0, width: 375, height: 44)
+        subject.configure(viewModel: createViewModel(withAccessory: true))
+
+        let manualX = subject.frame.width
+            - (subject.accessoryView?.frame.width ?? 0)
+            - OneLineTableViewCell.UX.accessoryViewTrailingPadding
+            - subject.safeAreaInsets.right
+
+        subject.isEditing = true
+        subject.layoutSubviews()
+
+        if let accessoryView = subject.accessoryView {
+            XCTAssertNotEqual(
+                accessoryView.frame.origin.x,
+                manualX,
+                "In editing mode the accessory view should NOT be manually repositioned"
+            )
+        }
+    }
+
+    func testLayoutSubviews_noAccessoryView_noOp() {
+        let subject = createSubject()
+        subject.frame = CGRect(x: 0, y: 0, width: 375, height: 44)
+        subject.configure(viewModel: createViewModel(withAccessory: false))
+
+        subject.layoutSubviews()
+
+        XCTAssertNil(subject.accessoryView)
+    }
+
+    // MARK: - configure
+
+    func testConfigure_setsAccessoryAndEditingAccessory() {
+        let subject = createSubject()
+        subject.configure(viewModel: createViewModel(withAccessory: true, withEditingAccessory: true))
+
+        XCTAssertNotNil(subject.accessoryView, "accessoryView should be set after configure")
+        XCTAssertNotNil(subject.editingAccessoryView, "editingAccessoryView should be set after configure")
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> OneLineTableViewCell {
+        let subject = OneLineTableViewCell(style: .default, reuseIdentifier: OneLineTableViewCell.cellIdentifier)
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+
+    private func createViewModel(
+        withAccessory: Bool,
+        withEditingAccessory: Bool = false
+    ) -> OneLineTableViewCellViewModel {
+        let accessoryView: UIView? = withAccessory ? UIView(frame: CGRect(x: 0, y: 0, width: 24, height: 24)) : nil
+        let editingAccessoryView: UIImageView? = withEditingAccessory
+            ? UIImageView(image: UIImage(systemName: "chevron.right"))
+            : nil
+
+        return OneLineTableViewCellViewModel(
+            title: "Test Bookmark",
+            leftImageView: nil,
+            accessoryView: accessoryView,
+            accessoryType: .none,
+            editingAccessoryView: editingAccessoryView
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Widgets/OneLineTableViewCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Widgets/OneLineTableViewCellTests.swift
@@ -7,22 +7,12 @@ import XCTest
 
 @MainActor
 final class OneLineTableViewCellTests: XCTestCase {
-    override func setUp() async throws {
-        try await super.setUp()
-        await DependencyHelperMock().bootstrapDependencies()
-    }
-
-    override func tearDown() async throws {
-        DependencyHelperMock().reset()
-        try await super.tearDown()
-    }
-
     // MARK: - layoutSubviews
 
     func testLayoutSubviews_nonEditingMode_accessoryViewPositionedAtTrailingEdge() {
         let subject = createSubject()
         subject.frame = CGRect(x: 0, y: 0, width: 375, height: 44)
-        subject.configure(viewModel: createViewModel(withAccessory: true))
+        subject.configure(viewModel: createViewModel(isAccessoryEnabled: true))
 
         subject.layoutSubviews()
 
@@ -37,7 +27,6 @@ final class OneLineTableViewCellTests: XCTestCase {
         XCTAssertEqual(
             accessoryView.frame.origin.x,
             expectedX,
-            accuracy: 0.5,
             "In non-editing mode the accessory view should be positioned at the trailing edge"
         )
     }
@@ -45,7 +34,7 @@ final class OneLineTableViewCellTests: XCTestCase {
     func testLayoutSubviews_editingMode_accessoryViewNotRepositioned() {
         let subject = createSubject()
         subject.frame = CGRect(x: 0, y: 0, width: 375, height: 44)
-        subject.configure(viewModel: createViewModel(withAccessory: true))
+        subject.configure(viewModel: createViewModel(isAccessoryEnabled: true))
 
         let manualX = subject.frame.width
             - (subject.accessoryView?.frame.width ?? 0)
@@ -55,19 +44,21 @@ final class OneLineTableViewCellTests: XCTestCase {
         subject.isEditing = true
         subject.layoutSubviews()
 
-        if let accessoryView = subject.accessoryView {
-            XCTAssertNotEqual(
-                accessoryView.frame.origin.x,
-                manualX,
-                "In editing mode the accessory view should NOT be manually repositioned"
-            )
+        guard let accessoryView = subject.accessoryView else {
+            XCTFail("Expected accessoryView to be set")
+            return
         }
+        XCTAssertNotEqual(
+            accessoryView.frame.origin.x,
+            manualX,
+            "In editing mode the accessory view should NOT be manually repositioned"
+        )
     }
 
     func testLayoutSubviews_noAccessoryView_noOp() {
         let subject = createSubject()
         subject.frame = CGRect(x: 0, y: 0, width: 375, height: 44)
-        subject.configure(viewModel: createViewModel(withAccessory: false))
+        subject.configure(viewModel: createViewModel(isAccessoryEnabled: false))
 
         subject.layoutSubviews()
 
@@ -78,7 +69,7 @@ final class OneLineTableViewCellTests: XCTestCase {
 
     func testConfigure_setsAccessoryAndEditingAccessory() {
         let subject = createSubject()
-        subject.configure(viewModel: createViewModel(withAccessory: true, withEditingAccessory: true))
+        subject.configure(viewModel: createViewModel(isAccessoryEnabled: true, isEditingAccessoryEnabled: true))
 
         XCTAssertNotNil(subject.accessoryView, "accessoryView should be set after configure")
         XCTAssertNotNil(subject.editingAccessoryView, "editingAccessoryView should be set after configure")
@@ -93,11 +84,13 @@ final class OneLineTableViewCellTests: XCTestCase {
     }
 
     private func createViewModel(
-        withAccessory: Bool,
-        withEditingAccessory: Bool = false
+        isAccessoryEnabled: Bool,
+        isEditingAccessoryEnabled: Bool = false
     ) -> OneLineTableViewCellViewModel {
-        let accessoryView: UIView? = withAccessory ? UIView(frame: CGRect(x: 0, y: 0, width: 24, height: 24)) : nil
-        let editingAccessoryView: UIImageView? = withEditingAccessory
+        let accessoryView: UIView? = isAccessoryEnabled
+            ? UIView(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
+            : nil
+        let editingAccessoryView: UIImageView? = isEditingAccessoryEnabled
             ? UIImageView(image: UIImage(systemName: "chevron.right"))
             : nil
 


### PR DESCRIPTION
## :scroll: Tickets
Jira ticket: [FXIOS-11367](https://mozilla-hub.atlassian.net/browse/FXIOS-11367) (external contribution, no JIRA access)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24741)

## :bulb: Description

**Root cause:** `OneLineTableViewCell.layoutSubviews()` manually overwrites `accessoryView.frame.origin.x` on every layout pass, computed from the cell's current `frame.width`:

```swift
if let accessoryView {
    accessoryView.frame.origin.x = frame.width - accessoryView.frame.width
        - UX.accessoryViewTrailingPadding - safeAreaInsets.right
    // (+ RTL branch)
}
```

`layoutSubviews()` fires repeatedly while `setEditing(animated:)` animates the cell's bounds to make room for the reorder control — and UIKit is *independently* animating/repositioning the same accessory view for the same reason. This manual frame assignment fights that transition frame-by-frame, leaving a stale/duplicate chevron rendered on top of the new one.

I confirmed this by reproducing on a fresh install on current `main` (no prior fork changes): creating several folders while repeatedly toggling Edit mode produces a doubled trailing chevron on every row. Critically, in a screen recording of the repro, the doubled chevron **outlived the edit-mode transition itself** — it persisted for many seconds after the delete-circles/reorder handles had already disappeared (i.e., after the table had already left editing state), ruling out ordinary animation blur. Toggling Edit again reproduced it immediately.

This matches @farcasandreialexandru's investigation on the issue: *"a problem with the edit state, for cells"*, and their note that *"with the current implementation ... also appear this issue"* (i.e., intermittent even before removing the accessory-margin workaround). Their experiment of removing the block entirely also confirms why it exists: doing so fixes the edit-state bug but regresses the trailing margin in normal (non-editing) mode.

**Fix:** skip the manual repositioning while the cell is in editing state, so UIKit's own internal edit-transition layout is left alone. Non-editing behavior (which the block exists for) is unchanged:

```swift
if !isEditing, let accessoryView {
```

## :movie_camera: Demos

Steps to reproduce (from the issue): Bookmarks → Edit → create a new folder → save, with several folders already present, then toggle Edit off/on a few times.

- **Before:** doubled/overlapping trailing chevron on each row, persisting well past the edit-mode transition.
- **After:** single chevron at the trailing edge in both editing and non-editing states; verified visually on a fresh iPhone 16 (iOS 18.2) simulator install with 9 folders, toggling Edit repeatedly.

Screenshots/screen recording from the repro session are available locally — happy to attach via the web UI if useful for review.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code — added `OneLineTableViewCellTests` (4 tests); full `ClientTests` suite run (4046 tests) shows no new failures (1 pre-existing, unrelated failure in `BrowserCoordinatorTests` Google Lens camera-availability test)
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — the change only affects the x-position of an already-existing accessory view during editing transitions; no new accessibility properties introduced
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review — N/A, no telemetry added
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n — N/A, no strings added
- [x] If needed, I updated documentation and added comments to complex code

Fixes #24741

[FXIOS-11367]: https://mozilla-hub.atlassian.net/browse/FXIOS-11367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ