### PR TITLE
Remove FXIOS-16355 [Periphery] Unused Storage imports

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Common
-import Storage
 import UIKit
 
 /// Holds section layout logic for the new homepage as part of the rebuild project

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSiteCell.swift
@@ -6,7 +6,6 @@ import Common
 import Foundation
 import Shared
 import SiteImageView
-import Storage
 import UIKit
 
 /// The TopSite cell that appears for the homepage rebuild project.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16355)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34800)
## :bulb: Description
The `Storage` module was imported in 18 Homepage-related files per the Periphery warnings listed in the issue. I checked each file's actual usage against Storage's public symbols (`Site`, `SiteType`, `BookmarksHandler`, etc.) before removing anything.

Only 2 of the 18 files had a genuinely unused `import Storage`:
- `HomepageSectionLayoutProvider.swift` — no reference to anything from Storage
- `TopSiteCell.swift` — only accesses already-typed values (e.g. `topSite.site.url`) and pattern-matches `topSite.type` without ever naming a Storage type directly, so the import isn't load-bearing

The remaining 16 files listed in the issue (e.g. `TopSite.swift`, `Site+createSponsoredSite.swift`, `HomepageViewController.swift`) explicitly reference `Site`/`SiteType`/`BookmarksHandler` via type annotations, static calls, or enum pattern matches — removing `import Storage` there would break the build. This looks like a stale or misconfigured Periphery result for those files. Scoping this PR to the 2 confirmed-safe removals and flagging the discrepancy here for @thatswinnie to confirm against a fresh Periphery run before the rest of the ticket is actioned.
## :movie_camera: Demos
N/A — import-only change, no UI impact.
## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code