### PR TITLE
Remove FXIOS-16367 [NotificationManager] Unused methods removed

### DIFF
--- a/firefox-ios/Client/NotificationManager.swift
+++ b/firefox-ios/Client/NotificationManager.swift
@@ -9,7 +9,6 @@ import Shared
 
 protocol NotificationManagerProtocol {
     func requestAuthorization(completion: @escaping @Sendable (Bool, Error?) -> Void)
-    func requestAuthorization(completion: @escaping @Sendable (Result<Bool, Error>) -> Void)
     func requestAuthorization() async throws -> Bool
     func getNotificationSettings(sendTelemetry: Bool) async -> UNNotificationSettings
     func hasPermission() async -> Bool
@@ -18,19 +17,9 @@ protocol NotificationManagerProtocol {
                   id: String,
                   userInfo: [AnyHashable: Any]?,
                   categoryIdentifier: String,
-                  date: Date,
-                  repeats: Bool)
-    func schedule(title: String,
-                  body: String,
-                  id: String,
-                  userInfo: [AnyHashable: Any]?,
-                  categoryIdentifier: String,
                   interval: TimeInterval,
                   repeats: Bool)
-    func findDeliveredNotifications() async -> [UNNotification]
     func findDeliveredNotificationForId(id: String) async -> UNNotification?
-    func removeAllPendingNotifications()
-    func removePendingNotificationsWithId(ids: [String])
 }
 
 // TODO: FXIOS-14114 - NotificationManager @unchecked Sendable
@@ -50,17 +39,6 @@ final class NotificationManager: NotificationManagerProtocol, @unchecked Sendabl
             completion(granted, error)
 
             self.telemetry.sendNotificationPermissionPrompt(isPermissionGranted: granted)
-        }
-    }
-
-    @available(*, renamed: "requestAuthorization()")
-    func requestAuthorization(completion: @escaping @Sendable (Result<Bool, Error>) -> Void) {
-        self.requestAuthorization { granted, error in
-            if let error = error {
-                completion(.failure(error))
-            } else {
-                completion(.success(granted))
-            }
         }
     }
 
@@ -98,26 +76,6 @@ final class NotificationManager: NotificationManagerProtocol, @unchecked Sendabl
         return hasPermission
     }
 
-    // Scheduling push notification based on the Date trigger (Ex 25 December at 10:00PM)
-    func schedule(title: String,
-                  body: String,
-                  id: String,
-                  userInfo: [AnyHashable: Any]? = nil,
-                  categoryIdentifier: String = "",
-                  date: Date,
-                  repeats: Bool = false) {
-        let units: Set<Calendar.Component> = [.minute, .hour, .day, .month, .year]
-        let dateComponents = Calendar.current.dateComponents(units, from: date)
-        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents,
-                                                    repeats: repeats)
-        schedule(title: title,
-                 body: body,
-                 id: id,
-                 userInfo: userInfo,
-                 categoryIdentifier: categoryIdentifier,
-                 trigger: trigger)
-    }
-
     // Scheduling push notification based on the time interval trigger (Ex 2 sec, 10min)
     func schedule(title: String,
                   body: String,
@@ -136,33 +94,18 @@ final class NotificationManager: NotificationManagerProtocol, @unchecked Sendabl
                  trigger: trigger)
     }
 
-    // Fetches all delivered notifications that are still present in Notification Center.
-    func findDeliveredNotifications() async -> [UNNotification] {
-        return await center.deliveredNotifications()
-    }
-
     // Fetches all delivered notifications that are still present in Notification Center by id
     func findDeliveredNotificationForId(id: String) async -> UNNotification? {
-        let notificationList: [UNNotification] = await findDeliveredNotifications()
+        let notificationList: [UNNotification] = await center.deliveredNotifications()
         let notification = notificationList.first(where: { notification -> Bool in
             notification.request.identifier == id
         })
         return notification
     }
 
-    // Remove all pending notifications
-    func removeAllPendingNotifications() {
-        center.removeAllPendingNotificationRequests()
-    }
-
-    // Remove pending notifications with id
-    func removePendingNotificationsWithId(ids: [String]) {
-        center.removePendingNotificationRequests(withIdentifiers: ids)
-    }
-
     // MARK: - Private
 
-    // Helper method that takes trigger based on date or time interval
+    // Helper method that takes a time interval trigger
     private func schedule(title: String,
                           body: String,
                           id: String,

--- a/firefox-ios/Client/NotificationManager.swift
+++ b/firefox-ios/Client/NotificationManager.swift
@@ -44,8 +44,12 @@ final class NotificationManager: NotificationManagerProtocol, @unchecked Sendabl
 
     func requestAuthorization() async throws -> Bool {
         return try await withCheckedThrowingContinuation { continuation in
-            requestAuthorization { result in
-                continuation.resume(with: result)
+            requestAuthorization { granted, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: granted)
+                }
             }
         }
     }

--- a/firefox-ios/Client/UserNotificationCenterProtocol.swift
+++ b/firefox-ios/Client/UserNotificationCenterProtocol.swift
@@ -12,12 +12,7 @@ protocol UserNotificationCenterProtocol {
     func requestAuthorization(options: UNAuthorizationOptions,
                               completionHandler: @escaping @Sendable (Bool, Error?) -> Void)
     func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: (@Sendable (Error?) -> Void)?)
-    func getPendingNotificationRequests(completionHandler: @escaping @Sendable ([UNNotificationRequest]) -> Void)
-    func removePendingNotificationRequests(withIdentifiers identifiers: [String])
-    func removeAllPendingNotificationRequests()
     func deliveredNotifications() async -> [UNNotification]
-    func removeDeliveredNotifications(withIdentifiers identifiers: [String])
-    func removeAllDeliveredNotifications()
 }
 
 extension UNUserNotificationCenter: UserNotificationCenterProtocol {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/NotificationManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/NotificationManagerTests.swift
@@ -34,14 +34,6 @@ class NotificationManagerTests: XCTestCase {
         XCTAssertTrue(self.center.getSettingsWasCalled)
     }
 
-    func testScheduleDate() {
-        notificationManager.schedule(title: "Title",
-                                     body: "Body",
-                                     id: "test-id",
-                                     date: Date.tomorrow)
-        XCTAssertTrue(center.addWasCalled)
-    }
-
     func testScheduleInterval() {
         notificationManager.schedule(title: "Title",
                                      body: "Body",
@@ -50,34 +42,9 @@ class NotificationManagerTests: XCTestCase {
         XCTAssertTrue(center.addWasCalled)
     }
 
-    func testFindDeliveredNotifications() async {
-        _ = await notificationManager.findDeliveredNotifications()
-        XCTAssertTrue(self.center.getDeliveredWasCalled)
-    }
-
     func testFindDeliveredNotificationForId() async {
         _ = await notificationManager.findDeliveredNotificationForId(id: "id1")
         XCTAssertTrue(self.center.getDeliveredWasCalled)
-    }
-
-    func testRemoveAllPendingNotifications() {
-        let notification1 = buildRequest(title: "title", body: "body", id: "id1")
-        let notification2 = buildRequest(title: "title", body: "body", id: "id2")
-        center.pendingRequests = [notification1, notification2]
-
-        notificationManager.removeAllPendingNotifications()
-        XCTAssertTrue(self.center.removeAllPendingRequestsWasCalled)
-        XCTAssertEqual(self.center.pendingRequests.count, 0)
-    }
-
-    func testRemovePendingNotificationsWithId() {
-        let notification1 = buildRequest(title: "title", body: "body", id: "id1")
-        let notification2 = buildRequest(title: "title", body: "body", id: "id2")
-        center.pendingRequests = [notification1, notification2]
-
-        notificationManager.removePendingNotificationsWithId(ids: ["id1"])
-        XCTAssertTrue(self.center.getPendingRequestsWithIdWasCalled)
-        XCTAssertEqual(self.center.pendingRequests.count, 1)
     }
 
     func testCloseRemoteTabNotification() {
@@ -93,18 +60,5 @@ class NotificationManagerTests: XCTestCase {
                 XCTFail("Error adding notification request: \(error)")
             }
         }
-    }
-
-    // MARK: - Helpers
-
-    private func buildRequest(title: String, body: String, id: String) -> UNNotificationRequest {
-        let notificationContent = UNMutableNotificationContent()
-        notificationContent.title = title
-        notificationContent.body = body
-        notificationContent.sound = UNNotificationSound.default
-        let request = UNNotificationRequest(identifier: id,
-                                            content: notificationContent,
-                                            trigger: nil)
-        return request
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNotificationManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockNotificationManager.swift
@@ -16,9 +16,6 @@ class MockNotificationManager: NotificationManagerProtocol {
         completion(shouldGrantPermission, errorToReturn)
     }
 
-    func requestAuthorization(completion: @escaping @Sendable (Result<Bool, Error>) -> Void) {
-    }
-
     func requestAuthorization() async throws -> Bool {
         return wasAuthorizationSuccessful
     }
@@ -37,18 +34,6 @@ class MockNotificationManager: NotificationManagerProtocol {
     }
 
     var scheduledNotifications = 0
-    var scheduleWithDateWasCalled = false
-    func schedule(title: String,
-                  body: String,
-                  id: String,
-                  userInfo: [AnyHashable: Any]?,
-                  categoryIdentifier: String,
-                  date: Date,
-                  repeats: Bool) {
-        scheduledNotifications += 1
-        scheduleWithDateWasCalled = true
-    }
-
     var scheduleWithIntervalWasCalled = false
     func schedule(title: String,
                   body: String,
@@ -61,23 +46,7 @@ class MockNotificationManager: NotificationManagerProtocol {
         scheduleWithIntervalWasCalled = true
     }
 
-    func findDeliveredNotifications() async -> [UNNotification] {
-        return []
-    }
-
     func findDeliveredNotificationForId(id: String) async -> UNNotification? {
         return nil
-    }
-
-    var removeAllPendingNotificationsWasCalled = false
-    func removeAllPendingNotifications() {
-        removeAllPendingNotificationsWasCalled = true
-        scheduledNotifications = 0
-    }
-
-    var removePendingNotificationsWithIdWasCalled = false
-    func removePendingNotificationsWithId(ids: [String]) {
-        scheduledNotifications -= 1
-        removePendingNotificationsWithIdWasCalled = true
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUserNotificationCenter.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockUserNotificationCenter.swift
@@ -7,8 +7,6 @@ import UserNotifications
 @testable import Client
 
 class MockUserNotificationCenter: UserNotificationCenterProtocol, @unchecked Sendable {
-    var pendingRequests = [UNNotificationRequest]()
-
     var getSettingsWasCalled = false
     func notificationSettings() async -> UNNotificationSettings {
         getSettingsWasCalled = true
@@ -31,37 +29,9 @@ class MockUserNotificationCenter: UserNotificationCenterProtocol, @unchecked Sen
         addWasCalled = true
     }
 
-    var getPendingRequestsWasCalled = false
-    func getPendingNotificationRequests(completionHandler: @escaping ([UNNotificationRequest]) -> Void) {
-        getPendingRequestsWasCalled = true
-        completionHandler(pendingRequests)
-    }
-
-    var getPendingRequestsWithIdWasCalled = false
-    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
-        getPendingRequestsWithIdWasCalled = true
-        pendingRequests.removeAll(where: { identifiers.contains($0.identifier) })
-    }
-
-    var removeAllPendingRequestsWasCalled = false
-    func removeAllPendingNotificationRequests() {
-        removeAllPendingRequestsWasCalled = true
-        pendingRequests.removeAll()
-    }
-
     var getDeliveredWasCalled = false
     func deliveredNotifications() async -> [UNNotification] {
         getDeliveredWasCalled = true
         return []
-    }
-
-    var removeDeliveredWithIdsWasCalled = false
-    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
-        removeDeliveredWithIdsWasCalled = true
-    }
-
-    var removeAllDeliveredWasCalled = false
-    func removeAllDeliveredNotifications() {
-        removeAllDeliveredWasCalled = true
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16367)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34803)
## :bulb: Description
Removes methods in `NotificationManager.swift` that are declared in the protocol and implementation but never called (per Periphery warnings):
- `requestAuthorization(completion: Result<Bool, Error>)`
- `schedule(title:body:id:userInfo:categoryIdentifier:date:repeats:)`
- `findDeliveredNotifications()`
- `removeAllPendingNotifications()`
- `removePendingNotificationsWithId(ids:)`

Also removes the related unused pass-through methods on `UserNotificationCenterProtocol.swift` that only existed to back the methods above:
- `getPendingNotificationRequests(completionHandler:)`
- `removePendingNotificationRequests(withIdentifiers:)`
- `removeAllPendingNotificationRequests()`
- `removeDeliveredNotifications(withIdentifiers:)`
- `removeAllDeliveredNotifications()`

`findDeliveredNotificationForId(id:)` now calls `center.deliveredNotifications()` directly instead of routing through the removed `findDeliveredNotifications()`.

Updates `MockNotificationManager`, `MockUserNotificationCenter`, and `NotificationManagerTests` to drop coverage for the removed methods.
## :movie_camera: Demos
N/A — no UI changes, dead code removal only.
## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [[PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [[data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg)](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [[guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog)](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code