### PR TITLE
Refactor FXIOS-15351 [Technical Debt] [Redux] Use @Copyable macro for TabTrayState

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -14,6 +14,7 @@ enum TabTrayLayoutType: Equatable {
 
 @Copyable
 struct TabTrayState: ScreenState, Equatable {
+    var windowUUID: WindowUUID
     var isPrivateMode: Bool
     var selectedPanel: TabTrayPanelType
     var normalTabsCount: String
@@ -21,7 +22,6 @@ struct TabTrayState: ScreenState, Equatable {
     var hasSyncableAccount: Bool
     var shouldDismiss: Bool
     var toastType: ToastType?
-    var windowUUID: WindowUUID
     var showCloseConfirmation: Bool
     var enableDeleteTabsButton: Bool?
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import ModifiedCopy
 import Redux
 import Common
 
@@ -11,6 +12,7 @@ enum TabTrayLayoutType: Equatable {
     case compact // iPhone
 }
 
+@Copyable
 struct TabTrayState: ScreenState, Equatable {
     var isPrivateMode: Bool
     var selectedPanel: TabTrayPanelType
@@ -121,42 +123,42 @@ struct TabTrayState: ScreenState, Equatable {
         switch action.actionType {
         case TabTrayActionType.didLoadTabTray:
             guard let tabTrayModel = action.tabTrayModel else { return defaultState(from: state) }
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: tabTrayModel.isPrivateMode,
-                                selectedPanel: tabTrayModel.selectedPanel,
-                                normalTabsCount: tabTrayModel.normalTabsCount,
-                                privateTabsCount: tabTrayModel.privateTabsCount,
-                                hasSyncableAccount: tabTrayModel.hasSyncableAccount,
-                                enableDeleteTabsButton: tabTrayModel.enableDeleteTabsButton)
+            return state
+                .copy(isPrivateMode: tabTrayModel.isPrivateMode)
+                .copy(selectedPanel: tabTrayModel.selectedPanel)
+                .copy(normalTabsCount: tabTrayModel.normalTabsCount)
+                .copy(privateTabsCount: tabTrayModel.privateTabsCount)
+                .copy(hasSyncableAccount: tabTrayModel.hasSyncableAccount)
+                .copy(shouldDismiss: false)
+                .copy(toastType: nil)
+                .copy(showCloseConfirmation: false)
+                .copy(enableDeleteTabsButton: tabTrayModel.enableDeleteTabsButton)
 
         case TabTrayActionType.changePanel:
             guard let panelType = action.panelType else { return defaultState(from: state) }
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: panelType == .privateTabs,
-                                selectedPanel: panelType,
-                                normalTabsCount: state.normalTabsCount,
-                                privateTabsCount: state.privateTabsCount,
-                                hasSyncableAccount: state.hasSyncableAccount)
+            return state
+                .copy(isPrivateMode: panelType == .privateTabs)
+                .copy(selectedPanel: panelType)
+                .copy(shouldDismiss: false)
+                .copy(toastType: nil)
+                .copy(showCloseConfirmation: false)
+                .copy(enableDeleteTabsButton: nil)
 
         case TabTrayActionType.dismissTabTray:
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: state.isPrivateMode,
-                                selectedPanel: state.selectedPanel,
-                                normalTabsCount: state.normalTabsCount,
-                                privateTabsCount: state.privateTabsCount,
-                                hasSyncableAccount: state.hasSyncableAccount,
-                                shouldDismiss: true)
+            return state
+                .copy(shouldDismiss: true)
+                .copy(toastType: nil)
+                .copy(showCloseConfirmation: false)
+                .copy(enableDeleteTabsButton: nil)
 
         case TabTrayActionType.firefoxAccountChanged:
             guard let isSyncAccountEnabled = action.hasSyncableAccount else { return defaultState(from: state) }
-            // Account updates may occur in a global manner, independent of specific windows.
-            let uuid = state.windowUUID
-            return TabTrayState(windowUUID: uuid,
-                                isPrivateMode: state.isPrivateMode,
-                                selectedPanel: state.selectedPanel,
-                                normalTabsCount: state.normalTabsCount,
-                                privateTabsCount: state.privateTabsCount,
-                                hasSyncableAccount: isSyncAccountEnabled)
+            return state
+                .copy(hasSyncableAccount: isSyncAccountEnabled)
+                .copy(shouldDismiss: false)
+                .copy(toastType: nil)
+                .copy(showCloseConfirmation: false)
+                .copy(enableDeleteTabsButton: nil)
 
         default:
             return defaultState(from: state)
@@ -169,26 +171,28 @@ struct TabTrayState: ScreenState, Equatable {
         case TabPanelMiddlewareActionType.didChangeTabPanel:
             guard let tabDisplayModel = action.tabDisplayModel else { return defaultState(from: state) }
             let panelType = tabDisplayModel.isPrivateMode ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: tabDisplayModel.isPrivateMode,
-                                selectedPanel: panelType,
-                                normalTabsCount: tabDisplayModel.normalTabsCount,
-                                privateTabsCount: "\(tabDisplayModel.tabs.filter({ $0.isPrivate == true }).count)",
-                                hasSyncableAccount: state.hasSyncableAccount,
-                                enableDeleteTabsButton: tabDisplayModel.enableDeleteTabsButton)
+            return state
+                .copy(isPrivateMode: tabDisplayModel.isPrivateMode)
+                .copy(selectedPanel: panelType)
+                .copy(normalTabsCount: tabDisplayModel.normalTabsCount)
+                .copy(privateTabsCount: "\(tabDisplayModel.tabs.filter({ $0.isPrivate == true }).count)")
+                .copy(shouldDismiss: false)
+                .copy(toastType: nil)
+                .copy(showCloseConfirmation: false)
+                .copy(enableDeleteTabsButton: tabDisplayModel.enableDeleteTabsButton)
 
         case TabPanelMiddlewareActionType.refreshTabs:
             // Only update the normal tab count if the tabs being refreshed are not private
             guard let tabDisplayModel = action.tabDisplayModel else { return defaultState(from: state) }
             let isPrivate = tabDisplayModel.tabs.first?.isPrivate ?? false
             let tabCount = isPrivate ? state.normalTabsCount : tabDisplayModel.normalTabsCount
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: state.isPrivateMode,
-                                selectedPanel: state.selectedPanel,
-                                normalTabsCount: tabCount,
-                                privateTabsCount: tabDisplayModel.privateTabsCount,
-                                hasSyncableAccount: state.hasSyncableAccount,
-                                enableDeleteTabsButton: tabDisplayModel.enableDeleteTabsButton)
+            return state
+                .copy(normalTabsCount: tabCount)
+                .copy(privateTabsCount: tabDisplayModel.privateTabsCount)
+                .copy(shouldDismiss: false)
+                .copy(toastType: nil)
+                .copy(showCloseConfirmation: false)
+                .copy(enableDeleteTabsButton: tabDisplayModel.enableDeleteTabsButton)
 
         default:
             return defaultState(from: state)
@@ -199,13 +203,11 @@ struct TabTrayState: ScreenState, Equatable {
     static func reduceTabPanelViewAction(action: TabPanelViewAction, state: TabTrayState) -> TabTrayState {
         switch action.actionType {
         case TabPanelViewActionType.closeAllTabs:
-            return TabTrayState(windowUUID: state.windowUUID,
-                                isPrivateMode: state.isPrivateMode,
-                                selectedPanel: state.selectedPanel,
-                                normalTabsCount: state.normalTabsCount,
-                                privateTabsCount: state.privateTabsCount,
-                                hasSyncableAccount: state.hasSyncableAccount,
-                                showCloseConfirmation: true)
+            return state
+                .copy(shouldDismiss: false)
+                .copy(toastType: nil)
+                .copy(showCloseConfirmation: true)
+                .copy(enableDeleteTabsButton: nil)
 
         default:
             return defaultState(from: state)
@@ -213,11 +215,10 @@ struct TabTrayState: ScreenState, Equatable {
     }
 
     static func defaultState(from state: TabTrayState) -> TabTrayState {
-        return TabTrayState(windowUUID: state.windowUUID,
-                            isPrivateMode: state.isPrivateMode,
-                            selectedPanel: state.selectedPanel,
-                            normalTabsCount: state.normalTabsCount,
-                            privateTabsCount: state.privateTabsCount,
-                            hasSyncableAccount: state.hasSyncableAccount)
+        return state
+            .copy(shouldDismiss: false)
+            .copy(toastType: nil)
+            .copy(showCloseConfirmation: false)
+            .copy(enableDeleteTabsButton: nil)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15351)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32938)

## :bulb: Description
Applies the `@Copyable` macro (from the `ModifiedCopy` package) to `TabTrayState`, replacing the reducer's manual full-constructor reconstructions with `.copy(...)` chains that only touch the fields actually changing in each action handler. This follows the same pattern already established in the codebase (e.g. `SearchBarState`, `HomepageState`) and applied most recently to `TabPeekState` (#34744) and `RemoteTabsPanelState` (#34762).

No behavioral change. Each reducer branch preserves the existing (implicit) behavior of the old manual initializer calls: `shouldDismiss`, `toastType`, `showCloseConfirmation`, and `enableDeleteTabsButton` are reset to their defaults (`false`/`nil`) on every action unless that specific branch explicitly sets one — this mirrors the initializer's default-parameter behavior in the pre-refactor code exactly, so no state-transition semantics changed.

`TabTrayStateTests.swift` is unmodified.

## :movie_camera: Demos
N/A — internal Redux state refactor, no UI change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [ ] I ensured unit tests pass and wrote tests for new code — **note:** could not run `xcodebuild test` locally (this environment isn't fully bootstrapped — verified the same script-phase failure occurs on unmodified `main` too, so it's unrelated to this change); relying on CI to verify `TabTrayStateTests` still pass unmodified
- [ ] N/A — no UI changes
- [ ] N/A — no telemetry changes
- [ ] N/A — no string changes
- [ ] N/A — no documentation changes needed