### PR TITLE
Refactor FXIOS-16347 [Automation] Adjust tech lead assignement logic

### DIFF
--- a/.github/workflows/assign-tech-lead-review.yml
+++ b/.github/workflows/assign-tech-lead-review.yml
@@ -49,27 +49,48 @@ jobs:
             exit 0
           fi
 
-          # Build the JSON reviewers array, skipping the PR author (GitHub 422s if
-          # you request the author as their own reviewer).
-          reviewers_json=""
-          for login in $REVIEWERS; do
-            [ "$login" = "$PR_AUTHOR" ] && continue
-            reviewers_json="${reviewers_json:+$reviewers_json,}\"$login\""
+          # Fetch currently requested reviewers so we don't stack multiple tech leads on the same PR
+          # (e.g. on `synchronize` re-runs) and don't re-request someone who is already reviewing.
+          current_reviewers=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GH_REPO/pulls/$NUMBER/requested_reviewers" \
+            --jq '.users[].login' | tr '\n' ' ')
+
+          # If any tech lead is already a requested reviewer, skip assignment and just make sure the label is set.
+          for cur in $current_reviewers; do
+            for login in $REVIEWERS; do
+              if [ "$login" = "$cur" ]; then
+                echo "Tech lead $cur is already requested for review; skipping assignment."
+                retry gh pr edit "$NUMBER" -R "$GH_REPO" --add-label "$LABEL_NAME"
+                exit 0
+              fi
+            done
           done
 
-          if [ -z "$reviewers_json" ]; then
+          # Build the eligible list: not the PR author (GitHub 422s if you request the author as their own reviewer).
+          eligible=()
+          for login in $REVIEWERS; do
+            [ "$login" = "$PR_AUTHOR" ] && continue
+            eligible+=("$login")
+          done
+
+          if [ ${#eligible[@]} -eq 0 ]; then
             echo "No eligible reviewers to request (list empty or only the author). Nothing to do."
             exit 0
           fi
 
-          # Request review from the individual reviewers. Fails the workflow if unsuccessful after retries.
+          # Pick one random reviewer from the eligible list.
+          picked="${eligible[$((RANDOM % ${#eligible[@]}))]}"
+          echo "Requesting review from: $picked"
+
+          # Request review from the picked reviewer. Fails the workflow if unsuccessful after retries.
           request_reviewer() {
             gh api \
               --method POST \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2026-03-10" \
               "/repos/$GH_REPO/pulls/$NUMBER/requested_reviewers" \
-              --input - <<< "{\"reviewers\":[$reviewers_json]}"
+              --input - <<< "{\"reviewers\":[\"$picked\"]}"
           }
           retry request_reviewer
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16347)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34753)

## :bulb: Description
Adjust tech lead assignement logic
1. Fetches currently-requested reviewers via GET /pulls/{n}/requested_reviewers.
2. If any tech lead from the list is already requested, it exits early (just re-applies the label). This prevents stacking on synchronize re-runs.
3. Filters the PR author out of the candidate list.
4. Picks one reviewer at random using RANDOM % ${#eligible[@]} and requests only that one.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

