### PR TITLE
Add FXIOS-16398 - [Strings] - Add "Signing out…" strings for the account sign-out transitional state

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4146,7 +4146,11 @@ extension String {
                 tableName: nil,
                 value: "Sign in to sync tabs, bookmarks, passwords, and more.",
                 comment: "Ddescription that appears in the settings screen to explain what Firefox Sync is useful for.")
-
+            public static let SigningOutTitle = MZLocalizedString(
+                key: "Settings.Sync.SigningOut.Title.v154",
+                tableName: nil,
+                value: "Signing out…",
+                comment: "In the settings account row, shown transiently while the user is being signed out of their account.")
             public struct SignInView {
                 public static let Title = MZLocalizedString(
                     key: "Settings.Sync.SignInView.Title.v103",
@@ -6179,6 +6183,11 @@ extension String {
                 tableName: "MainMenu",
                 value: "Manage what you back up and sync",
                 comment: "On the main menu, when the user is signed in.")
+            public static let SigningOutTitle = MZLocalizedString(
+                key: "MainMenu.Account.SigningOut.Title.v154",
+                tableName: "MainMenu",
+                value: "Signing out…",
+                comment: "On the main menu account header, shown transiently while the user is being signed out of their account.")
             public static let SyncErrorTitle = MZLocalizedString(
                 key: "MainMenu.Account.SyncError.Title.v131",
                 tableName: "MainMenu",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16398)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34842)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

- Strings PR related to https://github.com/mozilla-mobile/firefox-ios/pull/34840

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

