### PR TITLE
Bugfix FXIOS-16399 Remove #if TESTING compile condition from file

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
@@ -270,8 +270,6 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
     }
 
     // MARK: - Testing
-    // Compiled only for test builds using the TESTING compilation condition
-#if TESTING
     func handlePanGestureForTesting(_ gesture: UIPanGestureRecognizer) {
         handlePanGesture(gesture)
     }
@@ -279,5 +277,4 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
     func handleSwipeGestureForTesting(_ gesture: UISwipeGestureRecognizer) {
         handleSwipeGesture(gesture)
     }
-#endif
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16399)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34849)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Deleted an #if TESTING block that stopped functions used for testing from being compiled. This #if block is defined on the Fennec scheme but not the Firefox scheme, so it won't build (very large oops).

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

