### PR TITLE
Add FXIOS-16183 [WebCompat] Collect native report payload fields

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1347,6 +1347,8 @@
 		8C2FB1E82FF3D68100C9A803 /* WebCompatReporterMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1E72FF3D68100C9A803 /* WebCompatReporterMiddleware.swift */; };
 		8C2FB1EB2FF3D6BB00C9A803 /* WebCompatReporterStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1EA2FF3D6BB00C9A803 /* WebCompatReporterStateTests.swift */; };
 		8C2FB1ED2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1EC2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift */; };
+		8CB4742130011A9900BB0119 /* WebCompatReportDataCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB4742030011A9900BB0119 /* WebCompatReportDataCollectorTests.swift */; };
+		8CB4742330011A9900BB0119 /* WebCompatReportPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB4742230011A9900BB0119 /* WebCompatReportPayloadTests.swift */; };
 		8C381F002EBE1C74009A54AA /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = 8C381EFF2EBE1C74009A54AA /* SiteImageView */; };
 		8C381F022EBE1CC3009A54AA /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = 8C381F012EBE1CC3009A54AA /* SiteImageView */; };
 		8C3A17792E68390000341A01 /* OnboardingLaunchScreenViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3A17782E68390000341A01 /* OnboardingLaunchScreenViewControllerTests.swift */; };
@@ -10022,6 +10024,8 @@
 		8C2FB1E72FF3D68100C9A803 /* WebCompatReporterMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReporterMiddleware.swift; sourceTree = "<group>"; };
 		8C2FB1EA2FF3D6BB00C9A803 /* WebCompatReporterStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReporterStateTests.swift; sourceTree = "<group>"; };
 		8C2FB1EC2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReporterMiddlewareTests.swift; sourceTree = "<group>"; };
+		8CB4742030011A9900BB0119 /* WebCompatReportDataCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportDataCollectorTests.swift; sourceTree = "<group>"; };
+		8CB4742230011A9900BB0119 /* WebCompatReportPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportPayloadTests.swift; sourceTree = "<group>"; };
 		8C3A17782E68390000341A01 /* OnboardingLaunchScreenViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingLaunchScreenViewControllerTests.swift; sourceTree = "<group>"; };
 		8C3B0B892F72767000E2C370 /* TranslationLanguagePickerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationLanguagePickerViewControllerTests.swift; sourceTree = "<group>"; };
 		8C3B1A1A2F73C8D100E2C370 /* TranslationToggleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationToggleCell.swift; sourceTree = "<group>"; };
@@ -15175,6 +15179,8 @@
 			children = (
 				8C2FB1EA2FF3D6BB00C9A803 /* WebCompatReporterStateTests.swift */,
 				8C2FB1EC2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift */,
+				8CB4742030011A9900BB0119 /* WebCompatReportDataCollectorTests.swift */,
+				8CB4742230011A9900BB0119 /* WebCompatReportPayloadTests.swift */,
 			);
 			path = WebCompatReporter;
 			sourceTree = "<group>";
@@ -21070,6 +21076,8 @@
 				0A80C4262F3CD45900DB85AE /* MockLAContext.swift in Sources */,
 				C8C3FEA129F973C40038E3BA /* MockBrowserViewController.swift in Sources */,
 				8C2FB1ED2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift in Sources */,
+				8CB4742130011A9900BB0119 /* WebCompatReportDataCollectorTests.swift in Sources */,
+				8CB4742330011A9900BB0119 /* WebCompatReportPayloadTests.swift in Sources */,
 				391C281C3007C3D700833828 /* TrackerBlockStatsStoreTests.swift in Sources */,
 				391C281D3007C3D700833828 /* TrackingProtectionPageStatsTests.swift in Sources */,
 				8A93F86B29D39BDA004159D9 /* BaseCoordinatorTests.swift in Sources */,

--- a/firefox-ios/Client/Extensions/UIImage+RenderingUtilities.swift
+++ b/firefox-ios/Client/Extensions/UIImage+RenderingUtilities.swift
@@ -11,8 +11,17 @@ extension UIImage {
     ///   - targetSize: the target size for the image. Leave nil to use the default.
     ///   - minimumSize: the minimum size for the image. It will be scaled up to this size
     ///   if needed (keeping proportions).
+    ///   - scale: the renderer scale. Leave nil for the natural screen scale; pass 1 for
+    ///   very tall pages, where the native-scale bitmap would be prohibitively large.
+    ///   - backgroundColor: the fill drawn behind the page. Defaults to clear.
     /// - Returns: an image of the PDF. Returns nil if an issue occurs or the PDF data is invalid.
-    static func imageFromPDF(data: Data, targetSize: CGSize? = nil, minimumSize: CGSize? = nil) -> UIImage? {
+    static func imageFromPDF(
+        data: Data,
+        targetSize: CGSize? = nil,
+        minimumSize: CGSize? = nil,
+        scale: CGFloat? = nil,
+        backgroundColor: UIColor = .clear
+    ) -> UIImage? {
         guard let document = PDFDocument(data: data), let page = document.page(at: 0) else {
             return nil
         }
@@ -33,11 +42,13 @@ extension UIImage {
             size = baseSize
         }
 
-        let renderer = UIGraphicsImageRenderer(size: size)
+        let format = UIGraphicsImageRendererFormat.default()
+        if let scale { format.scale = scale }
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
         return renderer.image { context in
             let cgContext = context.cgContext
 
-            UIColor.clear.setFill()
+            backgroundColor.setFill()
             context.fill(CGRect(origin: .zero, size: size))
 
             // Coordinate system must be flipped to match PDF rendering

--- a/firefox-ios/Client/Extensions/UIImage+RenderingUtilities.swift
+++ b/firefox-ios/Client/Extensions/UIImage+RenderingUtilities.swift
@@ -42,7 +42,7 @@ extension UIImage {
             size = baseSize
         }
 
-        let format = UIGraphicsImageRendererFormat.default()
+        let format = UIGraphicsImageRendererFormat.preferred()
         if let scale { format.scale = scale }
         let renderer = UIGraphicsImageRenderer(size: size, format: format)
         return renderer.image { context in

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
@@ -67,8 +67,9 @@ enum WebCompatReportDataCollector {
         payload.hasTouchScreen = true
         payload.defaultUseragentString = device.defaultUserAgent
 
-        let pageUserAgent = tab.pageUserAgent
-        payload.useragentString = (pageUserAgent?.isEmpty == false) ? pageUserAgent : device.defaultUserAgent
+        // Only set when something overrode the UA, so a nil here is distinguishable from a
+        // page that matched the default. The real value is navigator.userAgent (FXIOS-16184).
+        payload.useragentString = tab.pageUserAgent.flatMap { $0.isEmpty ? nil : $0 }
         // An off-screen web view reports a display scale of 0, not nil.
         let pageScale = tab.displayScale ?? 0
         payload.devicePixelRatio = String(format: "%g", pageScale > 0 ? pageScale : device.displayScale)

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
@@ -23,7 +23,7 @@ struct WebCompatDeviceInfoProvider: WebCompatDeviceInfoProviding {
     var preferredLanguages: [String] { Locale.preferredLanguages }
     var isTablet: Bool { UIDeviceDetails.userInterfaceIdiom == .pad }
     var physicalMemoryMegabytes: Int { Int(ProcessInfo.processInfo.physicalMemory / (1024 * 1024)) }
-    /// Desktop UA on iPad, which is what the app actually sends.
+    /// Desktop User Agent on iPad, which is what the app actually sends.
     var defaultUserAgent: String { UserAgent.getUserAgent() }
     var displayScale: CGFloat { UITraitCollection.current.displayScale }
 }
@@ -67,7 +67,7 @@ enum WebCompatReportDataCollector {
         payload.hasTouchScreen = true
         payload.defaultUseragentString = device.defaultUserAgent
 
-        // Only set when something overrode the UA, so a nil here is distinguishable from a
+        // Only set when something overrode the User Agent, so a nil here is distinguishable from a
         // page that matched the default. The real value is navigator.userAgent (FXIOS-16184).
         payload.useragentString = tab.pageUserAgent.flatMap { $0.isEmpty ? nil : $0 }
         // An off-screen web view reports a display scale of 0, not nil.

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import PDFKit
+import Shared
+import UIKit
+import WebKit
+
+/// Device and process values for the report payload. Behind a protocol so tests
+/// can fake them instead of reading `UIDevice`/`ProcessInfo`/`Locale` statics.
+protocol WebCompatDeviceInfoProviding {
+    var preferredLanguages: [String] { get }
+    var isTablet: Bool { get }
+    var physicalMemoryMegabytes: Int { get }
+    var defaultUserAgent: String { get }
+    var displayScale: CGFloat { get }
+}
+
+struct WebCompatDeviceInfoProvider: WebCompatDeviceInfoProviding {
+    var preferredLanguages: [String] { Locale.preferredLanguages }
+    var isTablet: Bool { UIDeviceDetails.userInterfaceIdiom == .pad }
+    var physicalMemoryMegabytes: Int { Int(ProcessInfo.processInfo.physicalMemory / (1024 * 1024)) }
+    /// Desktop UA on iPad, which is what the app actually sends.
+    var defaultUserAgent: String { UserAgent.getUserAgent() }
+    var displayScale: CGFloat { UITraitCollection.current.displayScale }
+}
+
+/// Tab inputs to the payload mapping as a plain value, so tests don't need a live
+/// `Tab`/`WKWebView`. Nil `blockingStrength` means no content blocker.
+/// `blockedOrigins` is only filled when the user opted in.
+struct WebCompatTabSnapshot: Equatable {
+    var isPrivate: Bool
+    var pageUserAgent: String?
+    var displayScale: CGFloat?
+    var blockingStrength: BlockingStrength?
+    var blockedOrigins: [String]?
+}
+
+/// Fills in the parts of the `broken-site-report` payload we can read natively,
+/// plus the page screenshot. The `fastclick`/`marfeel`/`mobify` flags need
+/// JavaScript, so they stay nil until FXIOS-16184.
+enum WebCompatReportDataCollector {
+    /// Reads the tab into a snapshot and hands off to the pure mapping below.
+    @MainActor
+    static func enrich(
+        _ payload: WebCompatReportPayload,
+        tab: Tab,
+        includeBlockedList: Bool,
+        device: WebCompatDeviceInfoProviding = WebCompatDeviceInfoProvider()
+    ) -> WebCompatReportPayload {
+        return enrich(payload, device: device, tab: makeSnapshot(from: tab, includeBlockedList: includeBlockedList))
+    }
+
+    /// The mapping itself — no UIKit, no `Tab` — so tests can drive it with fakes.
+    static func enrich(
+        _ payload: WebCompatReportPayload,
+        device: WebCompatDeviceInfoProviding,
+        tab: WebCompatTabSnapshot
+    ) -> WebCompatReportPayload {
+        var payload = payload
+        // The metric documents `languages` as the page's navigator.languages, which
+        // needs FXIOS-16184. Only `defaultLocales` is an app-level list.
+        payload.defaultLocales = device.preferredLanguages
+        payload.isTablet = device.isTablet
+        payload.memory = device.physicalMemoryMegabytes
+        payload.hasTouchScreen = true
+        payload.defaultUseragentString = device.defaultUserAgent
+
+        let pageUserAgent = tab.pageUserAgent
+        payload.useragentString = (pageUserAgent?.isEmpty == false) ? pageUserAgent : device.defaultUserAgent
+        payload.devicePixelRatio = devicePixelRatioString(tab.displayScale ?? device.displayScale)
+        payload.isPrivateBrowsing = tab.isPrivate
+
+        if let blockingStrength = tab.blockingStrength {
+            payload.blockList = blockingStrength.rawValue
+            payload.etpCategory = blockingStrength.rawValue
+            payload.blockedOrigins = tab.blockedOrigins
+        }
+        return payload
+    }
+
+    /// Blocked trackers, or nil when the user didn't opt in. Kept out of
+    /// `makeSnapshot` so the opt-out is testable without a live `Tab`.
+    static func blockedOrigins(from stats: TPPageStats, includeBlockedList: Bool) -> [String]? {
+        guard includeBlockedList else { return nil }
+        return stats.domains.values.flatMap { $0 }.sorted()
+    }
+
+    /// The page as one tall image, via the same PDF route as "Save as PDF".
+    /// WebKit paginates very tall content and we only render page one, so anything
+    /// past ~14400pt is cut off. Nil if there's no web view or the capture fails.
+    @MainActor
+    static func captureFullPage(
+        from tab: Tab,
+        logger: Logger = DefaultLogger.shared
+    ) async -> UIImage? {
+        guard let webView = tab.webView else {
+            logger.log("WebCompat screenshot skipped: tab has no web view", level: .warning, category: .webview)
+            return nil
+        }
+        do {
+            let data = try await webView.pdf()
+            if let document = PDFDocument(data: data), document.pageCount > 1 {
+                logger.log(
+                    "WebCompat screenshot truncated to the first of \(document.pageCount) PDF pages",
+                    level: .warning,
+                    category: .webview
+                )
+            }
+            // Scale 1: at native scale a full-page bitmap runs to hundreds of MB.
+            guard let image = UIImage.imageFromPDF(data: data, scale: 1, backgroundColor: .white) else {
+                logger.log("WebCompat screenshot failed: could not render the PDF", level: .warning, category: .webview)
+                return nil
+            }
+            return image
+        } catch {
+            logger.log(
+                "WebCompat screenshot failed: \(error.localizedDescription)",
+                level: .warning,
+                category: .webview
+            )
+            return nil
+        }
+    }
+
+    @MainActor
+    private static func makeSnapshot(from tab: Tab, includeBlockedList: Bool) -> WebCompatTabSnapshot {
+        let blocker = tab.contentBlocker
+        return WebCompatTabSnapshot(
+            isPrivate: tab.isPrivate,
+            pageUserAgent: tab.webView?.customUserAgent,
+            displayScale: tab.webView?.traitCollection.displayScale,
+            blockingStrength: blocker?.blockingStrengthPref,
+            blockedOrigins: blocker.flatMap { blockedOrigins(from: $0.stats, includeBlockedList: includeBlockedList) }
+        )
+    }
+
+    private static func devicePixelRatioString(_ value: CGFloat) -> String {
+        return String(format: "%g", value)
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
@@ -65,11 +65,11 @@ enum WebCompatReportDataCollector {
         payload.isTablet = device.isTablet
         payload.memory = device.physicalMemoryMegabytes
         payload.hasTouchScreen = true
-        payload.defaultUseragentString = device.defaultUserAgent
+        payload.defaultUserAgentString = device.defaultUserAgent
 
         // Only set when something overrode the User Agent, so a nil here is distinguishable from a
         // page that matched the default. The real value is navigator.userAgent (FXIOS-16184).
-        payload.useragentString = tab.pageUserAgent.flatMap { $0.isEmpty ? nil : $0 }
+        payload.userAgentString = tab.pageUserAgent.flatMap { $0.isEmpty ? nil : $0 }
         // An off-screen web view reports a display scale of 0, not nil.
         let pageScale = tab.displayScale ?? 0
         payload.devicePixelRatio = String(format: "%g", pageScale > 0 ? pageScale : device.displayScale)

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
@@ -9,8 +9,8 @@ import Shared
 import UIKit
 import WebKit
 
-/// Device and process values for the report payload. Behind a protocol so tests
-/// can fake them instead of reading `UIDevice`/`ProcessInfo`/`Locale` statics.
+/// Device and process values, behind a protocol so tests can fake the
+/// `UIDevice`/`ProcessInfo`/`Locale` statics.
 protocol WebCompatDeviceInfoProviding {
     var preferredLanguages: [String] { get }
     var isTablet: Bool { get }
@@ -28,9 +28,8 @@ struct WebCompatDeviceInfoProvider: WebCompatDeviceInfoProviding {
     var displayScale: CGFloat { UITraitCollection.current.displayScale }
 }
 
-/// Tab inputs to the payload mapping as a plain value, so tests don't need a live
-/// `Tab`/`WKWebView`. Nil `blockingStrength` means no content blocker.
-/// `blockedOrigins` is only filled when the user opted in.
+/// Tab inputs as a plain value, so tests don't need a live `Tab`/`WKWebView`. Nil
+/// `blockingStrength` means no content blocker; `blockedOrigins` is filled only on opt-in.
 struct WebCompatTabSnapshot: Equatable {
     var isPrivate: Bool
     var pageUserAgent: String?
@@ -39,9 +38,8 @@ struct WebCompatTabSnapshot: Equatable {
     var blockedOrigins: [String]?
 }
 
-/// Fills in the parts of the `broken-site-report` payload we can read natively,
-/// plus the page screenshot. The `fastclick`/`marfeel`/`mobify` flags need
-/// JavaScript, so they stay nil until FXIOS-16184.
+/// Fills the `broken-site-report` fields readable natively, plus the page screenshot.
+/// The `fastclick`/`marfeel`/`mobify` flags need JavaScript, so they stay nil until FXIOS-16184.
 enum WebCompatReportDataCollector {
     /// Reads the tab into a snapshot and hands off to the pure mapping below.
     @MainActor
@@ -54,15 +52,15 @@ enum WebCompatReportDataCollector {
         return enrich(payload, device: device, tab: makeSnapshot(from: tab, includeBlockedList: includeBlockedList))
     }
 
-    /// The mapping itself — no UIKit, no `Tab` — so tests can drive it with fakes.
+    /// Pure mapping: no UIKit, no `Tab`, so tests can drive it with fakes.
     static func enrich(
         _ payload: WebCompatReportPayload,
         device: WebCompatDeviceInfoProviding,
         tab: WebCompatTabSnapshot
     ) -> WebCompatReportPayload {
         var payload = payload
-        // The metric documents `languages` as the page's navigator.languages, which
-        // needs FXIOS-16184. Only `defaultLocales` is an app-level list.
+        // `languages` is the page's navigator.languages (FXIOS-16184); only
+        // `defaultLocales` is an app-level list.
         payload.defaultLocales = device.preferredLanguages
         payload.isTablet = device.isTablet
         payload.memory = device.physicalMemoryMegabytes
@@ -71,7 +69,9 @@ enum WebCompatReportDataCollector {
 
         let pageUserAgent = tab.pageUserAgent
         payload.useragentString = (pageUserAgent?.isEmpty == false) ? pageUserAgent : device.defaultUserAgent
-        payload.devicePixelRatio = devicePixelRatioString(tab.displayScale ?? device.displayScale)
+        // An off-screen web view reports a display scale of 0, not nil.
+        let pageScale = tab.displayScale ?? 0
+        payload.devicePixelRatio = String(format: "%g", pageScale > 0 ? pageScale : device.displayScale)
         payload.isPrivateBrowsing = tab.isPrivate
 
         if let blockingStrength = tab.blockingStrength {
@@ -82,16 +82,16 @@ enum WebCompatReportDataCollector {
         return payload
     }
 
-    /// Blocked trackers, or nil when the user didn't opt in. Kept out of
-    /// `makeSnapshot` so the opt-out is testable without a live `Tab`.
+    /// Blocked trackers, or nil without opt-in. Kept out of `makeSnapshot` so the
+    /// opt-out is testable without a live `Tab`.
     static func blockedOrigins(from stats: TPPageStats, includeBlockedList: Bool) -> [String]? {
         guard includeBlockedList else { return nil }
         return stats.domains.values.flatMap { $0 }.sorted()
     }
 
-    /// The page as one tall image, via the same PDF route as "Save as PDF".
-    /// WebKit paginates very tall content and we only render page one, so anything
-    /// past ~14400pt is cut off. Nil if there's no web view or the capture fails.
+    /// The page as one tall image, via the same PDF route as Save as PDF. WebKit
+    /// paginates tall content and only page one is rendered, so anything past
+    /// ~14400pt is cut. Nil if there's no web view or the capture fails.
     @MainActor
     static func captureFullPage(
         from tab: Tab,
@@ -136,9 +136,5 @@ enum WebCompatReportDataCollector {
             blockingStrength: blocker?.blockingStrengthPref,
             blockedOrigins: blocker.flatMap { blockedOrigins(from: $0.stats, includeBlockedList: includeBlockedList) }
         )
-    }
-
-    private static func devicePixelRatioString(_ value: CGFloat) -> String {
-        return String(format: "%g", value)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -14,7 +14,7 @@ struct WebCompatReportPayload: Equatable {
     var description: String?
     // broken_site_report.tab_info
     var languages: [String]?
-    var useragentString: String?
+    var userAgentString: String?
     // broken_site_report.tab_info.antitracking
     var blockList: String?
     var blockedOrigins: [String]?
@@ -26,7 +26,7 @@ struct WebCompatReportPayload: Equatable {
     var mobify: Bool?
     // broken_site_report.browser_info.app
     var defaultLocales: [String]?
-    var defaultUseragentString: String?
+    var defaultUserAgentString: String?
     // broken_site_report.browser_info.graphics
     var devicePixelRatio: String?
     var hasTouchScreen: Bool?

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// One property per Glean metric in `broken_site_report.yaml`. The Report Preview
+/// screen and the eventual submission (FXIOS-16185) both read from here, so field
+/// names are written once rather than per screen.
+///
+/// Page-context data still needs FXIOS-16184, so those fields stay nil.
+struct WebCompatReportPayload: Equatable {
+    // basic
+    var url: String?
+    var breakageCategory: String?
+    var description: String?
+    // tabInfo
+    var languages: [String]?
+    var useragentString: String?
+    // tabInfo.antitracking
+    var blockList: String?
+    var blockedOrigins: [String]?
+    var etpCategory: String?
+    var isPrivateBrowsing: Bool?
+    // tabInfo.frameworks
+    var fastclick: Bool?
+    var marfeel: Bool?
+    var mobify: Bool?
+    // browserInfo.app
+    var defaultLocales: [String]?
+    var defaultUseragentString: String?
+    // browserInfo.graphics
+    var devicePixelRatio: String?
+    var hasTouchScreen: Bool?
+    // browserInfo.system
+    var isTablet: Bool?
+    var memory: Int?
+
+    /// Seeds the payload from the in-progress report: only what the user typed or
+    /// picked, with everything gathered at send time left nil. The sub-option is
+    /// the more specific answer, so it beats the category.
+    static func make(from state: WebCompatReporterState) -> WebCompatReportPayload {
+        var payload = WebCompatReportPayload()
+        payload.url = state.url.isEmpty ? nil : state.url
+        payload.breakageCategory = state.selectedSubOptionID ?? state.selectedCategory?.rawValue
+        payload.description = state.additionalDetails.isEmpty ? nil : state.additionalDetails
+        return payload
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -4,41 +4,38 @@
 
 import Foundation
 
-/// One property per Glean metric in `broken_site_report.yaml`. The Report Preview
-/// screen and the eventual submission (FXIOS-16185) both read from here, so field
-/// names are written once rather than per screen.
-///
-/// Page-context data still needs FXIOS-16184, so those fields stay nil.
+/// One property per Glean metric in `broken_site_report.yaml`, so the field names
+/// live in one place. The struct is flat; each comment below is the Glean category
+/// the fields under it belong to. Page-context fields stay nil until FXIOS-16184.
 struct WebCompatReportPayload: Equatable {
-    // basic
+    // broken_site_report
     var url: String?
     var breakageCategory: String?
     var description: String?
-    // tabInfo
+    // broken_site_report.tab_info
     var languages: [String]?
     var useragentString: String?
-    // tabInfo.antitracking
+    // broken_site_report.tab_info.antitracking
     var blockList: String?
     var blockedOrigins: [String]?
     var etpCategory: String?
     var isPrivateBrowsing: Bool?
-    // tabInfo.frameworks
+    // broken_site_report.tab_info.frameworks
     var fastclick: Bool?
     var marfeel: Bool?
     var mobify: Bool?
-    // browserInfo.app
+    // broken_site_report.browser_info.app
     var defaultLocales: [String]?
     var defaultUseragentString: String?
-    // browserInfo.graphics
+    // broken_site_report.browser_info.graphics
     var devicePixelRatio: String?
     var hasTouchScreen: Bool?
-    // browserInfo.system
+    // broken_site_report.browser_info.system
     var isTablet: Bool?
     var memory: Int?
 
-    /// Seeds the payload from the in-progress report: only what the user typed or
-    /// picked, with everything gathered at send time left nil. The sub-option is
-    /// the more specific answer, so it beats the category.
+    /// Only what the user typed or picked; send-time data stays nil. The sub-option
+    /// wins over the category as the more specific answer.
     static func make(from state: WebCompatReporterState) -> WebCompatReportPayload {
         var payload = WebCompatReportPayload()
         payload.url = state.url.isEmpty ? nil : state.url

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 
 @testable import Client
@@ -137,7 +138,35 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         XCTAssertNil(payload.blockedOrigins)
     }
 
+    // MARK: - Tab-backed collection
+
+    // A tab with no web view still has to produce a payload, falling back to the
+    // device for anything the page would have supplied.
+    func test_enrich_fromTabWithoutWebView_usesTabPrivacyAndDeviceScale() {
+        let tab = Tab(profile: MockProfile(), isPrivate: true, windowUUID: windowUUID)
+
+        let payload = WebCompatReportDataCollector.enrich(
+            WebCompatReportPayload(),
+            tab: tab,
+            includeBlockedList: false,
+            device: FakeDeviceInfoProvider(displayScale: 2.0)
+        )
+
+        XCTAssertEqual(payload.isPrivateBrowsing, true)
+        XCTAssertEqual(payload.devicePixelRatio, "2")
+    }
+
+    func test_captureFullPage_withoutWebView_returnsNil() async {
+        let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
+
+        let image = await WebCompatReportDataCollector.captureFullPage(from: tab)
+
+        XCTAssertNil(image)
+    }
+
     // MARK: - Helpers
+
+    private let windowUUID: WindowUUID = .XCTestDefaultUUID
 
     private func makeSnapshot(
         isPrivate: Bool = false,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
@@ -30,30 +30,30 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
 
         let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
 
-        XCTAssertEqual(payload.useragentString, "PageUA/2.0")
-        XCTAssertEqual(payload.defaultUseragentString, "DefaultUA/1.0")
+        XCTAssertEqual(payload.userAgentString, "PageUA/2.0")
+        XCTAssertEqual(payload.defaultUserAgentString, "DefaultUA/1.0")
     }
 
     // Without an override there is no page UA to report. Copying the device default
     // would be indistinguishable in the ping from a page that genuinely matched it.
-    func test_enrich_emptyPageUserAgent_leavesUseragentStringNil() {
+    func test_enrich_emptyPageUserAgent_leavesUserAgentStringNil() {
         let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
         let snapshot = makeSnapshot(pageUserAgent: "")
 
         let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
 
-        XCTAssertNil(payload.useragentString)
-        XCTAssertEqual(payload.defaultUseragentString, "DefaultUA/1.0")
+        XCTAssertNil(payload.userAgentString)
+        XCTAssertEqual(payload.defaultUserAgentString, "DefaultUA/1.0")
     }
 
-    func test_enrich_nilPageUserAgent_leavesUseragentStringNil() {
+    func test_enrich_nilPageUserAgent_leavesUserAgentStringNil() {
         let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
         let snapshot = makeSnapshot(pageUserAgent: nil)
 
         let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
 
-        XCTAssertNil(payload.useragentString)
-        XCTAssertEqual(payload.defaultUseragentString, "DefaultUA/1.0")
+        XCTAssertNil(payload.userAgentString)
+        XCTAssertEqual(payload.defaultUserAgentString, "DefaultUA/1.0")
     }
 
     // MARK: - devicePixelRatio precedence

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
@@ -1,0 +1,174 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class WebCompatReportDataCollectorTests: XCTestCase {
+    // MARK: - Device fields
+
+    // The native locale list must only reach `defaultLocales`. `languages` is page
+    // data and needs FXIOS-16184.
+    func test_enrich_deviceLocales_populateDefaultLocalesButNotLanguages() {
+        let device = FakeDeviceInfoProvider(preferredLanguages: ["en-US", "fr-FR"])
+
+        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: makeSnapshot())
+
+        XCTAssertEqual(payload.defaultLocales, ["en-US", "fr-FR"])
+        XCTAssertNil(payload.languages)
+    }
+
+    // MARK: - useragent fallback
+
+    func test_enrich_nonEmptyPageUserAgent_isUsed() {
+        let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
+        let snapshot = makeSnapshot(pageUserAgent: "PageUA/2.0")
+
+        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
+
+        XCTAssertEqual(payload.useragentString, "PageUA/2.0")
+    }
+
+    func test_enrich_emptyPageUserAgent_fallsBackToDevice() {
+        let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
+        let snapshot = makeSnapshot(pageUserAgent: "")
+
+        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
+
+        XCTAssertEqual(payload.useragentString, "DefaultUA/1.0")
+    }
+
+    func test_enrich_nilPageUserAgent_fallsBackToDevice() {
+        let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
+        let snapshot = makeSnapshot(pageUserAgent: nil)
+
+        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
+
+        XCTAssertEqual(payload.useragentString, "DefaultUA/1.0")
+    }
+
+    // MARK: - devicePixelRatio precedence
+
+    func test_enrich_tabDisplayScale_takesPrecedenceOverDevice() {
+        let device = FakeDeviceInfoProvider(displayScale: 2.0)
+        let snapshot = makeSnapshot(displayScale: 3.0)
+
+        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
+
+        XCTAssertEqual(payload.devicePixelRatio, "3")
+    }
+
+    func test_enrich_nilTabDisplayScale_fallsBackToDevice() {
+        let device = FakeDeviceInfoProvider(displayScale: 2.0)
+        let snapshot = makeSnapshot(displayScale: nil)
+
+        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
+
+        XCTAssertEqual(payload.devicePixelRatio, "2")
+    }
+
+    // MARK: - ETP category
+
+    func test_enrich_strictBlocking_mapsToStrictCategory() {
+        let snapshot = makeSnapshot(blockingStrength: .strict)
+
+        let payload = WebCompatReportDataCollector.enrich(
+            WebCompatReportPayload(),
+            device: FakeDeviceInfoProvider(),
+            tab: snapshot
+        )
+
+        XCTAssertEqual(payload.blockList, "strict")
+        XCTAssertEqual(payload.etpCategory, "strict")
+    }
+
+    func test_enrich_basicBlocking_mapsToBasicCategory() {
+        let snapshot = makeSnapshot(blockingStrength: .basic)
+
+        let payload = WebCompatReportDataCollector.enrich(
+            WebCompatReportPayload(),
+            device: FakeDeviceInfoProvider(),
+            tab: snapshot
+        )
+
+        XCTAssertEqual(payload.blockList, "basic")
+        XCTAssertEqual(payload.etpCategory, "basic")
+    }
+
+    func test_enrich_noBlocker_leavesBlockListAndCategoryNil() {
+        let snapshot = makeSnapshot(blockingStrength: nil)
+
+        let payload = WebCompatReportDataCollector.enrich(
+            WebCompatReportPayload(),
+            device: FakeDeviceInfoProvider(),
+            tab: snapshot
+        )
+
+        XCTAssertNil(payload.blockList)
+        XCTAssertNil(payload.etpCategory)
+        XCTAssertNil(payload.blockedOrigins)
+    }
+
+    // MARK: - blockedOrigins opt-in
+
+    func test_blockedOrigins_whenNotIncluded_isNil() {
+        XCTAssertNil(WebCompatReportDataCollector.blockedOrigins(from: makeStats(), includeBlockedList: false))
+    }
+
+    func test_blockedOrigins_whenIncluded_isSortedAcrossCategories() {
+        let origins = WebCompatReportDataCollector.blockedOrigins(from: makeStats(), includeBlockedList: true)
+
+        XCTAssertEqual(origins, ["a.example", "b.example", "c.example"])
+    }
+
+    // No content blocker means no blocked list, even if the user opted in.
+    func test_enrich_blockedOriginsWithoutBlockingStrength_areDropped() {
+        let snapshot = makeSnapshot(blockingStrength: nil, blockedOrigins: ["a.example"])
+
+        let payload = WebCompatReportDataCollector.enrich(
+            WebCompatReportPayload(),
+            device: FakeDeviceInfoProvider(),
+            tab: snapshot
+        )
+
+        XCTAssertNil(payload.blockedOrigins)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSnapshot(
+        isPrivate: Bool = false,
+        pageUserAgent: String? = nil,
+        displayScale: CGFloat? = nil,
+        blockingStrength: BlockingStrength? = nil,
+        blockedOrigins: [String]? = nil
+    ) -> WebCompatTabSnapshot {
+        return WebCompatTabSnapshot(
+            isPrivate: isPrivate,
+            pageUserAgent: pageUserAgent,
+            displayScale: displayScale,
+            blockingStrength: blockingStrength,
+            blockedOrigins: blockedOrigins
+        )
+    }
+
+    private func makeStats() -> TPPageStats {
+        var stats = TPPageStats()
+        stats.domains = [
+            .advertising: ["b.example", "a.example"],
+            .analytics: ["c.example"]
+        ]
+        return stats
+    }
+
+    private struct FakeDeviceInfoProvider: WebCompatDeviceInfoProviding {
+        var preferredLanguages: [String] = ["en-US"]
+        var isTablet = false
+        var physicalMemoryMegabytes = 2048
+        var defaultUserAgent = "FakeUA/1.0"
+        var displayScale: CGFloat = 2.0
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
@@ -22,7 +22,7 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         XCTAssertNil(payload.languages)
     }
 
-    // MARK: - useragent fallback
+    // MARK: - useragent
 
     func test_enrich_nonEmptyPageUserAgent_isUsed() {
         let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
@@ -31,24 +31,29 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
 
         XCTAssertEqual(payload.useragentString, "PageUA/2.0")
+        XCTAssertEqual(payload.defaultUseragentString, "DefaultUA/1.0")
     }
 
-    func test_enrich_emptyPageUserAgent_fallsBackToDevice() {
+    // Without an override there is no page UA to report. Copying the device default
+    // would be indistinguishable in the ping from a page that genuinely matched it.
+    func test_enrich_emptyPageUserAgent_leavesUseragentStringNil() {
         let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
         let snapshot = makeSnapshot(pageUserAgent: "")
 
         let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
 
-        XCTAssertEqual(payload.useragentString, "DefaultUA/1.0")
+        XCTAssertNil(payload.useragentString)
+        XCTAssertEqual(payload.defaultUseragentString, "DefaultUA/1.0")
     }
 
-    func test_enrich_nilPageUserAgent_fallsBackToDevice() {
+    func test_enrich_nilPageUserAgent_leavesUseragentStringNil() {
         let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
         let snapshot = makeSnapshot(pageUserAgent: nil)
 
         let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
 
-        XCTAssertEqual(payload.useragentString, "DefaultUA/1.0")
+        XCTAssertNil(payload.useragentString)
+        XCTAssertEqual(payload.defaultUseragentString, "DefaultUA/1.0")
     }
 
     // MARK: - devicePixelRatio precedence

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+
+@testable import Client
+
+final class WebCompatReportPayloadTests: XCTestCase {
+    func testMake_emptyURLAndDetails_stayNil() {
+        let payload = WebCompatReportPayload.make(from: makeState(url: "", additionalDetails: ""))
+
+        XCTAssertNil(payload.url)
+        XCTAssertNil(payload.description)
+    }
+
+    func testMake_subOption_winsOverCategory() {
+        let state = makeState(selectedCategory: .videoOrAudio, selectedSubOptionID: "no_audio")
+
+        let payload = WebCompatReportPayload.make(from: state)
+
+        XCTAssertEqual(payload.breakageCategory, "no_audio")
+    }
+
+    func testMake_categoryWithoutSubOption_usesCategory() {
+        let state = makeState(selectedCategory: .siteNotUsable, selectedSubOptionID: nil)
+
+        let payload = WebCompatReportPayload.make(from: state)
+
+        XCTAssertEqual(payload.breakageCategory, WebCompatIssueCategory.siteNotUsable.rawValue)
+    }
+
+    func testMake_noCategorySelected_leavesBreakageCategoryNil() {
+        let payload = WebCompatReportPayload.make(from: makeState())
+
+        XCTAssertNil(payload.breakageCategory)
+    }
+
+    // MARK: - Helpers
+
+    private func makeState(
+        url: String = "",
+        selectedCategory: WebCompatIssueCategory? = nil,
+        selectedSubOptionID: String? = nil,
+        additionalDetails: String = ""
+    ) -> WebCompatReporterState {
+        return WebCompatReporterState(
+            windowUUID: .XCTestDefaultUUID,
+            url: url,
+            selectedCategory: selectedCategory,
+            selectedSubOptionID: selectedSubOptionID,
+            additionalDetails: additionalDetails,
+            includeScreenshot: true,
+            includeBlockedList: false
+        )
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16183](https://mozilla-hub.atlassian.net/browse/FXIOS-16183)

## :bulb: Description
Adds the report payload model and the collector that fills in its device- and tab-derived fields. Taken out of #34610 and rebuilt on `main`.

`WebCompatReportPayload` has one property per Glean `broken_site_report` metric, so the field names live in one place. The Report Preview screen and the eventual Glean submission both read from it.

`WebCompatReportDataCollector` reads the device and the current tab and captures a full-page screenshot via `createPDF`, the same mechanism as Save as PDF. Device and tab access goes through `WebCompatDeviceInfoProviding` and a flat `WebCompatTabSnapshot`, which keeps the field mapping a pure function. Tests can feed it fakes and never touch `UIDevice`/`ProcessInfo`/`Locale`.

Two things to know about what lands in the ping. `useragentString` is only set when the page overrode the user agent; copying the device default would be indistinguishable from a page that genuinely matched it, so it stays nil until `navigator.userAgent` arrives with FXIOS-16184. And `devicePixelRatio` falls back to the device scale when the web view reports none, since an off-screen web view returns 0 rather than nil.

The `fastclick`/`marfeel`/`mobify` flags need the page-context script, so they stay nil until FXIOS-16184.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
No UI and nothing calls this yet. Read `WebCompatReportDataCollector` and its tests in `WebCompatReportDataCollectorTests.swift`.


[FXIOS-16183]: https://mozilla-hub.atlassian.net/browse/FXIOS-16183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
