### PR TITLE
Add FXIOS-16182 [WebCompat] Send button

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatSendButtonCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatSendButtonCell.swift
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import UIKit
+
+final class WebCompatSendButtonCell: UICollectionViewListCell, ThemeApplicable, ReusableCell {
+    private var tapHandler: (() -> Void)?
+
+    private lazy var button: PrimaryRoundedButton = .build { button in
+        button.addTarget(self, action: #selector(self.didTap), for: .touchUpInside)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        backgroundConfiguration = UIBackgroundConfiguration.clear()
+        contentView.addSubview(button)
+        NSLayoutConstraint.activate([
+            button.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            button.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            button.topAnchor.constraint(equalTo: contentView.topAnchor),
+            button.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+
+    func configure(title: String, isEnabled: Bool, a11yIdentifier: String, onTap: @escaping () -> Void) {
+        tapHandler = onTap
+        button.configure(
+            viewModel: PrimaryRoundedButtonViewModel(title: title, a11yIdentifier: a11yIdentifier)
+        )
+        button.isEnabled = isEnabled
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        button.applyTheme(theme: theme)
+    }
+
+    @objc
+    private func didTap() {
+        tapHandler?()
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatSendButtonCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatSendButtonCell.swift
@@ -6,7 +6,7 @@ import Common
 import ComponentLibrary
 import UIKit
 
-final class WebCompatSendButtonCell: UICollectionViewListCell, ThemeApplicable, ReusableCell {
+final class WebCompatSendButtonCell: UICollectionViewListCell, ThemeApplicable {
     private var tapHandler: (() -> Void)?
 
     private lazy var button: PrimaryRoundedButton = .build { button in

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -55,9 +55,23 @@ private func previewSubOption(_ id: String, _ title: String, selected: Bool = fa
     return WebCompatReportViewModel.Row(id: id, title: title, kind: .subOption(isSelected: selected), a11yIdentifier: id)
 }
 
+private func previewSendSection(isEnabled: Bool) -> WebCompatReportViewModel.Section {
+    return WebCompatReportViewModel.Section(id: "send", rows: [
+        WebCompatReportViewModel.Row(
+            id: "send",
+            title: "Send Report",
+            kind: .sendButton(isEnabled: isEnabled),
+            a11yIdentifier: "send"
+        )
+    ])
+}
+
 @available(iOS 17.0, *)
 #Preview("Placeholder") {
-    previewSheet(sections: [previewCategorySection(selectedTitle: nil)])
+    previewSheet(sections: [
+        previewCategorySection(selectedTitle: nil),
+        previewSendSection(isEnabled: false)
+    ])
 }
 
 @available(iOS 17.0, *)
@@ -69,7 +83,8 @@ private func previewSubOption(_ id: String, _ title: String, selected: Bool = fa
             previewSubOption("page_not_loading", "Page not loading correctly", selected: true),
             previewSubOption("missing_items", "Missing items"),
             previewSubOption("buttons_not_working", "Buttons or links not working")
-        ])
+        ]),
+        previewSendSection(isEnabled: true)
     ])
 }
 #endif

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -14,6 +14,7 @@ public protocol WebCompatReportSheetDelegate: AnyObject {
     func webCompatReportSheetDidTapPreview()
     func webCompatReportSheetDidSelectCategory(id: String)
     func webCompatReportSheetDidSelectSubOption(id: String)
+    func webCompatReportSheetDidTapButton(id: String)
 }
 
 /// The "Report a Website Issue" sheet content, shown as an iOS-26 `.large`
@@ -153,6 +154,18 @@ public final class WebCompatReportSheetViewController: UIViewController,
             }
         }
 
+        let sendButtonRegistration = UICollectionView.CellRegistration<
+            WebCompatSendButtonCell, WebCompatReportViewModel.Row
+        > { [weak self] cell, _, row in
+            guard let self, case let .sendButton(isEnabled) = row.kind else { return }
+            cell.configure(title: row.title, isEnabled: isEnabled, a11yIdentifier: row.a11yIdentifier) { [weak self] in
+                // Text fields report on end-editing, so commit the active one before submitting.
+                self?.view.endEditing(true)
+                self?.delegate?.webCompatReportSheetDidTapButton(id: row.id)
+            }
+            cell.applyTheme(theme: self.theme)
+        }
+
         let dataSource = UICollectionViewDiffableDataSource<String, String>(
             collectionView: collectionView
         ) { [weak self] collectionView, indexPath, rowID in
@@ -167,6 +180,12 @@ public final class WebCompatReportSheetViewController: UIViewController,
             case .subOption:
                 return collectionView.dequeueConfiguredReusableCell(
                     using: subOptionRegistration,
+                    for: indexPath,
+                    item: row
+                )
+            case .sendButton:
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: sendButtonRegistration,
                     for: indexPath,
                     item: row
                 )

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
@@ -36,12 +36,12 @@ public struct WebCompatReportViewModel: Equatable, Sendable {
             }
         }
 
-        /// How a row renders: a plain title row, the category pull-down, or a
-        /// selectable sub-option row.
+        /// How a row renders in the list.
         public enum Kind: Hashable, Sendable {
             case plain
             case categoryMenu(isPlaceholder: Bool, options: [MenuOption])
             case subOption(isSelected: Bool)
+            case sendButton(isEnabled: Bool)
         }
 
         public let id: String

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -145,19 +145,15 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         XCTAssertEqual(delegate.tappedButtonIDs, ["send"])
     }
 
-    func testSendButton_whenDisabled_doesNotNotifyDelegate() {
-        let delegate = MockWebCompatReportSheetDelegate()
+    func testSendButton_whenNotSubmittable_rendersDisabledButton() {
         let subject = createSubject()
-        subject.delegate = delegate
         subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
         subject.loadViewIfNeeded()
         subject.configure(with: makeViewModel(sections: sendSections(isEnabled: false)))
         subject.view.layoutIfNeeded()
 
         let cell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 0))
-        let button = firstSubview(ofType: UIButton.self, in: cell)
-        XCTAssertEqual(button?.isEnabled, false)
-        XCTAssertTrue(delegate.tappedButtonIDs.isEmpty)
+        XCTAssertEqual(firstSubview(ofType: UIButton.self, in: cell)?.isEnabled, false)
     }
 
     // MARK: - Helpers

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -117,7 +117,79 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         )
     }
 
+    func testConfigure_withSendSection_dequeuesSendButtonCell() {
+        let subject = createSubject()
+        subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        subject.loadViewIfNeeded()
+
+        subject.configure(with: makeViewModel(sections: sendSections(isEnabled: true)))
+        subject.view.layoutIfNeeded()
+
+        XCTAssertTrue(
+            collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 0)) is WebCompatSendButtonCell
+        )
+    }
+
+    func testSendButton_whenTapped_notifiesDelegateWithRowID() {
+        let delegate = MockWebCompatReportSheetDelegate()
+        let subject = createSubject()
+        subject.delegate = delegate
+        subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        subject.loadViewIfNeeded()
+        subject.configure(with: makeViewModel(sections: sendSections(isEnabled: true)))
+        subject.view.layoutIfNeeded()
+
+        let cell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 0))
+        fireActions(firstSubview(ofType: UIButton.self, in: cell), for: .touchUpInside)
+
+        XCTAssertEqual(delegate.tappedButtonIDs, ["send"])
+    }
+
+    func testSendButton_whenDisabled_doesNotNotifyDelegate() {
+        let delegate = MockWebCompatReportSheetDelegate()
+        let subject = createSubject()
+        subject.delegate = delegate
+        subject.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        subject.loadViewIfNeeded()
+        subject.configure(with: makeViewModel(sections: sendSections(isEnabled: false)))
+        subject.view.layoutIfNeeded()
+
+        let cell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 0))
+        let button = firstSubview(ofType: UIButton.self, in: cell)
+        XCTAssertEqual(button?.isEnabled, false)
+        XCTAssertTrue(delegate.tappedButtonIDs.isEmpty)
+    }
+
     // MARK: - Helpers
+
+    private func collectionView(in subject: WebCompatReportSheetViewController) -> UICollectionView? {
+        return subject.view.subviews.compactMap { $0 as? UICollectionView }.first
+    }
+
+    // UIControl.sendActions needs a running UIApplication, which logic tests lack,
+    // so invoke each registered target/action selector directly.
+    private func fireActions(_ control: UIControl?, for event: UIControl.Event) {
+        guard let control else { return }
+        for target in control.allTargets {
+            let object = target as NSObject
+            control.actions(forTarget: target, forControlEvent: event)?.forEach {
+                object.perform(Selector($0))
+            }
+        }
+    }
+
+    private func sendSections(isEnabled: Bool) -> [WebCompatReportViewModel.Section] {
+        return [
+            WebCompatReportViewModel.Section(id: "send", rows: [
+                WebCompatReportViewModel.Row(
+                    id: "send",
+                    title: "Send Report",
+                    kind: .sendButton(isEnabled: isEnabled),
+                    a11yIdentifier: "send"
+                )
+            ])
+        ]
+    }
 
     private func pickerSections() -> [WebCompatReportViewModel.Section] {
         let options = [
@@ -208,6 +280,7 @@ private final class MockWebCompatReportSheetDelegate: WebCompatReportSheetDelega
     var didTapPreviewCallCount = 0
     var selectedCategoryIDs: [String] = []
     var selectedSubOptionIDs: [String] = []
+    var tappedButtonIDs: [String] = []
 
     func webCompatReportSheetDidTapClose() {
         didTapCloseCallCount += 1
@@ -223,5 +296,9 @@ private final class MockWebCompatReportSheetDelegate: WebCompatReportSheetDelega
 
     func webCompatReportSheetDidSelectSubOption(id: String) {
         selectedSubOptionIDs.append(id)
+    }
+
+    func webCompatReportSheetDidTapButton(id: String) {
+        tappedButtonIDs.append(id)
     }
 }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/XCTestCase+Subviews.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/XCTestCase+Subviews.swift
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import XCTest
+
+extension XCTestCase {
+    /// Depth-first search for the first subview of the given type.
+    @MainActor
+    func firstSubview<T: UIView>(ofType type: T.Type, in view: UIView?) -> T? {
+        guard let view else { return nil }
+        for subview in view.subviews {
+            if let match = subview as? T { return match }
+            if let match = firstSubview(ofType: type, in: subview) { return match }
+        }
+        return nil
+    }
+}

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -137,6 +137,7 @@ struct AccessibilityIdentifiers {
     struct WebCompatReporter {
         static let categoryMenu = "WebCompatReporter.CategoryMenu"
         static let subOption = "WebCompatReporter.SubOption"
+        static let sendButton = "WebCompatReporter.SendButton"
     }
 
     struct UnifiedSearch {

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -112,13 +112,40 @@ final class WebCompatReportViewController: UINavigationController,
             closeButtonAccessibilityLabel: .WebCompatReporter.Sheet.CloseButtonAccessibilityLabel,
             previewButtonTitle: .WebCompatReporter.Sheet.PreviewButton,
             isPreviewEnabled: state.canPreview,
-            sections: makeIssueSections(from: state)
+            sections: makeSections(from: state)
         )
     }
 
     private enum SectionID: String {
         case issueCategory
         case issueSubOptions
+        case send
+    }
+
+    private enum RowID: String {
+        case send
+    }
+
+    static func makeSections(
+        from state: WebCompatReporterState
+    ) -> [WebCompatReportViewModel.Section] {
+        var sections = makeIssueSections(from: state)
+        sections.append(sendSection(from: state))
+        return sections
+    }
+
+    private static func sendSection(from state: WebCompatReporterState) -> WebCompatReportViewModel.Section {
+        return WebCompatReportViewModel.Section(
+            id: SectionID.send.rawValue,
+            rows: [
+                WebCompatReportViewModel.Row(
+                    id: RowID.send.rawValue,
+                    title: .WebCompatReporter.SendButton.Title,
+                    kind: .sendButton(isEnabled: state.canSubmit),
+                    a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.sendButton
+                )
+            ]
+        )
     }
 
     static func makeIssueSections(
@@ -226,6 +253,14 @@ final class WebCompatReportViewController: UINavigationController,
             subOptionID: subOption.rawValue,
             windowUUID: windowUUID,
             actionType: WebCompatReporterViewActionType.selectSubOption
+        ))
+    }
+
+    func webCompatReportSheetDidTapButton(id: String) {
+        guard RowID(rawValue: id) == .send else { return }
+        store.dispatch(WebCompatReporterViewAction(
+            windowUUID: windowUUID,
+            actionType: WebCompatReporterViewActionType.submit
         ))
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -3,22 +3,26 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Redux
 import WebCompatReporterKit
 import XCTest
 
 @testable import Client
 
 @MainActor
-final class WebCompatReportViewControllerTests: XCTestCase {
+final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
     let windowUUID: WindowUUID = .XCTestDefaultUUID
+    var mockStore: MockStoreForMiddleware<AppState>!
 
     override func setUp() async throws {
         try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
+        setupStore()
     }
 
     override func tearDown() async throws {
         DependencyHelperMock().reset()
+        resetStore()
         try await super.tearDown()
     }
 
@@ -40,6 +44,49 @@ final class WebCompatReportViewControllerTests: XCTestCase {
         subject.webCompatReportSheetDidTapClose()
 
         XCTAssertEqual(coordinator.didFinishCallCount, 1)
+    }
+
+    // MARK: - Delegate intents → Redux actions
+
+    func testDidTapButton_onSendRow_dispatchesSubmit() {
+        let subject = createSubject(reportedURL: nil)
+
+        subject.webCompatReportSheetDidTapButton(id: "send")
+
+        XCTAssertEqual(lastViewAction()?.actionType as? WebCompatReporterViewActionType, .submit)
+    }
+
+    func testDidTapButton_onUnhandledRow_dispatchesNothing() {
+        let subject = createSubject(reportedURL: nil)
+
+        subject.webCompatReportSheetDidTapButton(id: "unknown")
+
+        XCTAssertTrue(dispatchedViewActions().isEmpty)
+    }
+
+    // MARK: - makeSections
+
+    func testMakeSections_withoutCategory_appendsDisabledSendButton() {
+        let state = WebCompatReporterState(windowUUID: windowUUID, url: "https://example.com")
+
+        let sections = WebCompatReportViewController.makeSections(from: state)
+
+        XCTAssertEqual(sections.map(\.id), ["issueCategory", "send"])
+        XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: false)])
+    }
+
+    func testMakeSections_withCategory_enablesSendButtonAndKeepsItLast() {
+        let state = WebCompatReporterState(
+            windowUUID: windowUUID,
+            url: "https://example.com",
+            selectedCategory: .siteNotUsable,
+            selectedSubOptionID: WebCompatSubOption.pageNotLoading.rawValue
+        )
+
+        let sections = WebCompatReportViewController.makeSections(from: state)
+
+        XCTAssertEqual(sections.map(\.id), ["issueCategory", "issueSubOptions", "send"])
+        XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: true)])
     }
 
     func testSimpleCreation_hasNoLeaks() {
@@ -104,6 +151,35 @@ final class WebCompatReportViewControllerTests: XCTestCase {
 
     private func createSubject(reportedURL: URL?) -> WebCompatReportViewController {
         return WebCompatReportViewController(windowUUID: windowUUID, reportedURL: reportedURL)
+    }
+
+    private func dispatchedViewActions() -> [WebCompatReporterViewAction] {
+        return mockStore.dispatchedActions.compactMap { $0 as? WebCompatReporterViewAction }
+    }
+
+    private func lastViewAction() -> WebCompatReporterViewAction? {
+        return dispatchedViewActions().last
+    }
+
+    // MARK: - StoreTestUtility
+
+    func setupAppState() -> AppState {
+        return AppState(
+            presentedComponents: PresentedComponentsState(
+                components: [
+                    .webCompatReporter(WebCompatReporterState(windowUUID: windowUUID))
+                ]
+            )
+        )
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16182](https://mozilla-hub.atlassian.net/browse/FXIOS-16182)

## :bulb: Description
Adds the **Send Report** row to the report sheet. Came out of #34555, split off so it doesn't have to wait on the rest of that stack.

The button stays disabled until a category is picked. The tap handler resigns the active field before forwarding. @adudenamedruby caught on #34555 that Send wouldn't commit an in-progress text field. It's a no-op today; it matters once #34834 and #34862 land.

Heads up: this and #34859 both add a `Row.Kind` case and introduce `makeSections`. Whichever merges second needs a rebase for switch exhaustiveness.

<img height="600" alt="IMG_5001" src="https://github.com/user-attachments/assets/f4637122-a026-4253-b2a9-6e1f90434d5a" />

<img height="600" alt="IMG_4999" src="https://github.com/user-attachments/assets/d5896955-348c-4996-a758-e0df78daf9d2" />



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
Tools menu > **Report a Website Issue**. Look at the Send Report row, before and after picking a category.

Canvas: the "Placeholder" and "Category selected" previews in `WebCompatReportSheetPreview.swift`.


[FXIOS-16182]: https://mozilla-hub.atlassian.net/browse/FXIOS-16182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
