### PR TITLE
Add FXIOS-16164 Add new feature flaggable EditFolder UI

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2243,6 +2243,8 @@
 		EC4F28163011A64900BAD351 /* CertificateTestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4F28153011A64400BAD351 /* CertificateTestFactory.swift */; };
 		EC4F28183011A6BF00BAD351 /* CertificatesFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4F28173011A6B900BAD351 /* CertificatesFetcherTests.swift */; };
 		EC82F42B3013C75300194A83 /* GroupedEditFolderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC82F42A3013C74D00194A83 /* GroupedEditFolderViewController.swift */; };
+		EC82F42D3017AEC200194A83 /* GroupedEditFolderViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC82F42C3017AEB200194A83 /* GroupedEditFolderViewControllerTests.swift */; };
+		EC82F42F3017B03B00194A83 /* MockGroupedFolderHierarchyFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC82F42E3017B02D00194A83 /* MockGroupedFolderHierarchyFetcher.swift */; };
 		ECD8E56C2FF7EB69002092C6 /* WaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E56B2FF7EB64002092C6 /* WaybackService.swift */; };
 		ECD8E56E2FF7ED79002092C6 /* WaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E56D2FF7ED75002092C6 /* WaybackServiceTests.swift */; };
 		ECD8E8062FFBE6A2002092C6 /* WaybackCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E8052FFBE69E002092C6 /* WaybackCodes.swift */; };
@@ -11849,6 +11851,8 @@
 		EC724CF0B0021AE49EDC95DC /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		EC734AD49E5483F11375E891 /* zh-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/AuthenticationManager.strings"; sourceTree = "<group>"; };
 		EC82F42A3013C74D00194A83 /* GroupedEditFolderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditFolderViewController.swift; sourceTree = "<group>"; };
+		EC82F42C3017AEB200194A83 /* GroupedEditFolderViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditFolderViewControllerTests.swift; sourceTree = "<group>"; };
+		EC82F42E3017B02D00194A83 /* MockGroupedFolderHierarchyFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGroupedFolderHierarchyFetcher.swift; sourceTree = "<group>"; };
 		EC934F7BB2F8B247BC714BE2 /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		ECD8E56B2FF7EB64002092C6 /* WaybackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaybackService.swift; sourceTree = "<group>"; };
 		ECD8E56D2FF7ED75002092C6 /* WaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaybackServiceTests.swift; sourceTree = "<group>"; };
@@ -12523,6 +12527,7 @@
 		0B7CF8852CAC1BFB00DC02F8 /* Bookmarks */ = {
 			isa = PBXGroup;
 			children = (
+				EC82F42C3017AEB200194A83 /* GroupedEditFolderViewControllerTests.swift */,
 				EC407901300AA88F0003DE07 /* GroupedEditFolderViewModelTests.swift */,
 				EC4078FF300AA7EF0003DE07 /* GroupedDefaultFolderHierarchyFetcherTests.swift */,
 				EC0FBD3030069258005CCA62 /* LinkActionCellTests.swift */,
@@ -15998,6 +16003,7 @@
 		C889D7D22858C85200121E1D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				EC82F42E3017B02D00194A83 /* MockGroupedFolderHierarchyFetcher.swift */,
 				617D8AC12FC8D5B700E1C7A5 /* MockConversionValueUpdater.swift */,
 				C2E4F4C52F62F959002A8524 /* MockMainMenuCoordinatorDelegate.swift */,
 				0A80C4252F3CD45400DB85AE /* MockLAContext.swift */,
@@ -20904,6 +20910,7 @@
 				8AFC09572FA54A240070CA11 /* TabManagerPreserveTabsTests.swift in Sources */,
 				8AFC09582FA54A240070CA11 /* TabManagerRemoveTabTests.swift in Sources */,
 				1D8956212FFD58E40041B982 /* TabErrorTelemetryHelperTests.swift in Sources */,
+				EC82F42F3017B03B00194A83 /* MockGroupedFolderHierarchyFetcher.swift in Sources */,
 				8AFC09592FA54A240070CA11 /* TabManagerTestsBase.swift in Sources */,
 				8AFC095A2FA54A240070CA11 /* TabManagerOlderTabsTests.swift in Sources */,
 				8AFC095B2FA54A240070CA11 /* TabManagerRestoreTabsTests.swift in Sources */,
@@ -21031,6 +21038,7 @@
 				354F8FAB2E0985B9007DFFEB /* SearchBarStateTests.swift in Sources */,
 				8C2FB1EB2FF3D6BB00C9A803 /* WebCompatReporterStateTests.swift in Sources */,
 				399BA8002F901D9200CCC502 /* UserFeaturePreferenceManagerTests.swift in Sources */,
+				EC82F42D3017AEC200194A83 /* GroupedEditFolderViewControllerTests.swift in Sources */,
 				5A475E9129DB8AA7009C13FD /* MockDiskImageStore.swift in Sources */,
 				AAD9D64B2EB25B3500BFECAF /* TranslationsMiddlewareTests.swift in Sources */,
 				C2506C952A6A8D2600F2B76E /* HistoryCoordinatorTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2242,6 +2242,7 @@
 		EC4F28143011A62600BAD351 /* CertificatesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4F28133011A61D00BAD351 /* CertificatesHandlerTests.swift */; };
 		EC4F28163011A64900BAD351 /* CertificateTestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4F28153011A64400BAD351 /* CertificateTestFactory.swift */; };
 		EC4F28183011A6BF00BAD351 /* CertificatesFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4F28173011A6B900BAD351 /* CertificatesFetcherTests.swift */; };
+		EC82F42B3013C75300194A83 /* GroupedEditFolderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC82F42A3013C74D00194A83 /* GroupedEditFolderViewController.swift */; };
 		ECD8E56C2FF7EB69002092C6 /* WaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E56B2FF7EB64002092C6 /* WaybackService.swift */; };
 		ECD8E56E2FF7ED79002092C6 /* WaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E56D2FF7ED75002092C6 /* WaybackServiceTests.swift */; };
 		ECD8E8062FFBE6A2002092C6 /* WaybackCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E8052FFBE69E002092C6 /* WaybackCodes.swift */; };
@@ -11847,6 +11848,7 @@
 		EC4F28173011A6B900BAD351 /* CertificatesFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatesFetcherTests.swift; sourceTree = "<group>"; };
 		EC724CF0B0021AE49EDC95DC /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		EC734AD49E5483F11375E891 /* zh-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/AuthenticationManager.strings"; sourceTree = "<group>"; };
+		EC82F42A3013C74D00194A83 /* GroupedEditFolderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditFolderViewController.swift; sourceTree = "<group>"; };
 		EC934F7BB2F8B247BC714BE2 /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		ECD8E56B2FF7EB64002092C6 /* WaybackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaybackService.swift; sourceTree = "<group>"; };
 		ECD8E56D2FF7ED75002092C6 /* WaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaybackServiceTests.swift; sourceTree = "<group>"; };
@@ -12572,6 +12574,7 @@
 		0BDDB33B2CA6B19B00D501DF /* Edit Folder */ = {
 			isa = PBXGroup;
 			children = (
+				EC82F42A3013C74D00194A83 /* GroupedEditFolderViewController.swift */,
 				EC4084E0300FCAE40003DE07 /* BookmarkFolderData+Copy.swift */,
 				EC4078FB300AA2C50003DE07 /* GroupedEditFolderViewModel.swift */,
 				EC0FBD2230053136005CCA62 /* LinkActionCell.swift */,
@@ -20566,6 +20569,7 @@
 				C27EF6132EBA28E100BED719 /* LanguageDetector.swift in Sources */,
 				8AB8571F27D931B40075C173 /* EmptyTopSiteCell.swift in Sources */,
 				8AC6F2262D6E263500D10A9F /* ExperimentRemoteTabsEmptyView.swift in Sources */,
+				EC82F42B3013C75300194A83 /* GroupedEditFolderViewController.swift in Sources */,
 				CAC458F1249429C20042561A /* PasswordManagerSelectionHelper.swift in Sources */,
 				C8656D75270F834600E199EA /* FlaggableFeatureOptions.swift in Sources */,
 				1BE7A4922C636AEA00460798 /* URLSessionConfiguration+defaultMPTCP.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -48,7 +48,8 @@ extension BookmarksCoordinatorDelegate {
 class BookmarksCoordinator: BaseCoordinator,
                             BookmarksCoordinatorDelegate,
                             QRCodeNavigationHandler,
-                            ParentCoordinatorDelegate {
+                            ParentCoordinatorDelegate,
+                            FeatureFlaggable {
     // MARK: - Properties
 
     private let profile: Profile
@@ -163,6 +164,11 @@ class BookmarksCoordinator: BaseCoordinator,
             return makeEditBookmarkController(for: nil, folder: parentFolder)
         }
         if type == .folder {
+            if featureFlagsProvider.isEnabled(.newBookmarkFolderTree) {
+                return makeGroupedEditFolderController(for: nil,
+                                                       folder: parentFolder,
+                                                       parentFolderSelector: parentFolderSelector)
+            }
             return makeEditFolderController(for: nil, folder: parentFolder, parentFolderSelector: parentFolderSelector)
         }
         return UIViewController()
@@ -173,6 +179,9 @@ class BookmarksCoordinator: BaseCoordinator,
             return makeEditBookmarkController(for: node, folder: folder)
         }
         if node.type == .folder {
+            if featureFlagsProvider.isEnabled(.newBookmarkFolderTree) {
+                return makeGroupedEditFolderController(for: node, folder: folder, parentFolderSelector: nil)
+            }
             return makeEditFolderController(for: node, folder: folder, parentFolderSelector: nil)
         }
         return UIViewController()
@@ -211,6 +220,30 @@ class BookmarksCoordinator: BaseCoordinator,
         setBackBarButtonItemTitle("")
         let controller = EditFolderViewController(viewModel: viewModel,
                                                   windowUUID: windowUUID)
+        controller.onViewWillAppear = { [weak self] in
+            self?.libraryNavigationHandler?.setNavigationBarHidden(true)
+        }
+        controller.onViewWillDisappear = { [weak self] in
+            if !(controller.transitionCoordinator?.isInteractive ?? false) {
+                self?.libraryNavigationHandler?.setNavigationBarHidden(false)
+            }
+        }
+        return controller
+    }
+
+    private func makeGroupedEditFolderController(for node: FxBookmarkNode?,
+                                                 folder: FxBookmarkNode,
+                                                 parentFolderSelector: ParentFolderSelector?) -> UIViewController {
+        let viewModel = GroupedEditFolderViewModel(profile: profile,
+                                                   parentFolder: folder,
+                                                   folder: node)
+        viewModel.onBookmarkSaved = { [weak self] in
+            self?.reloadLastBookmarksController()
+        }
+        viewModel.parentFolderSelector = parentFolderSelector
+        setBackBarButtonItemTitle("")
+        let controller = GroupedEditFolderViewController(viewModel: viewModel,
+                                                         windowUUID: windowUUID)
         controller.onViewWillAppear = { [weak self] in
             self?.libraryNavigationHandler?.setNavigationBarHidden(true)
         }

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -199,10 +199,9 @@ class BookmarksCoordinator: BaseCoordinator,
         controller.onViewWillAppear = { [weak self] in
             self?.libraryNavigationHandler?.setNavigationBarHidden(true)
         }
-        controller.onViewWillDisappear = { [weak self] in
-            if !(controller.transitionCoordinator?.isInteractive ?? false) {
-                self?.libraryNavigationHandler?.setNavigationBarHidden(false)
-            }
+        controller.onViewWillDisappear = { [weak self, weak controller] in
+            guard !(controller?.transitionCoordinator?.isInteractive ?? false) else { return }
+            self?.libraryNavigationHandler?.setNavigationBarHidden(false)
         }
         return controller
     }
@@ -223,10 +222,9 @@ class BookmarksCoordinator: BaseCoordinator,
         controller.onViewWillAppear = { [weak self] in
             self?.libraryNavigationHandler?.setNavigationBarHidden(true)
         }
-        controller.onViewWillDisappear = { [weak self] in
-            if !(controller.transitionCoordinator?.isInteractive ?? false) {
-                self?.libraryNavigationHandler?.setNavigationBarHidden(false)
-            }
+        controller.onViewWillDisappear = { [weak self, weak controller] in
+            guard !(controller?.transitionCoordinator?.isInteractive ?? false) else { return }
+            self?.libraryNavigationHandler?.setNavigationBarHidden(false)
         }
         return controller
     }
@@ -247,10 +245,9 @@ class BookmarksCoordinator: BaseCoordinator,
         controller.onViewWillAppear = { [weak self] in
             self?.libraryNavigationHandler?.setNavigationBarHidden(true)
         }
-        controller.onViewWillDisappear = { [weak self] in
-            if !(controller.transitionCoordinator?.isInteractive ?? false) {
-                self?.libraryNavigationHandler?.setNavigationBarHidden(false)
-            }
+        controller.onViewWillDisappear = { [weak self, weak controller] in
+            guard !(controller?.transitionCoordinator?.isInteractive ?? false) else { return }
+            self?.libraryNavigationHandler?.setNavigationBarHidden(false)
         }
         return controller
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/FolderSectionHeaderView.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/FolderSectionHeaderView.swift
@@ -18,13 +18,13 @@ final class FolderSectionHeaderView: UITableViewHeaderFooterView {
     }
 
     lazy var captionLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Regular.caption1.scaledFont()
+        label.font = FXFontStyles.Regular.headline.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }
 
     lazy var titleLabel: UILabel = .build { label in
-        label.font = FXFontStyles.Bold.callout.scaledFont()
+        label.font = FXFontStyles.Bold.title3.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/FolderTreeCell.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/FolderTreeCell.swift
@@ -69,6 +69,7 @@ final class FolderTreeCell: UITableViewCell, ReusableCell, ThemeApplicable {
         leftImageView.image = nil
         accessoryType = .none
         indentationLevel = 0
+        selectionStyle = .default
     }
 
     private func setMargin() {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
@@ -385,6 +385,7 @@ final class GroupedEditFolderViewController: UIViewController,
 
     // MARK: - Helpers
 
+    // TODO: FXIOS-16414 Add a caching mechanism to avoid constant computation
     private var groupSections: [(groupIndex: Int, blockIndex: Int)] {
         var result: [(groupIndex: Int, blockIndex: Int)] = []
         for (groupIndex, group) in viewModel.folderGroups.enumerated() {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
@@ -1,0 +1,384 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+class GroupedEditFolderViewController: UIViewController,
+                                       UITableViewDelegate,
+                                       UITableViewDataSource,
+                                       Themeable {
+    private struct UX {
+        static let editFolderCellTopPadding: CGFloat = 25.0
+    }
+
+    private static let editFolderSection = 0
+    private static let firstGroupSection = 1
+
+    var currentWindowUUID: WindowUUID?
+    var themeManager: any ThemeManager
+    var themeListenerCancellable: Any?
+    var notificationCenter: any NotificationProtocol
+    var onViewWillDisappear: (() -> Void)?
+    var onViewWillAppear: (() -> Void)?
+    private var theme: any Theme {
+        return themeManager.getCurrentTheme(for: currentWindowUUID)
+    }
+
+    private let viewModel: GroupedEditFolderViewModel
+
+    private lazy var tableView: UITableView = .build({ view in
+        view.dataSource = self
+        view.delegate = self
+        view.register(cellType: EditFolderCell.self)
+        view.register(cellType: FolderTreeCell.self)
+        view.register(cellType: LinkActionCell.self)
+        view.register(FolderSectionHeaderView.self,
+                      forHeaderFooterViewReuseIdentifier: FolderSectionHeaderView.reuseIdentifier)
+        let headerSpacerView = UIView(frame: CGRect(origin: .zero,
+                                                    size: CGSize(width: 0, height: UX.editFolderCellTopPadding)))
+        view.tableHeaderView = headerSpacerView
+        view.keyboardDismissMode = .onDrag
+    }, {
+        if #available(iOS 26.0, *) {
+            UITableView(frame: .zero, style: .insetGrouped)
+        } else {
+            UITableView()
+        }
+    })
+
+    private lazy var saveBarButton: UIBarButtonItem =  {
+        let button = UIBarButtonItem(
+            title: String.Bookmarks.Menu.EditBookmarkSave,
+            style: .plain,
+            target: self,
+            action: #selector(saveButtonAction)
+        )
+        button.accessibilityIdentifier = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.saveButton
+        return button
+    }()
+
+    init(viewModel: GroupedEditFolderViewModel,
+         windowUUID: WindowUUID,
+         themeManager: any ThemeManager = AppContainer.shared.resolve(),
+         notificationCenter: any NotificationProtocol = NotificationCenter.default) {
+        self.currentWindowUUID = windowUUID
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Life Cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = viewModel.controllerTitle
+        navigationItem.rightBarButtonItem = saveBarButton
+
+        viewModel.onFolderStatusUpdate = { [weak self] in
+            self?.tableView.reloadData()
+        }
+
+        setupSubviews()
+
+        listenForThemeChanges(withNotificationCenter: notificationCenter)
+        applyTheme()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+        setTheme(theme)
+        onViewWillAppear?()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        let editFolderCell = tableView.visibleCells.first {
+            return $0 is EditFolderCell
+        }
+        editFolderCell?.becomeFirstResponder()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if let isDraggingDown = transitionCoordinator?.isInteractive, !isDraggingDown {
+            navigationController?.setNavigationBarHidden(true, animated: true)
+        }
+        onViewWillDisappear?()
+
+        // Only save when clicking the back button, not when we swipe the view controller away
+        if isMovingFromParent {
+            viewModel.save()
+        }
+    }
+
+    private func setupSubviews() {
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    // MARK: - Actions
+
+    @objc
+    func saveButtonAction() {
+        // Save will happen in viewWillDisappear
+        navigationController?.popViewController(animated: true)
+    }
+
+    private func toggleGroup(at groupIndex: Int) {
+        guard let group = viewModel.folderGroups[safe: groupIndex],
+              let headerOffset = groupSections.firstIndex(where: { $0.groupIndex == groupIndex })
+        else { return }
+
+        let headerSection = Self.firstGroupSection + headerOffset
+        let willExpand = !group.isExpanded
+        let blocks = group.blocks
+        let firstBlockRowCount = blocks.first?.folders.count ?? 0
+        let trailingSectionCount = max(blocks.count - 1, 0)
+
+        if let header = tableView.headerView(forSection: headerSection) as? FolderSectionHeaderView {
+            header.setExpanded(willExpand, animated: true)
+        }
+
+        viewModel.toggleGroupExpansion(at: groupIndex)
+
+        let rowIndexPaths = (0..<firstBlockRowCount).map { IndexPath(row: $0, section: headerSection) }
+        let trailingSections = trailingSectionCount > 0
+            ? IndexSet(integersIn: (headerSection + 1)...(headerSection + trailingSectionCount))
+            : IndexSet()
+
+        guard !rowIndexPaths.isEmpty || !trailingSections.isEmpty else { return }
+
+        tableView.performBatchUpdates({
+            if willExpand {
+                self.tableView.insertRows(at: rowIndexPaths, with: .fade)
+                if !trailingSections.isEmpty {
+                    self.tableView.insertSections(trailingSections, with: .fade)
+                }
+            } else {
+                self.tableView.deleteRows(at: rowIndexPaths, with: .fade)
+                if !trailingSections.isEmpty {
+                    self.tableView.deleteSections(trailingSections, with: .fade)
+                }
+            }
+        })
+    }
+
+    // MARK: - Themeable
+
+    func applyTheme() {
+        setTheme(theme)
+        tableView.reloadData()
+    }
+
+    private func setTheme(_ theme: any Theme) {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = theme.colors.layer1
+        // remove divider from navigation bar
+        appearance.shadowColor = .clear
+        appearance.titleTextAttributes = [
+            .foregroundColor: theme.colors.textPrimary
+        ]
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
+        view.backgroundColor = theme.colors.layer1
+        tableView.backgroundColor = theme.colors.layer1
+        if #available(iOS 26.0, *) {
+            saveBarButton.tintColor = theme.colors.textAccent
+        }
+    }
+
+    // MARK: - UITableViewDataSource & UITableViewDelegate
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        guard viewModel.isBrowsingFolders else {
+            return Self.firstGroupSection + 1
+        }
+        return Self.firstGroupSection + groupSections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section == Self.editFolderSection { return 1 }
+        guard viewModel.isBrowsingFolders else { return 2 }
+        guard let location = groupSections[safe: section - Self.firstGroupSection],
+              let group = viewModel.folderGroups[safe: location.groupIndex],
+              group.isExpanded
+        else { return 0 }
+        return group.blocks[safe: location.blockIndex]?.folders.count ?? 0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.section == Self.editFolderSection {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: EditFolderCell.cellIdentifier,
+                                                           for: indexPath) as? EditFolderCell
+            else { return UITableViewCell() }
+            configureEditFolderCell(cell)
+            return cell
+        }
+
+        if !viewModel.isBrowsingFolders {
+            return configureSummaryRow(tableView, at: indexPath)
+        }
+
+        guard let location = groupSections[safe: indexPath.section - Self.firstGroupSection],
+              let group = viewModel.folderGroups[safe: location.groupIndex],
+              let folder = group.blocks[safe: location.blockIndex]?.folders[safe: indexPath.row],
+              let cell = tableView.dequeueReusableCell(withIdentifier: FolderTreeCell.cellIdentifier,
+                                                       for: indexPath) as? FolderTreeCell
+        else { return UITableViewCell() }
+
+        configureParentFolderCell(cell, folder: folder)
+        cell.accessibilityIdentifier =
+            "\(AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.bookmarkParentFolderCell)_\(indexPath.section)_\(indexPath.row)"
+        return cell
+    }
+
+    private func configureSummaryRow(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.row == 0 {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: FolderTreeCell.cellIdentifier,
+                                                           for: indexPath) as? FolderTreeCell
+            else { return UITableViewCell() }
+            let folderImage = UIImage(named: StandardImageIdentifiers.Large.folder)
+            cell.indentationLevel = 0
+            cell.configure(title: viewModel.selectedFolder?.title ?? "",
+                           breadcrumb: nil,
+                           image: folderImage,
+                           isSelected: false)
+            cell.selectionStyle = .none
+            cell.applyTheme(theme: theme)
+            return cell
+        }
+
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: LinkActionCell.cellIdentifier,
+                                                       for: indexPath) as? LinkActionCell
+        else { return UITableViewCell() }
+        cell.configure(title: .Bookmarks.Menu.EditBookmarkChangeLocationLabel)
+        cell.applyTheme(theme: theme)
+        return cell
+    }
+
+    private func configureEditFolderCell(_ cell: EditFolderCell) {
+        cell.setTitle(viewModel.editedFolderTitle)
+        cell.onTitleFieldUpdate = { [weak self] in
+            self?.viewModel.updateFolderTitle($0)
+        }
+        cell.applyTheme(theme: theme)
+    }
+
+    private func configureParentFolderCell(_ cell: FolderTreeCell, folder: GroupedFolder) {
+        let breadcrumb: String?
+        if folder.indentation > 0, let parentTitle = folder.parentTitle, !parentTitle.isEmpty {
+            breadcrumb = String(format: String.Bookmarks.Menu.EditBookmarkParentFolderBreadcrumbFormat, parentTitle)
+        } else {
+            breadcrumb = nil
+        }
+
+        let folderImage = UIImage(named: StandardImageIdentifiers.Large.folder)
+        cell.indentationLevel = folder.indentation
+        cell.configure(title: folder.title,
+                       breadcrumb: breadcrumb,
+                       image: folderImage,
+                       isSelected: folder.guid == viewModel.selectedFolder?.guid)
+        cell.applyTheme(theme: theme)
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard indexPath.section != Self.editFolderSection else { return }
+
+        guard viewModel.isBrowsingFolders else {
+            if indexPath.row == 1 {
+                viewModel.beginBrowsingFolders()
+            }
+            return
+        }
+
+        guard let location = groupSections[safe: indexPath.section - Self.firstGroupSection],
+              let group = viewModel.folderGroups[safe: location.groupIndex],
+              let folder = group.blocks[safe: location.blockIndex]?.folders[safe: indexPath.row]
+        else { return }
+        viewModel.selectFolder(folder)
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard section != Self.editFolderSection,
+              let header = tableView.dequeueReusableHeaderFooterView(
+                withIdentifier: FolderSectionHeaderView.reuseIdentifier
+              ) as? FolderSectionHeaderView
+        else { return nil }
+
+        guard viewModel.isBrowsingFolders else {
+            guard section == Self.firstGroupSection else { return nil }
+            header.configure(
+                title: nil,
+                caption: .Bookmarks.Menu.EditBookmarkLocationLabel,
+                showsChevron: false,
+                titleColor: theme.colors.textPrimary,
+                captionColor: theme.colors.textSecondary
+            )
+            header.onTap = nil
+            return header
+        }
+
+        guard let location = groupSections[safe: section - Self.firstGroupSection],
+              location.blockIndex == 0,
+              let group = viewModel.folderGroups[safe: location.groupIndex]
+        else { return nil }
+
+        let isFirstGroup = location.groupIndex == 0
+        header.configure(
+            title: group.title,
+            caption: isFirstGroup ? .Bookmarks.Menu.EditBookmarkAllFoldersLabel : nil,
+            showsChevron: true,
+            isExpanded: group.isExpanded,
+            titleColor: theme.colors.textPrimary,
+            captionColor: theme.colors.textSecondary
+        )
+        header.onTap = { [weak self] in
+            self?.toggleGroup(at: location.groupIndex)
+        }
+        return header
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        guard section != Self.editFolderSection else { return 0 }
+        guard viewModel.isBrowsingFolders else {
+            return section == Self.firstGroupSection ? UITableView.automaticDimension : 0
+        }
+        guard let location = groupSections[safe: section - Self.firstGroupSection] else { return 0 }
+        return location.blockIndex == 0 ? UITableView.automaticDimension : CGFloat.leastNormalMagnitude
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    // MARK: - Helpers
+
+    private var groupSections: [(groupIndex: Int, blockIndex: Int)] {
+        var result: [(groupIndex: Int, blockIndex: Int)] = []
+        for (groupIndex, group) in viewModel.folderGroups.enumerated() {
+            guard group.isExpanded, !group.folders.isEmpty else {
+                result.append((groupIndex, 0))
+                continue
+            }
+            for blockIndex in group.blocks.indices {
+                result.append((groupIndex, blockIndex))
+            }
+        }
+        return result
+    }
+}

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
@@ -28,7 +28,7 @@ class GroupedEditFolderViewController: UIViewController,
 
     private let viewModel: GroupedEditFolderViewModel
 
-    private lazy var tableView: UITableView = .build({ view in
+    lazy var tableView: UITableView = .build({ view in
         view.dataSource = self
         view.delegate = self
         view.register(cellType: EditFolderCell.self)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
@@ -212,32 +212,26 @@ class GroupedEditFolderViewController: UIViewController,
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if section == Self.editFolderSection { return 1 }
+        guard section != Self.editFolderSection else { return 1 }
         guard viewModel.isBrowsingFolders else { return 2 }
-        guard let location = groupSections[safe: section - Self.firstGroupSection],
-              let group = viewModel.folderGroups[safe: location.groupIndex],
-              group.isExpanded
-        else { return 0 }
-        return group.blocks[safe: location.blockIndex]?.folders.count ?? 0
+
+        guard let group = folderGroup(forSection: section) else { return 0 }
+        guard group.isExpanded else { return 0 }
+        guard let block = folderBlock(forSection: section) else { return 0 }
+
+        return block.folders.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.section == Self.editFolderSection {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: EditFolderCell.cellIdentifier,
-                                                           for: indexPath) as? EditFolderCell
-            else { return UITableViewCell() }
-            configureEditFolderCell(cell)
-            return cell
+        guard indexPath.section != Self.editFolderSection else {
+            return configureEditFolderCell(tableView, at: indexPath)
         }
-
-        if !viewModel.isBrowsingFolders {
+        guard viewModel.isBrowsingFolders else {
             return configureSummaryRow(tableView, at: indexPath)
         }
 
-        guard let location = groupSections[safe: indexPath.section - Self.firstGroupSection],
-              let group = viewModel.folderGroups[safe: location.groupIndex],
-              let folder = group.blocks[safe: location.blockIndex]?.folders[safe: indexPath.row],
-              let cell = tableView.dequeueReusableCell(withIdentifier: FolderTreeCell.cellIdentifier,
+        guard let folder = folder(at: indexPath) else { return UITableViewCell() }
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: FolderTreeCell.cellIdentifier,
                                                        for: indexPath) as? FolderTreeCell
         else { return UITableViewCell() }
 
@@ -247,11 +241,111 @@ class GroupedEditFolderViewController: UIViewController,
         return cell
     }
 
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard indexPath.section != Self.editFolderSection else { return }
+
+        guard viewModel.isBrowsingFolders else {
+            guard indexPath.row == 1 else { return }
+            viewModel.beginBrowsingFolders()
+            return
+        }
+
+        guard let folder = folder(at: indexPath) else { return }
+        viewModel.selectFolder(folder)
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard section != Self.editFolderSection else { return nil }
+        guard let header = tableView.dequeueReusableHeaderFooterView(
+            withIdentifier: FolderSectionHeaderView.reuseIdentifier
+        ) as? FolderSectionHeaderView else { return nil }
+
+        guard viewModel.isBrowsingFolders else {
+            guard section == Self.firstGroupSection else { return nil }
+            header.configure(
+                title: nil,
+                caption: .Bookmarks.Menu.EditBookmarkLocationLabel,
+                showsChevron: false,
+                titleColor: theme.colors.textPrimary,
+                captionColor: theme.colors.textSecondary
+            )
+            header.onTap = nil
+            return header
+        }
+
+        guard let location = groupLocation(forSection: section) else { return nil }
+        guard location.blockIndex == 0 else { return nil }
+        guard let group = viewModel.folderGroups[safe: location.groupIndex] else { return nil }
+
+        header.configure(
+            title: group.title,
+            caption: location.groupIndex == 0 ? .Bookmarks.Menu.EditBookmarkAllFoldersLabel : nil,
+            showsChevron: true,
+            isExpanded: group.isExpanded,
+            titleColor: theme.colors.textPrimary,
+            captionColor: theme.colors.textSecondary
+        )
+        header.onTap = { [weak self] in
+            self?.toggleGroup(at: location.groupIndex)
+        }
+        return header
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        guard section != Self.editFolderSection else { return 0 }
+        guard viewModel.isBrowsingFolders else {
+            return section == Self.firstGroupSection ? UITableView.automaticDimension : 0
+        }
+        guard let location = groupLocation(forSection: section) else { return 0 }
+        return location.blockIndex == 0 ? UITableView.automaticDimension : CGFloat.leastNormalMagnitude
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    // MARK: - Section/Folder Resolution
+
+    private func groupLocation(forSection section: Int) -> (groupIndex: Int, blockIndex: Int)? {
+        groupSections[safe: section - Self.firstGroupSection]
+    }
+
+    private func folderGroup(forSection section: Int) -> FolderGroup? {
+        guard let location = groupLocation(forSection: section) else { return nil }
+        return viewModel.folderGroups[safe: location.groupIndex]
+    }
+
+    private func folderBlock(forSection section: Int) -> FolderGroup.Block? {
+        guard let location = groupLocation(forSection: section) else { return nil }
+        return viewModel.folderGroups[safe: location.groupIndex]?.blocks[safe: location.blockIndex]
+    }
+
+    private func folder(at indexPath: IndexPath) -> GroupedFolder? {
+        guard let block = folderBlock(forSection: indexPath.section) else { return nil }
+        return block.folders[safe: indexPath.row]
+    }
+
+    // MARK: - Cell Configuration
+
+    private func configureEditFolderCell(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: EditFolderCell.cellIdentifier,
+                                                       for: indexPath) as? EditFolderCell
+        else { return UITableViewCell() }
+
+        cell.setTitle(viewModel.editedFolderTitle)
+        cell.onTitleFieldUpdate = { [weak self] in
+            self?.viewModel.updateFolderTitle($0)
+        }
+        cell.applyTheme(theme: theme)
+        return cell
+    }
+
     private func configureSummaryRow(_ tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.row == 0 {
+        guard indexPath.row != 0 else {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: FolderTreeCell.cellIdentifier,
                                                            for: indexPath) as? FolderTreeCell
             else { return UITableViewCell() }
+
             let folderImage = UIImage(named: StandardImageIdentifiers.Large.folder)
             cell.indentationLevel = 0
             cell.configure(title: viewModel.selectedFolder?.title ?? "",
@@ -266,17 +360,10 @@ class GroupedEditFolderViewController: UIViewController,
         guard let cell = tableView.dequeueReusableCell(withIdentifier: LinkActionCell.cellIdentifier,
                                                        for: indexPath) as? LinkActionCell
         else { return UITableViewCell() }
+
         cell.configure(title: .Bookmarks.Menu.EditBookmarkChangeLocationLabel)
         cell.applyTheme(theme: theme)
         return cell
-    }
-
-    private func configureEditFolderCell(_ cell: EditFolderCell) {
-        cell.setTitle(viewModel.editedFolderTitle)
-        cell.onTitleFieldUpdate = { [weak self] in
-            self?.viewModel.updateFolderTitle($0)
-        }
-        cell.applyTheme(theme: theme)
     }
 
     private func configureParentFolderCell(_ cell: FolderTreeCell, folder: GroupedFolder) {
@@ -295,77 +382,6 @@ class GroupedEditFolderViewController: UIViewController,
                        isSelected: folder.guid == viewModel.selectedFolder?.guid)
         cell.applyTheme(theme: theme)
     }
-
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard indexPath.section != Self.editFolderSection else { return }
-
-        guard viewModel.isBrowsingFolders else {
-            if indexPath.row == 1 {
-                viewModel.beginBrowsingFolders()
-            }
-            return
-        }
-
-        guard let location = groupSections[safe: indexPath.section - Self.firstGroupSection],
-              let group = viewModel.folderGroups[safe: location.groupIndex],
-              let folder = group.blocks[safe: location.blockIndex]?.folders[safe: indexPath.row]
-        else { return }
-        viewModel.selectFolder(folder)
-    }
-
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard section != Self.editFolderSection,
-              let header = tableView.dequeueReusableHeaderFooterView(
-                withIdentifier: FolderSectionHeaderView.reuseIdentifier
-              ) as? FolderSectionHeaderView
-        else { return nil }
-
-        guard viewModel.isBrowsingFolders else {
-            guard section == Self.firstGroupSection else { return nil }
-            header.configure(
-                title: nil,
-                caption: .Bookmarks.Menu.EditBookmarkLocationLabel,
-                showsChevron: false,
-                titleColor: theme.colors.textPrimary,
-                captionColor: theme.colors.textSecondary
-            )
-            header.onTap = nil
-            return header
-        }
-
-        guard let location = groupSections[safe: section - Self.firstGroupSection],
-              location.blockIndex == 0,
-              let group = viewModel.folderGroups[safe: location.groupIndex]
-        else { return nil }
-
-        let isFirstGroup = location.groupIndex == 0
-        header.configure(
-            title: group.title,
-            caption: isFirstGroup ? .Bookmarks.Menu.EditBookmarkAllFoldersLabel : nil,
-            showsChevron: true,
-            isExpanded: group.isExpanded,
-            titleColor: theme.colors.textPrimary,
-            captionColor: theme.colors.textSecondary
-        )
-        header.onTap = { [weak self] in
-            self?.toggleGroup(at: location.groupIndex)
-        }
-        return header
-    }
-
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        guard section != Self.editFolderSection else { return 0 }
-        guard viewModel.isBrowsingFolders else {
-            return section == Self.firstGroupSection ? UITableView.automaticDimension : 0
-        }
-        guard let location = groupSections[safe: section - Self.firstGroupSection] else { return 0 }
-        return location.blockIndex == 0 ? UITableView.automaticDimension : CGFloat.leastNormalMagnitude
-    }
-
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
-    }
-
     // MARK: - Helpers
 
     private var groupSections: [(groupIndex: Int, blockIndex: Int)] {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
@@ -382,6 +382,7 @@ class GroupedEditFolderViewController: UIViewController,
                        isSelected: folder.guid == viewModel.selectedFolder?.guid)
         cell.applyTheme(theme: theme)
     }
+
     // MARK: - Helpers
 
     private var groupSections: [(groupIndex: Int, blockIndex: Int)] {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Common
 
-class GroupedEditFolderViewController: UIViewController,
+final class GroupedEditFolderViewController: UIViewController,
                                        UITableViewDelegate,
                                        UITableViewDataSource,
                                        Themeable {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewControllerTests.swift
@@ -117,12 +117,12 @@ final class GroupedEditFolderViewControllerTests: XCTestCase {
     func test_saveButtonAction_popsViewController() {
         let subject = createSubject()
         let navController = UINavigationController()
-        navController.pushViewController(subject, animated: false)
         navController.pushViewController(UIViewController(), animated: false)
+        navController.pushViewController(subject, animated: false)
 
         subject.saveButtonAction()
 
-        XCTAssertEqual(navController.viewControllers.count, 1)
+        XCTAssert(!navController.viewControllers.contains(subject))
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewControllerTests.swift
@@ -1,0 +1,180 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import MozillaAppServices
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class GroupedEditFolderViewControllerTests: XCTestCase {
+    private var profile: MockProfile!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile()
+    }
+
+    override func tearDown() async throws {
+        DependencyHelperMock().reset()
+        profile = nil
+        try await super.tearDown()
+    }
+
+    func test_numberOfSections_beforeBrowsing_returnsEditPlusSummarySection() {
+        let subject = createSubject()
+
+        XCTAssertEqual(subject.numberOfSections(in: subject.tableView), 2)
+    }
+
+    func test_numberOfRows_editFolderSection_isAlwaysOne() {
+        let subject = createSubject()
+
+        XCTAssertEqual(subject.tableView(subject.tableView, numberOfRowsInSection: 0), 1)
+    }
+
+    func test_numberOfRows_summarySection_beforeBrowsing_returnsTwo() {
+        let subject = createSubject()
+
+        XCTAssertEqual(subject.tableView(subject.tableView, numberOfRowsInSection: 1), 2)
+    }
+
+    func test_cellForRow_editFolderSection_returnsEditFolderCell() {
+        let subject = createSubject()
+
+        let cell = subject.tableView(subject.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+
+        XCTAssertTrue(cell is EditFolderCell)
+    }
+
+    func test_cellForRow_summaryRowOne_showsChangeLocationCell() {
+        let subject = createSubject()
+
+        let cell = subject.tableView(subject.tableView, cellForRowAt: IndexPath(row: 1, section: 1))
+
+        XCTAssertTrue(cell is LinkActionCell)
+    }
+
+    func test_didSelectRow_summaryRowOne_beginsBrowsingFolders() {
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        let expectation = XCTestExpectation(description: "folder status updated")
+        viewModel.onFolderStatusUpdate = { expectation.fulfill() }
+
+        subject.tableView(subject.tableView, didSelectRowAt: IndexPath(row: 1, section: 1))
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(viewModel.isBrowsingFolders)
+        XCTAssertEqual(fetcher.fetchFoldersCalled, 1)
+    }
+
+    func test_numberOfRows_groupSection_whenExpanded_matchesFolderCount() {
+        let folders = [GroupedFolder(title: "Top", guid: "top", indentation: 0)]
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        fetcher.mockFolderStructures = folders
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        beginBrowsingAndWait(viewModel, subject: subject)
+
+        XCTAssertEqual(subject.tableView(subject.tableView, numberOfRowsInSection: 1), folders.count)
+    }
+
+    func test_didSelectRow_whileBrowsing_selectsFolderOnViewModel() {
+        let folder = GroupedFolder(title: "Top", guid: "top", indentation: 0)
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        fetcher.mockFolderStructures = [folder]
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        beginBrowsingAndWait(viewModel, subject: subject)
+        subject.tableView(subject.tableView, didSelectRowAt: IndexPath(row: 0, section: 1))
+
+        XCTAssertEqual(viewModel.selectedFolder?.guid, folder.guid)
+        XCTAssertFalse(viewModel.isBrowsingFolders)
+    }
+
+    func test_headerTap_togglesGroupExpansionOnViewModel() {
+        let folder = GroupedFolder(title: "Top", guid: "top", indentation: 0)
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        fetcher.mockFolderStructures = [folder]
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        beginBrowsingAndWait(viewModel, subject: subject)
+        let wasExpanded = viewModel.folderGroups[0].isExpanded
+        let header = subject.tableView(subject.tableView, viewForHeaderInSection: 1) as? FolderSectionHeaderView
+        header?.onTap?()
+
+        XCTAssertEqual(viewModel.folderGroups[0].isExpanded, !wasExpanded)
+    }
+
+    func test_saveButtonAction_popsViewController() {
+        let subject = createSubject()
+        let navController = UINavigationController()
+        navController.pushViewController(subject, animated: false)
+        navController.pushViewController(UIViewController(), animated: false)
+
+        subject.saveButtonAction()
+
+        XCTAssertEqual(navController.viewControllers.count, 1)
+    }
+
+    // MARK: - Private
+
+    private func createSubject(
+        viewModel: GroupedEditFolderViewModel? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> GroupedEditFolderViewController {
+        let subject = GroupedEditFolderViewController(
+            viewModel: viewModel ?? createViewModel(),
+            windowUUID: .XCTestDefaultUUID
+        )
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
+    private func createViewModel(
+        folder: FxBookmarkNode? = nil,
+        folderFetcher: GroupedFolderHierarchyFetcher? = nil
+    ) -> GroupedEditFolderViewModel {
+        let parentFolder = BookmarkFolderData(
+            guid: "parent_guid",
+            dateAdded: 0,
+            lastModified: 0,
+            parentGUID: nil,
+            position: 0,
+            title: "Parent",
+            childGUIDs: [],
+            children: nil
+        )
+        return GroupedEditFolderViewModel(
+            profile: profile,
+            parentFolder: parentFolder,
+            folder: folder,
+            bookmarkSaver: MockBookmarksSaver(),
+            folderFetcher: folderFetcher ?? MockGroupedFolderHierarchyFetcher()
+        )
+    }
+
+    private func beginBrowsingAndWait(
+        _ viewModel: GroupedEditFolderViewModel,
+        subject: GroupedEditFolderViewController
+    ) {
+        let expectation = XCTestExpectation(description: "folder groups loaded")
+        viewModel.onFolderStatusUpdate = { [weak subject] in
+            subject?.tableView.reloadData()
+            subject?.view.setNeedsLayout()
+            subject?.view.layoutIfNeeded()
+            expectation.fulfill()
+        }
+        viewModel.beginBrowsingFolders()
+        wait(for: [expectation], timeout: 1.0)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewModelTests.swift
@@ -194,15 +194,3 @@ final class GroupedEditFolderViewModelTests: XCTestCase {
         return subject
     }
 }
-
-final class MockGroupedFolderHierarchyFetcher: GroupedFolderHierarchyFetcher, @unchecked Sendable {
-    var mockFolderStructures: [GroupedFolder] = []
-    private(set) var fetchFoldersCalled = 0
-    private(set) var capturedExcludedGuids: [String] = []
-
-    func fetchFolders(excludedGuids: [String]) async -> [GroupedFolder] {
-        fetchFoldersCalled += 1
-        capturedExcludedGuids = excludedGuids
-        return mockFolderStructures
-    }
-}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGroupedFolderHierarchyFetcher.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGroupedFolderHierarchyFetcher.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+final class MockGroupedFolderHierarchyFetcher: GroupedFolderHierarchyFetcher, @unchecked Sendable {
+    var mockFolderStructures: [GroupedFolder] = []
+    private(set) var fetchFoldersCalled = 0
+    private(set) var capturedExcludedGuids: [String] = []
+
+    func fetchFolders(excludedGuids: [String]) async -> [GroupedFolder] {
+        fetchFoldersCalled += 1
+        capturedExcludedGuids = excludedGuids
+        return mockFolderStructures
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16164)

## :bulb: Description
This PR introduces a new UI for the edit folders page, gated behind the newBookmarksFolderTree feature flag. When the flag is disabled, the existing UI remains in place.

To test:
1. Enable the newBookmarksFolderTree feature flag
2. Go to the Bookmarks page
3. Click Edit → New Folder, or select an existing folder

[Figma link for design](https://www.figma.com/design/BVqEYexibOA2betNVUMrfl/Mobile-Assembly-File-2026?node-id=22681-33877&t=KCFUG8yRk6q0YeI0-0)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

