### PR TITLE
Add FXIOS-16182 [WebCompat] URL field and keyboard handling

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatCategoryMenuCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatCategoryMenuCell.swift
@@ -70,10 +70,15 @@ final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
             chevronDownView.widthAnchor.constraint(equalToConstant: scaledChevronSize),
             chevronDownView.heightAnchor.constraint(equalToConstant: scaledChevronSize)
         ]
+        // .defaultHigh (not required) avoids the self-sizing vs. min-height constraint conflict.
+        let topConstraint = menuButton.topAnchor.constraint(equalTo: margins.topAnchor)
+        let bottomConstraint = menuButton.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
+        topConstraint.priority = .defaultHigh
+        bottomConstraint.priority = .defaultHigh
         NSLayoutConstraint.activate(chevronSizeConstraints + [
             menuButton.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
-            menuButton.topAnchor.constraint(equalTo: margins.topAnchor),
-            menuButton.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+            topConstraint,
+            bottomConstraint,
             menuButton.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
             menuButton.heightAnchor.constraint(
                 greaterThanOrEqualToConstant: WebCompatReporterUX.Control.minimumTapTarget

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
@@ -1,0 +1,143 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+
+/// Editable URL row: leading label + single-line field, stacking vertically at
+/// accessibility sizes. Reports the typed value on editing-end, not per keystroke.
+final class WebCompatURLCell: UICollectionViewListCell,
+                              ThemeApplicable,
+                              ReusableCell,
+                              UITextFieldDelegate,
+                              Notifiable {
+    private var editingEndedHandler: ((String) -> Void)?
+    private var placeholder = ""
+
+    private lazy var titleLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+
+    private lazy var textField: UITextField = .build { field in
+        field.font = FXFontStyles.Regular.body.scaledFont()
+        field.adjustsFontForContentSizeCategory = true
+        field.keyboardType = .URL
+        field.autocapitalizationType = .none
+        field.autocorrectionType = .no
+        // Native clear button carries a system-localized accessibility label for free.
+        field.clearButtonMode = .whileEditing
+        field.returnKeyType = .done
+        field.delegate = self
+    }
+
+    private lazy var stackView: UIStackView = .build { stack in
+        stack.spacing = WebCompatReporterUX.Spacing.interItem
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+        startObservingNotifications(
+            withNotificationCenter: NotificationCenter.default,
+            forObserver: self,
+            observing: [UIContentSizeCategory.didChangeNotification]
+        )
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(textField)
+        contentView.addSubview(stackView)
+        let margins = contentView.layoutMarginsGuide
+        // .defaultHigh (not required) avoids the self-sizing vs. min-height constraint conflict.
+        let topConstraint = stackView.topAnchor.constraint(equalTo: margins.topAnchor)
+        let bottomConstraint = stackView.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
+        topConstraint.priority = .defaultHigh
+        bottomConstraint.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+            topConstraint,
+            bottomConstraint,
+            stackView.heightAnchor.constraint(
+                greaterThanOrEqualToConstant: WebCompatReporterUX.Control.minimumTapTarget
+            )
+        ])
+        updateStackAxis()
+    }
+
+    private func updateStackAxis() {
+        applyStackLayout(isAccessibilityCategory: traitCollection.preferredContentSizeCategory.isAccessibilityCategory)
+    }
+
+    /// Horizontal at standard sizes; vertical (field below the label) at accessibility sizes.
+    func applyStackLayout(isAccessibilityCategory: Bool) {
+        stackView.axis = isAccessibilityCategory ? .vertical : .horizontal
+        stackView.alignment = isAccessibilityCategory ? .fill : .center
+        textField.textAlignment = isAccessibilityCategory ? .natural : .right
+    }
+
+    func configure(
+        title: String,
+        text: String,
+        placeholder: String,
+        a11yIdentifier: String,
+        onEditingEnded: @escaping (String) -> Void
+    ) {
+        editingEndedHandler = onEditingEnded
+        self.placeholder = placeholder
+        titleLabel.text = title
+        textField.accessibilityIdentifier = a11yIdentifier
+        // The field is the accessibility element; carry the label onto it so
+        // VoiceOver announces "<title>, text field" instead of a bare field.
+        titleLabel.isAccessibilityElement = false
+        textField.accessibilityLabel = title
+        // Don't overwrite the field mid-edit; the value round-trips on end.
+        if !textField.isFirstResponder {
+            textField.text = text
+        }
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        backgroundConfiguration = .listGroupedCell()
+        backgroundConfiguration?.backgroundColor = theme.colors.layer5
+        titleLabel.textColor = theme.colors.textSecondary
+        textField.textColor = theme.colors.textPrimary
+        textField.tintColor = theme.colors.actionPrimary
+        textField.attributedPlaceholder = NSAttributedString(
+            string: placeholder,
+            attributes: [.foregroundColor: theme.colors.textSecondary]
+        )
+    }
+
+    // MARK: - Notifiable
+
+    nonisolated func handleNotifications(_ notification: Notification) {
+        guard notification.name == UIContentSizeCategory.didChangeNotification else { return }
+        ensureMainThread { [weak self] in
+            self?.updateStackAxis()
+        }
+    }
+
+    // MARK: - UITextFieldDelegate
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        editingEndedHandler?(textField.text ?? "")
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -8,16 +8,30 @@ import SwiftUI
 import UIKit
 
 @MainActor
-private func previewSheet(sections: [WebCompatReportViewModel.Section]) -> UIViewController {
+private func previewSheet(
+    sections: [WebCompatReportViewModel.Section],
+    isPreviewEnabled: Bool
+) -> UIViewController {
     let viewModel = WebCompatReportViewModel(
-        navigationTitle: "Report a Website Issue",
+        navigationTitle: "Report Broken Site",
         closeButtonAccessibilityLabel: "Close",
         previewButtonTitle: "Preview",
-        isPreviewEnabled: !sections.isEmpty,
+        isPreviewEnabled: isPreviewEnabled,
         sections: sections
     )
     let sheet = WebCompatReportSheetViewController(viewModel: viewModel, theme: LightTheme())
     return UINavigationController(rootViewController: sheet)
+}
+
+private func previewURLSection() -> WebCompatReportViewModel.Section {
+    return WebCompatReportViewModel.Section(id: "url", rows: [
+        WebCompatReportViewModel.Row(
+            id: "url",
+            title: "URL",
+            kind: .urlField(text: "https://houseandhome.com/recipe/croque-monsieur", placeholder: "Website address"),
+            a11yIdentifier: "url"
+        )
+    ])
 }
 
 private func previewCategoryOptions(selectedID: String?) -> [WebCompatReportViewModel.Row.MenuOption] {
@@ -111,16 +125,9 @@ private func previewFooterSection() -> WebCompatReportViewModel.Section {
 }
 
 @available(iOS 17.0, *)
-#Preview("Placeholder") {
+#Preview("Filled") {
     previewSheet(sections: [
-        previewCategorySection(selectedTitle: nil),
-        previewSendSection(isEnabled: false)
-    ])
-}
-
-@available(iOS 17.0, *)
-#Preview("Category selected") {
-    previewSheet(sections: [
+        previewURLSection(),
         previewCategorySection(selectedTitle: "Site is not usable"),
         WebCompatReportViewModel.Section(id: "issue-suboptions", rows: [
             previewSubOption("browser_blocked", "Browser is blocked or unsupported"),
@@ -130,7 +137,16 @@ private func previewFooterSection() -> WebCompatReportViewModel.Section {
         ]),
         previewAdvancedSection(includeScreenshot: true, includeBlockedList: true),
         previewSendSection(isEnabled: true)
-    ])
+    ], isPreviewEnabled: true)
+}
+
+@available(iOS 17.0, *)
+#Preview("Empty / Send disabled") {
+    previewSheet(sections: [
+        previewURLSection(),
+        previewCategorySection(selectedTitle: nil),
+        previewSendSection(isEnabled: false)
+    ], isPreviewEnabled: false)
 }
 
 @available(iOS 17.0, *)
@@ -147,6 +163,6 @@ private func previewFooterSection() -> WebCompatReportViewModel.Section {
     previewSheet(sections: [
         previewCategorySection(selectedTitle: "Site is not usable"),
         previewFooterSection()
-    ])
+    ], isPreviewEnabled: false)
 }
 #endif

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -155,7 +155,7 @@ private func previewFooterSection() -> WebCompatReportViewModel.Section {
         previewCategorySection(selectedTitle: nil),
         previewAdvancedSection(includeScreenshot: false, includeBlockedList: false),
         previewSendSection(isEnabled: false)
-    ])
+    ], isPreviewEnabled: false)
 }
 
 @available(iOS 17.0, *)

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -130,7 +130,12 @@ public final class WebCompatReportSheetViewController: UIViewController,
             let keyboardFrameInView = view.convert(endFrameInScreen, from: nil)
             let overlap = max(0, collectionView.frame.maxY - keyboardFrameInView.minY)
             // adjustedContentInset already covers the bottom safe area, so add only the rest.
-            bottomInset = max(0, overlap - view.safeAreaInsets.bottom) + WebCompatReporterUX.Keyboard.focusPadding
+            let uncoveredOverlap = max(0, overlap - view.safeAreaInsets.bottom)
+            if uncoveredOverlap > 0 {
+                bottomInset = uncoveredOverlap + WebCompatReporterUX.Keyboard.focusPadding
+            }
+            // Otherwise the keyboard hides nothing (hardware, or undocked on iPad) and the
+            // inset stays at zero, so focusing a field doesn't shift the list.
         }
         collectionView.contentInset.bottom = bottomInset
         collectionView.verticalScrollIndicatorInsets.bottom = bottomInset

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -5,9 +5,7 @@
 import Common
 import UIKit
 
-/// The intents the sheet emits. The Client translates these into dispatched
-/// Redux actions and coordinator navigation; the view controller itself never
-/// dismisses or navigates.
+/// The intents the sheet emits; the Client maps these to Redux actions and navigation.
 @MainActor
 public protocol WebCompatReportSheetDelegate: AnyObject {
     func webCompatReportSheetDidTapClose()
@@ -17,22 +15,21 @@ public protocol WebCompatReportSheetDelegate: AnyObject {
     func webCompatReportSheetDidTapButton(id: String)
     func webCompatReportSheetDidToggle(id: String, isOn: Bool)
     func webCompatReportSheetDidTapLearnMore(url: URL)
+    func webCompatReportSheetDidEditText(id: String, text: String)
 }
 
-/// The "Report a Website Issue" sheet content, shown as an iOS-26 `.large`
-/// detent sheet inside a nav controller. Store-agnostic: configured with a
+/// The "Report a Website Issue" sheet content. Store-agnostic: configured with a
 /// `WebCompatReportViewModel`, emits intents via `WebCompatReportSheetDelegate`.
 public final class WebCompatReportSheetViewController: UIViewController,
                                                        ThemeApplicable,
-                                                       UICollectionViewDelegate {
+                                                       UICollectionViewDelegate,
+                                                       Notifiable {
     public weak var delegate: WebCompatReportSheetDelegate?
 
     private var viewModel: WebCompatReportViewModel
     private var theme: Theme
 
-    /// The diffable data source keys on stable section/row `id`s (not content),
-    /// so content changes reconfigure a row in place instead of delete+insert.
-    /// The current values are looked up here by id.
+    /// The data source keys on stable section/row `id`s; current values are looked up here.
     private var rowsByID: [String: WebCompatReportViewModel.Row] = [:]
     private var sectionsByID: [String: WebCompatReportViewModel.Section] = [:]
 
@@ -45,6 +42,7 @@ public final class WebCompatReportSheetViewController: UIViewController,
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.delegate = self
+        collectionView.keyboardDismissMode = .onDrag
         return collectionView
     }()
 
@@ -81,6 +79,14 @@ public final class WebCompatReportSheetViewController: UIViewController,
         setupCollectionView()
         configure(with: viewModel)
         applyTheme(theme: theme)
+        startObservingNotifications(
+            withNotificationCenter: NotificationCenter.default,
+            forObserver: self,
+            observing: [
+                UIResponder.keyboardWillShowNotification,
+                UIResponder.keyboardWillHideNotification
+            ]
+        )
     }
 
     // MARK: - Configuration
@@ -115,6 +121,32 @@ public final class WebCompatReportSheetViewController: UIViewController,
         ])
     }
 
+    // MARK: - Keyboard
+
+    private func adjustForKeyboard(endFrameInScreen: CGRect, isHiding: Bool) {
+        guard isViewLoaded else { return }
+        var bottomInset: CGFloat = 0
+        if !isHiding {
+            let keyboardFrameInView = view.convert(endFrameInScreen, from: nil)
+            let overlap = max(0, collectionView.frame.maxY - keyboardFrameInView.minY)
+            // adjustedContentInset already covers the bottom safe area, so add only the rest.
+            bottomInset = max(0, overlap - view.safeAreaInsets.bottom) + WebCompatReporterUX.Keyboard.focusPadding
+        }
+        collectionView.contentInset.bottom = bottomInset
+        collectionView.verticalScrollIndicatorInsets.bottom = bottomInset
+        guard let responder = firstResponder(in: collectionView) else { return }
+        let responderFrame = responder.convert(responder.bounds, to: collectionView)
+        collectionView.scrollRectToVisible(responderFrame, animated: true)
+    }
+
+    private func firstResponder(in view: UIView) -> UIView? {
+        if view.isFirstResponder { return view }
+        for subview in view.subviews {
+            if let found = firstResponder(in: subview) { return found }
+        }
+        return nil
+    }
+
     private func makeLayout(backgroundColor: UIColor? = nil) -> UICollectionViewCompositionalLayout {
         return UICollectionViewCompositionalLayout { [weak self] index, environment in
             var config = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
@@ -130,98 +162,36 @@ public final class WebCompatReportSheetViewController: UIViewController,
 
     // MARK: - Data source
 
+    // Registrations MUST be created up front and reused; UIKit asserts if one is
+    // created lazily inside the cell provider. So they're built once here and the
+    // provider only dequeues with them.
     private func makeDataSource() -> UICollectionViewDiffableDataSource<String, String> {
-        let plainRegistration = UICollectionView.CellRegistration<
-            UICollectionViewListCell, WebCompatReportViewModel.Row
-        > { cell, _, row in
-            var content = cell.defaultContentConfiguration()
-            content.text = row.title
-            cell.contentConfiguration = content
-            cell.accessories = []
-        }
-
-        let subOptionRegistration = UICollectionView.CellRegistration<
-            WebCompatSubOptionCell, WebCompatReportViewModel.Row
-        > { [weak self] cell, _, row in
-            guard let self, case let .subOption(isSelected) = row.kind else { return }
-            cell.configure(title: row.title, isSelected: isSelected, theme: self.theme, a11yIdentifier: row.a11yIdentifier)
-        }
-
-        let categoryRegistration = UICollectionView.CellRegistration<
-            WebCompatCategoryMenuCell, WebCompatReportViewModel.Row
-        > { [weak self] cell, _, row in
-            guard let self, case let .categoryMenu(isPlaceholder, options) = row.kind else { return }
-            cell.configure(
-                title: row.title,
-                isPlaceholder: isPlaceholder,
-                options: options,
-                theme: self.theme,
-                a11yIdentifier: row.a11yIdentifier
-            ) { [weak self] optionID in
-                self?.delegate?.webCompatReportSheetDidSelectCategory(id: optionID)
-            }
-        }
-
-        let sendButtonRegistration = UICollectionView.CellRegistration<
-            WebCompatSendButtonCell, WebCompatReportViewModel.Row
-        > { [weak self] cell, _, row in
-            guard let self, case let .sendButton(isEnabled) = row.kind else { return }
-            cell.configure(title: row.title, isEnabled: isEnabled, a11yIdentifier: row.a11yIdentifier) { [weak self] in
-                // Text fields report on end-editing, so commit the active one before submitting.
-                self?.view.endEditing(true)
-                self?.delegate?.webCompatReportSheetDidTapButton(id: row.id)
-            }
-            cell.applyTheme(theme: self.theme)
-        }
-
-        let toggleRegistration = UICollectionView.CellRegistration<
-            WebCompatToggleCell, WebCompatReportViewModel.Row
-        > { [weak self] cell, _, row in
-            guard let self, case let .toggle(isOn) = row.kind else { return }
-            cell.configure(title: row.title, isOn: isOn, a11yIdentifier: row.a11yIdentifier) { [weak self] isOn in
-                self?.delegate?.webCompatReportSheetDidToggle(id: row.id, isOn: isOn)
-            }
-            cell.applyTheme(theme: self.theme)
-        }
+        let plain = plainCellRegistration()
+        let subOption = subOptionCellRegistration()
+        let category = categoryCellRegistration()
+        let url = urlCellRegistration()
+        let sendButton = sendButtonCellRegistration()
+        let toggle = toggleCellRegistration()
 
         let dataSource = UICollectionViewDiffableDataSource<String, String>(
             collectionView: collectionView
         ) { [weak self] collectionView, indexPath, rowID in
-            guard let self, let row = self.rowsByID[rowID] else { return UICollectionViewListCell() }
+            guard let row = self?.rowsByID[rowID] else { return UICollectionViewListCell() }
             switch row.kind {
             case .categoryMenu:
-                return collectionView.dequeueConfiguredReusableCell(
-                    using: categoryRegistration,
-                    for: indexPath,
-                    item: row
-                )
+                return collectionView.dequeueConfiguredReusableCell(using: category, for: indexPath, item: row)
             case .subOption:
-                return collectionView.dequeueConfiguredReusableCell(
-                    using: subOptionRegistration,
-                    for: indexPath,
-                    item: row
-                )
+                return collectionView.dequeueConfiguredReusableCell(using: subOption, for: indexPath, item: row)
+            case .urlField:
+                return collectionView.dequeueConfiguredReusableCell(using: url, for: indexPath, item: row)
             case .sendButton:
-                return collectionView.dequeueConfiguredReusableCell(
-                    using: sendButtonRegistration,
-                    for: indexPath,
-                    item: row
-                )
+                return collectionView.dequeueConfiguredReusableCell(using: sendButton, for: indexPath, item: row)
             case .toggle:
-                return collectionView.dequeueConfiguredReusableCell(
-                    using: toggleRegistration,
-                    for: indexPath,
-                    item: row
-                )
+                return collectionView.dequeueConfiguredReusableCell(using: toggle, for: indexPath, item: row)
             case .plain:
-                return collectionView.dequeueConfiguredReusableCell(
-                    using: plainRegistration,
-                    for: indexPath,
-                    item: row
-                )
+                return collectionView.dequeueConfiguredReusableCell(using: plain, for: indexPath, item: row)
             }
         }
-
         configureSupplementaryProvider(on: dataSource)
         return dataSource
     }
@@ -234,6 +204,80 @@ public final class WebCompatReportSheetViewController: UIViewController,
                 return collectionView.dequeueConfiguredReusableSupplementary(using: footer, for: indexPath)
             }
             return collectionView.dequeueConfiguredReusableSupplementary(using: header, for: indexPath)
+        }
+    }
+
+    private func plainCellRegistration()
+    -> UICollectionView.CellRegistration<UICollectionViewListCell, WebCompatReportViewModel.Row> {
+        return UICollectionView.CellRegistration { cell, _, row in
+            var content = cell.defaultContentConfiguration()
+            content.text = row.title
+            cell.contentConfiguration = content
+            cell.accessories = []
+        }
+    }
+
+    private func subOptionCellRegistration()
+    -> UICollectionView.CellRegistration<WebCompatSubOptionCell, WebCompatReportViewModel.Row> {
+        return UICollectionView.CellRegistration { [weak self] cell, _, row in
+            guard let self, case let .subOption(isSelected) = row.kind else { return }
+            cell.configure(title: row.title, isSelected: isSelected, theme: self.theme, a11yIdentifier: row.a11yIdentifier)
+        }
+    }
+
+    private func categoryCellRegistration()
+    -> UICollectionView.CellRegistration<WebCompatCategoryMenuCell, WebCompatReportViewModel.Row> {
+        return UICollectionView.CellRegistration { [weak self] cell, _, row in
+            guard let self, case let .categoryMenu(isPlaceholder, options) = row.kind else { return }
+            cell.configure(
+                title: row.title,
+                isPlaceholder: isPlaceholder,
+                options: options,
+                theme: self.theme,
+                a11yIdentifier: row.a11yIdentifier
+            ) { [weak self] optionID in
+                self?.delegate?.webCompatReportSheetDidSelectCategory(id: optionID)
+            }
+        }
+    }
+
+    private func urlCellRegistration()
+    -> UICollectionView.CellRegistration<WebCompatURLCell, WebCompatReportViewModel.Row> {
+        return UICollectionView.CellRegistration { [weak self] cell, _, row in
+            guard let self, case let .urlField(text, placeholder) = row.kind else { return }
+            cell.configure(
+                title: row.title,
+                text: text,
+                placeholder: placeholder,
+                a11yIdentifier: row.a11yIdentifier
+            ) { [weak self] text in
+                self?.delegate?.webCompatReportSheetDidEditText(id: row.id, text: text)
+            }
+            cell.applyTheme(theme: self.theme)
+        }
+    }
+
+    private func sendButtonCellRegistration()
+    -> UICollectionView.CellRegistration<WebCompatSendButtonCell, WebCompatReportViewModel.Row> {
+        return UICollectionView.CellRegistration { [weak self] cell, _, row in
+            guard let self, case let .sendButton(isEnabled) = row.kind else { return }
+            cell.configure(title: row.title, isEnabled: isEnabled, a11yIdentifier: row.a11yIdentifier) { [weak self] in
+                // Text fields report on end-editing, so commit the active one before submitting.
+                self?.view.endEditing(true)
+                self?.delegate?.webCompatReportSheetDidTapButton(id: row.id)
+            }
+            cell.applyTheme(theme: self.theme)
+        }
+    }
+
+    private func toggleCellRegistration()
+    -> UICollectionView.CellRegistration<WebCompatToggleCell, WebCompatReportViewModel.Row> {
+        return UICollectionView.CellRegistration { [weak self] cell, _, row in
+            guard let self, case let .toggle(isOn) = row.kind else { return }
+            cell.configure(title: row.title, isOn: isOn, a11yIdentifier: row.a11yIdentifier) { [weak self] isOn in
+                self?.delegate?.webCompatReportSheetDidToggle(id: row.id, isOn: isOn)
+            }
+            cell.applyTheme(theme: self.theme)
         }
     }
 
@@ -318,7 +362,18 @@ public final class WebCompatReportSheetViewController: UIViewController,
 
     @objc
     private func didTapPreview() {
+        view.endEditing(true)
         delegate?.webCompatReportSheetDidTapPreview()
+    }
+
+    // MARK: - Notifiable
+
+    nonisolated public func handleNotifications(_ notification: Notification) {
+        let isHiding = notification.name == UIResponder.keyboardWillHideNotification
+        let endFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue ?? .zero
+        ensureMainThread { [weak self] in
+            self?.adjustForKeyboard(endFrameInScreen: endFrame, isHiding: isHiding)
+        }
     }
 
     // MARK: - ThemeApplicable

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
@@ -59,6 +59,7 @@ public struct WebCompatReportViewModel: Equatable, Sendable {
             case plain
             case categoryMenu(isPlaceholder: Bool, options: [MenuOption])
             case subOption(isSelected: Bool)
+            case urlField(text: String, placeholder: String)
             case sendButton(isEnabled: Bool)
             case toggle(isOn: Bool)
         }

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -30,4 +30,8 @@ enum WebCompatReporterUX {
     enum Chevron {
         static let size: CGFloat = 10
     }
+
+    enum Keyboard {
+        static let focusPadding: CGFloat = 16
+    }
 }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -32,23 +32,6 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         XCTAssertEqual(subject.navigationItem.rightBarButtonItem?.isEnabled, true)
     }
 
-    func testConfigure_withSections_populatesList() {
-        let subject = createSubject()
-        subject.loadViewIfNeeded()
-
-        subject.configure(with: makeViewModel(sections: [
-            .init(id: "url", rows: [.init(id: "url", title: "https://example.com", a11yIdentifier: "url")]),
-            .init(id: "advanced", rows: [
-                .init(id: "screenshot", title: "Include screenshot", a11yIdentifier: "screenshot"),
-                .init(id: "blocklist", title: "Include blocked list", a11yIdentifier: "blocklist")
-            ])
-        ]))
-
-        let collectionView = subject.view.subviews.compactMap { $0 as? UICollectionView }.first
-        XCTAssertEqual(collectionView?.numberOfSections, 2)
-        XCTAssertEqual(collectionView?.numberOfItems(inSection: 1), 2)
-    }
-
     func testCloseButton_notifiesDelegate() {
         let delegate = MockWebCompatReportSheetDelegate()
         let subject = createSubject()
@@ -273,6 +256,19 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         XCTAssertNil(footerView(in: subject))
     }
 
+    func testConfigure_withFieldSections_dequeuesTypedCells() {
+        let subject = createSubject()
+        subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 2000)
+        subject.loadViewIfNeeded()
+
+        subject.configure(with: makeViewModel(sections: fieldSections()))
+        subject.view.layoutIfNeeded()
+
+        XCTAssertTrue(
+            collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 0)) is WebCompatURLCell
+        )
+    }
+
     // MARK: - Helpers
 
     private func collectionView(in subject: WebCompatReportSheetViewController) -> UICollectionView? {
@@ -344,6 +340,19 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
                     title: "Include screenshot",
                     kind: .toggle(isOn: isOn),
                     a11yIdentifier: "screenshot"
+                )
+            ])
+        ]
+    }
+
+    private func fieldSections() -> [WebCompatReportViewModel.Section] {
+        return [
+            WebCompatReportViewModel.Section(id: "url", rows: [
+                WebCompatReportViewModel.Row(
+                    id: "url",
+                    title: "URL",
+                    kind: .urlField(text: "https://example.com", placeholder: "Website address"),
+                    a11yIdentifier: "url"
                 )
             ])
         ]
@@ -504,6 +513,7 @@ private final class MockWebCompatReportSheetDelegate: WebCompatReportSheetDelega
     var tappedButtonIDs: [String] = []
     var toggles: [(id: String, isOn: Bool)] = []
     var learnMoreURLs: [URL] = []
+    var editedText: [(id: String, text: String)] = []
 
     func webCompatReportSheetDidTapClose() {
         didTapCloseCallCount += 1
@@ -531,5 +541,9 @@ private final class MockWebCompatReportSheetDelegate: WebCompatReportSheetDelega
 
     func webCompatReportSheetDidTapLearnMore(url: URL) {
         learnMoreURLs.append(url)
+    }
+
+    func webCompatReportSheetDidEditText(id: String, text: String) {
+        editedText.append((id, text))
     }
 }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatURLCellTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatURLCellTests.swift
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+@testable import WebCompatReporterKit
+
+@MainActor
+final class WebCompatURLCellTests: XCTestCase {
+    func testConfigure_carriesTitleAndIdentifierOntoFieldAndSetsText() throws {
+        let subject = createSubject()
+
+        subject.configure(
+            title: "URL",
+            text: "https://example.com",
+            placeholder: "Website address",
+            a11yIdentifier: "WebCompatReporter.URLField",
+            onEditingEnded: { _ in }
+        )
+
+        let field = try XCTUnwrap(firstSubview(ofType: UITextField.self, in: subject.contentView))
+        XCTAssertEqual(field.accessibilityLabel, "URL")
+        XCTAssertEqual(field.accessibilityIdentifier, "WebCompatReporter.URLField")
+        XCTAssertEqual(field.text, "https://example.com")
+    }
+
+    func testApplyStackLayout_switchesAxisAndAlignmentBetweenStandardAndAccessibilitySizes() throws {
+        let subject = createSubject()
+        subject.configure(title: "URL", text: "", placeholder: "", a11yIdentifier: "url", onEditingEnded: { _ in })
+        let stack = try XCTUnwrap(firstSubview(ofType: UIStackView.self, in: subject.contentView))
+        let field = try XCTUnwrap(firstSubview(ofType: UITextField.self, in: subject.contentView))
+
+        subject.applyStackLayout(isAccessibilityCategory: false)
+        XCTAssertEqual(stack.axis, .horizontal)
+        XCTAssertEqual(stack.alignment, .center)
+        XCTAssertEqual(field.textAlignment, .right)
+
+        subject.applyStackLayout(isAccessibilityCategory: true)
+        XCTAssertEqual(stack.axis, .vertical)
+        XCTAssertEqual(stack.alignment, .fill)
+        XCTAssertEqual(field.textAlignment, .natural)
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> WebCompatURLCell {
+        return WebCompatURLCell(frame: CGRect(x: 0, y: 0, width: 320, height: 60))
+    }
+}

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -135,6 +135,7 @@ struct AccessibilityIdentifiers {
     }
 
     struct WebCompatReporter {
+        static let urlField = "WebCompatReporter.URLField"
         static let categoryMenu = "WebCompatReporter.CategoryMenu"
         static let subOption = "WebCompatReporter.SubOption"
         static let sendButton = "WebCompatReporter.SendButton"

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -629,10 +629,6 @@ final class BrowserCoordinator: BaseCoordinator,
     func presentReportBrokenSite(url: URL?) {
         let reportViewController = WebCompatReportViewController(windowUUID: windowUUID, reportedURL: url)
         reportViewController.reportCoordinator = self
-        if let sheetPresentationController = reportViewController.sheetPresentationController {
-            sheetPresentationController.detents = [.large()]
-            sheetPresentationController.prefersGrabberVisible = true
-        }
         router.present(reportViewController, animated: true, completion: nil)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -119,6 +119,7 @@ final class WebCompatReportViewController: UINavigationController,
     }
 
     private enum SectionID: String {
+        case url
         case issueCategory
         case issueSubOptions
         case advancedOptions
@@ -126,6 +127,7 @@ final class WebCompatReportViewController: UINavigationController,
     }
 
     private enum RowID: String {
+        case url
         case includeScreenshot
         case includeBlockedList
         case send
@@ -134,10 +136,25 @@ final class WebCompatReportViewController: UINavigationController,
     static func makeSections(
         from state: WebCompatReporterState
     ) -> [WebCompatReportViewModel.Section] {
-        var sections = makeIssueSections(from: state)
+        var sections = [urlSection(from: state)]
+        sections.append(contentsOf: makeIssueSections(from: state))
         sections.append(advancedOptionsSection(from: state))
         sections.append(sendSection(from: state))
         return sections
+    }
+
+    private static func urlSection(from state: WebCompatReporterState) -> WebCompatReportViewModel.Section {
+        return WebCompatReportViewModel.Section(
+            id: SectionID.url.rawValue,
+            rows: [
+                WebCompatReportViewModel.Row(
+                    id: RowID.url.rawValue,
+                    title: .WebCompatReporter.Fields.URLLabel,
+                    kind: .urlField(text: state.url, placeholder: .WebCompatReporter.Fields.URLPlaceholder),
+                    a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.urlField
+                )
+            ]
+        )
     }
 
     private static func advancedOptionsSection(
@@ -322,7 +339,20 @@ final class WebCompatReportViewController: UINavigationController,
                 windowUUID: windowUUID,
                 actionType: WebCompatReporterViewActionType.toggleBlockedList
             ))
-        case .send, .none:
+        case .url, .send, .none:
+            break
+        }
+    }
+
+    func webCompatReportSheetDidEditText(id: String, text: String) {
+        switch RowID(rawValue: id) {
+        case .url:
+            store.dispatch(WebCompatReporterViewAction(
+                url: text,
+                windowUUID: windowUUID,
+                actionType: WebCompatReporterViewActionType.editURL
+            ))
+        case .includeScreenshot, .includeBlockedList, .send, .none:
             break
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -112,6 +112,16 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(dispatchedViewActions().isEmpty)
     }
 
+    func testDidEditText_onURLRow_dispatchesEditURLWithText() {
+        let subject = createSubject(reportedURL: nil)
+
+        subject.webCompatReportSheetDidEditText(id: "url", text: "https://changed.example.com")
+
+        let action = lastViewAction()
+        XCTAssertEqual(action?.actionType as? WebCompatReporterViewActionType, .editURL)
+        XCTAssertEqual(action?.url, "https://changed.example.com")
+    }
+
     func testSimpleCreation_hasNoLeaks() {
         let subject = createSubject(reportedURL: nil)
         subject.loadViewIfNeeded()
@@ -174,20 +184,25 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
 
     // MARK: - makeSections
 
-    func testMakeSections_withoutCategory_showsAdvancedTogglesAndDisabledSendButton() {
+    func testMakeSections_withoutCategory_showsURLCategoryAdvancedAndDisabledSend() {
         let state = WebCompatReporterState(windowUUID: windowUUID, url: "https://example.com")
 
         let sections = WebCompatReportViewController.makeSections(from: state)
 
-        // Category + advanced + send (no sub-options until a category is picked).
-        XCTAssertEqual(sections.map(\.id), ["issueCategory", "advancedOptions", "send"])
+        // URL + category + advanced + send (no sub-options until a category is picked).
+        XCTAssertEqual(sections.map(\.id), ["url", "issueCategory", "advancedOptions", "send"])
 
         let advanced = sections.first { $0.id == "advancedOptions" }
         XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: true), .toggle(isOn: false)])
         XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: false)])
+
+        guard case let .urlField(text, _) = sections.first?.rows.first?.kind else {
+            return XCTFail("Expected a URL field row")
+        }
+        XCTAssertEqual(text, "https://example.com")
     }
 
-    func testMakeSections_withCategory_keepsAdvancedTogglesBeforeSendButton() {
+    func testMakeSections_withCategory_keepsAdvancedTogglesBeforeEnabledSendButton() {
         let state = WebCompatReporterState(
             windowUUID: windowUUID,
             url: "https://example.com",
@@ -199,7 +214,10 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
 
         let sections = WebCompatReportViewController.makeSections(from: state)
 
-        XCTAssertEqual(sections.map(\.id), ["issueCategory", "issueSubOptions", "advancedOptions", "send"])
+        XCTAssertEqual(
+            sections.map(\.id),
+            ["url", "issueCategory", "issueSubOptions", "advancedOptions", "send"]
+        )
 
         let advanced = sections.first { $0.id == "advancedOptions" }
         XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: false), .toggle(isOn: true)])


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16182](https://mozilla-hub.atlassian.net/browse/FXIOS-16182)

## :bulb: Description
Adds the URL row to the report sheet, plus the `contentInset` keyboard avoidance that serves the sheet's text fields.

FXIOS-16182 is split so each piece stays small — #34859 (toggles), #34860 (send button), #34555 (footer) are all independent off `main`; #34862 (details field) stacks here because it needs this PR's `didEditText` hook and keyboard handling.

## :movie_camera: Demos
<img height="600" alt="IMG_4976" src="https://github.com/user-attachments/assets/ce431207-b690-4e2a-8bb8-3b1c0a991051" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
Open **Report a Website Issue** from the tools menu.

- URL row is prefilled with the current page
- Tap it — the field scrolls above the keyboard with a little padding
- Return dismisses the keyboard; so does dragging the form
- Edit the URL, tap away, close and reopen the sheet — the change persisted
- Bump the text size to an accessibility setting: the row stacks vertically instead of label-beside-field


[FXIOS-16182]: https://mozilla-hub.atlassian.net/browse/FXIOS-16182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ