### PR TITLE
Refactor FXIOS [Code owner] Make codeowner change for strings file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 /firefox-ios/Client/Experiments/initial_experiments.json @afurlan-firefox @mozilla-mobile/fxios-eng
 /firefox-ios/Client/Assets/CC_Script @nbhasin2 @issammani
 /firefox-ios/Client/Assets/RemoteSettingsData/ @nbhasin2 @issammani @mattreaganmozilla
+/firefox-ios/Shared/Strings.swift @mozilla-mobile/fxios-eng @mozilla-mobile/firefox-ios-l10n
 /MozillaRustComponents/Package.swift @mozilla-mobile/fxios-eng
 /MozillaRustComponents/Package.resolved @mozilla-mobile/fxios-eng
 /MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated @mozilla-mobile/fxios-eng

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -14,7 +14,6 @@ let releaseCheck = ReleaseBranchCheck()
 if releaseCheck.isReleaseBranch {
     releaseCheck.postReleaseBranchComment()
 } else {
-    checkStringsFile()
     checkForFunMetrics()
     checkAlphabeticalOrder(inFile: standardImageIdentifiersPath)
     checkForSpecificFileChange()
@@ -943,22 +942,6 @@ func checkAlphabeticalOrder(inFile filePath: String) {
         }
     } catch {
         warn("Failed to read or process file \(filePath): \(error)")
-    }
-}
-
-// Check if there's String file changes, and if so ask the l10n reviewers
-func checkStringsFile() {
-    let edited = danger.git.modifiedFiles
-    let touchedStrings = edited.filter { path in
-        path.localizedCaseInsensitiveContains("/Strings.swift")
-    }
-
-    if !touchedStrings.isEmpty {
-        markdown("""
-        ### ✍️ **Strings Updated**
-        Detected changes in `Shared/Strings.swift`.
-        To keep strings up to standards, please add a member of the [firefox-ios-l10n team](https://github.com/orgs/mozilla-mobile/teams/firefox-ios-l10n) as reviewer. 🌍
-        """)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
No tickets

## :bulb: Description
Make changes so l10n AND the eng team are both added as reviewer of the strings file. If I understood properly how codeowners work, if l10n team doesn't review it shouldn't block the merge of the PR, but they will at least be asked for review.

I am cleaning up the Danger file as well since the comment won't be necessary anymore.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

