### PR TITLE
Add FXIOS-16182 [WebCompat] Advanced options toggles

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatDetailsCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatDetailsCell.swift
@@ -15,8 +15,11 @@ final class WebCompatDetailsCell: UICollectionViewListCell,
     private var editingEndedHandler: ((String) -> Void)?
     private var heightConstraint: NSLayoutConstraint?
 
-    private var scaledMinimumHeight: CGFloat {
-        return UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.DetailsField.minimumHeight)
+    func scaledMinimumHeight(compatibleWith traitCollection: UITraitCollection) -> CGFloat {
+        return UIFontMetrics.default.scaledValue(
+            for: WebCompatReporterUX.DetailsField.minimumHeight,
+            compatibleWith: traitCollection
+        )
     }
 
     private lazy var textView: UITextView = .build { textView in
@@ -54,7 +57,7 @@ final class WebCompatDetailsCell: UICollectionViewListCell,
         contentView.addSubview(textView)
         contentView.addSubview(placeholderLabel)
         let margins = contentView.layoutMarginsGuide
-        let height = textView.heightAnchor.constraint(equalToConstant: scaledMinimumHeight)
+        let height = textView.heightAnchor.constraint(equalToConstant: scaledMinimumHeight(compatibleWith: traitCollection))
         heightConstraint = height
         NSLayoutConstraint.activate([
             textView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
@@ -103,7 +106,7 @@ final class WebCompatDetailsCell: UICollectionViewListCell,
         guard notification.name == UIContentSizeCategory.didChangeNotification else { return }
         ensureMainThread { [weak self] in
             guard let self else { return }
-            self.heightConstraint?.constant = self.scaledMinimumHeight
+            self.heightConstraint?.constant = self.scaledMinimumHeight(compatibleWith: self.traitCollection)
         }
     }
 

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatDetailsCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatDetailsCell.swift
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+
+/// Optional multiline details row: a fixed-height box (scaled with Dynamic Type) whose
+/// text view scrolls internally once the content exceeds it. Value reported on editing-end.
+final class WebCompatDetailsCell: UICollectionViewListCell,
+                                  ThemeApplicable,
+                                  ReusableCell,
+                                  UITextViewDelegate,
+                                  Notifiable {
+    private var editingEndedHandler: ((String) -> Void)?
+    private var heightConstraint: NSLayoutConstraint?
+
+    private var scaledMinimumHeight: CGFloat {
+        return UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.DetailsField.minimumHeight)
+    }
+
+    private lazy var textView: UITextView = .build { textView in
+        textView.font = FXFontStyles.Regular.body.scaledFont()
+        textView.adjustsFontForContentSizeCategory = true
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.delegate = self
+    }
+
+    private lazy var placeholderLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        // Purely a visual hint; the text view owns the accessibility label/value.
+        label.isAccessibilityElement = false
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+        startObservingNotifications(
+            withNotificationCenter: NotificationCenter.default,
+            forObserver: self,
+            observing: [UIContentSizeCategory.didChangeNotification]
+        )
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        contentView.addSubview(textView)
+        contentView.addSubview(placeholderLabel)
+        let margins = contentView.layoutMarginsGuide
+        let height = textView.heightAnchor.constraint(equalToConstant: scaledMinimumHeight)
+        heightConstraint = height
+        NSLayoutConstraint.activate([
+            textView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+            textView.topAnchor.constraint(equalTo: margins.topAnchor),
+            textView.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+            height,
+
+            placeholderLabel.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
+            placeholderLabel.trailingAnchor.constraint(equalTo: textView.trailingAnchor),
+            placeholderLabel.topAnchor.constraint(equalTo: textView.topAnchor)
+        ])
+    }
+
+    func configure(
+        text: String,
+        placeholder: String,
+        accessibilityLabel: String,
+        a11yIdentifier: String,
+        onEditingEnded: @escaping (String) -> Void
+    ) {
+        editingEndedHandler = onEditingEnded
+        if !textView.isFirstResponder {
+            textView.text = text
+        }
+        textView.accessibilityLabel = accessibilityLabel
+        textView.accessibilityIdentifier = a11yIdentifier
+        placeholderLabel.text = placeholder
+        placeholderLabel.isHidden = !textView.text.isEmpty
+        updateAccessibilityValue()
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        backgroundConfiguration = .listGroupedCell()
+        backgroundConfiguration?.backgroundColor = theme.colors.layer5
+        textView.textColor = theme.colors.textPrimary
+        textView.tintColor = theme.colors.actionPrimary
+        placeholderLabel.textColor = theme.colors.textSecondary
+    }
+
+    // MARK: - Notifiable
+
+    nonisolated func handleNotifications(_ notification: Notification) {
+        guard notification.name == UIContentSizeCategory.didChangeNotification else { return }
+        ensureMainThread { [weak self] in
+            guard let self else { return }
+            self.heightConstraint?.constant = self.scaledMinimumHeight
+        }
+    }
+
+    /// Only the typed text is exposed as the value; the placeholder is a visual
+    /// hint, so VoiceOver announces the field label once rather than twice.
+    private func updateAccessibilityValue() {
+        textView.accessibilityValue = textView.text.isEmpty ? nil : textView.text
+    }
+
+    // MARK: - UITextViewDelegate
+
+    func textViewDidChange(_ textView: UITextView) {
+        placeholderLabel.isHidden = !textView.text.isEmpty
+        updateAccessibilityValue()
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        editingEndedHandler?(textView.text ?? "")
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatToggleCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatToggleCell.swift
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import UIKit
+
+final class WebCompatToggleCell: UICollectionViewListCell, ThemeApplicable, ReusableCell {
+    private var toggleHandler: ((Bool) -> Void)?
+    private var isOn = false
+
+    private lazy var titleLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        // The switch carries the label for VoiceOver, so this is decorative.
+        label.isAccessibilityElement = false
+    }
+
+    // Not built via `.build`: as a custom-view cell accessory it must keep
+    // `translatesAutoresizingMaskIntoConstraints = true` (UIKit asserts otherwise).
+    private lazy var switchControl: ThemedSwitch = {
+        let control = ThemedSwitch()
+        control.addTarget(self, action: #selector(switchChanged), for: .valueChanged)
+        return control
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        contentView.addSubview(titleLabel)
+        let margins = contentView.layoutMarginsGuide
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+            titleLabel.topAnchor.constraint(equalTo: margins.topAnchor),
+            titleLabel.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
+        ])
+        accessories = [.customView(configuration: UICellAccessory.CustomViewConfiguration(
+            customView: switchControl,
+            placement: .trailing()
+        ))]
+    }
+
+    func configure(title: String, isOn: Bool, a11yIdentifier: String, onToggle: @escaping (Bool) -> Void) {
+        toggleHandler = onToggle
+        self.isOn = isOn
+        titleLabel.text = title
+        switchControl.accessibilityLabel = title
+        switchControl.accessibilityIdentifier = a11yIdentifier
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        backgroundConfiguration = .listGroupedCell()
+        backgroundConfiguration?.backgroundColor = theme.colors.layer5
+        titleLabel.textColor = theme.colors.textPrimary
+        // Canonical ThemedSwitch order (cf. PaddedSwitch.configure,
+        // ClearPrivateDataTableViewController): apply theme first, then set the value so
+        // the off-track color resolves from the now-populated theme colors.
+        switchControl.applyTheme(theme: theme)
+        switchControl.isOn = isOn
+    }
+
+    @objc
+    private func switchChanged() {
+        toggleHandler?(switchControl.isOn)
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -83,6 +83,27 @@ private func previewDetailsSection() -> WebCompatReportViewModel.Section {
     ])
 }
 
+private func previewAdvancedSection(includeScreenshot: Bool, includeBlockedList: Bool)
+-> WebCompatReportViewModel.Section {
+    return WebCompatReportViewModel.Section(
+        id: "advanced",
+        title: "Additional Info",
+        rows: [
+            WebCompatReportViewModel.Row(
+                id: "screenshot",
+                title: "Automatically include a screenshot to show the problem",
+                kind: .toggle(isOn: includeScreenshot),
+                a11yIdentifier: "screenshot"
+            ),
+            WebCompatReportViewModel.Row(
+                id: "blocklist",
+                title: "Send list of items blocked by tracking protection",
+                kind: .toggle(isOn: includeBlockedList),
+                a11yIdentifier: "blocklist"
+            )
+        ]
+    )
+}
 
 @available(iOS 17.0, *)
 #Preview("Filled") {
@@ -95,15 +116,17 @@ private func previewDetailsSection() -> WebCompatReportViewModel.Section {
             previewSubOption("missing_items", "Missing items"),
             previewSubOption("buttons_not_working", "Buttons or links not working")
         ]),
-        previewDetailsSection()
+        previewDetailsSection(),
+        previewAdvancedSection(includeScreenshot: true, includeBlockedList: true)
     ], isPreviewEnabled: true)
 }
 
 @available(iOS 17.0, *)
-#Preview("Empty / Send disabled") {
+#Preview("Empty") {
     previewSheet(sections: [
         previewURLSection(),
-        previewCategorySection(selectedTitle: nil)
+        previewCategorySection(selectedTitle: nil),
+        previewAdvancedSection(includeScreenshot: true, includeBlockedList: false)
     ], isPreviewEnabled: false)
 }
 #endif

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -69,6 +69,21 @@ private func previewSubOption(_ id: String, _ title: String, selected: Bool = fa
     return WebCompatReportViewModel.Row(id: id, title: title, kind: .subOption(isSelected: selected), a11yIdentifier: id)
 }
 
+private func previewDetailsSection() -> WebCompatReportViewModel.Section {
+    return WebCompatReportViewModel.Section(id: "details", rows: [
+        WebCompatReportViewModel.Row(
+            id: "details",
+            title: "Describe the issue in detail",
+            kind: .detailsField(
+                text: "The recipe images never load on this page.",
+                placeholder: "Describe the issue in detail (optional)"
+            ),
+            a11yIdentifier: "details"
+        )
+    ])
+}
+
+
 @available(iOS 17.0, *)
 #Preview("Filled") {
     previewSheet(sections: [
@@ -79,7 +94,8 @@ private func previewSubOption(_ id: String, _ title: String, selected: Bool = fa
             previewSubOption("page_not_loading", "Page not loading correctly", selected: true),
             previewSubOption("missing_items", "Missing items"),
             previewSubOption("buttons_not_working", "Buttons or links not working")
-        ])
+        ]),
+        previewDetailsSection()
     ], isPreviewEnabled: true)
 }
 

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -13,6 +13,7 @@ public protocol WebCompatReportSheetDelegate: AnyObject {
     func webCompatReportSheetDidSelectCategory(id: String)
     func webCompatReportSheetDidSelectSubOption(id: String)
     func webCompatReportSheetDidEditText(id: String, text: String)
+    func webCompatReportSheetDidToggle(id: String, isOn: Bool)
 }
 
 /// The "Report a Website Issue" sheet content. Store-agnostic: configured with a
@@ -167,6 +168,7 @@ public final class WebCompatReportSheetViewController: UIViewController,
         let category = categoryCellRegistration()
         let url = urlCellRegistration()
         let details = detailsCellRegistration()
+        let toggle = toggleCellRegistration()
 
         let dataSource = UICollectionViewDiffableDataSource<String, String>(
             collectionView: collectionView
@@ -181,6 +183,8 @@ public final class WebCompatReportSheetViewController: UIViewController,
                 return collectionView.dequeueConfiguredReusableCell(using: url, for: indexPath, item: row)
             case .detailsField:
                 return collectionView.dequeueConfiguredReusableCell(using: details, for: indexPath, item: row)
+            case .toggle:
+                return collectionView.dequeueConfiguredReusableCell(using: toggle, for: indexPath, item: row)
             case .plain:
                 return collectionView.dequeueConfiguredReusableCell(using: plain, for: indexPath, item: row)
             }
@@ -263,6 +267,16 @@ public final class WebCompatReportSheetViewController: UIViewController,
         }
     }
 
+    private func toggleCellRegistration()
+    -> UICollectionView.CellRegistration<WebCompatToggleCell, WebCompatReportViewModel.Row> {
+        return UICollectionView.CellRegistration { [weak self] cell, _, row in
+            guard let self, case let .toggle(isOn) = row.kind else { return }
+            cell.configure(title: row.title, isOn: isOn, a11yIdentifier: row.a11yIdentifier) { [weak self] isOn in
+                self?.delegate?.webCompatReportSheetDidToggle(id: row.id, isOn: isOn)
+            }
+            cell.applyTheme(theme: self.theme)
+        }
+    }
 
     private func headerRegistration()
     -> UICollectionView.SupplementaryRegistration<UICollectionViewListCell> {

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -166,6 +166,7 @@ public final class WebCompatReportSheetViewController: UIViewController,
         let subOption = subOptionCellRegistration()
         let category = categoryCellRegistration()
         let url = urlCellRegistration()
+        let details = detailsCellRegistration()
 
         let dataSource = UICollectionViewDiffableDataSource<String, String>(
             collectionView: collectionView
@@ -178,6 +179,8 @@ public final class WebCompatReportSheetViewController: UIViewController,
                 return collectionView.dequeueConfiguredReusableCell(using: subOption, for: indexPath, item: row)
             case .urlField:
                 return collectionView.dequeueConfiguredReusableCell(using: url, for: indexPath, item: row)
+            case .detailsField:
+                return collectionView.dequeueConfiguredReusableCell(using: details, for: indexPath, item: row)
             case .plain:
                 return collectionView.dequeueConfiguredReusableCell(using: plain, for: indexPath, item: row)
             }
@@ -242,6 +245,24 @@ public final class WebCompatReportSheetViewController: UIViewController,
             cell.applyTheme(theme: self.theme)
         }
     }
+
+    private func detailsCellRegistration()
+    -> UICollectionView.CellRegistration<WebCompatDetailsCell, WebCompatReportViewModel.Row> {
+        return UICollectionView.CellRegistration { [weak self] cell, _, row in
+            guard let self, case let .detailsField(text, placeholder) = row.kind else { return }
+            cell.configure(
+                text: text,
+                placeholder: placeholder,
+                accessibilityLabel: row.title,
+                a11yIdentifier: row.a11yIdentifier,
+                onEditingEnded: { [weak self] text in
+                    self?.delegate?.webCompatReportSheetDidEditText(id: row.id, text: text)
+                }
+            )
+            cell.applyTheme(theme: self.theme)
+        }
+    }
+
 
     private func headerRegistration()
     -> UICollectionView.SupplementaryRegistration<UICollectionViewListCell> {

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
@@ -43,6 +43,7 @@ public struct WebCompatReportViewModel: Equatable, Sendable {
             case subOption(isSelected: Bool)
             case urlField(text: String, placeholder: String)
             case detailsField(text: String, placeholder: String)
+            case toggle(isOn: Bool)
         }
 
         public let id: String

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
@@ -42,6 +42,7 @@ public struct WebCompatReportViewModel: Equatable, Sendable {
             case categoryMenu(isPlaceholder: Bool, options: [MenuOption])
             case subOption(isSelected: Bool)
             case urlField(text: String, placeholder: String)
+            case detailsField(text: String, placeholder: String)
         }
 
         public let id: String

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -31,6 +31,11 @@ enum WebCompatReporterUX {
         static let size: CGFloat = 10
     }
 
+    enum DetailsField {
+        /// Fixed box height (~three lines, scaled with Dynamic Type); the text view scrolls internally.
+        static let minimumHeight: CGFloat = 88
+    }
+
     enum Keyboard {
         static let focusPadding: CGFloat = 16
     }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatDetailsCellTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatDetailsCellTests.swift
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+@testable import WebCompatReporterKit
+
+@MainActor
+final class WebCompatDetailsCellTests: XCTestCase {
+    func testConfigure_carriesLabelAndIdentifierOntoTextViewAndSetsText() throws {
+        let subject = createSubject()
+
+        subject.configure(
+            text: "The images never load",
+            placeholder: "Describe the issue",
+            accessibilityLabel: "Additional details",
+            a11yIdentifier: "WebCompatReporter.AdditionalDetails",
+            onEditingEnded: { _ in }
+        )
+
+        let textView = try XCTUnwrap(firstSubview(ofType: UITextView.self, in: subject.contentView))
+        XCTAssertEqual(textView.text, "The images never load")
+        XCTAssertEqual(textView.accessibilityLabel, "Additional details")
+        XCTAssertEqual(textView.accessibilityIdentifier, "WebCompatReporter.AdditionalDetails")
+    }
+
+    func testScaledMinimumHeight_growsAtAccessibilityContentSize() {
+        let subject = createSubject()
+
+        let standard = subject.scaledMinimumHeight(
+            compatibleWith: UITraitCollection(preferredContentSizeCategory: .large)
+        )
+        let accessibility = subject.scaledMinimumHeight(
+            compatibleWith: UITraitCollection(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge)
+        )
+
+        XCTAssertGreaterThan(accessibility, standard)
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> WebCompatDetailsCell {
+        return WebCompatDetailsCell(frame: CGRect(x: 0, y: 0, width: 320, height: 120))
+    }
+}

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -110,7 +110,27 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
 
         let collectionView = subject.view.subviews.compactMap { $0 as? UICollectionView }.first
         XCTAssertTrue(collectionView?.cellForItem(at: IndexPath(item: 0, section: 0)) is WebCompatURLCell)
-        XCTAssertTrue(collectionView?.cellForItem(at: IndexPath(item: 0, section: 1)) is WebCompatDetailsCell)
+        XCTAssertTrue(collectionView?.cellForItem(at: IndexPath(item: 0, section: 1)) is WebCompatToggleCell)
+        XCTAssertTrue(collectionView?.cellForItem(at: IndexPath(item: 0, section: 2)) is WebCompatDetailsCell)
+    }
+
+    func testToggleCell_activation_notifiesDelegateWithRowIDAndValue() {
+        let delegate = MockWebCompatReportSheetDelegate()
+        let subject = createSubject()
+        subject.delegate = delegate
+        subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        subject.loadViewIfNeeded()
+        subject.configure(with: makeViewModel(sections: fieldSections()))
+        subject.view.layoutIfNeeded()
+
+        let collectionView = subject.view.subviews.compactMap { $0 as? UICollectionView }.first
+        let toggleCell = collectionView?.cellForItem(at: IndexPath(item: 0, section: 1))
+        let toggle = firstSubview(ofType: UISwitch.self, in: toggleCell)
+        toggle?.isOn = true
+        fireActions(toggle, for: .valueChanged)
+
+        XCTAssertEqual(delegate.toggles.map(\.id), ["screenshot"])
+        XCTAssertEqual(delegate.toggles.map(\.isOn), [true])
     }
 
     func testURLCell_editingEnd_notifiesDelegateWithRowIDAndText() {
@@ -133,7 +153,7 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         let (subject, window) = hostedFieldSubject(delegate: delegate)
         defer { window.isHidden = true }
 
-        let detailsCell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 1))
+        let detailsCell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 2))
         let textView = firstSubview(ofType: UITextView.self, in: detailsCell?.contentView)
         textView?.becomeFirstResponder()
         textView?.text = "The images never load"
@@ -150,8 +170,8 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
     ) -> (WebCompatReportSheetViewController, UIWindow) {
         let subject = createSubject()
         subject.delegate = delegate
-        // A tall key window lays out every section and gives text fields a real
-        // editing session for first-responder changes.
+        // A tall key window lays out every section (so the send cell exists) and
+        // gives text fields a real editing session for first-responder changes.
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 2000))
         window.rootViewController = subject
         window.makeKeyAndVisible()
@@ -164,6 +184,18 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         return subject.view.subviews.compactMap { $0 as? UICollectionView }.first
     }
 
+    // UIControl.sendActions needs a running UIApplication, which logic tests lack,
+    // so invoke each registered target/action selector directly.
+    private func fireActions(_ control: UIControl?, for event: UIControl.Event) {
+        guard let control else { return }
+        for target in control.allTargets {
+            let object = target as NSObject
+            control.actions(forTarget: target, forControlEvent: event)?.forEach {
+                object.perform(Selector($0))
+            }
+        }
+    }
+
     private func fieldSections() -> [WebCompatReportViewModel.Section] {
         return [
             WebCompatReportViewModel.Section(id: "url", rows: [
@@ -174,6 +206,24 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
                     a11yIdentifier: "url"
                 )
             ]),
+            WebCompatReportViewModel.Section(
+                id: "advanced",
+                title: "Advanced Options",
+                rows: [
+                    WebCompatReportViewModel.Row(
+                        id: "screenshot",
+                        title: "Include screenshot",
+                        kind: .toggle(isOn: false),
+                        a11yIdentifier: "screenshot"
+                    ),
+                    WebCompatReportViewModel.Row(
+                        id: "blocklist",
+                        title: "Include blocked list",
+                        kind: .toggle(isOn: true),
+                        a11yIdentifier: "blocklist"
+                    )
+                ]
+            ),
             WebCompatReportViewModel.Section(id: "details", rows: [
                 WebCompatReportViewModel.Row(
                     id: "details",
@@ -275,6 +325,7 @@ private final class MockWebCompatReportSheetDelegate: WebCompatReportSheetDelega
     var selectedCategoryIDs: [String] = []
     var selectedSubOptionIDs: [String] = []
     var editedText: [(id: String, text: String)] = []
+    var toggles: [(id: String, isOn: Bool)] = []
 
     func webCompatReportSheetDidTapClose() {
         didTapCloseCallCount += 1
@@ -294,5 +345,9 @@ private final class MockWebCompatReportSheetDelegate: WebCompatReportSheetDelega
 
     func webCompatReportSheetDidEditText(id: String, text: String) {
         editedText.append((id, text))
+    }
+
+    func webCompatReportSheetDidToggle(id: String, isOn: Bool) {
+        toggles.append((id, isOn))
     }
 }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -110,9 +110,59 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
 
         let collectionView = subject.view.subviews.compactMap { $0 as? UICollectionView }.first
         XCTAssertTrue(collectionView?.cellForItem(at: IndexPath(item: 0, section: 0)) is WebCompatURLCell)
+        XCTAssertTrue(collectionView?.cellForItem(at: IndexPath(item: 0, section: 1)) is WebCompatDetailsCell)
+    }
+
+    func testURLCell_editingEnd_notifiesDelegateWithRowIDAndText() {
+        let delegate = MockWebCompatReportSheetDelegate()
+        let (subject, window) = hostedFieldSubject(delegate: delegate)
+        defer { window.isHidden = true }
+
+        let urlCell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 0))
+        let textField = firstSubview(ofType: UITextField.self, in: urlCell?.contentView)
+        textField?.becomeFirstResponder()
+        textField?.text = "https://changed.example.com"
+        textField?.resignFirstResponder()
+
+        XCTAssertEqual(delegate.editedText.map(\.id), ["url"])
+        XCTAssertEqual(delegate.editedText.map(\.text), ["https://changed.example.com"])
+    }
+
+    func testDetailsCell_editingEnd_notifiesDelegateWithRowIDAndText() {
+        let delegate = MockWebCompatReportSheetDelegate()
+        let (subject, window) = hostedFieldSubject(delegate: delegate)
+        defer { window.isHidden = true }
+
+        let detailsCell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 1))
+        let textView = firstSubview(ofType: UITextView.self, in: detailsCell?.contentView)
+        textView?.becomeFirstResponder()
+        textView?.text = "The images never load"
+        textView?.resignFirstResponder()
+
+        XCTAssertEqual(delegate.editedText.map(\.id), ["details"])
+        XCTAssertEqual(delegate.editedText.map(\.text), ["The images never load"])
     }
 
     // MARK: - Helpers
+
+    private func hostedFieldSubject(
+        delegate: MockWebCompatReportSheetDelegate
+    ) -> (WebCompatReportSheetViewController, UIWindow) {
+        let subject = createSubject()
+        subject.delegate = delegate
+        // A tall key window lays out every section and gives text fields a real
+        // editing session for first-responder changes.
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 2000))
+        window.rootViewController = subject
+        window.makeKeyAndVisible()
+        subject.configure(with: makeViewModel(sections: fieldSections()))
+        subject.view.layoutIfNeeded()
+        return (subject, window)
+    }
+
+    private func collectionView(in subject: WebCompatReportSheetViewController) -> UICollectionView? {
+        return subject.view.subviews.compactMap { $0 as? UICollectionView }.first
+    }
 
     private func fieldSections() -> [WebCompatReportViewModel.Section] {
         return [
@@ -122,6 +172,14 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
                     title: "URL",
                     kind: .urlField(text: "https://example.com", placeholder: "Website address"),
                     a11yIdentifier: "url"
+                )
+            ]),
+            WebCompatReportViewModel.Section(id: "details", rows: [
+                WebCompatReportViewModel.Row(
+                    id: "details",
+                    title: "Additional details",
+                    kind: .detailsField(text: "", placeholder: "Additional Details (optional)"),
+                    a11yIdentifier: "details"
                 )
             ])
         ]

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -139,6 +139,8 @@ struct AccessibilityIdentifiers {
         static let categoryMenu = "WebCompatReporter.CategoryMenu"
         static let subOption = "WebCompatReporter.SubOption"
         static let additionalDetails = "WebCompatReporter.AdditionalDetails"
+        static let includeScreenshot = "WebCompatReporter.IncludeScreenshot"
+        static let includeBlockedList = "WebCompatReporter.IncludeBlockedList"
     }
 
     struct UnifiedSearch {

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -138,6 +138,7 @@ struct AccessibilityIdentifiers {
         static let urlField = "WebCompatReporter.URLField"
         static let categoryMenu = "WebCompatReporter.CategoryMenu"
         static let subOption = "WebCompatReporter.SubOption"
+        static let additionalDetails = "WebCompatReporter.AdditionalDetails"
     }
 
     struct UnifiedSearch {

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -121,11 +121,14 @@ final class WebCompatReportViewController: UINavigationController,
         case issueCategory
         case issueSubOptions
         case additionalDetails
+        case advancedOptions
     }
 
     private enum RowID: String {
         case url
         case additionalDetails
+        case includeScreenshot
+        case includeBlockedList
     }
 
     static func makeSections(
@@ -137,6 +140,7 @@ final class WebCompatReportViewController: UINavigationController,
         if state.selectedCategory != nil {
             sections.append(detailsSection(from: state))
         }
+        sections.append(advancedOptionsSection(from: state))
         return sections
     }
 
@@ -166,6 +170,29 @@ final class WebCompatReportViewController: UINavigationController,
                         placeholder: .WebCompatReporter.Fields.DetailsPlaceholder
                     ),
                     a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.additionalDetails
+                )
+            ]
+        )
+    }
+
+    private static func advancedOptionsSection(
+        from state: WebCompatReporterState
+    ) -> WebCompatReportViewModel.Section {
+        return WebCompatReportViewModel.Section(
+            id: SectionID.advancedOptions.rawValue,
+            title: .WebCompatReporter.AdditionalInfo.Title,
+            rows: [
+                WebCompatReportViewModel.Row(
+                    id: RowID.includeScreenshot.rawValue,
+                    title: .WebCompatReporter.AdditionalInfo.IncludeScreenshot,
+                    kind: .toggle(isOn: state.includeScreenshot),
+                    a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.includeScreenshot
+                ),
+                WebCompatReportViewModel.Row(
+                    id: RowID.includeBlockedList.rawValue,
+                    title: .WebCompatReporter.AdditionalInfo.IncludeBlockedList,
+                    kind: .toggle(isOn: state.includeBlockedList),
+                    a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.includeBlockedList
                 )
             ]
         )
@@ -293,7 +320,26 @@ final class WebCompatReportViewController: UINavigationController,
                 windowUUID: windowUUID,
                 actionType: WebCompatReporterViewActionType.setAdditionalDetails
             ))
-        case .none:
+        case .includeScreenshot, .includeBlockedList, .none:
+            break
+        }
+    }
+
+    func webCompatReportSheetDidToggle(id: String, isOn: Bool) {
+        switch RowID(rawValue: id) {
+        case .includeScreenshot:
+            store.dispatch(WebCompatReporterViewAction(
+                includeScreenshot: isOn,
+                windowUUID: windowUUID,
+                actionType: WebCompatReporterViewActionType.toggleScreenshot
+            ))
+        case .includeBlockedList:
+            store.dispatch(WebCompatReporterViewAction(
+                includeBlockedList: isOn,
+                windowUUID: windowUUID,
+                actionType: WebCompatReporterViewActionType.toggleBlockedList
+            ))
+        case .url, .additionalDetails, .none:
             break
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -120,10 +120,12 @@ final class WebCompatReportViewController: UINavigationController,
         case url
         case issueCategory
         case issueSubOptions
+        case additionalDetails
     }
 
     private enum RowID: String {
         case url
+        case additionalDetails
     }
 
     static func makeSections(
@@ -131,6 +133,10 @@ final class WebCompatReportViewController: UINavigationController,
     ) -> [WebCompatReportViewModel.Section] {
         var sections = [urlSection(from: state)]
         sections.append(contentsOf: makeIssueSections(from: state))
+        // Only show details once a category is selected.
+        if state.selectedCategory != nil {
+            sections.append(detailsSection(from: state))
+        }
         return sections
     }
 
@@ -143,6 +149,23 @@ final class WebCompatReportViewController: UINavigationController,
                     title: .WebCompatReporter.Fields.URLLabel,
                     kind: .urlField(text: state.url, placeholder: .WebCompatReporter.Fields.URLPlaceholder),
                     a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.urlField
+                )
+            ]
+        )
+    }
+
+    private static func detailsSection(from state: WebCompatReporterState) -> WebCompatReportViewModel.Section {
+        return WebCompatReportViewModel.Section(
+            id: SectionID.additionalDetails.rawValue,
+            rows: [
+                WebCompatReportViewModel.Row(
+                    id: RowID.additionalDetails.rawValue,
+                    title: .WebCompatReporter.Fields.DetailsAccessibilityLabel,
+                    kind: .detailsField(
+                        text: state.additionalDetails,
+                        placeholder: .WebCompatReporter.Fields.DetailsPlaceholder
+                    ),
+                    a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.additionalDetails
                 )
             ]
         )
@@ -263,6 +286,12 @@ final class WebCompatReportViewController: UINavigationController,
                 url: text,
                 windowUUID: windowUUID,
                 actionType: WebCompatReporterViewActionType.editURL
+            ))
+        case .additionalDetails:
+            store.dispatch(WebCompatReporterViewAction(
+                additionalDetails: text,
+                windowUUID: windowUUID,
+                actionType: WebCompatReporterViewActionType.setAdditionalDetails
             ))
         case .none:
             break

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -76,6 +76,34 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(dispatchedViewActions().isEmpty)
     }
 
+    func testDidToggle_onScreenshotRow_dispatchesToggleScreenshotWithValue() {
+        let subject = createSubject(reportedURL: nil)
+
+        subject.webCompatReportSheetDidToggle(id: "includeScreenshot", isOn: false)
+
+        let action = lastViewAction()
+        XCTAssertEqual(action?.actionType as? WebCompatReporterViewActionType, .toggleScreenshot)
+        XCTAssertEqual(action?.includeScreenshot, false)
+    }
+
+    func testDidToggle_onBlockedListRow_dispatchesToggleBlockedListWithValue() {
+        let subject = createSubject(reportedURL: nil)
+
+        subject.webCompatReportSheetDidToggle(id: "includeBlockedList", isOn: true)
+
+        let action = lastViewAction()
+        XCTAssertEqual(action?.actionType as? WebCompatReporterViewActionType, .toggleBlockedList)
+        XCTAssertEqual(action?.includeBlockedList, true)
+    }
+
+    func testDidToggle_onUnhandledRow_dispatchesNothing() {
+        let subject = createSubject(reportedURL: nil)
+
+        subject.webCompatReportSheetDidToggle(id: "url", isOn: true)
+
+        XCTAssertTrue(dispatchedViewActions().isEmpty)
+    }
+
     func testSimpleCreation_hasNoLeaks() {
         let subject = createSubject(reportedURL: nil)
         subject.loadViewIfNeeded()
@@ -138,38 +166,49 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
 
     // MARK: - makeSections
 
-    func testMakeSections_withoutCategory_showsURLAndCategoryOnly() {
+    func testMakeSections_withoutCategory_omitsDetailsShowsAdvancedToggles() {
         let state = WebCompatReporterState(windowUUID: windowUUID, url: "https://example.com")
 
         let sections = WebCompatReportViewController.makeSections(from: state)
 
-        // URL + category only (no sub-options, no details until a category is picked).
-        XCTAssertEqual(sections.map(\.id), ["url", "issueCategory"])
+        // URL + category + advanced (no sub-options, no details until a category is picked).
+        XCTAssertEqual(sections.map(\.id), ["url", "issueCategory", "advancedOptions"])
 
         guard case let .urlField(text, _) = sections.first?.rows.first?.kind else {
             return XCTFail("Expected a URL field row")
         }
         XCTAssertEqual(text, "https://example.com")
+
+        let advanced = sections.first { $0.id == "advancedOptions" }
+        XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: true), .toggle(isOn: false)])
     }
 
-    func testMakeSections_withCategory_showsDetails() {
+    func testMakeSections_withCategory_showsDetailsAndAdvancedToggles() {
         let state = WebCompatReporterState(
             windowUUID: windowUUID,
             url: "https://example.com",
             selectedCategory: .siteNotUsable,
             selectedSubOptionID: WebCompatSubOption.pageNotLoading.rawValue,
-            additionalDetails: "Broken images"
+            additionalDetails: "Broken images",
+            includeScreenshot: false,
+            includeBlockedList: true
         )
 
         let sections = WebCompatReportViewController.makeSections(from: state)
 
-        XCTAssertEqual(sections.map(\.id), ["url", "issueCategory", "issueSubOptions", "additionalDetails"])
+        XCTAssertEqual(
+            sections.map(\.id),
+            ["url", "issueCategory", "issueSubOptions", "additionalDetails", "advancedOptions"]
+        )
 
         let details = sections.first { $0.id == "additionalDetails" }
         guard case let .detailsField(text, _) = details?.rows.first?.kind else {
             return XCTFail("Expected a details field row")
         }
         XCTAssertEqual(text, "Broken images")
+
+        let advanced = sections.first { $0.id == "advancedOptions" }
+        XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: false), .toggle(isOn: true)])
     }
 
     private func createSubject(reportedURL: URL?) -> WebCompatReportViewController {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -58,6 +58,24 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(action?.url, "https://changed.example.com")
     }
 
+    func testDidEditText_onDetailsRow_dispatchesSetAdditionalDetailsWithText() {
+        let subject = createSubject(reportedURL: nil)
+
+        subject.webCompatReportSheetDidEditText(id: "additionalDetails", text: "Images never load")
+
+        let action = lastViewAction()
+        XCTAssertEqual(action?.actionType as? WebCompatReporterViewActionType, .setAdditionalDetails)
+        XCTAssertEqual(action?.additionalDetails, "Images never load")
+    }
+
+    func testDidEditText_onUnhandledRow_dispatchesNothing() {
+        let subject = createSubject(reportedURL: nil)
+
+        subject.webCompatReportSheetDidEditText(id: "send", text: "ignored")
+
+        XCTAssertTrue(dispatchedViewActions().isEmpty)
+    }
+
     func testSimpleCreation_hasNoLeaks() {
         let subject = createSubject(reportedURL: nil)
         subject.loadViewIfNeeded()
@@ -125,7 +143,7 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
 
         let sections = WebCompatReportViewController.makeSections(from: state)
 
-        // URL + category only (no sub-options until a category is picked).
+        // URL + category only (no sub-options, no details until a category is picked).
         XCTAssertEqual(sections.map(\.id), ["url", "issueCategory"])
 
         guard case let .urlField(text, _) = sections.first?.rows.first?.kind else {
@@ -134,18 +152,24 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(text, "https://example.com")
     }
 
-    func testMakeSections_withCategory_addsSubOptions() {
+    func testMakeSections_withCategory_showsDetails() {
         let state = WebCompatReporterState(
             windowUUID: windowUUID,
             url: "https://example.com",
             selectedCategory: .siteNotUsable,
-            selectedSubOptionID: WebCompatSubOption.pageNotLoading.rawValue
+            selectedSubOptionID: WebCompatSubOption.pageNotLoading.rawValue,
+            additionalDetails: "Broken images"
         )
 
-        XCTAssertEqual(
-            WebCompatReportViewController.makeSections(from: state).map(\.id),
-            ["url", "issueCategory", "issueSubOptions"]
-        )
+        let sections = WebCompatReportViewController.makeSections(from: state)
+
+        XCTAssertEqual(sections.map(\.id), ["url", "issueCategory", "issueSubOptions", "additionalDetails"])
+
+        let details = sections.first { $0.id == "additionalDetails" }
+        guard case let .detailsField(text, _) = details?.rows.first?.kind else {
+            return XCTFail("Expected a details field row")
+        }
+        XCTAssertEqual(text, "Broken images")
     }
 
     private func createSubject(reportedURL: URL?) -> WebCompatReportViewController {


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16182](https://mozilla-hub.atlassian.net/browse/FXIOS-16182)

## :bulb: Description
Part 3 of the WebCompat report-fields stack. **Stacked on #34834 — review/merge that first.**

Adds the Additional Info section's two toggles: "include a screenshot" and "send the tracking-protection blocked list". This is the `.toggle` view-model kind, the `WebCompatToggleCell` (reusing ComponentLibrary's `ThemedSwitch`), its registration, the Client `advancedOptionsSection` mapping, and the `toggleScreenshot` / `toggleBlockedList` wiring. The section's Learn More footer and the send button come in the final PR.

## :movie_camera: Demos
<img height="700" alt="Screenshot 2026-07-24 at 09 37 26" src="https://github.com/user-attachments/assets/c24bca2e-60d6-416a-9006-67402d00842e" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
Run the `WebCompatReporterKit` package tests (16 tests, all green locally). Manually: open Report a Website Issue, toggle each Additional Info switch and confirm the state sticks; VoiceOver announces each switch and its on/off value.


[FXIOS-16182]: https://mozilla-hub.atlassian.net/browse/FXIOS-16182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ