### PR TITLE
Remove FXIOS-16363 [Telemetry] Unused telemetry enums

### DIFF
--- a/firefox-ios/Client/Telemetry/AutoplaySettingTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/AutoplaySettingTelemetry.swift
@@ -11,10 +11,6 @@ class AutoplaySettingTelemetry {
         self.gleanWrapper = gleanWrapper
     }
 
-    enum EventExtraKey: String {
-        case mediaType
-    }
-
     func settingChanged(mediaType: AutoplayAction) {
         let extras = GleanMetrics.Preferences.AutoplaySettingChangedExtra(mediaType: mediaType.rawValue)
         gleanWrapper.recordEvent(for: GleanMetrics.Preferences.autoplaySettingChanged,

--- a/firefox-ios/Client/Telemetry/SearchTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/SearchTelemetry.swift
@@ -89,10 +89,6 @@ enum SearchTelemetryValues {
         case persistedSearchTermsRefined = "persisted_search_terms_refined"
     }
 
-    enum Provider: String {
-        case iOS_app
-    }
-
     enum EngagementType: String {
         case tap
         case enter

--- a/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
@@ -28,13 +28,6 @@ struct TabsPanelTelemetry {
         case old
     }
 
-    private enum TabType: String {
-        case normal
-        case `private`
-        case inactive
-        case total
-    }
-
     private let gleanWrapper: GleanWrapper
     private let logger: Logger
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16363)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34799)

## :bulb: Description
Removes three unused telemetry enum declarations reported by Periphery:

- `AutoplaySettingTelemetry.EventExtraKey`
- `SearchTelemetryValues.Provider`
- `TabsPanelTelemetry.TabType`

The declarations have no references, so this cleanup does not change runtime behavior.

## :movie_camera: Demos
Not applicable. This is a non-UI dead-code cleanup.

## :white_check_mark: Validation
- Built the `Fennec` scheme successfully for a generic iOS Simulator destination.
- Verified the three declarations have no references in the repository.
- Ran `git diff --check`.
- The Periphery scan was not run locally because Periphery is not installed in the development environment.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured relevant checks pass; no tests were added because this only removes unreferenced declarations
- [x] Accessibility is not applicable because this change does not affect UI
- [x] Data review is not required because this does not add or modify telemetry collection
- [x] String review is not required because this does not add or modify strings
- [x] Documentation updates are not needed for this dead-code cleanup
