### PR TITLE
Bump FXIOS-16390 [Maintenance] Update SwiftDraw dependency to 0.29.0

### DIFF
--- a/BrowserKit/Package.resolved
+++ b/BrowserKit/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f7769db9aa06ae33623b4c8785d7d9f26a9fdda24cd4057a8041d63d8e740b03",
+  "originHash" : "b0d302059a5d10226cf478ad62db8b67846d36f9c3c1d1bc9f055a1f51cb6888",
   "pins" : [
     {
       "identity" : "dip",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swhitty/SwiftDraw",
       "state" : {
-        "revision" : "2cfd97c753feafe23c767ad3cb4daaf5c5415272",
-        "version" : "0.18.3"
+        "revision" : "82699f4bdf2f075793cfa0d392eb27c59b41a3fe",
+        "version" : "0.29.0"
       }
     },
     {

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -90,7 +90,7 @@ let package = Package(
             branch: "master"),
         .package(
             url: "https://github.com/swhitty/SwiftDraw",
-            exact: "0.18.3"),
+            exact: "0.29.0"),
         .package(
             url: "https://github.com/johnxnguyen/Down.git",
             exact: "0.11.0"),

--- a/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SVGImageProcessor.swift
+++ b/BrowserKit/Sources/SiteImageView/ImageProcessing/SiteImageFetcher/SVGImageProcessor.swift
@@ -25,7 +25,7 @@ struct SVGImageProcessor: ImageProcessor {
         case .data(let data):
             if let image = UIImage(data: data) {
                 return image
-            } else if let svgImage = SVG(data: data)?.rasterize(with: defaultFaviconSize) {
+            } else if let svgImage = SVG(data: data)?.rasterize(size: defaultFaviconSize) {
                 return svgImage
             }
             return nil

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1fc06f7411e74236e2c3b66c5ff148d5a580722e4cc3b9a13d8858c1199f9a56",
+  "originHash" : "11f4c221cb65cc51b27a66e05123e8d93bab966dfb34dd69ac976a0770f80ea5",
   "pins" : [
     {
       "identity" : "a-star",
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swhitty/SwiftDraw",
       "state" : {
-        "revision" : "2cfd97c753feafe23c767ad3cb4daaf5c5415272",
-        "version" : "0.18.3"
+        "revision" : "82699f4bdf2f075793cfa0d392eb27c59b41a3fe",
+        "version" : "0.29.0"
       }
     },
     {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16390)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34816)

## :bulb: Description
This PR bumps the version of [SwiftDraw](https://github.com/swhitty/SwiftDraw/releases) to latest version. There was a breaking change, although our usage of this library is limited. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

