### PR TITLE
Add FXIOS-15685 [Automation] Claude review github action

### DIFF
--- a/.github/workflows/claude-architecture-review.yml
+++ b/.github/workflows/claude-architecture-review.yml
@@ -1,0 +1,195 @@
+# Automated architecture review using Claude.
+# Trigger:
+#   - On demand by commenting "@claude" on a PR (non-fork PRs only).
+# Claude reads the PR diff and the architecture rules in docs/architecture-guidelines.md,
+# then posts inline review comments flagging violations of those rules.
+#
+# Modeled on:
+#   - mozilla/bigquery-etl/.github/workflows/claude-review.yml
+#   - mozilla/global-platform-admin/.github/workflows/claude-tf-plan-review.yaml
+#
+# Repo secret:
+# - ANTHROPIC_API_KEY: Anthropic API key (repository secret, created manually).
+name: Claude Architecture Review
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: claude-architecture-review-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: >-
+      github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open' &&
+      contains(github.event.comment.body, '@claude') &&
+      github.event.comment.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check PR is not from a fork
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Fail closed: on any API error or unexpected result, default to 'true' (treat as a
+          # fork) and bail, so the secret-bearing steps below never run for a fork PR.
+          IS_FORK=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} --jq '.head.repo.fork' || echo 'true')
+          if [[ "${IS_FORK:-true}" != "false" ]]; then
+            echo "PR is from a fork (or fork status could not be confirmed); refusing to run."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          # issue_comment defaults to the default branch, so check out the PR head instead
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Minimize previous Claude architecture reviews
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          # Filter on the `<!-- claude-architecture-review -->` marker that the prompt asks
+          # Claude to embed in the review body, so we only minimize our own prior reviews.
+          ids=$(gh api graphql \
+            -f query='
+              query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    reviews(last: 100) {
+                      nodes {
+                        id
+                        isMinimized
+                        author { login }
+                        body
+                        comments(first: 100) { nodes { id isMinimized } }
+                      }
+                    }
+                  }
+                }
+              }' \
+            -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" \
+            | jq -r '.data.repository.pullRequest.reviews.nodes[]
+                    | select(.author.login == "github-actions"
+                             and (.body | test("<!-- claude-architecture-review -->")))
+                    | (
+                        (select(.isMinimized | not) | .id),
+                        (.comments.nodes[] | select(.isMinimized | not) | .id)
+                      )')
+          for id in $ids; do
+            echo "Minimizing $id"
+            gh api graphql \
+              -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { clientMutationId } }' \
+              -f id="$id"
+          done
+
+      - name: Unset runner tokens before agent step
+        # Prevents a prompt injection in the agent step below from using these to touch the
+        # Actions cache/artifacts API or mint an OIDC token.
+        run: |
+          echo "ACTIONS_RUNTIME_TOKEN=" >> "$GITHUB_ENV"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN=" >> "$GITHUB_ENV"
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL=" >> "$GITHUB_ENV"
+
+      - name: Run Claude architecture review
+        # Mozilla org allowlist permits "anthropics/claude-code-action@v1" (mutable tag).
+        uses: anthropics/claude-code-action@v1 # zizmor: ignore[unpinned-uses]
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Pass GITHUB_TOKEN explicitly so the action doesn't try to mint an OIDC token
+          # (which would require `id-token: write`). Comments will be authored by
+          # github-actions[bot].
+          github_token: ${{ github.token }}
+          trigger_phrase: "@claude"
+          include_fix_links: false
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.issue.number }}
+
+            Review this pull request against the architecture rules documented in
+            `docs/architecture-guidelines.md`. That file is the sole source of truth for
+            what counts as a violation. Read it before reviewing anything.
+
+            Only flag violations of rules in that document. Do not enforce personal style
+            preferences, generic best practices, or rules not stated there. Skip anything
+            already caught by Danger (`Dangerfile.swift`) or SwiftLint (`.swiftlint.yml`),
+            for example `print()`, `NSLog()`, `os_log()`, force casts (`as!`), force try
+            (`try!`), `Deferred<`, `NotificationCenter.default.addObserver`, `UIScreen.main`,
+            `userInterfaceIdiom`, `UIDevice.current.orientation`, or new
+            `BrowserViewController+*.swift` extensions.
+
+            Label each finding with a Conventional Comments label: `issue`, `suggestion`,
+            or `nitpick`. Do not use the `praise` label or the `(blocking)` decorator;
+            humans decide what is blocking.
+
+            State the concrete problem and the fix, and match your wording to the label:
+            do not hedge an `issue` ("maybe", "you may want to") or inflate a `nitpick`
+            into a demand. Anchor each comment to a changed line; flag unchanged code only
+            when a change breaks or depends on it. Comment only when you are confident the
+            issue is real. Do not post comments that:
+            - Praise the code or restate what it does. If a change is correct, say nothing.
+            - Ask for verification ("Check if...", "Ensure that..."). Verify it yourself
+              or do not raise it.
+            - Flag style preferences not backed by `docs/architecture-guidelines.md`.
+
+            Post a single GitHub review using these tools in order:
+            1. `mcp__github__create_pending_pull_request_review` to start a pending review.
+            2. `mcp__github__add_comment_to_pending_review` for each inline finding,
+               prefixed with its label.
+            3. `mcp__github__submit_pending_pull_request_review` to finalize. Required
+               parameters:
+               - `event`: must be `"COMMENT"`. Never `APPROVE` or `REQUEST_CHANGES`; those
+                 statuses are reserved for human reviewers.
+               - `body`: a few sentences of overall context. Open with a factual
+                 description of what the PR does, not a characterization. Do not include a
+                 bulleted list restating the inline findings; those belong inline only.
+                 Always include the literal string `<!-- claude-architecture-review -->`
+                 in this body. It is a hidden HTML comment used to auto-collapse this
+                 review on rerun.
+
+            If any of those tools fail, fall back to posting a single consolidated
+            top-level comment via `gh pr comment` so the run is not silent.
+          claude_args: |
+            --max-budget-usd 6.00
+            --allowedTools mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review
+            --allowedTools mcp__github_inline_comment__create_inline_comment
+            --allowedTools mcp__github__submit_pending_pull_request_review,mcp__github__delete_pending_pull_request_review
+            --allowedTools mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments,mcp__github__add_reply_to_pull_request_comment
+            --allowedTools mcp__github__get_pull_request,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_file_contents
+            --allowedTools mcp__github__get_workflow_run,mcp__github__list_workflow_runs,mcp__github__list_workflow_jobs
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob"
+
+      - name: Log Claude permission denials
+        if: always()
+        env:
+          LOG: ${{ runner.temp }}/claude-execution-output.json
+        run: |
+          set -euo pipefail
+          if [[ ! -f "$LOG" ]]; then
+            echo "No execution log at $LOG; skipping denial check."
+            exit 0
+          fi
+          DENIALS=$(jq '[.[] | select(.type == "result") | .permission_denials // []] | add' "$LOG")
+          COUNT=$(jq 'length' <<< "$DENIALS")
+          if [[ "$COUNT" -eq 0 ]]; then
+            echo "No permission denials detected."
+            exit 0
+          fi
+          TOOLS=$(jq -r 'map(.tool_name) | unique | join(",")' <<< "$DENIALS")
+          echo "::warning::Claude had $COUNT permission denial(s), review may be incomplete. Denied tools: $TOOLS"
+          echo "::group::Permission denial details"
+          jq -r '.[] | "- \(.tool_name): \(.tool_input | tojson)"' <<< "$DENIALS"
+          echo "::endgroup::"

--- a/.github/workflows/claude-architecture-review.yml
+++ b/.github/workflows/claude-architecture-review.yml
@@ -125,11 +125,7 @@ jobs:
 
             Only flag violations of rules in that document. Do not enforce personal style
             preferences, generic best practices, or rules not stated there. Skip anything
-            already caught by Danger (`Dangerfile.swift`) or SwiftLint (`.swiftlint.yml`),
-            for example `print()`, `NSLog()`, `os_log()`, force casts (`as!`), force try
-            (`try!`), `Deferred<`, `NotificationCenter.default.addObserver`, `UIScreen.main`,
-            `userInterfaceIdiom`, `UIDevice.current.orientation`, or new
-            `BrowserViewController+*.swift` extensions.
+            already caught by Danger (`Dangerfile.swift`) or SwiftLint (`.swiftlint.yml`).
 
             Label each finding with a Conventional Comments label: `issue`, `suggestion`,
             or `nitpick`. Do not use the `praise` label or the `(blocking)` decorator;

--- a/docs/architecture-guidelines.md
+++ b/docs/architecture-guidelines.md
@@ -1,0 +1,83 @@
+# Architecture Guidelines
+
+Compact rules for the architectural patterns used in Firefox iOS. This document is the checklist used by our automated PR reviewer.
+
+Every rule below should be traceable to an ADR, a Confluence page or a Google document. All sources should be linked.. Do not add a rule here without a source; document it first, then add it.
+
+## Coordinators
+
+Coordinators own navigation. View controllers should be flow-agnostic.
+
+- Coordinators control app flow: create view controllers and call the `Router` to push/present. They should not decide *what* to show or contain business logic. The one exception is that a coordinator may hold A/B test variant logic.
+- Coordinators should manage only view controllers.
+- Coordinators should not hold references to the view controllers they present, unless there is a specific reason to do so.
+- `Router` wraps `UINavigationController` and is passed between coordinators. Extend it only to handle navigation events.
+- A view controller must not know its position in the app flow. `ViewController A` should not know it is presenting `ViewController B`. Navigation is delegated to a coordinator, or expressed as a Redux navigation action (see Redux → Navigation).
+
+References: [ADR 0002](../adr/0002-coordinators-for-navigation.md), [Confluence: Navigation and Coordinators](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2545713156).
+
+## Redux
+
+Our in-house Redux implementation lives in [`BrowserKit/Sources/Redux`](../BrowserKit/Sources/Redux). New state-holding features use Redux, not MVVM.
+
+References: [0003 Redux Pilot](../adr/0003-redux-pilot.md), [0004 Redux replaces MVVM](../adr/0004-using-redux-to-replace-mvvm.md), [0005 Redux Navigation](../adr/0005-redux-and-navigation.md), [0011 Copy macro](../adr/0011-redux-state-reducer-initializer-cleanup-with-copy-macro.md), [Redux](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2647621724), [Redux: How to Implement](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2647556179), [Redux Guidelines & FAQs](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2647392306)
+
+### State
+
+- State is an immutable `struct` conforming to `ScreenState` and `Equatable`.
+- State typically includes a `windowUUID` property to support multiple iPad windows.
+- The reducer is a pure function exposed as `static let reducer: Reducer<Self>`.
+- Reducers must always return a **new** state. Never `return state`; use `defaultState(from:)` in `else` and `default` branches so transient properties reset to their defaults.
+- Reducers should not contain complex logic; they return the state for the view.
+- Call sub-reducers explicitly (e.g. `SubState.reducer(state.subState, action)`), rather than passing the previous sub-state through unchanged.
+- For large states, prefer the `@Copyable` macro (`state.copy(...)`) over re-initializing every property.
+
+### Actions
+
+- Actions are **classes** inheriting from `Action`. Never `struct`, and never `enum` cases with associated values.
+- Each action lives in its own file, paired with a matching `ActionType` enum.
+- Payload lives as properties on the action class, not as associated values on the `ActionType` case.
+- Actions must carry a `windowUUID` (required by the `Action` protocol).
+- Name actions after the **event that triggered them**, not the outcome. Prefer `tapOnButton` over `updateView`.
+- User actions are dispatched from the view. Middleware-originated actions are dispatched from the middleware.
+
+### Middleware
+
+- Middleware is where side effects live: network, storage, telemetry, and other external dependencies.
+- Middleware is optional. Do not add one without an explicit reason.
+- All external dependencies must be injected via the initializer so tests can substitute mocks.
+- Middleware handles business logic; reducers handle presentation logic. Keep the split clean.
+- If a middleware grows too large or spans multiple responsibilities, split it.
+- Do not manually dispatch to the main thread; the store guarantees actions run on the main thread.
+- Middleware runs once per action (not once per active screen), so it must respect `windowUUID` when the action targets a specific window.
+
+### Switch statements
+
+- Switch cases in reducers and middleware have a **2-line maximum** per case, to keep them readable.
+
+### Navigation in Redux
+
+- Navigation intent is expressed as Redux state or actions (`NavigationBrowserAction`, `NavigationDestination`), not as direct view controller calls inside reducers or views.
+- `BrowserViewController` observes `state.navigationDestination` and calls `handleNavigation(to:)` when it is non-nil. New navigation should follow the same pattern.
+
+### View models
+
+- Do not introduce new view models. Business logic goes to middleware; presentation logic goes to the reducer.
+- If a model needs presentation-side shaping, name it `*Configuration` (e.g. `TopSiteConfiguration`).
+
+### Tests
+
+- Every action a state handles directly should have a test.
+- Middleware should be tested with mocked dependencies.
+
+## Tests
+
+- Tests must call `super.setUp()` and `super.tearDown()` in their respective overrides.
+- `setUp` and `tearDown` must mirror each other. Every property assigned in `setUp` must be reset (typically to `nil`) in `tearDown`, so state does not leak across tests.
+- Tests should test for leaks with `trackForMemoryLeaks` whenever possible.
+
+
+## BrowserKit libraries
+
+- When a new BrowserKit package is added, it should be reminded to check that the code coverage is properly gathered. This needs to be done manually by the owner of the PR. Steps to fix code coverage are [listed in Confluence](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2316894216/How+to+create+a+BrowserKit+package).
+- Do not add new code to the `Shared` library. If it's meant to be shared, it should be under `Common` or place new code in a specific feature module, or an appropriate `BrowserKit` component. The `Shared` library is there for historical reasons but we don't want to expand on it.

--- a/docs/architecture-guidelines.md
+++ b/docs/architecture-guidelines.md
@@ -2,7 +2,14 @@
 
 Compact rules for the architectural patterns used in Firefox iOS. This document is the checklist used by our automated PR reviewer.
 
-Every rule below should be traceable to an ADR, a Confluence page or a Google document. All sources should be linked.. Do not add a rule here without a source; document it first, then add it.
+Every rule below should be traceable to an ADR, a Confluence page, a Google document, or a team agreement recorded in a Jira ticket (e.g. [FXIOS-15685](https://mozilla-hub.atlassian.net/browse/FXIOS-15685)). All sources should be linked. Do not add a rule here without a source; document it first, then add it.
+
+## Patterns
+
+- Challenge any singleton used without a proper reason. Watch for new `static let shared = X()` or `static let sharedInstance = X()`. Should we use dependency injection, or our `DependencyHelper` instead of a singleton?
+- Do not add new global variables or functions in the code.
+- Escaping closures and `Task { }` blocks must capture `self` weakly (`[weak self]`) when the enclosing object can outlive the closure. This applies in particular to middleware, coordinators, network callbacks, notification handlers, and other long-lived services. Strong captures are only acceptable when the closure is short-lived and cannot cause a retain cycle.
+
 
 ## Coordinators
 
@@ -13,8 +20,41 @@ Coordinators own navigation. View controllers should be flow-agnostic.
 - Coordinators should not hold references to the view controllers they present, unless there is a specific reason to do so.
 - `Router` wraps `UINavigationController` and is passed between coordinators. Extend it only to handle navigation events.
 - A view controller must not know its position in the app flow. `ViewController A` should not know it is presenting `ViewController B`. Navigation is delegated to a coordinator, or expressed as a Redux navigation action (see Redux → Navigation).
+- View controllers must not perform navigation themselves. Calls like `navigationController?.pushViewController(...)`, `present(_:animated:completion:)`, `dismiss(animated:)`, or `show(_:sender:)` from inside a view controller are red flags. Route the navigation through a coordinator or dispatch a `NavigationBrowserAction`.
 
 References: [ADR 0002](../adr/0002-coordinators-for-navigation.md), [Confluence: Navigation and Coordinators](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2545713156).
+
+## Theming
+
+All colors and themed images go through the theming system. Hardcoded colors are the most common violation we want to catch.
+
+- UIKit views must conform to `Themeable`, implement `applyTheme()`, and call `listenForThemeChanges()` in `viewDidLoad()`. Child views conform to `ThemeApplicable` and receive the theme from their parent.
+- SwiftUI views use `@Environment(\.themeType)` and implement `applyTheme(theme:)`.
+- Use themed colors exclusively: `theme.colors.textPrimary`, `theme.colors.layer1`, etc. Do not use hardcoded `UIColor(red:green:blue:alpha:)`, `UIColor(hex:)`, hex string literals, or system colors such as `UIColor.red` in production code. The only unthemed exception is `.clear`.
+- Do not reference `FXColors.*` directly in feature code. Colors are consumed through the theme's colors namespace.
+- Do not branch on the theme type in view code (`if theme == .dark { ... }`). If a value must differ between themes, add a token to the theme and let each theme resolve it.
+- Themed images use `ThemeType.getThemedImageName(name:)`. Do not switch images manually based on theme.
+- If the color you need is not in the mobile theme, ask designers to add it to the Figma color tokens before writing the code. Do not add local color constants as a workaround.
+
+Reference: [Theming system wiki](https://github.com/mozilla-mobile/firefox-ios/wiki/Theming-system).
+
+## Accessibility
+
+Every visible UI element must be usable with VoiceOver and Dynamic Type. The reviewer looks for missing or misused accessibility APIs on new views.
+
+- **`accessibilityLabel`**: set on custom UI elements, or on standard elements whose default label is missing or wrong. The label must be a localized string. Do not leave VoiceOver reading unlocalized text or raw asset names.
+- **`accessibilityTraits`**: set traits that reflect the element's function when they differ from the default. Common patterns: `.button` for tappable images, `.link` for elements that navigate to external content, `.header` for section headers.
+- **`accessibilityHint`**: use only when the label alone does not convey what the action does. VoiceOver reads it after the label, trait, and value, and users can disable hints.
+- **`accessibilityIdentifier`**: for UI testing only. It is not user-facing and must not be used in place of `accessibilityLabel`. All identifiers must be declared in the `AccessibilityIdentifiers` struct (never inlined as raw strings in view code), and new entries must be added in alphabetical order within their group.
+- **Element grouping**: for composite cells (image + title + description), disable `isAccessibilityElement` on the child views and enable it on the parent container with a combined `accessibilityLabel`. VoiceOver should navigate the cell as one element.
+
+### Dynamic Type
+
+- Text-containing views must support Dynamic Type. Use `FXFontStyles` for fonts and set `adjustsFontForContentSizeCategory = true` on labels.
+- Scale icon sizes with `UIFontMetrics.default.scaledValue(for:)` so icons grow with text.
+- Do not set fixed heights on views that contain text. Use `UIStackView` and set `numberOfLines = 0` for multi-line labels so content can reflow.
+
+References: [Accessibility overview wiki](https://github.com/mozilla-mobile/firefox-ios/wiki/A-Brief-Overview-of-Accessibility), [Strings, AccessibilityIdentifiers, ImageIdentifiers wiki](https://github.com/mozilla-mobile/firefox-ios/wiki/Strings,-%60AccessibilityIdentifiers%60,-%60ImageIdentifiers%60).
 
 ## Redux
 
@@ -75,7 +115,6 @@ References: [0003 Redux Pilot](../adr/0003-redux-pilot.md), [0004 Redux replaces
 - Tests must call `super.setUp()` and `super.tearDown()` in their respective overrides.
 - `setUp` and `tearDown` must mirror each other. Every property assigned in `setUp` must be reset (typically to `nil`) in `tearDown`, so state does not leak across tests.
 - Tests should test for leaks with `trackForMemoryLeaks` whenever possible.
-
 
 ## BrowserKit libraries
 

--- a/docs/architecture-guidelines.md
+++ b/docs/architecture-guidelines.md
@@ -2,38 +2,45 @@
 
 Compact rules for the architectural patterns used in Firefox iOS. This document is the checklist used by our automated PR reviewer.
 
-Every rule below should be traceable to an ADR, a Confluence page, a Google document, or a team agreement recorded in a Jira ticket (e.g. [FXIOS-15685](https://mozilla-hub.atlassian.net/browse/FXIOS-15685)). All sources should be linked. Do not add a rule here without a source; document it first, then add it.
+Every rule below should be traceable to an ADR, a Confluence page, a Google document, or a team agreement. All sources should ideally be linked. Do not add a rule here without a source; document it first, then add it.
 
-## Patterns
+## General guidelines
 
-- Challenge any singleton used without a proper reason. Watch for new `static let shared = X()` or `static let sharedInstance = X()`. Should we use dependency injection, or our `DependencyHelper` instead of a singleton?
 - Do not add new global variables or functions in the code.
-- Escaping closures and `Task { }` blocks must capture `self` weakly (`[weak self]`) when the enclosing object can outlive the closure. This applies in particular to middleware, coordinators, network callbacks, notification handlers, and other long-lived services. Strong captures are only acceptable when the closure is short-lived and cannot cause a retain cycle.
+- Challenge any singleton used without a proper reason. Watch for new `static let shared = X()` or `static let sharedInstance = X()`. Alternatives could be to use dependency injection, or our `DependencyHelper` instead of a singleton.
+- Challenge the use of `static func` unless there's a clear reason. Static methods can hide dependencies, bypass dependency injection, reduce testability, and encourage global access patterns. They should generally be reserved for pure, stateless utility functions, factory methods, or namespaced algorithms.
+- Any closure that can outlive its caller must capture `self` weakly (`[weak self]`) to avoid retain cycles. This applies to escaping closures (completion handlers, delegate callbacks, `NotificationCenter` observer blocks, timer closures), `Task { }` blocks, and any closure stored as a property. 
 
+## BrowserKit libraries
+
+- When a new BrowserKit package is added, it should be reminded to check that the code coverage is properly gathered. This needs to be done manually by the owner of the PR. Steps to fix code coverage are [listed in Confluence](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2316894216/How+to+create+a+BrowserKit+package).
+- Do not add new code to the `Shared` library. If it's meant to be shared, it should be under `Common` or place new code in a specific feature module, or an appropriate `BrowserKit` component. The `Shared` library is there for historical reasons but we don't want to expand on it.
+
+## Modern concurrency
+- `Task { ... }` belongs at the topmost entry point of the chain (a view lifecycle callback, an action handler, a Redux middleware entry). Inside an already-`async` function, call the next `async` function directly instead of wrapping it in a new `Task { }`.
+- Do not mix Grand Central Dispatch (`DispatchQueue.*`, `.async`, `.asyncAfter`) with Swift concurrency (`async`/`await`, `Task`) in the same call chain. If a path uses Swift concurrency, keep it there. If it still uses GCD, migrate the whole path rather than bridging back and forth between the two models, or keep using GCD.
+- `@unchecked Sendable` may only be used on a class that provides its own thread-safety guarantee, such as a lock, or equivalent synchronization mechanism. Test-only classes may use `@unchecked Sendable` without a locking mechanism.
+
+References: [Confluence: Swift Concurrency Best Practices](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2287304722/Swift+Concurrency+Best+Practices).
 
 ## Coordinators
 
-Coordinators own navigation. View controllers should be flow-agnostic.
-
-- Coordinators control app flow: create view controllers and call the `Router` to push/present. They should not decide *what* to show or contain business logic. The one exception is that a coordinator may hold A/B test variant logic.
-- Coordinators should manage only view controllers.
+- Coordinators own navigation. View controllers should be flow-agnostic.
+- Coordinators control app flow: create view controllers and call the `Router` to push/present. They should not decide *what* to show or contain business logic (like network calls, database calls or side-effects). The one exception is that a coordinator may hold A/B test variant logic.
 - Coordinators should not hold references to the view controllers they present, unless there is a specific reason to do so.
-- `Router` wraps `UINavigationController` and is passed between coordinators. Extend it only to handle navigation events.
-- A view controller must not know its position in the app flow. `ViewController A` should not know it is presenting `ViewController B`. Navigation is delegated to a coordinator, or expressed as a Redux navigation action (see Redux → Navigation).
-- View controllers must not perform navigation themselves. Calls like `navigationController?.pushViewController(...)`, `present(_:animated:completion:)`, `dismiss(animated:)`, or `show(_:sender:)` from inside a view controller are red flags. Route the navigation through a coordinator or dispatch a `NavigationBrowserAction`.
+- View controllers must not perform navigation themselves. Calls like `navigationController?.pushViewController(...)`, `present(_:animated:completion:)`, `dismiss(animated:)` from inside a view controller should be flagged. Route the navigation through a coordinator or dispatch a `NavigationBrowserAction`.
 
 References: [ADR 0002](../adr/0002-coordinators-for-navigation.md), [Confluence: Navigation and Coordinators](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2545713156).
 
 ## Theming
 
-All colors and themed images go through the theming system. Hardcoded colors are the most common violation we want to catch.
+All colors and themed images go through the theming system. Hardcoded colors are to be avoided.
 
 - UIKit views must conform to `Themeable`, implement `applyTheme()`, and call `listenForThemeChanges()` in `viewDidLoad()`. Child views conform to `ThemeApplicable` and receive the theme from their parent.
 - SwiftUI views use `@Environment(\.themeType)` and implement `applyTheme(theme:)`.
 - Use themed colors exclusively: `theme.colors.textPrimary`, `theme.colors.layer1`, etc. Do not use hardcoded `UIColor(red:green:blue:alpha:)`, `UIColor(hex:)`, hex string literals, or system colors such as `UIColor.red` in production code. The only unthemed exception is `.clear`.
 - Do not reference `FXColors.*` directly in feature code. Colors are consumed through the theme's colors namespace.
 - Do not branch on the theme type in view code (`if theme == .dark { ... }`). If a value must differ between themes, add a token to the theme and let each theme resolve it.
-- Themed images use `ThemeType.getThemedImageName(name:)`. Do not switch images manually based on theme.
 - If the color you need is not in the mobile theme, ask designers to add it to the Figma color tokens before writing the code. Do not add local color constants as a workaround.
 
 Reference: [Theming system wiki](https://github.com/mozilla-mobile/firefox-ios/wiki/Theming-system).
@@ -45,7 +52,7 @@ Every visible UI element must be usable with VoiceOver and Dynamic Type. The rev
 - **`accessibilityLabel`**: set on custom UI elements, or on standard elements whose default label is missing or wrong. The label must be a localized string. Do not leave VoiceOver reading unlocalized text or raw asset names.
 - **`accessibilityTraits`**: set traits that reflect the element's function when they differ from the default. Common patterns: `.button` for tappable images, `.link` for elements that navigate to external content, `.header` for section headers.
 - **`accessibilityHint`**: use only when the label alone does not convey what the action does. VoiceOver reads it after the label, trait, and value, and users can disable hints.
-- **`accessibilityIdentifier`**: for UI testing only. It is not user-facing and must not be used in place of `accessibilityLabel`. All identifiers must be declared in the `AccessibilityIdentifiers` struct (never inlined as raw strings in view code), and new entries must be added in alphabetical order within their group.
+- **`accessibilityIdentifier`**: for UI testing only. It is not user-facing and must not be used in place of `accessibilityLabel`. All identifiers must be declared in the `AccessibilityIdentifiers` struct (never inlined as raw strings in view code), and new entries must be added in alphabetical order within their group. All elements on screen should have an accessibility identifier.
 - **Element grouping**: for composite cells (image + title + description), disable `isAccessibilityElement` on the child views and enable it on the parent container with a combined `accessibilityLabel`. VoiceOver should navigate the cell as one element.
 
 ### Dynamic Type
@@ -58,65 +65,15 @@ References: [Accessibility overview wiki](https://github.com/mozilla-mobile/fire
 
 ## Redux
 
-Our in-house Redux implementation lives in [`BrowserKit/Sources/Redux`](../BrowserKit/Sources/Redux). New state-holding features use Redux, not MVVM.
+// TODO: Add Redux guidelines into Github Claude action review https://mozilla-hub.atlassian.net/browse/FXIOS-16394*
+
+- Do not comment on Redux implementation for now since this section needs to be written.
 
 References: [0003 Redux Pilot](../adr/0003-redux-pilot.md), [0004 Redux replaces MVVM](../adr/0004-using-redux-to-replace-mvvm.md), [0005 Redux Navigation](../adr/0005-redux-and-navigation.md), [0011 Copy macro](../adr/0011-redux-state-reducer-initializer-cleanup-with-copy-macro.md), [Redux](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2647621724), [Redux: How to Implement](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2647556179), [Redux Guidelines & FAQs](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2647392306)
-
-### State
-
-- State is an immutable `struct` conforming to `ScreenState` and `Equatable`.
-- State typically includes a `windowUUID` property to support multiple iPad windows.
-- The reducer is a pure function exposed as `static let reducer: Reducer<Self>`.
-- Reducers must always return a **new** state. Never `return state`; use `defaultState(from:)` in `else` and `default` branches so transient properties reset to their defaults.
-- Reducers should not contain complex logic; they return the state for the view.
-- Call sub-reducers explicitly (e.g. `SubState.reducer(state.subState, action)`), rather than passing the previous sub-state through unchanged.
-- For large states, prefer the `@Copyable` macro (`state.copy(...)`) over re-initializing every property.
-
-### Actions
-
-- Actions are **classes** inheriting from `Action`. Never `struct`, and never `enum` cases with associated values.
-- Each action lives in its own file, paired with a matching `ActionType` enum.
-- Payload lives as properties on the action class, not as associated values on the `ActionType` case.
-- Actions must carry a `windowUUID` (required by the `Action` protocol).
-- Name actions after the **event that triggered them**, not the outcome. Prefer `tapOnButton` over `updateView`.
-- User actions are dispatched from the view. Middleware-originated actions are dispatched from the middleware.
-
-### Middleware
-
-- Middleware is where side effects live: network, storage, telemetry, and other external dependencies.
-- Middleware is optional. Do not add one without an explicit reason.
-- All external dependencies must be injected via the initializer so tests can substitute mocks.
-- Middleware handles business logic; reducers handle presentation logic. Keep the split clean.
-- If a middleware grows too large or spans multiple responsibilities, split it.
-- Do not manually dispatch to the main thread; the store guarantees actions run on the main thread.
-- Middleware runs once per action (not once per active screen), so it must respect `windowUUID` when the action targets a specific window.
-
-### Switch statements
-
-- Switch cases in reducers and middleware have a **2-line maximum** per case, to keep them readable.
-
-### Navigation in Redux
-
-- Navigation intent is expressed as Redux state or actions (`NavigationBrowserAction`, `NavigationDestination`), not as direct view controller calls inside reducers or views.
-- `BrowserViewController` observes `state.navigationDestination` and calls `handleNavigation(to:)` when it is non-nil. New navigation should follow the same pattern.
-
-### View models
-
-- Do not introduce new view models. Business logic goes to middleware; presentation logic goes to the reducer.
-- If a model needs presentation-side shaping, name it `*Configuration` (e.g. `TopSiteConfiguration`).
-
-### Tests
-
-- Every action a state handles directly should have a test.
-- Middleware should be tested with mocked dependencies.
 
 ## Tests
 
 - Tests must call `super.setUp()` and `super.tearDown()` in their respective overrides.
 - `setUp` and `tearDown` must mirror each other. Every property assigned in `setUp` must be reset (typically to `nil`) in `tearDown`, so state does not leak across tests.
 - Tests should test for leaks with `trackForMemoryLeaks` whenever possible.
-
-## BrowserKit libraries
-
-- When a new BrowserKit package is added, it should be reminded to check that the code coverage is properly gathered. This needs to be done manually by the owner of the PR. Steps to fix code coverage are [listed in Confluence](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2316894216/How+to+create+a+BrowserKit+package).
-- Do not add new code to the `Shared` library. If it's meant to be shared, it should be under `Common` or place new code in a specific feature module, or an appropriate `BrowserKit` component. The `Shared` library is there for historical reasons but we don't want to expand on it.
+- Unit tests cases shouldn't only cover happy path.

--- a/docs/architecture-guidelines.md
+++ b/docs/architecture-guidelines.md
@@ -73,7 +73,12 @@ References: [0003 Redux Pilot](../adr/0003-redux-pilot.md), [0004 Redux replaces
 
 ## Tests
 
-- Tests must call `super.setUp()` and `super.tearDown()` in their respective overrides.
-- `setUp` and `tearDown` must mirror each other. Every property assigned in `setUp` must be reset (typically to `nil`) in `tearDown`, so state does not leak across tests.
-- Tests should test for leaks with `trackForMemoryLeaks` whenever possible.
-- Unit tests cases shouldn't only cover happy path.
+- Tests must call `super.setUp()` first in `setUp()` and `super.tearDown()` last in `tearDown()`.
+- `setUp` and `tearDown` must mirror each other. Every property assigned in `setUp` must be reset (typically to `nil`) in `tearDown`, in reverse order of setup so dependencies are still valid when their owners are cleaned up.
+- Track memory leaks with `trackForMemoryLeaks` from `TestKit`. This is a minimum requirement for tests covering view controllers and coordinators, and encouraged elsewhere.
+- Do not exercise real external services (network, disk, keychain) in unit tests. Inject a mock through the type's protocol dependency. Tests that hit real services belong in integration tests.
+- Do not call `Date()`, `Locale.current`, or `Locale.preferredLanguages` directly in tested logic. Inject them so tests can control the value.
+- Prefer `XCTUnwrap` over force-unwrapping in test code. Tests should fail gracefully instead of crashing on `nil`.
+- Unit tests should not cover only the happy path. Include error paths, edge cases, and boundary conditions.
+
+References: [Unit Tests Guidelines wiki](https://github.com/mozilla-mobile/firefox-ios/wiki/Unit-Tests-Guidelines).


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15685)

## :bulb: Description
> I totally don't expect this to be merged on my last day 😆 But still wanted to pitch in something before my leave. Do what you think is best with this thing. My personal opinion is, it might need fine-tuning at first, but I think it has great potential 🤞 I highly prefer Claude reviews over Copilot which I found to be meaningless. With the addition of specific rules/pitfalls to watch for in our codebase, I think this action has the possibility to help us improve the quality of our reviews over time.

### Context
Reviewing PRs can be very time consuming, and it’s easy to miss some changes whenever PRs are bigger/touches many areas one is not always familiar with. We already have a lot of guidelines in place for our code base (on wiki / confluence), but they are not necessarily followed due to many reasons (ex: some documentation is not always known / its hard to be an expert on all the things). It was also raised recently that AI adds burdens on reviewers. This github action I am proposing to add basically fights fire with fire, I want to try to reduce the reviewers burden by using AI haha.

### Goal
My goal is to experiment with a Claude review that checks some of those guidelines for us. I am basing this work on existing approved Mozilla github action (links in the JIRA ticket and the yml). The "Architecture guidelines" aims to be rules we previously approved as a team, that are already documented. Hopefully I am starting small enough that it actually makes sense and isn't too noisy / it's useful for the team. 

Notes:
- Claude will only comment on rules that are in that architecture file. It shouldn't invent anything.
- Claude will only be triggered on non-fork PRs (no contributors) by a comment `@claude` on the said PR. So if merged, this won't be noisy since it requires manual trigger and will only work on Mozilla teammates PRs.
- Claude is working using Mozilla API key, there's a limit of $ spent also configured for this action to run

### Architecture rules
I am proposing some rules here, that I hope are not too opiniated. Although architeture guidelines needs to be opiniated at some point to be effective haha. I think there's potential for AI to help us review in the following areas first:
- Theming
- A11y
- Modern concurrency (ex: do not mix GCD / async-await)
- General guidelines (ex: singletons, static functions, etc)
- Unit tests (ex: setup/teardown)
- BrowserKit libraries 
- Coordinators
- I created [a follow up task](https://mozilla-hub.atlassian.net/browse/FXIOS-16394) for Redux since I would ask our residential expert (@ih-codes) to implement guidelines for it, if we find the github action to be useful for other rules.

### Demo
Have a look at this demo on my personal fork [here](https://github.com/lmarceau/firefox-ios/pull/133#pullrequestreview-4769977068). It was ran on dummy code that was AI generated to trigger a bunch of the rules.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

