### PR TITLE
Add FXIOS-16182 [WebCompat] Advanced options toggles

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatToggleCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatToggleCell.swift
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import UIKit
+
+final class WebCompatToggleCell: UICollectionViewListCell, ThemeApplicable, ReusableCell {
+    private var toggleHandler: ((Bool) -> Void)?
+    private var isOn = false
+
+    private lazy var titleLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        // The switch carries the label for VoiceOver, so this is decorative.
+        label.isAccessibilityElement = false
+    }
+
+    // Not built via `.build`: as a custom-view cell accessory it must keep
+    // `translatesAutoresizingMaskIntoConstraints = true` (UIKit asserts otherwise).
+    private lazy var switchControl: ThemedSwitch = {
+        let control = ThemedSwitch()
+        control.addTarget(self, action: #selector(switchChanged), for: .valueChanged)
+        return control
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        contentView.addSubview(titleLabel)
+        let margins = contentView.layoutMarginsGuide
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+            titleLabel.topAnchor.constraint(equalTo: margins.topAnchor),
+            titleLabel.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
+        ])
+        accessories = [.customView(configuration: UICellAccessory.CustomViewConfiguration(
+            customView: switchControl,
+            placement: .trailing()
+        ))]
+    }
+
+    func configure(title: String, isOn: Bool, a11yIdentifier: String, onToggle: @escaping (Bool) -> Void) {
+        toggleHandler = onToggle
+        self.isOn = isOn
+        titleLabel.text = title
+        switchControl.accessibilityLabel = title
+        switchControl.accessibilityIdentifier = a11yIdentifier
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        backgroundConfiguration = .listGroupedCell()
+        backgroundConfiguration?.backgroundColor = theme.colors.layer5
+        titleLabel.textColor = theme.colors.textPrimary
+        // Canonical ThemedSwitch order (cf. PaddedSwitch.configure,
+        // ClearPrivateDataTableViewController): apply theme first, then set the value so
+        // the off-track color resolves from the now-populated theme colors.
+        switchControl.applyTheme(theme: theme)
+        switchControl.isOn = isOn
+    }
+
+    @objc
+    private func switchChanged() {
+        toggleHandler?(switchControl.isOn)
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatToggleCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatToggleCell.swift
@@ -8,7 +8,6 @@ import UIKit
 
 final class WebCompatToggleCell: UICollectionViewListCell, ThemeApplicable, ReusableCell {
     private var toggleHandler: ((Bool) -> Void)?
-    private var isOn = false
 
     private lazy var titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.body.scaledFont()
@@ -18,13 +17,7 @@ final class WebCompatToggleCell: UICollectionViewListCell, ThemeApplicable, Reus
         label.isAccessibilityElement = false
     }
 
-    // Not built via `.build`: as a custom-view cell accessory it must keep
-    // `translatesAutoresizingMaskIntoConstraints = true` (UIKit asserts otherwise).
-    private lazy var switchControl: ThemedSwitch = {
-        let control = ThemedSwitch()
-        control.addTarget(self, action: #selector(switchChanged), for: .valueChanged)
-        return control
-    }()
+    private let switchControl = ThemedSwitch()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -36,6 +29,7 @@ final class WebCompatToggleCell: UICollectionViewListCell, ThemeApplicable, Reus
     }
 
     private func setupLayout() {
+        switchControl.addTarget(self, action: #selector(switchChanged), for: .valueChanged)
         contentView.addSubview(titleLabel)
         let margins = contentView.layoutMarginsGuide
         NSLayoutConstraint.activate([
@@ -52,8 +46,8 @@ final class WebCompatToggleCell: UICollectionViewListCell, ThemeApplicable, Reus
 
     func configure(title: String, isOn: Bool, a11yIdentifier: String, onToggle: @escaping (Bool) -> Void) {
         toggleHandler = onToggle
-        self.isOn = isOn
         titleLabel.text = title
+        switchControl.isOn = isOn
         switchControl.accessibilityLabel = title
         switchControl.accessibilityIdentifier = a11yIdentifier
     }
@@ -64,11 +58,7 @@ final class WebCompatToggleCell: UICollectionViewListCell, ThemeApplicable, Reus
         backgroundConfiguration = .listGroupedCell()
         backgroundConfiguration?.backgroundColor = theme.colors.layer5
         titleLabel.textColor = theme.colors.textPrimary
-        // Canonical ThemedSwitch order (cf. PaddedSwitch.configure,
-        // ClearPrivateDataTableViewController): apply theme first, then set the value so
-        // the off-track color resolves from the now-populated theme colors.
         switchControl.applyTheme(theme: theme)
-        switchControl.isOn = isOn
     }
 
     @objc

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -66,6 +66,28 @@ private func previewSendSection(isEnabled: Bool) -> WebCompatReportViewModel.Sec
     ])
 }
 
+private func previewAdvancedSection(includeScreenshot: Bool, includeBlockedList: Bool)
+-> WebCompatReportViewModel.Section {
+    return WebCompatReportViewModel.Section(
+        id: "advanced",
+        title: "Additional Info",
+        rows: [
+            WebCompatReportViewModel.Row(
+                id: "screenshot",
+                title: "Automatically include a screenshot to show the problem",
+                kind: .toggle(isOn: includeScreenshot),
+                a11yIdentifier: "screenshot"
+            ),
+            WebCompatReportViewModel.Row(
+                id: "blocklist",
+                title: "Send list of items blocked by tracking protection",
+                kind: .toggle(isOn: includeBlockedList),
+                a11yIdentifier: "blocklist"
+            )
+        ]
+    )
+}
+
 @available(iOS 17.0, *)
 #Preview("Placeholder") {
     previewSheet(sections: [
@@ -84,7 +106,17 @@ private func previewSendSection(isEnabled: Bool) -> WebCompatReportViewModel.Sec
             previewSubOption("missing_items", "Missing items"),
             previewSubOption("buttons_not_working", "Buttons or links not working")
         ]),
+        previewAdvancedSection(includeScreenshot: true, includeBlockedList: true),
         previewSendSection(isEnabled: true)
+    ])
+}
+
+@available(iOS 17.0, *)
+#Preview("Advanced options off") {
+    previewSheet(sections: [
+        previewCategorySection(selectedTitle: nil),
+        previewAdvancedSection(includeScreenshot: false, includeBlockedList: false),
+        previewSendSection(isEnabled: false)
     ])
 }
 #endif

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -35,6 +35,11 @@ public final class WebCompatReportSheetViewController: UIViewController,
     private var rowsByID: [String: WebCompatReportViewModel.Row] = [:]
     private var sectionsByID: [String: WebCompatReportViewModel.Section] = [:]
 
+    /// configure(with:) themes cells at build time, so the first applyTheme must skip the
+    /// reconfigure — running it then lands in the nav bar's large-title pass and collapses
+    /// the title on load. Later (live) theme changes do reconfigure to re-theme cells.
+    private var hasAppliedThemeOnce = false
+
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
@@ -289,6 +294,9 @@ public final class WebCompatReportSheetViewController: UIViewController,
         collectionView.backgroundColor = theme.colors.layer1
         collectionView.setCollectionViewLayout(makeLayout(backgroundColor: theme.colors.layer1), animated: false)
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
-        reconfigureAllItems()
+        if hasAppliedThemeOnce {
+            reconfigureAllItems()
+        }
+        hasAppliedThemeOnce = true
     }
 }

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -15,6 +15,7 @@ public protocol WebCompatReportSheetDelegate: AnyObject {
     func webCompatReportSheetDidSelectCategory(id: String)
     func webCompatReportSheetDidSelectSubOption(id: String)
     func webCompatReportSheetDidTapButton(id: String)
+    func webCompatReportSheetDidToggle(id: String, isOn: Bool)
 }
 
 /// The "Report a Website Issue" sheet content, shown as an iOS-26 `.large`
@@ -166,6 +167,16 @@ public final class WebCompatReportSheetViewController: UIViewController,
             cell.applyTheme(theme: self.theme)
         }
 
+        let toggleRegistration = UICollectionView.CellRegistration<
+            WebCompatToggleCell, WebCompatReportViewModel.Row
+        > { [weak self] cell, _, row in
+            guard let self, case let .toggle(isOn) = row.kind else { return }
+            cell.configure(title: row.title, isOn: isOn, a11yIdentifier: row.a11yIdentifier) { [weak self] isOn in
+                self?.delegate?.webCompatReportSheetDidToggle(id: row.id, isOn: isOn)
+            }
+            cell.applyTheme(theme: self.theme)
+        }
+
         let dataSource = UICollectionViewDiffableDataSource<String, String>(
             collectionView: collectionView
         ) { [weak self] collectionView, indexPath, rowID in
@@ -186,6 +197,12 @@ public final class WebCompatReportSheetViewController: UIViewController,
             case .sendButton:
                 return collectionView.dequeueConfiguredReusableCell(
                     using: sendButtonRegistration,
+                    for: indexPath,
+                    item: row
+                )
+            case .toggle:
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: toggleRegistration,
                     for: indexPath,
                     item: row
                 )

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -240,6 +240,7 @@ public final class WebCompatReportSheetViewController: UIViewController,
     }
 
     private func applySnapshot() {
+        let previousRowsByID = rowsByID
         rowsByID = [:]
         sectionsByID = [:]
         let previousItems = Set(dataSource.snapshot().itemIdentifiers)
@@ -251,8 +252,14 @@ public final class WebCompatReportSheetViewController: UIViewController,
             snapshot.appendItems(section.rows.map { $0.id }, toSection: section.id)
         }
         // The data source keys on id, so rows that persist won't re-render on
-        // content change unless explicitly reconfigured.
-        snapshot.reconfigureItems(snapshot.itemIdentifiers.filter { previousItems.contains($0) })
+        // content change unless explicitly reconfigured. Only reconfigure the ones
+        // whose content actually changed: cells rebuild their accessories on every
+        // configure, and the list animates that as a remove+insert, so reconfiguring
+        // untouched rows flickers their checkmark away.
+        let changedItems = snapshot.itemIdentifiers.filter { rowID in
+            previousItems.contains(rowID) && previousRowsByID[rowID] != rowsByID[rowID]
+        }
+        snapshot.reconfigureItems(changedItems)
         dataSource.apply(snapshot, animatingDifferences: !previousItems.isEmpty)
     }
 

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
@@ -42,6 +42,7 @@ public struct WebCompatReportViewModel: Equatable, Sendable {
             case categoryMenu(isPlaceholder: Bool, options: [MenuOption])
             case subOption(isSelected: Bool)
             case sendButton(isEnabled: Bool)
+            case toggle(isOn: Bool)
         }
 
         public let id: String

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -207,7 +207,7 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         XCTAssertTrue(checkmarkBefore === checkmarkView(in: subject, at: subOptionIndexPath))
     }
 
-    func testConfigure_whenASubOptionChanges_rebuildsItsCheckmark() {
+    func testConfigure_whenASubOptionChanges_dropsItsCheckmark() {
         let subject = createSubject()
         subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
         subject.loadViewIfNeeded()
@@ -215,14 +215,14 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         subject.view.layoutIfNeeded()
 
         let subOptionIndexPath = IndexPath(item: 0, section: 0)
-        XCTAssertNotNil(checkmarkView(in: subject, at: subOptionIndexPath))
+        XCTAssertEqual(accessoryCount(in: subject, at: subOptionIndexPath), 1)
 
         subject.configure(
             with: makeViewModel(sections: subOptionAndToggleSections(isOn: false, isSubOptionSelected: false))
         )
         subject.view.layoutIfNeeded()
 
-        XCTAssertNil(checkmarkView(in: subject, at: subOptionIndexPath))
+        XCTAssertEqual(accessoryCount(in: subject, at: subOptionIndexPath), 0)
     }
 
     // MARK: - Helpers
@@ -265,6 +265,16 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
     ) -> UIImageView? {
         let cell = collectionView(in: subject)?.cellForItem(at: indexPath)
         return firstSubview(ofType: UIImageView.self, in: cell)
+    }
+
+    /// The accessory model, which updates synchronously — unlike the accessory views,
+    /// which linger in the hierarchy while the list animates them out.
+    private func accessoryCount(
+        in subject: WebCompatReportSheetViewController,
+        at indexPath: IndexPath
+    ) -> Int? {
+        let cell = collectionView(in: subject)?.cellForItem(at: indexPath) as? UICollectionViewListCell
+        return cell?.accessories.count
     }
 
     private func subOptionAndToggleSections(

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -156,6 +156,37 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         XCTAssertEqual(firstSubview(ofType: UIButton.self, in: cell)?.isEnabled, false)
     }
 
+    func testConfigure_withToggleSection_dequeuesToggleCell() {
+        let subject = createSubject()
+        subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        subject.loadViewIfNeeded()
+
+        subject.configure(with: makeViewModel(sections: toggleSections()))
+        subject.view.layoutIfNeeded()
+
+        XCTAssertTrue(
+            collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 0)) is WebCompatToggleCell
+        )
+    }
+
+    func testToggleCell_activation_notifiesDelegateWithRowIDAndValue() {
+        let delegate = MockWebCompatReportSheetDelegate()
+        let subject = createSubject()
+        subject.delegate = delegate
+        subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        subject.loadViewIfNeeded()
+        subject.configure(with: makeViewModel(sections: toggleSections()))
+        subject.view.layoutIfNeeded()
+
+        let toggleCell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 0))
+        let toggle = firstSubview(ofType: UISwitch.self, in: toggleCell)
+        toggle?.isOn = true
+        fireActions(toggle, for: .valueChanged)
+
+        XCTAssertEqual(delegate.toggles.map(\.id), ["screenshot"])
+        XCTAssertEqual(delegate.toggles.map(\.isOn), [true])
+    }
+
     // MARK: - Helpers
 
     private func collectionView(in subject: WebCompatReportSheetViewController) -> UICollectionView? {
@@ -184,6 +215,29 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
                     a11yIdentifier: "send"
                 )
             ])
+        ]
+    }
+
+    private func toggleSections() -> [WebCompatReportViewModel.Section] {
+        return [
+            WebCompatReportViewModel.Section(
+                id: "advanced",
+                title: "Additional Info",
+                rows: [
+                    WebCompatReportViewModel.Row(
+                        id: "screenshot",
+                        title: "Include screenshot",
+                        kind: .toggle(isOn: false),
+                        a11yIdentifier: "screenshot"
+                    ),
+                    WebCompatReportViewModel.Row(
+                        id: "blocklist",
+                        title: "Include blocked list",
+                        kind: .toggle(isOn: true),
+                        a11yIdentifier: "blocklist"
+                    )
+                ]
+            )
         ]
     }
 
@@ -277,6 +331,7 @@ private final class MockWebCompatReportSheetDelegate: WebCompatReportSheetDelega
     var selectedCategoryIDs: [String] = []
     var selectedSubOptionIDs: [String] = []
     var tappedButtonIDs: [String] = []
+    var toggles: [(id: String, isOn: Bool)] = []
 
     func webCompatReportSheetDidTapClose() {
         didTapCloseCallCount += 1
@@ -296,5 +351,9 @@ private final class MockWebCompatReportSheetDelegate: WebCompatReportSheetDelega
 
     func webCompatReportSheetDidTapButton(id: String) {
         tappedButtonIDs.append(id)
+    }
+
+    func webCompatReportSheetDidToggle(id: String, isOn: Bool) {
+        toggles.append((id, isOn))
     }
 }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -187,6 +187,44 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         XCTAssertEqual(delegate.toggles.map(\.isOn), [true])
     }
 
+    // A toggle flip re-renders the whole view model. Rows that didn't change must not
+    // be reconfigured: sub-option cells rebuild their checkmark accessory on configure,
+    // and the list animates that as a remove+insert, so the checkmark visibly flickers.
+    func testConfigure_whenOnlyAToggleChanges_doesNotRebuildTheSubOptionCheckmark() {
+        let subject = createSubject()
+        subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        subject.loadViewIfNeeded()
+        subject.configure(with: makeViewModel(sections: subOptionAndToggleSections(isOn: false)))
+        subject.view.layoutIfNeeded()
+
+        let subOptionIndexPath = IndexPath(item: 0, section: 0)
+        let checkmarkBefore = checkmarkView(in: subject, at: subOptionIndexPath)
+
+        subject.configure(with: makeViewModel(sections: subOptionAndToggleSections(isOn: true)))
+        subject.view.layoutIfNeeded()
+
+        XCTAssertNotNil(checkmarkBefore)
+        XCTAssertTrue(checkmarkBefore === checkmarkView(in: subject, at: subOptionIndexPath))
+    }
+
+    func testConfigure_whenASubOptionChanges_rebuildsItsCheckmark() {
+        let subject = createSubject()
+        subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        subject.loadViewIfNeeded()
+        subject.configure(with: makeViewModel(sections: subOptionAndToggleSections(isOn: false)))
+        subject.view.layoutIfNeeded()
+
+        let subOptionIndexPath = IndexPath(item: 0, section: 0)
+        XCTAssertNotNil(checkmarkView(in: subject, at: subOptionIndexPath))
+
+        subject.configure(
+            with: makeViewModel(sections: subOptionAndToggleSections(isOn: false, isSubOptionSelected: false))
+        )
+        subject.view.layoutIfNeeded()
+
+        XCTAssertNil(checkmarkView(in: subject, at: subOptionIndexPath))
+    }
+
     // MARK: - Helpers
 
     private func collectionView(in subject: WebCompatReportSheetViewController) -> UICollectionView? {
@@ -213,6 +251,41 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
                     title: "Send Report",
                     kind: .sendButton(isEnabled: isEnabled),
                     a11yIdentifier: "send"
+                )
+            ])
+        ]
+    }
+
+    /// The image view backing a sub-option's checkmark accessory, or nil when unselected.
+    /// Identity matters: the cell builds a fresh one on every configure, so a new instance
+    /// means the row was reconfigured.
+    private func checkmarkView(
+        in subject: WebCompatReportSheetViewController,
+        at indexPath: IndexPath
+    ) -> UIImageView? {
+        let cell = collectionView(in: subject)?.cellForItem(at: indexPath)
+        return firstSubview(ofType: UIImageView.self, in: cell)
+    }
+
+    private func subOptionAndToggleSections(
+        isOn: Bool,
+        isSubOptionSelected: Bool = true
+    ) -> [WebCompatReportViewModel.Section] {
+        return [
+            WebCompatReportViewModel.Section(id: "issue-suboptions", rows: [
+                WebCompatReportViewModel.Row(
+                    id: "page_not_loading",
+                    title: "Page not loading correctly",
+                    kind: .subOption(isSelected: isSubOptionSelected),
+                    a11yIdentifier: "page_not_loading"
+                )
+            ]),
+            WebCompatReportViewModel.Section(id: "advanced", title: "Additional Info", rows: [
+                WebCompatReportViewModel.Row(
+                    id: "screenshot",
+                    title: "Include screenshot",
+                    kind: .toggle(isOn: isOn),
+                    a11yIdentifier: "screenshot"
                 )
             ])
         ]

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -138,6 +138,8 @@ struct AccessibilityIdentifiers {
         static let categoryMenu = "WebCompatReporter.CategoryMenu"
         static let subOption = "WebCompatReporter.SubOption"
         static let sendButton = "WebCompatReporter.SendButton"
+        static let includeScreenshot = "WebCompatReporter.IncludeScreenshot"
+        static let includeBlockedList = "WebCompatReporter.IncludeBlockedList"
     }
 
     struct UnifiedSearch {

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -119,10 +119,13 @@ final class WebCompatReportViewController: UINavigationController,
     private enum SectionID: String {
         case issueCategory
         case issueSubOptions
+        case advancedOptions
         case send
     }
 
     private enum RowID: String {
+        case includeScreenshot
+        case includeBlockedList
         case send
     }
 
@@ -130,8 +133,32 @@ final class WebCompatReportViewController: UINavigationController,
         from state: WebCompatReporterState
     ) -> [WebCompatReportViewModel.Section] {
         var sections = makeIssueSections(from: state)
+        sections.append(advancedOptionsSection(from: state))
         sections.append(sendSection(from: state))
         return sections
+    }
+
+    private static func advancedOptionsSection(
+        from state: WebCompatReporterState
+    ) -> WebCompatReportViewModel.Section {
+        return WebCompatReportViewModel.Section(
+            id: SectionID.advancedOptions.rawValue,
+            title: .WebCompatReporter.AdditionalInfo.Title,
+            rows: [
+                WebCompatReportViewModel.Row(
+                    id: RowID.includeScreenshot.rawValue,
+                    title: .WebCompatReporter.AdditionalInfo.IncludeScreenshot,
+                    kind: .toggle(isOn: state.includeScreenshot),
+                    a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.includeScreenshot
+                ),
+                WebCompatReportViewModel.Row(
+                    id: RowID.includeBlockedList.rawValue,
+                    title: .WebCompatReporter.AdditionalInfo.IncludeBlockedList,
+                    kind: .toggle(isOn: state.includeBlockedList),
+                    a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.includeBlockedList
+                )
+            ]
+        )
     }
 
     private static func sendSection(from state: WebCompatReporterState) -> WebCompatReportViewModel.Section {
@@ -262,6 +289,25 @@ final class WebCompatReportViewController: UINavigationController,
             windowUUID: windowUUID,
             actionType: WebCompatReporterViewActionType.submit
         ))
+    }
+
+    func webCompatReportSheetDidToggle(id: String, isOn: Bool) {
+        switch RowID(rawValue: id) {
+        case .includeScreenshot:
+            store.dispatch(WebCompatReporterViewAction(
+                includeScreenshot: isOn,
+                windowUUID: windowUUID,
+                actionType: WebCompatReporterViewActionType.toggleScreenshot
+            ))
+        case .includeBlockedList:
+            store.dispatch(WebCompatReporterViewAction(
+                includeBlockedList: isOn,
+                windowUUID: windowUUID,
+                actionType: WebCompatReporterViewActionType.toggleBlockedList
+            ))
+        case .send, .none:
+            break
+        }
     }
 
     // MARK: - Themeable

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -64,29 +64,40 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(dispatchedViewActions().isEmpty)
     }
 
-    // MARK: - makeSections
+    func testDidToggle_onScreenshotRow_dispatchesToggleScreenshotWithValue() {
+        let subject = createSubject(reportedURL: nil)
 
-    func testMakeSections_withoutCategory_appendsDisabledSendButton() {
-        let state = WebCompatReporterState(windowUUID: windowUUID, url: "https://example.com")
+        subject.webCompatReportSheetDidToggle(id: "includeScreenshot", isOn: false)
 
-        let sections = WebCompatReportViewController.makeSections(from: state)
-
-        XCTAssertEqual(sections.map(\.id), ["issueCategory", "send"])
-        XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: false)])
+        let action = lastViewAction()
+        XCTAssertEqual(action?.actionType as? WebCompatReporterViewActionType, .toggleScreenshot)
+        XCTAssertEqual(action?.includeScreenshot, false)
     }
 
-    func testMakeSections_withCategory_enablesSendButtonAndKeepsItLast() {
-        let state = WebCompatReporterState(
-            windowUUID: windowUUID,
-            url: "https://example.com",
-            selectedCategory: .siteNotUsable,
-            selectedSubOptionID: WebCompatSubOption.pageNotLoading.rawValue
-        )
+    func testDidToggle_onBlockedListRow_dispatchesToggleBlockedListWithValue() {
+        let subject = createSubject(reportedURL: nil)
 
-        let sections = WebCompatReportViewController.makeSections(from: state)
+        subject.webCompatReportSheetDidToggle(id: "includeBlockedList", isOn: true)
 
-        XCTAssertEqual(sections.map(\.id), ["issueCategory", "issueSubOptions", "send"])
-        XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: true)])
+        let action = lastViewAction()
+        XCTAssertEqual(action?.actionType as? WebCompatReporterViewActionType, .toggleBlockedList)
+        XCTAssertEqual(action?.includeBlockedList, true)
+    }
+
+    func testDidToggle_onSendRow_dispatchesNothing() {
+        let subject = createSubject(reportedURL: nil)
+
+        subject.webCompatReportSheetDidToggle(id: "send", isOn: true)
+
+        XCTAssertTrue(dispatchedViewActions().isEmpty)
+    }
+
+    func testDidToggle_onUnhandledRow_dispatchesNothing() {
+        let subject = createSubject(reportedURL: nil)
+
+        subject.webCompatReportSheetDidToggle(id: "unknown", isOn: true)
+
+        XCTAssertTrue(dispatchedViewActions().isEmpty)
     }
 
     func testSimpleCreation_hasNoLeaks() {
@@ -147,6 +158,40 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         let sections = WebCompatReportViewController.makeIssueSections(from: state)
 
         XCTAssertEqual(sections.count, 1)
+    }
+
+    // MARK: - makeSections
+
+    func testMakeSections_withoutCategory_showsAdvancedTogglesAndDisabledSendButton() {
+        let state = WebCompatReporterState(windowUUID: windowUUID, url: "https://example.com")
+
+        let sections = WebCompatReportViewController.makeSections(from: state)
+
+        // Category + advanced + send (no sub-options until a category is picked).
+        XCTAssertEqual(sections.map(\.id), ["issueCategory", "advancedOptions", "send"])
+
+        let advanced = sections.first { $0.id == "advancedOptions" }
+        XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: true), .toggle(isOn: false)])
+        XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: false)])
+    }
+
+    func testMakeSections_withCategory_keepsAdvancedTogglesBeforeSendButton() {
+        let state = WebCompatReporterState(
+            windowUUID: windowUUID,
+            url: "https://example.com",
+            selectedCategory: .siteNotUsable,
+            selectedSubOptionID: WebCompatSubOption.pageNotLoading.rawValue,
+            includeScreenshot: false,
+            includeBlockedList: true
+        )
+
+        let sections = WebCompatReportViewController.makeSections(from: state)
+
+        XCTAssertEqual(sections.map(\.id), ["issueCategory", "issueSubOptions", "advancedOptions", "send"])
+
+        let advanced = sections.first { $0.id == "advancedOptions" }
+        XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: false), .toggle(isOn: true)])
+        XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: true)])
     }
 
     private func createSubject(reportedURL: URL?) -> WebCompatReportViewController {


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16182](https://mozilla-hub.atlassian.net/browse/FXIOS-16182)

## :bulb: Description
Adds the **Advanced Options** section to the report sheet: two switches. This was part of #34835; pulled out so it can land on `main` on its own.

It reuses the existing `includeScreenshot` / `includeBlockedList` state and the strings from #34728, so there's nothing new to review on the Redux or l10n side.

Heads up: this and #34860 both add a `Row.Kind` case and introduce `makeSections`. Whichever merges second needs a rebase for switch exhaustiveness.

<img height="600" alt="Screenshot 2026-07-27 at 11 57 47" src="https://github.com/user-attachments/assets/7a8bbeb6-95bc-4211-9f61-22b8c3d909fb" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
Tools menu > **Report a Website Issue**. Look at the Advanced Options section at the bottom of the sheet.

Canvas: the "Category selected" and "Advanced options off" previews in `WebCompatReportSheetPreview.swift`.


[FXIOS-16182]: https://mozilla-hub.atlassian.net/browse/FXIOS-16182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
