### PR TITLE
Bump FXIOS-16393 [Maintenance] Update swift certificates

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -33485,7 +33485,7 @@
 			repositoryURL = "https://github.com/apple/swift-certificates.git";
 			requirement = {
 				kind = exactVersion;
-				version = 1.2.0;
+				version = 1.19.3;
 			};
 		};
 		EDD592482FC1090C0015EF9E /* XCRemoteSwiftPackageReference "ModifiedCopyMacro" */ = {

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "56d50f70c44bb02c8f2972562e3a84aad337eee653481c4beca45f9b889ea42d",
+  "originHash" : "1fc06f7411e74236e2c3b66c5ff148d5a580722e4cc3b9a13d8858c1199f9a56",
   "pins" : [
     {
       "identity" : "a-star",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "bc566f88842b3b8001717326d935c2d113af5741",
-        "version" : "1.2.0"
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
       }
     },
     {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16393)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34819)

## :bulb: Description
Update [swift-certificates](github.com/apple/swift-certificates) to latest version. This used under the Tracking Protection certificate viewer and the native error page's certificate helper (with `import X509`). I'll ask QA to test this area of the code more thoroughly

<img width="366" height="348" alt="Screenshot 2026-07-23 at 11 45 23 AM" src="https://github.com/user-attachments/assets/60023953-1dcd-4d8b-9e61-b7bea7650bb2" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

