### PR TITLE
Refactor FXIOS-16377 [TrackerBlocker] Update stats store from archive to lifetime

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -10,11 +10,13 @@ public struct PrefsKeys {
     public static let KeyEnableChinaSyncService = "useChinaSyncService"
     public static let KeyLastRemoteTabSyncTime = "lastRemoteTabSyncTime"
 
-    // Long-term blocked-tracker stats (non-private), bucketed by ISO week and category.
-    // The current week is stored separately from completed weeks so the hot-path
-    // write only ever touches a small, fixed-size value.
+    // Long-term blocked-tracker stats (non-private), keyed by category. The
+    // in-progress week is stored separately from a single lifetime running total
+    // (the sum of all completed weeks) so the hot-path write only ever touches a
+    // small, fixed-size value. The start date marks when tracking first began.
     public static let TrackerBlockStatsCurrentWeek = "trackerBlockStatsCurrentWeek"
-    public static let TrackerBlockStatsArchive = "trackerBlockStatsArchive"
+    public static let TrackerBlockStatsLifetime = "trackerBlockStatsLifetime"
+    public static let TrackerBlockStatsStartDate = "trackerBlockStatsStartDate"
 
     // Global sync state for rust sync manager
     public static let RustSyncManagerPersistedState = "rustSyncManagerPersistedStateKey"

--- a/firefox-ios/Client/ContentBlocker/TrackerBlockStats/TrackerBlockStatsModels.swift
+++ b/firefox-ios/Client/ContentBlocker/TrackerBlockStats/TrackerBlockStatsModels.swift
@@ -4,9 +4,10 @@
 
 import Foundation
 
-/// Blocked-tracker counts for a single ISO-8601 week, keyed by category.
+/// Blocked-tracker counts for the in-progress ISO-8601 week, keyed by category.
 /// `year` is the ISO year-for-week-of-year (which can differ from the calendar
-/// year around January), and `week` is the ISO week-of-year (1...53).
+/// year around January), and `week` is the ISO week-of-year (1...53). Once the
+/// week rolls over, its counts are folded into `TrackerBlockStatsRunningTotal`.
 struct TrackerBlockStatsBucket: Codable, Equatable {
     let year: Int
     let week: Int
@@ -18,13 +19,19 @@ struct TrackerBlockStatsBucket: Codable, Equatable {
     }
 }
 
-/// The full persisted stats payload: an append-only list of weekly buckets.
-/// Lifetime figures are derived by summing across all buckets, so there is no
-/// separate running total to keep in sync.
-struct TrackerBlockStatsData: Codable, Equatable {
-    var buckets: [TrackerBlockStatsBucket]
+/// The lifetime running total of completed weeks, keyed by category. Holds no
+/// per-week identity: each completed week is added into these counts on rollover
+/// so lifetime figures stay a fixed-size value regardless of how long tracking
+/// has run. Lifetime totals add the in-progress week on top of this.
+struct TrackerBlockStatsRunningTotal: Codable, Equatable {
+    /// Category storage key (`BlocklistCategory.storageKey`) to blocked count.
+    var counts: [String: Int]
 
-    init(buckets: [TrackerBlockStatsBucket] = []) {
-        self.buckets = buckets
+    var total: Int {
+        return counts.values.reduce(0, +)
+    }
+
+    init(counts: [String: Int] = [:]) {
+        self.counts = counts
     }
 }

--- a/firefox-ios/Client/ContentBlocker/TrackerBlockStats/TrackerBlockStatsStore.swift
+++ b/firefox-ios/Client/ContentBlocker/TrackerBlockStats/TrackerBlockStatsStore.swift
@@ -5,50 +5,59 @@
 import Foundation
 import Shared
 
-/// Persists blocked-tracker counts long term, bucketed by ISO-8601 calendar
-/// week and by category. Lifetime figures are derived by summing all buckets.
+/// Persists blocked-tracker counts long term, keyed by category. Keeps the
+/// in-progress ISO-8601 week separate from a single lifetime running total, and
+/// records the date tracking first began. Lifetime figures are the running total
+/// plus the current week.
 protocol TrackerBlockStatsStore {
     func record(category: BlocklistCategory, count: Int, date: Date)
     func lifetimeTotal() -> Int
     func lifetimeByCategory() -> [BlocklistCategory: Int]
-    func weeklyTotal(for date: Date) -> Int
-    func weeklyByCategory(for date: Date) -> [BlocklistCategory: Int]
+    func currentWeekTotal(for date: Date) -> Int
+    func currentWeekByCategory(for date: Date) -> [BlocklistCategory: Int]
+    func trackingStartDate() -> Date?
     func reset()
 }
 
-/// Prefs-backed store that keeps the in-progress week separate from completed
-/// weeks. `record` runs on a hot path (once per newly-blocked host), so it only
-/// ever decodes/encodes the small, fixed-size current-week value. Completed
-/// weeks are folded into the archive on a week rollover, an operation that
-/// happens at most once per week, not per insert.
+/// Prefs-backed store that keeps the in-progress week separate from a lifetime
+/// running total. `record` runs on a hot path (once per newly-blocked host), so
+/// it only ever decodes/encodes the small, fixed-size current-week value.
+/// Completed weeks are folded into the running total on a week rollover, an
+/// operation that happens at most once per week, not per insert. The running
+/// total has no per-week identity, so storage stays a fixed size no matter how
+/// long tracking has run.
 final class DefaultTrackerBlockStatsStoreUtility: TrackerBlockStatsStore {
     private let prefs: Prefs
     private let calendar: Calendar
     private let currentWeekKey: String
-    private let archiveKey: String
+    private let lifetimeKey: String
+    private let startDateKey: String
 
     init(
         prefs: Prefs,
         calendar: Calendar = Calendar(identifier: .iso8601),
         currentWeekKey: String = PrefsKeys.TrackerBlockStatsCurrentWeek,
-        archiveKey: String = PrefsKeys.TrackerBlockStatsArchive
+        lifetimeKey: String = PrefsKeys.TrackerBlockStatsLifetime,
+        startDateKey: String = PrefsKeys.TrackerBlockStatsStartDate
     ) {
         self.prefs = prefs
         self.calendar = calendar
         self.currentWeekKey = currentWeekKey
-        self.archiveKey = archiveKey
+        self.lifetimeKey = lifetimeKey
+        self.startDateKey = startDateKey
     }
 
     // MARK: - TrackerBlockStatsStore
 
     func record(category: BlocklistCategory, count: Int, date: Date) {
         guard count > 0 else { return }
+        setStartDateIfNeeded(date)
         let (year, week) = isoYearWeek(for: date)
 
         var current = loadCurrentWeek()
-        // A new week has started: retire the completed week into the archive.
+        // A new week has started: fold the completed week into the running total.
         if let existing = current, existing.year != year || existing.week != week {
-            archive(existing)
+            foldIntoLifetime(existing)
             current = nil
         }
 
@@ -58,28 +67,37 @@ final class DefaultTrackerBlockStatsStoreUtility: TrackerBlockStatsStore {
     }
 
     func lifetimeTotal() -> Int {
-        let archived = loadArchive().buckets.reduce(0) { $0 + $1.total }
-        return archived + (loadCurrentWeek()?.total ?? 0)
+        return loadLifetime().total + (loadCurrentWeek()?.total ?? 0)
     }
 
     func lifetimeByCategory() -> [BlocklistCategory: Int] {
-        var buckets = loadArchive().buckets
-        if let current = loadCurrentWeek() { buckets.append(current) }
-        return aggregate(buckets: buckets)
+        var counts = loadLifetime().counts
+        if let current = loadCurrentWeek() {
+            for (key, count) in current.counts {
+                counts[key, default: 0] += count
+            }
+        }
+        return aggregate(counts: counts)
     }
 
-    func weeklyTotal(for date: Date) -> Int {
-        return bucket(for: date)?.total ?? 0
+    func currentWeekTotal(for date: Date) -> Int {
+        return currentWeekBucket(for: date)?.total ?? 0
     }
 
-    func weeklyByCategory(for date: Date) -> [BlocklistCategory: Int] {
-        guard let bucket = bucket(for: date) else { return [:] }
-        return aggregate(buckets: [bucket])
+    func currentWeekByCategory(for date: Date) -> [BlocklistCategory: Int] {
+        guard let bucket = currentWeekBucket(for: date) else { return [:] }
+        return aggregate(counts: bucket.counts)
+    }
+
+    func trackingStartDate() -> Date? {
+        guard let timestamp = prefs.timestampForKey(startDateKey) else { return nil }
+        return Date.fromTimestamp(timestamp)
     }
 
     func reset() {
         prefs.removeObjectForKey(currentWeekKey)
-        prefs.removeObjectForKey(archiveKey)
+        prefs.removeObjectForKey(lifetimeKey)
+        prefs.removeObjectForKey(startDateKey)
     }
 
     // MARK: - Helpers
@@ -89,34 +107,36 @@ final class DefaultTrackerBlockStatsStoreUtility: TrackerBlockStatsStore {
         return (components.yearForWeekOfYear ?? 0, components.weekOfYear ?? 0)
     }
 
-    private func bucket(for date: Date) -> TrackerBlockStatsBucket? {
+    /// Returns the stored current-week bucket only if it belongs to the ISO week
+    /// of `date`. A stale bucket from a prior week (not yet rolled over because
+    /// no new hit has been recorded) is treated as absent.
+    private func currentWeekBucket(for date: Date) -> TrackerBlockStatsBucket? {
         let (year, week) = isoYearWeek(for: date)
-        if let current = loadCurrentWeek(), current.year == year, current.week == week {
-            return current
+        guard let current = loadCurrentWeek(), current.year == year, current.week == week else {
+            return nil
         }
-        return loadArchive().buckets.first { $0.year == year && $0.week == week }
+        return current
     }
 
-    private func archive(_ bucket: TrackerBlockStatsBucket) {
+    private func foldIntoLifetime(_ bucket: TrackerBlockStatsBucket) {
         guard bucket.total > 0 else { return }
-        var data = loadArchive()
-        if let index = data.buckets.firstIndex(where: { $0.year == bucket.year && $0.week == bucket.week }) {
-            for (key, count) in bucket.counts {
-                data.buckets[index].counts[key, default: 0] += count
-            }
-        } else {
-            data.buckets.append(bucket)
+        var lifetime = loadLifetime()
+        for (key, count) in bucket.counts {
+            lifetime.counts[key, default: 0] += count
         }
-        saveArchive(data)
+        saveLifetime(lifetime)
     }
 
-    private func aggregate(buckets: [TrackerBlockStatsBucket]) -> [BlocklistCategory: Int] {
+    private func setStartDateIfNeeded(_ date: Date) {
+        guard prefs.timestampForKey(startDateKey) == nil else { return }
+        prefs.setTimestamp(date.toTimestamp(), forKey: startDateKey)
+    }
+
+    private func aggregate(counts: [String: Int]) -> [BlocklistCategory: Int] {
         var result = [BlocklistCategory: Int]()
-        for bucket in buckets {
-            for (storageKey, count) in bucket.counts {
-                guard let category = BlocklistCategory(storageKey: storageKey) else { continue }
-                result[category, default: 0] += count
-            }
+        for (storageKey, count) in counts {
+            guard let category = BlocklistCategory(storageKey: storageKey) else { continue }
+            result[category, default: 0] += count
         }
         return result
     }
@@ -131,12 +151,12 @@ final class DefaultTrackerBlockStatsStoreUtility: TrackerBlockStatsStore {
         encode(bucket, forKey: currentWeekKey)
     }
 
-    private func loadArchive() -> TrackerBlockStatsData {
-        return decode(TrackerBlockStatsData.self, forKey: archiveKey) ?? TrackerBlockStatsData()
+    private func loadLifetime() -> TrackerBlockStatsRunningTotal {
+        return decode(TrackerBlockStatsRunningTotal.self, forKey: lifetimeKey) ?? TrackerBlockStatsRunningTotal()
     }
 
-    private func saveArchive(_ data: TrackerBlockStatsData) {
-        encode(data, forKey: archiveKey)
+    private func saveLifetime(_ total: TrackerBlockStatsRunningTotal) {
+        encode(total, forKey: lifetimeKey)
     }
 
     private func decode<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TrackerBlockerModuleMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TrackerBlockerModuleMiddlewareTests.swift
@@ -124,7 +124,8 @@ private final class MockTrackerBlockStatsStore: TrackerBlockStatsStore {
     func record(category: BlocklistCategory, count: Int, date: Date) {}
     func lifetimeTotal() -> Int { return lifetimeTotalToReturn }
     func lifetimeByCategory() -> [BlocklistCategory: Int] { return [:] }
-    func weeklyTotal(for date: Date) -> Int { return 0 }
-    func weeklyByCategory(for date: Date) -> [BlocklistCategory: Int] { return [:] }
+    func currentWeekTotal(for date: Date) -> Int { return 0 }
+    func currentWeekByCategory(for date: Date) -> [BlocklistCategory: Int] { return [:] }
+    func trackingStartDate() -> Date? { return nil }
     func reset() {}
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackerBlockStatsStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackerBlockStatsStoreTests.swift
@@ -34,7 +34,7 @@ final class TrackerBlockStatsStoreTests: XCTestCase {
         subject.record(category: .advertising, count: 3, date: friday)
 
         XCTAssertEqual(subject.lifetimeTotal(), 5)
-        XCTAssertEqual(subject.weeklyTotal(for: monday), 5)
+        XCTAssertEqual(subject.currentWeekTotal(for: monday), 5)
     }
 
     func testRecord_attributesPerCategory() {
@@ -61,11 +61,12 @@ final class TrackerBlockStatsStoreTests: XCTestCase {
 
         XCTAssertEqual(subject.lifetimeTotal(), 0)
         XCTAssertTrue(subject.lifetimeByCategory().isEmpty)
+        XCTAssertNil(subject.trackingStartDate(), "Ignored records must not start tracking")
     }
 
     // MARK: - Week boundaries
 
-    func testRecord_crossingWeekBoundaryCreatesSeparateBuckets() {
+    func testRecord_crossingWeekBoundaryFoldsPreviousWeekIntoLifetime() {
         let subject = createSubject()
         let week24 = makeDate(year: 2024, month: 6, day: 14)
         let week25 = makeDate(year: 2024, month: 6, day: 17)
@@ -74,11 +75,11 @@ final class TrackerBlockStatsStoreTests: XCTestCase {
         subject.record(category: .advertising, count: 8, date: week25)
 
         XCTAssertEqual(subject.lifetimeTotal(), 11, "Lifetime is the sum of both weeks")
-        XCTAssertEqual(subject.weeklyTotal(for: week24), 3, "Weekly reflects only its own week")
-        XCTAssertEqual(subject.weeklyTotal(for: week25), 8)
+        XCTAssertEqual(subject.currentWeekTotal(for: week24), 0, "The previous week is no longer the current week")
+        XCTAssertEqual(subject.currentWeekTotal(for: week25), 8, "Only the in-progress week is reported")
     }
 
-    func testRecord_acrossISOYearRolloverCreatesSeparateBuckets() {
+    func testRecord_acrossISOYearRolloverFoldsPreviousWeekIntoLifetime() {
         let subject = createSubject()
         // 2020-12-31 falls in ISO week 53 of 2020; 2021-01-04 is ISO week 1 of 2021.
         let lastWeekOf2020 = makeDate(year: 2020, month: 12, day: 31)
@@ -88,13 +89,13 @@ final class TrackerBlockStatsStoreTests: XCTestCase {
         subject.record(category: .analytics, count: 9, date: firstWeekOf2021)
 
         XCTAssertEqual(subject.lifetimeTotal(), 15)
-        XCTAssertEqual(subject.weeklyTotal(for: lastWeekOf2020), 6)
-        XCTAssertEqual(subject.weeklyTotal(for: firstWeekOf2021), 9)
+        XCTAssertEqual(subject.currentWeekTotal(for: lastWeekOf2020), 0)
+        XCTAssertEqual(subject.currentWeekTotal(for: firstWeekOf2021), 9)
     }
 
-    // MARK: - Weekly by category
+    // MARK: - Current week
 
-    func testWeeklyByCategory_returnsOnlyCurrentWeek() {
+    func testCurrentWeekByCategory_reflectsOnlyTheInProgressWeek() {
         let subject = createSubject()
         let thisWeek = makeDate(year: 2024, month: 6, day: 10)
         let nextWeek = makeDate(year: 2024, month: 6, day: 17)
@@ -102,17 +103,89 @@ final class TrackerBlockStatsStoreTests: XCTestCase {
         subject.record(category: .advertising, count: 2, date: thisWeek)
         subject.record(category: .social, count: 5, date: nextWeek)
 
-        XCTAssertEqual(subject.weeklyByCategory(for: thisWeek), [.advertising: 2])
-        XCTAssertEqual(subject.weeklyByCategory(for: nextWeek), [.social: 5])
+        // Once the week rolls over, the earlier week is folded away and no longer
+        // reported per-week; only the in-progress week remains queryable.
+        XCTAssertEqual(subject.currentWeekByCategory(for: thisWeek), [:])
+        XCTAssertEqual(subject.currentWeekByCategory(for: nextWeek), [.social: 5])
     }
 
-    func testWeeklyTotal_returnsZeroForWeekWithoutData() {
+    func testCurrentWeekTotal_returnsZeroForNonCurrentWeek() {
         let subject = createSubject()
         subject.record(category: .advertising, count: 2, date: makeDate(year: 2024, month: 6, day: 10))
 
-        let untouchedWeek = makeDate(year: 2024, month: 1, day: 1)
-        XCTAssertEqual(subject.weeklyTotal(for: untouchedWeek), 0)
-        XCTAssertTrue(subject.weeklyByCategory(for: untouchedWeek).isEmpty)
+        let otherWeek = makeDate(year: 2024, month: 1, day: 1)
+        XCTAssertEqual(subject.currentWeekTotal(for: otherWeek), 0)
+        XCTAssertTrue(subject.currentWeekByCategory(for: otherWeek).isEmpty)
+    }
+
+    // MARK: - Lifetime across rollovers
+
+    func testLifetimeAndCurrentWeek_correctAfterWeekRollovers() {
+        let subject = createSubject()
+        let week1 = makeDate(year: 2024, month: 6, day: 3)
+        let week2 = makeDate(year: 2024, month: 6, day: 10)
+        let week3 = makeDate(year: 2024, month: 6, day: 17)
+
+        subject.record(category: .advertising, count: 2, date: week1)
+        subject.record(category: .analytics, count: 5, date: week2)
+        subject.record(category: .advertising, count: 3, date: week3)
+
+        XCTAssertEqual(subject.lifetimeTotal(), 10)
+        XCTAssertEqual(subject.currentWeekTotal(for: week1), 0, "A folded week is no longer the current week")
+        XCTAssertEqual(subject.currentWeekTotal(for: week2), 0)
+        XCTAssertEqual(subject.currentWeekTotal(for: week3), 3, "Current in-progress week")
+        XCTAssertEqual(subject.lifetimeByCategory()[.advertising], 5)
+        XCTAssertEqual(subject.lifetimeByCategory()[.analytics], 5)
+    }
+
+    func testStorage_staysFixedSizeAcrossManyWeeks() {
+        let subject = createSubject()
+        // Record one hit per week across ~15 weeks (day values overflow the month
+        // and are normalized by the calendar into successive weeks).
+        for day in stride(from: 1, through: 99, by: 7) {
+            subject.record(category: .advertising, count: 1, date: makeDate(year: 2024, month: 1, day: day))
+        }
+
+        // The hot-path value must never accumulate history: it holds exactly one week.
+        let current = decodeCurrentWeek()
+        XCTAssertNotNil(current)
+        XCTAssertEqual(current?.counts.values.reduce(0, +), 1, "Current week holds only the most recent week")
+
+        // All completed weeks collapse into a single running total, not a growing list.
+        let lifetime = decodeLifetime()
+        XCTAssertEqual(lifetime.counts.count, 1, "Running total is keyed by category only, not by week")
+        XCTAssertEqual(subject.lifetimeTotal(), 15)
+    }
+
+    // MARK: - Start date
+
+    func testTrackingStartDate_isSetToFirstRecordedDate() {
+        let subject = createSubject()
+        let firstDate = makeDate(year: 2024, month: 6, day: 10)
+
+        subject.record(category: .advertising, count: 1, date: firstDate)
+
+        XCTAssertEqual(subject.trackingStartDate()?.toTimestamp(), firstDate.toTimestamp())
+    }
+
+    func testTrackingStartDate_isNotOverwrittenByLaterRecords() {
+        let subject = createSubject()
+        let firstDate = makeDate(year: 2024, month: 6, day: 10)
+        let laterWeek = makeDate(year: 2024, month: 6, day: 17)
+
+        subject.record(category: .advertising, count: 1, date: firstDate)
+        subject.record(category: .analytics, count: 1, date: laterWeek)
+
+        XCTAssertEqual(subject.trackingStartDate()?.toTimestamp(), firstDate.toTimestamp())
+    }
+
+    func testTrackingStartDate_persistsAcrossStoreInstances() {
+        let firstDate = makeDate(year: 2024, month: 6, day: 10)
+        let first = createSubject()
+        first.record(category: .advertising, count: 1, date: firstDate)
+
+        let second = createSubject()
+        XCTAssertEqual(second.trackingStartDate()?.toTimestamp(), firstDate.toTimestamp())
     }
 
     // MARK: - Reset
@@ -125,8 +198,9 @@ final class TrackerBlockStatsStoreTests: XCTestCase {
         subject.reset()
 
         XCTAssertEqual(subject.lifetimeTotal(), 0)
-        XCTAssertEqual(subject.weeklyTotal(for: date), 0)
+        XCTAssertEqual(subject.currentWeekTotal(for: date), 0)
         XCTAssertTrue(subject.lifetimeByCategory().isEmpty)
+        XCTAssertNil(subject.trackingStartDate())
     }
 
     // MARK: - Persistence
@@ -140,45 +214,8 @@ final class TrackerBlockStatsStoreTests: XCTestCase {
         let second = createSubject()
 
         XCTAssertEqual(second.lifetimeTotal(), 4)
-        XCTAssertEqual(second.weeklyTotal(for: date), 4)
+        XCTAssertEqual(second.currentWeekTotal(for: date), 4)
         XCTAssertEqual(second.lifetimeByCategory()[.advertising], 4)
-    }
-
-    // MARK: - Current-week / archive separation
-
-    func testCurrentWeekBlob_staysSingleBucketAcrossManyWeeks() {
-        let subject = createSubject()
-        // Record one hit per week across ~15 weeks (day values overflow the month
-        // and are normalized by the calendar into successive weeks).
-        for day in stride(from: 1, through: 99, by: 7) {
-            subject.record(category: .advertising, count: 1, date: makeDate(year: 2024, month: 1, day: day))
-        }
-
-        // The hot-path value must never accumulate history: it holds exactly one bucket.
-        let current = decodeCurrentWeek()
-        XCTAssertNotNil(current)
-        XCTAssertEqual(current?.counts.values.reduce(0, +), 1, "Current week holds only the most recent week")
-
-        // All completed weeks live in the archive instead.
-        XCTAssertGreaterThan(decodeArchive().buckets.count, 1)
-    }
-
-    func testLifetimeAndWeekly_correctAfterWeekRollovers() {
-        let subject = createSubject()
-        let week1 = makeDate(year: 2024, month: 6, day: 3)
-        let week2 = makeDate(year: 2024, month: 6, day: 10)
-        let week3 = makeDate(year: 2024, month: 6, day: 17)
-
-        subject.record(category: .advertising, count: 2, date: week1)
-        subject.record(category: .analytics, count: 5, date: week2)
-        subject.record(category: .advertising, count: 3, date: week3)
-
-        XCTAssertEqual(subject.lifetimeTotal(), 10)
-        XCTAssertEqual(subject.weeklyTotal(for: week1), 2, "An archived week is still queryable")
-        XCTAssertEqual(subject.weeklyTotal(for: week2), 5)
-        XCTAssertEqual(subject.weeklyTotal(for: week3), 3, "Current in-progress week")
-        XCTAssertEqual(subject.lifetimeByCategory()[.advertising], 5)
-        XCTAssertEqual(subject.lifetimeByCategory()[.analytics], 5)
     }
 
     // MARK: - Helpers
@@ -191,8 +228,9 @@ final class TrackerBlockStatsStoreTests: XCTestCase {
         return decode(TrackerBlockStatsBucket.self, forKey: PrefsKeys.TrackerBlockStatsCurrentWeek)
     }
 
-    private func decodeArchive() -> TrackerBlockStatsData {
-        return decode(TrackerBlockStatsData.self, forKey: PrefsKeys.TrackerBlockStatsArchive) ?? TrackerBlockStatsData()
+    private func decodeLifetime() -> TrackerBlockStatsRunningTotal {
+        return decode(TrackerBlockStatsRunningTotal.self, forKey: PrefsKeys.TrackerBlockStatsLifetime)
+            ?? TrackerBlockStatsRunningTotal()
     }
 
     private func decode<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16377)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34769)

## :bulb: Description
I raised performance concerns as data would grow (from JSON encoding/decoding actions, not calculation) and PM has decided that we really only need current week and lifetime stats, instead of tracking weekly stats forever. This PR makes that change yasssssss

Note: the stats code is not yet in production/beta, so no migration is needed.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

