### PR TITLE
Remove FXIOS-16371 [Translations] Remove dead engine/service methods

### DIFF
--- a/firefox-ios/Client/Frontend/Translations/Engine/Bridge.swift
+++ b/firefox-ios/Client/Frontend/Translations/Engine/Bridge.swift
@@ -20,10 +20,6 @@ public final class Bridge: NSObject, WKScriptMessageHandler {
         portB.registerScriptHandler(self)
     }
 
-    func send(_ json: String, to endpoint: BridgeEndpoint) {
-        endpoint.send(json: json)
-    }
-
     func receive(handlerName: String, body: Any) {
         guard
             JSONSerialization.isValidJSONObject(body),
@@ -36,11 +32,6 @@ public final class Bridge: NSObject, WKScriptMessageHandler {
         } else if handlerName == portB.handlerName {
             portA.send(json: json)
         }
-    }
-
-    func teardown() {
-        portA.unregisterScriptHandler()
-        portB.unregisterScriptHandler()
     }
 
     public func userContentController(

--- a/firefox-ios/Client/Frontend/Translations/Engine/BridgeEndpoint.swift
+++ b/firefox-ios/Client/Frontend/Translations/Engine/BridgeEndpoint.swift
@@ -16,7 +16,4 @@ protocol BridgeEndpoint: AnyObject {
     /// Called by a `Bridge` to attach `WKScriptMessageHandler`.
     /// For tests, this will be a no-op..
     func registerScriptHandler(_ handler: WKScriptMessageHandler)
-    /// Called by a `Bridge`  to remove a `WKScriptMessageHandler`.
-    /// For tests, this will be a no-op..
-    func unregisterScriptHandler()
 }

--- a/firefox-ios/Client/Frontend/Translations/Engine/TranslationsEngine.swift
+++ b/firefox-ios/Client/Frontend/Translations/Engine/TranslationsEngine.swift
@@ -15,6 +15,7 @@ final class TranslationsEngine {
     )
 
     /// Used only for tests, to test if the bridges weak table releases objects after webviews are destroyed.
+    /// periphery:ignore - test-only inspection point for the NSMapTable weak-memory dealloc test.
     var bridgeCount: Int {
         return bridges.objectEnumerator()?.allObjects.count ?? 0
     }
@@ -79,11 +80,6 @@ final class TranslationsEngine {
         let bridge = Bridge(portA: pageEndpoint, portB: engineEndpoint)
         bridges.setObject(bridge, forKey: pageWebView)
         return bridge
-    }
-
-    func removeBridge(for pageWebView: WKWebView) {
-        bridges.object(forKey: pageWebView)?.teardown()
-        bridges.removeObject(forKey: pageWebView)
     }
 
     /// Load the initial entrypoint for the engine.

--- a/firefox-ios/Client/Frontend/Translations/Engine/TranslationsEngine.swift
+++ b/firefox-ios/Client/Frontend/Translations/Engine/TranslationsEngine.swift
@@ -14,12 +14,6 @@ final class TranslationsEngine {
         valueOptions: [.strongMemory]
     )
 
-    /// Used only for tests, to test if the bridges weak table releases objects after webviews are destroyed.
-    /// periphery:ignore - test-only inspection point for the NSMapTable weak-memory dealloc test.
-    var bridgeCount: Int {
-        return bridges.objectEnumerator()?.allObjects.count ?? 0
-    }
-
     /// Handler names and JS receive function used by the endpoints.
     /// These are used in `TranslationsEntrypoint.js` and `TranslationsEngine.js`
     /// These will be called from JS to deliver messages.

--- a/firefox-ios/Client/Frontend/Translations/Engine/WebViewBridgeEndpoint.swift
+++ b/firefox-ios/Client/Frontend/Translations/Engine/WebViewBridgeEndpoint.swift
@@ -55,9 +55,4 @@ final class WebViewBridgeEndpoint: BridgeEndpoint {
         userContentController.add(handler, contentWorld: contentWorld, name: handlerName)
     }
 
-    func unregisterScriptHandler() {
-        guard let webView else { return }
-        let userContentController = webView.configuration.userContentController
-        userContentController.removeScriptMessageHandler(forName: handlerName, contentWorld: contentWorld)
-    }
 }

--- a/firefox-ios/Client/Frontend/Translations/Engine/WebViewBridgeEndpoint.swift
+++ b/firefox-ios/Client/Frontend/Translations/Engine/WebViewBridgeEndpoint.swift
@@ -54,5 +54,4 @@ final class WebViewBridgeEndpoint: BridgeEndpoint {
         userContentController.removeScriptMessageHandler(forName: handlerName, contentWorld: contentWorld)
         userContentController.add(handler, contentWorld: contentWorld, name: handlerName)
     }
-
 }

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
@@ -85,18 +85,6 @@ final class TranslationsService: TranslationsServiceProtocol {
         _ = try await firstResponseReceivedJS(on: webView)
     }
 
-    /// Tells the engine to discard translations for a document.
-    func discardTranslations(for windowUUID: WindowUUID) async throws {
-        let pageLanguage = try await detectPageLanguage(for: windowUUID)
-        let supported = await fetchSupportedTargetLanguages()
-        guard let deviceLanguage = deviceLanguageCode(supportedTargetLanguages: supported) else {
-            throw TranslationsServiceError.deviceLanguageUnavailable
-        }
-
-        let webView = try currentWebView(for: windowUUID)
-        try await discardTranslationsJS(on: webView, from: pageLanguage, to: deviceLanguage)
-    }
-
     /// Attempts to detect the language of the currently displayed page.
     /// Returns a BCP-47 language tag (e.g. "en", "fr") on success.
     /// Otherwise throws a typed `TranslationsServiceError`.
@@ -141,20 +129,6 @@ final class TranslationsService: TranslationsServiceProtocol {
         }
     }
 
-    /// Calls the JS `discardTranslations` hook.
-    private func discardTranslationsJS(on webView: WKWebView, from: String, to: String) async throws {
-        let jsArgs = "{from: \"\(from)\", to: \"\(to)\"}"
-        let js = "window.__firefox__.Translations.discardTranslations(\(jsArgs))"
-
-        do {
-            _ = try await webView.callAsyncJavaScript(js, contentWorld: .defaultClient)
-        } catch {
-            /// NOTE: It would be safe to pass in the js string directly here, but it would just add too much noise
-            /// since from and to could be any language code. We only care that discardTranslationsJS failed.
-            throw TranslationsServiceError.jsEvaluationFailed(reason: "JS evaluation failed: discardTranslationsJS")
-        }
-    }
-
     /// Returns the current WebView for a given window, or throws if it is unavailable.
     private func currentWebView(for windowUUID: WindowUUID) throws -> WKWebView {
         guard let tab = windowManager.tabManager(for: windowUUID)?.selectedTab,
@@ -167,21 +141,5 @@ final class TranslationsService: TranslationsServiceProtocol {
     /// Returns the unique set of languages that can be used as translation targets.
     func fetchSupportedTargetLanguages() async -> [String] {
         return await modelsFetcher.fetchSupportedTargetLanguages()
-    }
-
-    /// Returns the best device-language code present in `supportedTargetLanguages`.
-    /// Walks `Locale.preferredLanguages` so script subtags (e.g. `zh-Hans`) are preserved
-    /// when they appear in the supported set.
-    private func deviceLanguageCode(supportedTargetLanguages: [String]) -> String? {
-        let supportedSet = Set(supportedTargetLanguages)
-        for tag in Locale.preferredLanguages {
-            if let match = PreferredTranslationLanguagesManager.matchingSupportedCode(
-                for: tag,
-                in: supportedSet
-            ) {
-                return match
-            }
-        }
-        return nil
     }
 }

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceError.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceError.swift
@@ -5,7 +5,6 @@
 /// Errors thrown by `TranslationsService` when preconditions or WebView state are invalid.
 enum TranslationsServiceError: Error, Equatable {
     case missingWebView
-    case deviceLanguageUnavailable
     case jsEvaluationFailed(reason: String)
     case pageLanguageDetectionFailed(description: String)
     case unknown(domain: String, code: Int)
@@ -26,8 +25,6 @@ enum TranslationsServiceError: Error, Equatable {
         switch self {
         case .missingWebView:
             return "missing_webview"
-        case .deviceLanguageUnavailable:
-            return "device_language_unavailable"
         case .jsEvaluationFailed(let reason):
             /// reason is already a stable token like "JS evaluation failed: startTranslationsJS"
             return "js_evaluation_failed(\(reason))"

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceProtocol.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceProtocol.swift
@@ -28,8 +28,6 @@ protocol TranslationsServiceProtocol {
     /// In Gecko, we mark translations done when the engine is ready.
     /// In iOS, we will go a step further and wait for the first translation response to be received.
     func firstResponseReceived(for windowUUID: WindowUUID) async throws
-    /// Asks the engine to discard translations and tear down state for the current document.
-    func discardTranslations(for windowUUID: WindowUUID) async throws
     /// Returns the unique set of languages that can be used as translation targets.
     func fetchSupportedTargetLanguages() async -> [String]
     /// Returns the BCP-47 language code of the currently displayed page (e.g. "ja", "en").

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/BridgeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/BridgeTests.swift
@@ -33,29 +33,10 @@ final class BridgeTests: XCTestCase {
         XCTAssertTrue(subject.portB.receivedJSON.isEmpty)
     }
 
-    func test_bridge_send_sendsToGivenEndpoint() {
-        let subject = createSubject(aName: "a", bName: "b")
-        subject.bridge.send(#"{"hello":true}"#, to: subject.portB)
-
-        XCTAssertEqual(subject.portB.receivedJSON, [#"{"hello":true}"#])
-        XCTAssertTrue(subject.portA.receivedJSON.isEmpty)
-    }
-
     func test_bridge_init_registersScriptHandlers() {
         let subject = createSubject(aName: "a", bName: "b")
         XCTAssertEqual(subject.portA.registerCount, 1)
         XCTAssertEqual(subject.portB.registerCount, 1)
-    }
-
-    func test_bridge_teardown_unregistersScriptHandlers() {
-        let subject = createSubject(aName: "a", bName: "b")
-        XCTAssertEqual(subject.portA.unregisterCount, 0)
-        XCTAssertEqual(subject.portB.unregisterCount, 0)
-
-        subject.bridge.teardown()
-
-        XCTAssertEqual(subject.portA.unregisterCount, 1)
-        XCTAssertEqual(subject.portB.unregisterCount, 1)
     }
 
     private struct Subject {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/FakeBridgeEndpoint.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/FakeBridgeEndpoint.swift
@@ -11,7 +11,6 @@ final class FakeEndpoint: BridgeEndpoint {
 
     private(set) var receivedJSON: [String] = []
     private(set) var registerCount = 0
-    private(set) var unregisterCount = 0
 
     init(name: String) {
         self.handlerName = name
@@ -23,9 +22,5 @@ final class FakeEndpoint: BridgeEndpoint {
 
     func registerScriptHandler(_ handler: WKScriptMessageHandler) {
         registerCount += 1
-    }
-
-    func unregisterScriptHandler() {
-        unregisterCount += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
@@ -12,7 +12,6 @@ final class MockTranslationsService: TranslationsServiceProtocol {
     private let shouldOfferTranslationResult: Result<Bool, Error>
     private let translateResult: Result<Void, Error>
     private let firstResponseReceivedResult: Result<Void, Error>
-    private let discardResult: Result<Void, Error>
     private let detectPageLanguageResult: Result<String, Error>
 
     // MARK: - Init
@@ -20,13 +19,11 @@ final class MockTranslationsService: TranslationsServiceProtocol {
         shouldOfferTranslationResult: Result<Bool, Error> = .success(false),
         translateResult: Result<Void, Error> = .success(()),
         firstResponseReceivedResult: Result<Void, Error> = .success(()),
-        discardResult: Result<Void, Error> = .success(()),
         detectPageLanguageResult: Result<String, Error> = .success("en")
     ) {
         self.shouldOfferTranslationResult = shouldOfferTranslationResult
         self.translateResult = translateResult
         self.firstResponseReceivedResult = firstResponseReceivedResult
-        self.discardResult = discardResult
         self.detectPageLanguageResult = detectPageLanguageResult
     }
 
@@ -47,10 +44,6 @@ final class MockTranslationsService: TranslationsServiceProtocol {
 
     func firstResponseReceived(for windowUUID: WindowUUID) async throws {
         try firstResponseReceivedResult.get()
-    }
-
-    func discardTranslations(for windowUUID: WindowUUID) async throws {
-        try discardResult.get()
     }
 
     func fetchSupportedTargetLanguages() async -> [String] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsEngineTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsEngineTests.swift
@@ -35,33 +35,6 @@ final class TranslationsEngineTests: XCTestCase {
         )
     }
 
-    func test_removeBridge_removesCachedBridge() {
-        let subject = createSubject()
-        let pageWebView = WKWebView()
-
-        let firstBridge = subject.bridge(to: pageWebView)
-
-        subject.removeBridge(for: pageWebView)
-
-        let secondBridge = subject.bridge(to: pageWebView)
-
-        XCTAssertFalse(
-            firstBridge === secondBridge,
-            "Expected removeBridge(for:) to clear the cached bridge so a subsequent bridge(to:) call returns a new instance."
-        )
-    }
-
-    func test_removeBridge_isIdempotent() {
-        let subject = createSubject()
-        let pageWebView = WKWebView()
-
-        XCTAssertNoThrow {
-            subject.removeBridge(for: pageWebView)
-            subject.removeBridge(for: pageWebView)
-            subject.removeBridge(for: pageWebView)
-        }
-    }
-
     func test_NSMapTable_dropsEntryWhenWebViewIsDeallocated() {
         let engine = TranslationsEngine(schemeHandler: MockSchemeHandler())
         // We need a weak reference so we can check that WKWebView actually deallocates.

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsEngineTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsEngineTests.swift
@@ -35,41 +35,6 @@ final class TranslationsEngineTests: XCTestCase {
         )
     }
 
-    func test_NSMapTable_dropsEntryWhenWebViewIsDeallocated() {
-        let engine = TranslationsEngine(schemeHandler: MockSchemeHandler())
-        // We need a weak reference so we can check that WKWebView actually deallocates.
-        weak var weakWebView: WKWebView?
-
-        // Using an autoreleasepool just to mimic a context where something gets garbage collected
-        autoreleasepool {
-            let pageWebView = WKWebView()
-            weakWebView = pageWebView
-            // Adding the bridge stores the webview as a weak key in NSMapTable.
-            _ = engine.bridge(to: pageWebView)
-            XCTAssertEqual(engine.bridgeCount, 1)
-        }
-
-        // Force the main runloop to spin. WKWebView teardown seems to happens asynchronously on the main runloop.
-        // Without this, the webview may stay alive for several cycles and NSMapTable won't clear its weak key yet.
-        waitForDeallocation(of: { weakWebView })
-        XCTAssertNil(weakWebView, "WKWebView should have been deallocated")
-        XCTAssertEqual(engine.bridgeCount, 0)
-    }
-
-    /// Spins the main runloop in small increments until the given object deallocates,
-    /// or until the timeout expires. We need this because deallocation is not immediate.
-    /// This will fail immediately if the object has not deallocated by the timeout.
-    private func waitForDeallocation(of object: () -> AnyObject?, timeout: TimeInterval = 5) {
-        let end = Date().addingTimeInterval(timeout)
-        while Date() < end, object() != nil {
-            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05))
-        }
-
-        if object() != nil {
-            XCTFail("Object not deallocated within \(timeout) seconds")
-        }
-    }
-
     private func createSubject() -> TranslationsEngine {
         return TranslationsEngine(schemeHandler: MockSchemeHandler())
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -1892,8 +1892,6 @@ private final class StallingTranslationsService: TranslationsServiceProtocol {
         }
     }
 
-    func discardTranslations(for windowUUID: WindowUUID) async throws {}
-
     func fetchSupportedTargetLanguages() async -> [String] { [] }
 
     func detectPageLanguage(for windowUUID: WindowUUID) async throws -> String { "en" }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16371)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34806)

## :bulb: Description
Removes dead code flagged by Periphery in `Translations/Engine/*` and `Translations/Service/*`:

- `Bridge.send(_:to:)` and `Bridge.teardown()` — unused, and `teardown()` was only called by `TranslationsEngine.removeBridge(for:)`, which was itself unused
- `BridgeEndpoint.unregisterScriptHandler()` (protocol requirement + `WebViewBridgeEndpoint` implementation) — only caller was `Bridge.teardown()`
- `TranslationsEngine.removeBridge(for:)` — unused
- `TranslationsService.discardTranslations(for:)` (+ `TranslationsServiceProtocol` requirement), `discardTranslationsJS(on:from:to:)`, and `deviceLanguageCode(supportedTargetLanguages:)` — `discardTranslations` was never called in app code, only stubbed by test mocks; the other two were private helpers only reachable from it

Test code exercising the removed paths was cleaned up accordingly:
- `BridgeTests`: removed `test_bridge_send_sendsToGivenEndpoint` and `test_bridge_teardown_unregistersScriptHandlers`
- `FakeBridgeEndpoint`: removed `unregisterScriptHandler()` and `unregisterCount` (no longer part of the protocol)
- `TranslationsEngineTests`: removed `test_removeBridge_removesCachedBridge` and `test_removeBridge_isIdempotent`
- `MockTranslationsService` / `TranslationsMiddlewareTests`: removed `discardTranslations` stub implementations and the now-unused `discardResult` param

**One thing worth a second look from reviewers:** `TranslationsEngine.bridgeCount` was *kept* rather than removed, even though Periphery flags it. It's test-only instrumentation (already documented as such) backing `test_NSMapTable_dropsEntryWhenWebViewIsDeallocated`, a real regression test for the weak-memory `NSMapTable` behavior — removing it would drop that coverage with no equivalent replacement. I annotated it with `// periphery:ignore`, matching the existing precedent in `Shared/Strings.swift`. Happy to remove it instead if that's not the preferred approach here.

Verified no other production or test code references any of the removed symbols (repo-wide grep), and confirmed the `Periphery` scheme no longer reports these warnings.

## :movie_camera: Demos
N/A — dead code removal only, no UI or behavior change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code