### PR TITLE
Add FXIOS-16186 [WebCompat] Add the full page screenshot viewer

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
@@ -50,6 +50,10 @@ private struct FullPageScreenshotPreview: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> WebCompatFullPageScreenshotViewController {
         return WebCompatFullPageScreenshotViewController(
             image: samplePage(),
+            viewModel: WebCompatFullPageScreenshotViewModel(
+                captureAccessibilityLabel: "Screenshot of the page",
+                captureAccessibilityIdentifier: "WebCompatReporter.Preview.ScreenshotCapture"
+            ),
             closeButtonViewModel: CloseButtonViewModel(
                 a11yLabel: "Close",
                 a11yIdentifier: "WebCompatReporter.Preview.ScreenshotClose"

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
@@ -8,57 +8,107 @@ import ComponentLibrary
 import SwiftUI
 import UIKit
 
-@MainActor
-private func previewFullPageScreenshot(pageHeight: CGFloat) -> UIViewController {
-    return WebCompatFullPageScreenshotViewController(
-        image: previewSampleCapture(pageHeight: pageHeight),
-        closeButtonViewModel: CloseButtonViewModel(
-            a11yLabel: "Close",
-            a11yIdentifier: "WebCompatReporter.Preview.ScreenshotClose"
-        ),
-        theme: LightTheme()
-    )
-}
+/// Hosts the viewer over a stand-in page: heading, image block, filler lines.
+private struct FullPageScreenshotPreview: UIViewControllerRepresentable {
+    enum PageLength: CGFloat {
+        case short = 400
+        case tall = 2400
+    }
 
-/// A stand-in page: heading, image block, filler lines. Enough for the rail and
-/// the highlight to track something.
-private func previewSampleCapture(pageHeight: CGFloat) -> UIImage {
-    let size = CGSize(width: 320, height: pageHeight)
-    let renderer = UIGraphicsImageRenderer(size: size)
-    return renderer.image { context in
-        UIColor.white.setFill()
-        context.fill(CGRect(origin: .zero, size: size))
+    private enum UX {
+        static let pageWidth: CGFloat = 320
+        static let horizontalInset: CGFloat = 16
 
-        "Croque Monsieur".draw(
-            at: CGPoint(x: 16, y: 24),
-            withAttributes: [.font: UIFont.boldSystemFont(ofSize: 28), .foregroundColor: UIColor.black]
+        enum Title {
+            static let top: CGFloat = 24
+            static let fontSize: CGFloat = 28
+        }
+
+        enum ImageBlock {
+            static let top: CGFloat = 72
+            static let height: CGFloat = 180
+            static let cornerRadius: CGFloat = 8
+            static let color = UIColor(red: 0.72, green: 0.55, blue: 0.36, alpha: 1)
+        }
+
+        enum TextLine {
+            static let top: CGFloat = 280
+            static let height: CGFloat = 10
+            static let spacing: CGFloat = 26
+            static let cornerRadius: CGFloat = 3
+            static let opacity: CGFloat = 0.12
+        }
+    }
+
+    let pageLength: PageLength
+
+    func makeUIViewController(context: Context) -> WebCompatFullPageScreenshotViewController {
+        return WebCompatFullPageScreenshotViewController(
+            image: samplePage(),
+            closeButtonViewModel: CloseButtonViewModel(
+                a11yLabel: "Close",
+                a11yIdentifier: "WebCompatReporter.Preview.ScreenshotClose"
+            ),
+            theme: LightTheme()
         )
+    }
 
-        UIColor(red: 0.72, green: 0.55, blue: 0.36, alpha: 1).setFill()
-        UIBezierPath(
-            roundedRect: CGRect(x: 16, y: 72, width: size.width - 32, height: 180),
-            cornerRadius: 8
-        ).fill()
+    func updateUIViewController(_ viewController: WebCompatFullPageScreenshotViewController, context: Context) {}
 
-        UIColor.black.withAlphaComponent(0.12).setFill()
-        var lineY: CGFloat = 280
-        while lineY < size.height - 20 {
+    private func samplePage() -> UIImage {
+        let size = CGSize(width: UX.pageWidth, height: pageLength.rawValue)
+        let contentWidth = size.width - UX.horizontalInset * 2
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+
+            "Croque Monsieur".draw(
+                at: CGPoint(x: UX.horizontalInset, y: UX.Title.top),
+                withAttributes: [
+                    .font: UIFont.boldSystemFont(ofSize: UX.Title.fontSize),
+                    .foregroundColor: UIColor.black
+                ]
+            )
+
+            UX.ImageBlock.color.setFill()
             UIBezierPath(
-                roundedRect: CGRect(x: 16, y: lineY, width: size.width - 32, height: 10),
-                cornerRadius: 3
+                roundedRect: CGRect(
+                    x: UX.horizontalInset,
+                    y: UX.ImageBlock.top,
+                    width: contentWidth,
+                    height: UX.ImageBlock.height
+                ),
+                cornerRadius: UX.ImageBlock.cornerRadius
             ).fill()
-            lineY += 26
+
+            UIColor.black.withAlphaComponent(UX.TextLine.opacity).setFill()
+            var lineY = UX.TextLine.top
+            while lineY + UX.TextLine.height < size.height {
+                UIBezierPath(
+                    roundedRect: CGRect(
+                        x: UX.horizontalInset,
+                        y: lineY,
+                        width: contentWidth,
+                        height: UX.TextLine.height
+                    ),
+                    cornerRadius: UX.TextLine.cornerRadius
+                ).fill()
+                lineY += UX.TextLine.spacing
+            }
         }
     }
 }
 
 @available(iOS 17.0, *)
 #Preview("Tall page") {
-    previewFullPageScreenshot(pageHeight: 2400)
+    FullPageScreenshotPreview(pageLength: .tall)
+        .ignoresSafeArea()
 }
 
 @available(iOS 17.0, *)
 #Preview("Short page") {
-    previewFullPageScreenshot(pageHeight: 400)
+    FullPageScreenshotPreview(pageLength: .short)
+        .ignoresSafeArea()
 }
 #endif

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
@@ -13,6 +13,8 @@ private struct FullPageScreenshotPreview: UIViewControllerRepresentable {
     enum PageLength: CGFloat {
         case short = 400
         case tall = 2400
+        /// Past the point where the rail runs out of vertical room.
+        case long = 8000
     }
 
     private enum UX {
@@ -109,6 +111,12 @@ private struct FullPageScreenshotPreview: UIViewControllerRepresentable {
 @available(iOS 17.0, *)
 #Preview("Short page") {
     FullPageScreenshotPreview(pageLength: .short)
+        .ignoresSafeArea()
+}
+
+@available(iOS 17.0, *)
+#Preview("Long page") {
+    FullPageScreenshotPreview(pageLength: .long)
         .ignoresSafeArea()
 }
 #endif

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+#if DEBUG
+import Common
+import ComponentLibrary
+import SwiftUI
+import UIKit
+
+@MainActor
+private func previewFullPageScreenshot(pageHeight: CGFloat) -> UIViewController {
+    return WebCompatFullPageScreenshotViewController(
+        image: previewSampleCapture(pageHeight: pageHeight),
+        closeButtonViewModel: CloseButtonViewModel(
+            a11yLabel: "Close",
+            a11yIdentifier: "WebCompatReporter.Preview.ScreenshotClose"
+        ),
+        theme: LightTheme()
+    )
+}
+
+/// A stand-in page: heading, image block, filler lines. Enough for the rail and
+/// the highlight to track something.
+private func previewSampleCapture(pageHeight: CGFloat) -> UIImage {
+    let size = CGSize(width: 320, height: pageHeight)
+    let renderer = UIGraphicsImageRenderer(size: size)
+    return renderer.image { context in
+        UIColor.white.setFill()
+        context.fill(CGRect(origin: .zero, size: size))
+
+        "Croque Monsieur".draw(
+            at: CGPoint(x: 16, y: 24),
+            withAttributes: [.font: UIFont.boldSystemFont(ofSize: 28), .foregroundColor: UIColor.black]
+        )
+
+        UIColor(red: 0.72, green: 0.55, blue: 0.36, alpha: 1).setFill()
+        UIBezierPath(
+            roundedRect: CGRect(x: 16, y: 72, width: size.width - 32, height: 180),
+            cornerRadius: 8
+        ).fill()
+
+        UIColor.black.withAlphaComponent(0.12).setFill()
+        var lineY: CGFloat = 280
+        while lineY < size.height - 20 {
+            UIBezierPath(
+                roundedRect: CGRect(x: 16, y: lineY, width: size.width - 32, height: 10),
+                cornerRadius: 3
+            ).fill()
+            lineY += 26
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview("Tall page") {
+    previewFullPageScreenshot(pageHeight: 2400)
+}
+
+@available(iOS 17.0, *)
+#Preview("Short page") {
+    previewFullPageScreenshot(pageHeight: 400)
+}
+#endif

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
@@ -9,6 +9,9 @@ import SwiftUI
 import UIKit
 
 /// Hosts the viewer over a stand-in page: heading, image block, filler lines.
+///
+/// The page is drawn the way a website would render, so its colours are the page's own and
+/// deliberately not the app theme — a real capture doesn't follow the theme either.
 private struct FullPageScreenshotPreview: UIViewControllerRepresentable {
     enum PageLength: CGFloat {
         case short = 400
@@ -30,7 +33,7 @@ private struct FullPageScreenshotPreview: UIViewControllerRepresentable {
             static let top: CGFloat = 72
             static let height: CGFloat = 180
             static let cornerRadius: CGFloat = 8
-            static let color = UIColor(red: 0.72, green: 0.55, blue: 0.36, alpha: 1)
+            static let color = UIColor.systemBrown
         }
 
         enum TextLine {

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
@@ -1,0 +1,254 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import UIKit
+
+/// The iOS "Full Page" screenshot preview, near enough (Figma 23608-67772). The
+/// capture scrolls in the middle; a slim thumbnail of the whole page floats in
+/// the right margin with a highlight that follows the scroll.
+final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollViewDelegate {
+    private enum UX {
+        static let topInset: CGFloat = 72
+        static let bottomInset: CGFloat = 24
+        static let railGap: CGFloat = 12
+        static let captureCornerRadius: CGFloat = 12
+        static let thumbnailCornerRadius: CGFloat = 10
+        static let thumbnailBorderWidth: CGFloat = 2
+        static let thumbnailWidth: CGFloat = 44
+        /// The thumbnail base is dimmed to this; a bright copy clipped over it
+        /// picks out the current viewport.
+        static let thumbnailDimOpacity: CGFloat = 0.4
+        static let highlightCornerRadius: CGFloat = 8
+        static let highlightBorderWidth: CGFloat = 3
+        static let highlightShadowOpacity: Float = 0.5
+        static let highlightShadowRadius: CGFloat = 3
+        static let minimumHighlightHeight: CGFloat = 24
+        static let closeButtonTopInset: CGFloat = 24
+        /// Under this we're still mid-presentation, so skip the layout and hide
+        /// the content until the size means something.
+        static let minimumUsableSide: CGFloat = 80
+    }
+
+    var onClose: (() -> Void)?
+
+    private let image: UIImage?
+    private let imageAspect: CGFloat
+
+    private var scrollFraction: CGFloat = 0
+    /// Cached in `layoutSubviews` so a scroll only moves the highlight instead of
+    /// redoing the whole geometry pass every frame.
+    private struct HighlightGeometry {
+        let thumbnailHeight: CGFloat
+        let viewportHeight: CGFloat
+        let pageHeight: CGFloat
+    }
+
+    private var highlightGeometry: HighlightGeometry?
+
+    // `private(set)` so the layout tests can read these frames directly rather
+    // than walking the hierarchy by index.
+    private(set) lazy var captureContainer: UIView = {
+        let view = UIView()
+        view.clipsToBounds = true
+        view.layer.cornerRadius = UX.captureCornerRadius
+        return view
+    }()
+
+    private(set) lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.delegate = self
+        return scrollView
+    }()
+
+    private lazy var pageImageView: UIImageView = {
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+
+    private(set) lazy var thumbnailContainer: UIView = {
+        let view = UIView()
+        view.clipsToBounds = true
+        view.layer.cornerRadius = UX.thumbnailCornerRadius
+        view.layer.borderWidth = UX.thumbnailBorderWidth
+        return view
+    }()
+
+    /// The dimmed whole page behind the highlight.
+    private lazy var thumbnailImageView: UIImageView = {
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleToFill
+        imageView.alpha = UX.thumbnailDimOpacity
+        return imageView
+    }()
+
+    /// A bright copy of the page clipped to the viewport, which is what gives the
+    /// native spotlight effect.
+    private lazy var brightWindowContainer: UIView = {
+        let view = UIView()
+        view.clipsToBounds = true
+        view.layer.cornerRadius = UX.highlightCornerRadius
+        return view
+    }()
+
+    private(set) lazy var brightWindowImageView: UIImageView = {
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleToFill
+        return imageView
+    }()
+
+    private(set) lazy var highlightView: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = UX.highlightCornerRadius
+        view.layer.borderWidth = UX.highlightBorderWidth
+        view.layer.shadowOpacity = UX.highlightShadowOpacity
+        view.layer.shadowRadius = UX.highlightShadowRadius
+        view.layer.shadowOffset = .zero
+        return view
+    }()
+
+    private lazy var closeButton: CloseButton = .build { button in
+        button.addTarget(self, action: #selector(self.didTapClose), for: .touchUpInside)
+    }
+
+    init(image: UIImage?, closeButtonViewModel: CloseButtonViewModel) {
+        self.image = image
+        let size = image?.size ?? .zero
+        let aspect = size.height / size.width
+        self.imageAspect = (size.width > 0 && aspect.isFinite) ? aspect : 1
+        super.init(frame: .zero)
+
+        captureContainer.addSubview(scrollView)
+        scrollView.addSubview(pageImageView)
+        thumbnailContainer.addSubview(thumbnailImageView)
+        brightWindowContainer.addSubview(brightWindowImageView)
+        addSubview(captureContainer)
+        addSubview(thumbnailContainer)
+        // A sibling of the thumbnail rather than a child, otherwise the border and
+        // shadow get clipped away.
+        addSubview(brightWindowContainer)
+        addSubview(highlightView)
+        addSubview(closeButton)
+
+        closeButton.configure(viewModel: closeButtonViewModel)
+        NSLayoutConstraint.activate([
+            closeButton.leadingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.leadingAnchor,
+                constant: WebCompatReporterUX.Spacing.screenHorizontal
+            ),
+            closeButton.topAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.topAnchor,
+                constant: UX.closeButtonTopInset
+            )
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let contentTop = safeAreaInsets.top + UX.topInset
+        let availableHeight = max(1, bounds.height - contentTop - safeAreaInsets.bottom - UX.bottomInset)
+        // The thumbnail shows the whole page, so cap its height or a tall page overflows.
+        var thumbnailWidth = UX.thumbnailWidth
+        var thumbnailHeight = thumbnailWidth * imageAspect
+        if thumbnailHeight > availableHeight {
+            thumbnailHeight = availableHeight
+            thumbnailWidth = max(1, thumbnailHeight / imageAspect)
+        }
+        // Equal margins either side keep the capture centered, with the rail in the right one.
+        let sideMargin = WebCompatReporterUX.Spacing.screenHorizontal + thumbnailWidth + UX.railGap
+        let captureWidth = max(1, bounds.width - sideMargin * 2)
+        // Wait for a real size. Laying out mid-transition gives the capture and rail
+        // wildly wrong proportions.
+        let hasUsableSize = captureWidth > UX.minimumUsableSide && availableHeight > UX.minimumUsableSide
+        let isRenderable = hasUsableSize && image != nil
+        for view in [captureContainer, thumbnailContainer, brightWindowContainer, highlightView] {
+            view.isHidden = !isRenderable
+        }
+        guard isRenderable else {
+            highlightGeometry = nil
+            return
+        }
+
+        let pageHeight = max(1, captureWidth * imageAspect)
+        captureContainer.frame = CGRect(x: sideMargin, y: contentTop, width: captureWidth, height: availableHeight)
+        scrollView.frame = captureContainer.bounds
+        pageImageView.frame = CGRect(x: 0, y: 0, width: captureWidth, height: pageHeight)
+        scrollView.contentSize = CGSize(width: captureWidth, height: pageHeight)
+
+        thumbnailContainer.frame = CGRect(
+            x: bounds.width - WebCompatReporterUX.Spacing.screenHorizontal - thumbnailWidth,
+            y: contentTop,
+            width: thumbnailWidth,
+            height: thumbnailHeight
+        )
+        thumbnailImageView.frame = thumbnailContainer.bounds
+        highlightGeometry = HighlightGeometry(
+            thumbnailHeight: thumbnailHeight,
+            viewportHeight: availableHeight,
+            pageHeight: pageHeight
+        )
+        layoutViewportHighlight()
+    }
+
+    private func layoutViewportHighlight() {
+        guard let geometry = highlightGeometry else { return }
+        // In the view's coordinate space, since it's a sibling of the thumbnail.
+        let thumbnailFrame = thumbnailContainer.frame
+        let width = thumbnailFrame.width
+        let visibleFraction = min(1, geometry.viewportHeight / geometry.pageHeight)
+        let highlightHeight = max(UX.minimumHighlightHeight, geometry.thumbnailHeight * visibleFraction)
+        let travel = max(0, geometry.thumbnailHeight - highlightHeight)
+        let highlightTop = scrollFraction * travel
+
+        let windowFrame = CGRect(
+            x: thumbnailFrame.minX,
+            y: thumbnailFrame.minY + highlightTop,
+            width: width,
+            height: highlightHeight
+        )
+        highlightView.frame = windowFrame
+        // Shift the bright copy so its visible slice lines up with the dimmed page
+        // underneath. Otherwise the spotlight shows the wrong part.
+        brightWindowContainer.frame = windowFrame
+        brightWindowImageView.frame = CGRect(x: 0, y: -highlightTop, width: width, height: geometry.thumbnailHeight)
+    }
+
+    // MARK: - Scroll sync
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let maximumOffset = max(1, scrollView.contentSize.height - scrollView.bounds.height)
+        let fraction = scrollView.contentOffset.y / maximumOffset
+        scrollFraction = min(max(fraction.isFinite ? fraction : 0, 0), 1)
+        // Only the highlight moves. No need for a full layout pass per frame.
+        layoutViewportHighlight()
+    }
+
+    // MARK: - Actions
+
+    @objc
+    private func didTapClose() {
+        onClose?()
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        // The scrim from the native full-page preview (Figma 23608-67772).
+        backgroundColor = theme.colors.layerScrim
+        thumbnailContainer.layer.borderColor = theme.colors.iconSecondary.cgColor
+        highlightView.layer.borderColor = theme.colors.borderInverted.cgColor
+        highlightView.layer.shadowColor = theme.colors.shadowStrong.cgColor
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
@@ -39,11 +39,12 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
     var onClose: (() -> Void)?
 
     private let image: UIImage?
-    private let imageAspect: CGFloat
+    private let viewModel: WebCompatFullPageScreenshotViewModel
+    private let imageHeightToWidthRatio: CGFloat
 
     /// The page as the capture renders it, which is what the highlight measures itself against.
     private var pageHeight: CGFloat {
-        return scrollView.bounds.width * imageAspect
+        return scrollView.bounds.width * imageHeightToWidthRatio
     }
 
     private var scrollFraction: CGFloat {
@@ -64,8 +65,8 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         return max(UX.minimumHighlightHeight, railHeight * visibleFraction)
     }
 
-    // `private(set)` so the module's layout tests can read these frames without walking the
-    // hierarchy. Nothing outside the view can mutate or replace them.
+    // `private(set)` so the module's layout tests can read these frames and accessibility wiring
+    // without walking the hierarchy. Nothing outside the view can reassign them.
     private(set) lazy var scrollView: UIScrollView = .build { scrollView in
         scrollView.showsVerticalScrollIndicator = false
         // Rounds the capture's corners.
@@ -74,9 +75,15 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         scrollView.delegate = self
     }
 
-    private lazy var pageImageView: UIImageView = .build { imageView in
+    /// The capture itself, and the one element VoiceOver reads on this screen. It sits inside the
+    /// scroll view so focusing it also lets the three-finger scroll move the page.
+    private(set) lazy var pageImageView: UIImageView = .build { imageView in
         imageView.image = self.image
         imageView.contentMode = .scaleToFill
+        imageView.isAccessibilityElement = true
+        imageView.accessibilityTraits = .image
+        imageView.accessibilityLabel = self.viewModel.captureAccessibilityLabel
+        imageView.accessibilityIdentifier = self.viewModel.captureAccessibilityIdentifier
     }
 
     private(set) lazy var thumbnailContainer: UIView = .build { view in
@@ -115,13 +122,25 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
 
     private(set) lazy var closeButton: CloseButton = .build { button in
         button.addTarget(self, action: #selector(self.didTapClose), for: .touchUpInside)
+        // Its icon is an appearance-adaptive asset rather than a template, so no tint reaches it.
+        // The dark variant fills the circle with #312F33, which all but disappears against the
+        // scrim; pinning the appearance keeps the white-filled variant over a surface that is
+        // dark in every palette.
+        button.overrideUserInterfaceStyle = .light
     }
 
-    init(image: UIImage?, closeButtonViewModel: CloseButtonViewModel) {
+    init(
+        image: UIImage?,
+        viewModel: WebCompatFullPageScreenshotViewModel,
+        closeButtonViewModel: CloseButtonViewModel
+    ) {
         self.image = image
+        self.viewModel = viewModel
         let size = image?.size ?? .zero
-        let aspect = size.height / size.width
-        self.imageAspect = (size.width > 0 && aspect.isFinite) ? aspect : 1
+        let ratio = size.height / size.width
+        // Both dimensions, or a zero-height capture yields a ratio of 0 that passes `isFinite`
+        // and then collapses the capture to nothing while still reporting itself renderable.
+        self.imageHeightToWidthRatio = (size.width > 0 && size.height > 0 && ratio.isFinite) ? ratio : 1
         super.init(frame: .zero)
 
         setupSubviews()
@@ -143,6 +162,12 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         for imageView in [pageImageView, thumbnailImageView, brightWindowImageView] {
             imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
             imageView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        }
+        // The rail is a map of the capture, not content of its own, so VoiceOver reads the capture
+        // once rather than three times over.
+        for view in [thumbnailContainer, thumbnailImageView, brightWindowContainer,
+                     brightWindowImageView, highlightView] {
+            view.isAccessibilityElement = false
         }
 
         scrollView.addSubview(pageImageView)
@@ -178,7 +203,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         // the image's bottom edge square.
         let ratio = scrollView.heightAnchor.constraint(
             equalTo: scrollView.widthAnchor,
-            multiplier: imageAspect
+            multiplier: imageHeightToWidthRatio
         )
         ratio.priority = .defaultHigh
         let width = scrollView.widthAnchor.constraint(
@@ -204,7 +229,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
             pageImageView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
             pageImageView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
             pageImageView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
-            pageImageView.heightAnchor.constraint(equalTo: pageImageView.widthAnchor, multiplier: imageAspect)
+            pageImageView.heightAnchor.constraint(equalTo: pageImageView.widthAnchor, multiplier: imageHeightToWidthRatio)
         ]
     }
 
@@ -212,7 +237,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         // The rail keeps a fixed width and squashes a tall page rather than narrowing, which
         // would otherwise feed back into the margins and reflow the capture.
         let height = thumbnailContainer.heightAnchor.constraint(
-            equalToConstant: max(UX.minimumRailHeight, UX.thumbnailWidth * imageAspect)
+            equalToConstant: max(UX.minimumRailHeight, UX.thumbnailWidth * imageHeightToWidthRatio)
         )
         height.priority = .defaultHigh
         let bottom = thumbnailContainer.bottomAnchor.constraint(
@@ -317,7 +342,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
     // MARK: - Accessibility
 
     /// The sheet underneath stays mounted, so VoiceOver needs pointing at the viewer.
-    func moveAccessibilityFocusToFirstElement() {
+    func moveAccessibilityFocusToCloseButton() {
         UIAccessibility.post(notification: .screenChanged, argument: closeButton)
     }
 
@@ -338,8 +363,11 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
 
     func applyTheme(theme: Theme) {
         backgroundColor = theme.colors.layerScrim
-        thumbnailContainer.layer.borderColor = theme.colors.iconSecondary.cgColor
-        highlightView.layer.borderColor = theme.colors.borderInverted.cgColor
+        // Both strokes sit over the scrim and the page capture, neither of which follows the theme,
+        // so they need a token that stays light in every palette. `borderInverted` and
+        // `iconSecondary` flip, which put a white ring on a white page in the light themes.
+        thumbnailContainer.layer.borderColor = theme.colors.iconOnColor.cgColor
+        highlightView.layer.borderColor = theme.colors.iconOnColor.cgColor
         highlightView.layer.shadowColor = theme.colors.shadowStrong.cgColor
     }
 }

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
@@ -25,6 +25,9 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         static let highlightShadowOpacity: Float = 0.5
         static let highlightShadowRadius: CGFloat = 3
         static let minimumHighlightHeight: CGFloat = 24
+        /// Comfortably above `minimumHighlightHeight`, otherwise a wide page gives the
+        /// highlight no room to travel and it sits frozen and overhanging.
+        static let minimumRailHeight: CGFloat = 64
         static let closeButtonTopInset: CGFloat = 24
         /// Below this we're still mid-presentation and the proportions are meaningless.
         static let minimumUsableSide: CGFloat = 80
@@ -75,7 +78,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
     }()
 
     /// A bright copy clipped to the viewport, which gives the spotlight effect.
-    private lazy var brightWindowContainer: UIView = {
+    private(set) lazy var brightWindowContainer: UIView = {
         let view = UIView()
         view.clipsToBounds = true
         view.layer.cornerRadius = UX.highlightCornerRadius
@@ -98,7 +101,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         return view
     }()
 
-    private lazy var closeButton: CloseButton = .build { button in
+    private(set) lazy var closeButton: CloseButton = .build { button in
         button.addTarget(self, action: #selector(self.didTapClose), for: .touchUpInside)
     }
 
@@ -145,7 +148,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         let availableHeight = max(1, bounds.height - contentTop - safeAreaInsets.bottom - UX.bottomInset)
         // The rail keeps a fixed width and squashes a tall page rather than narrowing, which
         // would otherwise feed back into the margins and reflow the capture.
-        let thumbnailHeight = min(availableHeight, UX.thumbnailWidth * imageAspect)
+        let thumbnailHeight = min(availableHeight, max(UX.minimumRailHeight, UX.thumbnailWidth * imageAspect))
         // Equal margins either side keep the capture centered, with the rail in the right one.
         let sideMargin = WebCompatReporterUX.Spacing.screenHorizontal + UX.thumbnailWidth + UX.railGap
         let captureWidth = max(1, bounds.width - sideMargin * 2)
@@ -157,7 +160,10 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         guard isRenderable else { return }
 
         let pageHeight = max(1, captureWidth * imageAspect)
-        scrollView.frame = CGRect(x: sideMargin, y: contentTop, width: captureWidth, height: availableHeight)
+        // A page shorter than the space available gets a card its own size. Stretching it
+        // would round the top corners over scrim and leave the image's bottom edge square.
+        let captureHeight = min(availableHeight, pageHeight)
+        scrollView.frame = CGRect(x: sideMargin, y: contentTop, width: captureWidth, height: captureHeight)
         pageImageView.frame = CGRect(x: 0, y: 0, width: captureWidth, height: pageHeight)
         scrollView.contentSize = CGSize(width: captureWidth, height: pageHeight)
 

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
@@ -6,9 +6,9 @@ import Common
 import ComponentLibrary
 import UIKit
 
-/// Mirrors the iOS "Full Page" screenshot preview (Figma 23608-67772): the capture
-/// scrolls in the middle, a thumbnail of the whole page sits in the right margin
-/// with a highlight that follows the scroll.
+/// Mirrors the iOS "Full Page" screenshot preview: the capture scrolls in the middle,
+/// a thumbnail of the whole page sits in the right margin with a highlight that follows
+/// the scroll.
 final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollViewDelegate {
     private enum UX {
         static let topInset: CGFloat = 72
@@ -31,6 +31,9 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         static let closeButtonTopInset: CGFloat = 24
         /// Below this we're still mid-presentation and the proportions are meaningless.
         static let minimumUsableSide: CGFloat = 80
+        /// Equal on both sides so the capture stays centered, with the rail in the right one.
+        static let captureSideMargin: CGFloat = WebCompatReporterUX.Spacing.screenHorizontal
+            + thumbnailWidth + railGap
     }
 
     var onClose: (() -> Void)?
@@ -38,68 +41,77 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
     private let image: UIImage?
     private let imageAspect: CGFloat
 
+    /// The page as the capture renders it, which is what the highlight measures itself against.
+    private var pageHeight: CGFloat {
+        return scrollView.bounds.width * imageAspect
+    }
+
     private var scrollFraction: CGFloat {
-        let maximumOffset = max(1, scrollView.contentSize.height - scrollView.bounds.height)
+        let maximumOffset = max(1, pageHeight - scrollView.bounds.height)
         let fraction = scrollView.contentOffset.y / maximumOffset
         return min(max(fraction.isFinite ? fraction : 0, 0), 1)
     }
 
-    // `private(set)` so the layout tests can read these frames without walking the hierarchy.
-    private(set) lazy var scrollView: UIScrollView = {
-        let scrollView = UIScrollView()
+    private var highlightHeightConstraint: NSLayoutConstraint?
+
+    /// Set by the rail's height against how much of the page the capture shows, so it holds still
+    /// while scrolling and only changes when the geometry does.
+    private var highlightHeight: CGFloat {
+        let railHeight = thumbnailContainer.bounds.height
+        guard railHeight > 0, pageHeight > 0 else { return UX.minimumHighlightHeight }
+
+        let visibleFraction = min(1, scrollView.bounds.height / pageHeight)
+        return max(UX.minimumHighlightHeight, railHeight * visibleFraction)
+    }
+
+    // `private(set)` so the module's layout tests can read these frames without walking the
+    // hierarchy. Nothing outside the view can mutate or replace them.
+    private(set) lazy var scrollView: UIScrollView = .build { scrollView in
         scrollView.showsVerticalScrollIndicator = false
+        // Rounds the capture's corners.
         scrollView.clipsToBounds = true
         scrollView.layer.cornerRadius = UX.captureCornerRadius
         scrollView.delegate = self
-        return scrollView
-    }()
+    }
 
-    private lazy var pageImageView: UIImageView = {
-        let imageView = UIImageView(image: image)
-        imageView.contentMode = .scaleAspectFill
-        imageView.clipsToBounds = true
-        return imageView
-    }()
+    private lazy var pageImageView: UIImageView = .build { imageView in
+        imageView.image = self.image
+        imageView.contentMode = .scaleToFill
+    }
 
-    private(set) lazy var thumbnailContainer: UIView = {
-        let view = UIView()
+    private(set) lazy var thumbnailContainer: UIView = .build { view in
+        // Rounds the dimmed page inside it.
         view.clipsToBounds = true
         view.layer.cornerRadius = UX.thumbnailCornerRadius
         view.layer.borderWidth = UX.thumbnailBorderWidth
-        return view
-    }()
+    }
 
     /// The dimmed whole page behind the highlight.
-    private lazy var thumbnailImageView: UIImageView = {
-        let imageView = UIImageView(image: image)
+    private lazy var thumbnailImageView: UIImageView = .build { imageView in
+        imageView.image = self.image
         imageView.contentMode = .scaleToFill
         imageView.alpha = UX.thumbnailDimOpacity
-        return imageView
-    }()
+    }
 
     /// A bright copy clipped to the viewport, which gives the spotlight effect.
-    private(set) lazy var brightWindowContainer: UIView = {
-        let view = UIView()
+    private(set) lazy var brightWindowContainer: UIView = .build { view in
+        // The clip *is* the spotlight: it crops the bright page down to the viewport window.
         view.clipsToBounds = true
         view.layer.cornerRadius = UX.highlightCornerRadius
-        return view
-    }()
+    }
 
-    private(set) lazy var brightWindowImageView: UIImageView = {
-        let imageView = UIImageView(image: image)
+    private(set) lazy var brightWindowImageView: UIImageView = .build { imageView in
+        imageView.image = self.image
         imageView.contentMode = .scaleToFill
-        return imageView
-    }()
+    }
 
-    private(set) lazy var highlightView: UIView = {
-        let view = UIView()
+    private(set) lazy var highlightView: UIView = .build { view in
         view.layer.cornerRadius = UX.highlightCornerRadius
         view.layer.borderWidth = UX.highlightBorderWidth
         view.layer.shadowOpacity = UX.highlightShadowOpacity
         view.layer.shadowRadius = UX.highlightShadowRadius
         view.layer.shadowOffset = .zero
-        return view
-    }()
+    }
 
     private(set) lazy var closeButton: CloseButton = .build { button in
         button.addTarget(self, action: #selector(self.didTapClose), for: .touchUpInside)
@@ -112,18 +124,43 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         self.imageAspect = (size.width > 0 && aspect.isFinite) ? aspect : 1
         super.init(frame: .zero)
 
+        setupSubviews()
+        setupConstraints()
+        closeButton.configure(viewModel: closeButtonViewModel)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupSubviews() {
+        // Every copy of the page is sized by the constraints below, so none of them may push
+        // back with its intrinsic size. A long page otherwise drags the rail down the screen:
+        // the bright copy is required-equal to the rail's height, and at the default priority
+        // its intrinsic height beats the rail's own height constraint.
+        for imageView in [pageImageView, thumbnailImageView, brightWindowImageView] {
+            imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+            imageView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        }
+
         scrollView.addSubview(pageImageView)
         thumbnailContainer.addSubview(thumbnailImageView)
         brightWindowContainer.addSubview(brightWindowImageView)
-        addSubview(scrollView)
-        addSubview(thumbnailContainer)
-        // Siblings of the thumbnail, not children: it clips, which would eat the border and shadow.
-        addSubview(brightWindowContainer)
-        addSubview(highlightView)
-        addSubview(closeButton)
+        // The bright window and the highlight are siblings of the thumbnail, not children:
+        // it clips, which would eat the highlight's border and shadow.
+        addSubviews(scrollView, thumbnailContainer, brightWindowContainer, highlightView, closeButton)
+    }
 
-        closeButton.configure(viewModel: closeButtonViewModel)
-        NSLayoutConstraint.activate([
+    private func setupConstraints() {
+        NSLayoutConstraint.activate(
+            closeButtonConstraints() + captureConstraints() + railConstraints() + highlightConstraints()
+        )
+    }
+
+    private func closeButtonConstraints() -> [NSLayoutConstraint] {
+        return [
             closeButton.leadingAnchor.constraint(
                 equalTo: safeAreaLayoutGuide.leadingAnchor,
                 constant: WebCompatReporterUX.Spacing.screenHorizontal
@@ -132,11 +169,105 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
                 equalTo: safeAreaLayoutGuide.topAnchor,
                 constant: UX.closeButtonTopInset
             )
-        ])
+        ]
     }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    private func captureConstraints() -> [NSLayoutConstraint] {
+        // A page shorter than the space available gets a card its own size, so the ratio only
+        // holds while it fits. Stretching it would round the top corners over scrim and leave
+        // the image's bottom edge square.
+        let ratio = scrollView.heightAnchor.constraint(
+            equalTo: scrollView.widthAnchor,
+            multiplier: imageAspect
+        )
+        ratio.priority = .defaultHigh
+        let width = scrollView.widthAnchor.constraint(
+            equalTo: safeAreaLayoutGuide.widthAnchor,
+            constant: -UX.captureSideMargin * 2
+        )
+        let bottom = scrollView.bottomAnchor.constraint(
+            lessThanOrEqualTo: safeAreaLayoutGuide.bottomAnchor,
+            constant: -UX.bottomInset
+        )
+        breakBeforeRequiredConstraints(width, bottom)
+
+        return [
+            scrollView.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
+            scrollView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: UX.topInset),
+            scrollView.widthAnchor.constraint(greaterThanOrEqualToConstant: 0),
+            width,
+            bottom,
+            ratio,
+
+            pageImageView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            pageImageView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            pageImageView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            pageImageView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            pageImageView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+            pageImageView.heightAnchor.constraint(equalTo: pageImageView.widthAnchor, multiplier: imageAspect)
+        ]
+    }
+
+    private func railConstraints() -> [NSLayoutConstraint] {
+        // The rail keeps a fixed width and squashes a tall page rather than narrowing, which
+        // would otherwise feed back into the margins and reflow the capture.
+        let height = thumbnailContainer.heightAnchor.constraint(
+            equalToConstant: max(UX.minimumRailHeight, UX.thumbnailWidth * imageAspect)
+        )
+        height.priority = .defaultHigh
+        let bottom = thumbnailContainer.bottomAnchor.constraint(
+            lessThanOrEqualTo: safeAreaLayoutGuide.bottomAnchor,
+            constant: -UX.bottomInset
+        )
+        breakBeforeRequiredConstraints(bottom)
+
+        return [
+            thumbnailContainer.trailingAnchor.constraint(
+                equalTo: safeAreaLayoutGuide.trailingAnchor,
+                constant: -WebCompatReporterUX.Spacing.screenHorizontal
+            ),
+            thumbnailContainer.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: UX.topInset),
+            thumbnailContainer.widthAnchor.constraint(equalToConstant: UX.thumbnailWidth),
+            bottom,
+            height,
+
+            thumbnailImageView.topAnchor.constraint(equalTo: thumbnailContainer.topAnchor),
+            thumbnailImageView.leadingAnchor.constraint(equalTo: thumbnailContainer.leadingAnchor),
+            thumbnailImageView.trailingAnchor.constraint(equalTo: thumbnailContainer.trailingAnchor),
+            thumbnailImageView.bottomAnchor.constraint(equalTo: thumbnailContainer.bottomAnchor)
+        ]
+    }
+
+    /// The highlight sits at the top of the rail and `updateHighlightOffset()` translates it down
+    /// from there, so its height is the only constant the layout owns.
+    private func highlightConstraints() -> [NSLayoutConstraint] {
+        let height = highlightView.heightAnchor.constraint(equalToConstant: UX.minimumHighlightHeight)
+        highlightHeightConstraint = height
+
+        return [
+            highlightView.leadingAnchor.constraint(equalTo: thumbnailContainer.leadingAnchor),
+            highlightView.trailingAnchor.constraint(equalTo: thumbnailContainer.trailingAnchor),
+            highlightView.topAnchor.constraint(equalTo: thumbnailContainer.topAnchor),
+            height,
+
+            brightWindowContainer.topAnchor.constraint(equalTo: highlightView.topAnchor),
+            brightWindowContainer.leadingAnchor.constraint(equalTo: highlightView.leadingAnchor),
+            brightWindowContainer.trailingAnchor.constraint(equalTo: highlightView.trailingAnchor),
+            brightWindowContainer.bottomAnchor.constraint(equalTo: highlightView.bottomAnchor),
+
+            brightWindowImageView.leadingAnchor.constraint(equalTo: brightWindowContainer.leadingAnchor),
+            brightWindowImageView.trailingAnchor.constraint(equalTo: brightWindowContainer.trailingAnchor),
+            brightWindowImageView.topAnchor.constraint(equalTo: brightWindowContainer.topAnchor),
+            brightWindowImageView.heightAnchor.constraint(equalTo: thumbnailContainer.heightAnchor)
+        ]
+    }
+
+    /// Keeps the near-zero bounds we get mid-presentation from reporting unsatisfiable
+    /// constraints, while still winning against the aspect-ratio constraints at a real size.
+    private func breakBeforeRequiredConstraints(_ constraints: NSLayoutConstraint...) {
+        for constraint in constraints {
+            constraint.priority = .required - 1
+        }
     }
 
     // MARK: - Layout
@@ -144,70 +275,56 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        let contentTop = safeAreaInsets.top + UX.topInset
-        let availableHeight = max(1, bounds.height - contentTop - safeAreaInsets.bottom - UX.bottomInset)
-        // The rail keeps a fixed width and squashes a tall page rather than narrowing, which
-        // would otherwise feed back into the margins and reflow the capture.
-        let thumbnailHeight = min(availableHeight, max(UX.minimumRailHeight, UX.thumbnailWidth * imageAspect))
-        // Equal margins either side keep the capture centered, with the rail in the right one.
-        let sideMargin = WebCompatReporterUX.Spacing.screenHorizontal + UX.thumbnailWidth + UX.railGap
-        let captureWidth = max(1, bounds.width - sideMargin * 2)
-        let hasUsableSize = captureWidth > UX.minimumUsableSide && availableHeight > UX.minimumUsableSide
-        let isRenderable = hasUsableSize && image != nil
-        for view in [scrollView, thumbnailContainer, brightWindowContainer, highlightView] {
-            view.isHidden = !isRenderable
+        updateContentVisibility()
+        // Guarded, or assigning it every pass would invalidate the layout it was just given.
+        if highlightHeightConstraint?.constant != highlightHeight {
+            highlightHeightConstraint?.constant = highlightHeight
         }
-        guard isRenderable else { return }
-
-        let pageHeight = max(1, captureWidth * imageAspect)
-        // A page shorter than the space available gets a card its own size. Stretching it
-        // would round the top corners over scrim and leave the image's bottom edge square.
-        let captureHeight = min(availableHeight, pageHeight)
-        scrollView.frame = CGRect(x: sideMargin, y: contentTop, width: captureWidth, height: captureHeight)
-        pageImageView.frame = CGRect(x: 0, y: 0, width: captureWidth, height: pageHeight)
-        scrollView.contentSize = CGSize(width: captureWidth, height: pageHeight)
-
-        thumbnailContainer.frame = CGRect(
-            x: bounds.width - WebCompatReporterUX.Spacing.screenHorizontal - UX.thumbnailWidth,
-            y: contentTop,
-            width: UX.thumbnailWidth,
-            height: thumbnailHeight
-        )
-        thumbnailImageView.frame = thumbnailContainer.bounds
-        layoutViewportHighlight()
+        updateHighlightOffset()
     }
 
-    private func layoutViewportHighlight() {
-        let thumbnailFrame = thumbnailContainer.frame
-        let pageHeight = scrollView.contentSize.height
-        guard !thumbnailContainer.isHidden, pageHeight > 0 else { return }
+    /// Bad geometry produces inf/NaN and kills rendering, so the derived views stay hidden
+    /// until the bounds and the image can actually describe a page.
+    private func updateContentVisibility() {
+        let availableWidth = bounds.width - safeAreaInsets.left - safeAreaInsets.right
+        let availableHeight = bounds.height - safeAreaInsets.top - safeAreaInsets.bottom
+            - UX.topInset - UX.bottomInset
+        let isRenderable = image != nil
+            && availableWidth - UX.captureSideMargin * 2 > UX.minimumUsableSide
+            && availableHeight > UX.minimumUsableSide
 
-        let visibleFraction = min(1, scrollView.bounds.height / pageHeight)
-        let highlightHeight = max(UX.minimumHighlightHeight, thumbnailFrame.height * visibleFraction)
-        let travel = max(0, thumbnailFrame.height - highlightHeight)
-        let highlightTop = scrollFraction * travel
+        let isHidden = !isRenderable
+        for view in [scrollView, thumbnailContainer, brightWindowContainer, highlightView]
+        where view.isHidden != isHidden {
+            view.isHidden = isHidden
+        }
+    }
 
-        let windowFrame = CGRect(
-            x: thumbnailFrame.minX,
-            y: thumbnailFrame.minY + highlightTop,
-            width: thumbnailFrame.width,
-            height: highlightHeight
-        )
-        highlightView.frame = windowFrame
-        // Shift the bright copy so its visible slice registers with the dimmed page underneath.
-        brightWindowContainer.frame = windowFrame
-        brightWindowImageView.frame = CGRect(
-            x: 0,
-            y: -highlightTop,
-            width: thumbnailFrame.width,
-            height: thumbnailFrame.height
-        )
+    /// Slides the window down the rail. A translation rather than a constraint constant because
+    /// `scrollViewDidScroll` lands mid-layout, where a constant only takes effect on the next
+    /// pass and the highlight visibly trails the capture.
+    private func updateHighlightOffset() {
+        let travel = max(0, thumbnailContainer.bounds.height - highlightHeight)
+        let offset = CGAffineTransform(translationX: 0, y: scrollFraction * travel)
+
+        highlightView.transform = offset
+        brightWindowContainer.transform = offset
+        // The inverse keeps the bright copy registered with the dimmed page underneath, so the
+        // window moves while the slice it exposes stays put.
+        brightWindowImageView.transform = offset.inverted()
+    }
+
+    // MARK: - Accessibility
+
+    /// The sheet underneath stays mounted, so VoiceOver needs pointing at the viewer.
+    func moveAccessibilityFocusToFirstElement() {
+        UIAccessibility.post(notification: .screenChanged, argument: closeButton)
     }
 
     // MARK: - Scroll sync
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        layoutViewportHighlight()
+        updateHighlightOffset()
     }
 
     // MARK: - Actions

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
@@ -6,9 +6,9 @@ import Common
 import ComponentLibrary
 import UIKit
 
-/// The iOS "Full Page" screenshot preview, near enough (Figma 23608-67772). The
-/// capture scrolls in the middle; a slim thumbnail of the whole page floats in
-/// the right margin with a highlight that follows the scroll.
+/// Mirrors the iOS "Full Page" screenshot preview (Figma 23608-67772): the capture
+/// scrolls in the middle, a thumbnail of the whole page sits in the right margin
+/// with a highlight that follows the scroll.
 final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollViewDelegate {
     private enum UX {
         static let topInset: CGFloat = 72
@@ -18,8 +18,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         static let thumbnailCornerRadius: CGFloat = 10
         static let thumbnailBorderWidth: CGFloat = 2
         static let thumbnailWidth: CGFloat = 44
-        /// The thumbnail base is dimmed to this; a bright copy clipped over it
-        /// picks out the current viewport.
+        /// The base thumbnail is dimmed to this; a bright copy clipped over it marks the viewport.
         static let thumbnailDimOpacity: CGFloat = 0.4
         static let highlightCornerRadius: CGFloat = 8
         static let highlightBorderWidth: CGFloat = 3
@@ -27,8 +26,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         static let highlightShadowRadius: CGFloat = 3
         static let minimumHighlightHeight: CGFloat = 24
         static let closeButtonTopInset: CGFloat = 24
-        /// Under this we're still mid-presentation, so skip the layout and hide
-        /// the content until the size means something.
+        /// Below this we're still mid-presentation and the proportions are meaningless.
         static let minimumUsableSide: CGFloat = 80
     }
 
@@ -38,8 +36,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
     private let imageAspect: CGFloat
 
     private var scrollFraction: CGFloat = 0
-    /// Cached in `layoutSubviews` so a scroll only moves the highlight instead of
-    /// redoing the whole geometry pass every frame.
+    /// Cached in `layoutSubviews` so scrolling only moves the highlight.
     private struct HighlightGeometry {
         let thumbnailHeight: CGFloat
         let viewportHeight: CGFloat
@@ -48,8 +45,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
 
     private var highlightGeometry: HighlightGeometry?
 
-    // `private(set)` so the layout tests can read these frames directly rather
-    // than walking the hierarchy by index.
+    // `private(set)` so the layout tests can read these frames without walking the hierarchy.
     private(set) lazy var captureContainer: UIView = {
         let view = UIView()
         view.clipsToBounds = true
@@ -87,8 +83,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         return imageView
     }()
 
-    /// A bright copy of the page clipped to the viewport, which is what gives the
-    /// native spotlight effect.
+    /// A bright copy clipped to the viewport, which gives the spotlight effect.
     private lazy var brightWindowContainer: UIView = {
         let view = UIView()
         view.clipsToBounds = true
@@ -129,8 +124,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         brightWindowContainer.addSubview(brightWindowImageView)
         addSubview(captureContainer)
         addSubview(thumbnailContainer)
-        // A sibling of the thumbnail rather than a child, otherwise the border and
-        // shadow get clipped away.
+        // Siblings of the thumbnail, not children: it clips, which would eat the border and shadow.
         addSubview(brightWindowContainer)
         addSubview(highlightView)
         addSubview(closeButton)
@@ -169,8 +163,6 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         // Equal margins either side keep the capture centered, with the rail in the right one.
         let sideMargin = WebCompatReporterUX.Spacing.screenHorizontal + thumbnailWidth + UX.railGap
         let captureWidth = max(1, bounds.width - sideMargin * 2)
-        // Wait for a real size. Laying out mid-transition gives the capture and rail
-        // wildly wrong proportions.
         let hasUsableSize = captureWidth > UX.minimumUsableSide && availableHeight > UX.minimumUsableSide
         let isRenderable = hasUsableSize && image != nil
         for view in [captureContainer, thumbnailContainer, brightWindowContainer, highlightView] {
@@ -204,7 +196,6 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
 
     private func layoutViewportHighlight() {
         guard let geometry = highlightGeometry else { return }
-        // In the view's coordinate space, since it's a sibling of the thumbnail.
         let thumbnailFrame = thumbnailContainer.frame
         let width = thumbnailFrame.width
         let visibleFraction = min(1, geometry.viewportHeight / geometry.pageHeight)
@@ -219,8 +210,7 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
             height: highlightHeight
         )
         highlightView.frame = windowFrame
-        // Shift the bright copy so its visible slice lines up with the dimmed page
-        // underneath. Otherwise the spotlight shows the wrong part.
+        // Shift the bright copy so its visible slice registers with the dimmed page underneath.
         brightWindowContainer.frame = windowFrame
         brightWindowImageView.frame = CGRect(x: 0, y: -highlightTop, width: width, height: geometry.thumbnailHeight)
     }
@@ -231,7 +221,6 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         let maximumOffset = max(1, scrollView.contentSize.height - scrollView.bounds.height)
         let fraction = scrollView.contentOffset.y / maximumOffset
         scrollFraction = min(max(fraction.isFinite ? fraction : 0, 0), 1)
-        // Only the highlight moves. No need for a full layout pass per frame.
         layoutViewportHighlight()
     }
 
@@ -245,7 +234,6 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
     // MARK: - ThemeApplicable
 
     func applyTheme(theme: Theme) {
-        // The scrim from the native full-page preview (Figma 23608-67772).
         backgroundColor = theme.colors.layerScrim
         thumbnailContainer.layer.borderColor = theme.colors.iconSecondary.cgColor
         highlightView.layer.borderColor = theme.colors.borderInverted.cgColor

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotView.swift
@@ -35,27 +35,18 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
     private let image: UIImage?
     private let imageAspect: CGFloat
 
-    private var scrollFraction: CGFloat = 0
-    /// Cached in `layoutSubviews` so scrolling only moves the highlight.
-    private struct HighlightGeometry {
-        let thumbnailHeight: CGFloat
-        let viewportHeight: CGFloat
-        let pageHeight: CGFloat
+    private var scrollFraction: CGFloat {
+        let maximumOffset = max(1, scrollView.contentSize.height - scrollView.bounds.height)
+        let fraction = scrollView.contentOffset.y / maximumOffset
+        return min(max(fraction.isFinite ? fraction : 0, 0), 1)
     }
 
-    private var highlightGeometry: HighlightGeometry?
-
     // `private(set)` so the layout tests can read these frames without walking the hierarchy.
-    private(set) lazy var captureContainer: UIView = {
-        let view = UIView()
-        view.clipsToBounds = true
-        view.layer.cornerRadius = UX.captureCornerRadius
-        return view
-    }()
-
     private(set) lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.showsVerticalScrollIndicator = false
+        scrollView.clipsToBounds = true
+        scrollView.layer.cornerRadius = UX.captureCornerRadius
         scrollView.delegate = self
         return scrollView
     }()
@@ -118,11 +109,10 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
         self.imageAspect = (size.width > 0 && aspect.isFinite) ? aspect : 1
         super.init(frame: .zero)
 
-        captureContainer.addSubview(scrollView)
         scrollView.addSubview(pageImageView)
         thumbnailContainer.addSubview(thumbnailImageView)
         brightWindowContainer.addSubview(brightWindowImageView)
-        addSubview(captureContainer)
+        addSubview(scrollView)
         addSubview(thumbnailContainer)
         // Siblings of the thumbnail, not children: it clips, which would eat the border and shadow.
         addSubview(brightWindowContainer)
@@ -153,74 +143,64 @@ final class WebCompatFullPageScreenshotView: UIView, ThemeApplicable, UIScrollVi
 
         let contentTop = safeAreaInsets.top + UX.topInset
         let availableHeight = max(1, bounds.height - contentTop - safeAreaInsets.bottom - UX.bottomInset)
-        // The thumbnail shows the whole page, so cap its height or a tall page overflows.
-        var thumbnailWidth = UX.thumbnailWidth
-        var thumbnailHeight = thumbnailWidth * imageAspect
-        if thumbnailHeight > availableHeight {
-            thumbnailHeight = availableHeight
-            thumbnailWidth = max(1, thumbnailHeight / imageAspect)
-        }
+        // The rail keeps a fixed width and squashes a tall page rather than narrowing, which
+        // would otherwise feed back into the margins and reflow the capture.
+        let thumbnailHeight = min(availableHeight, UX.thumbnailWidth * imageAspect)
         // Equal margins either side keep the capture centered, with the rail in the right one.
-        let sideMargin = WebCompatReporterUX.Spacing.screenHorizontal + thumbnailWidth + UX.railGap
+        let sideMargin = WebCompatReporterUX.Spacing.screenHorizontal + UX.thumbnailWidth + UX.railGap
         let captureWidth = max(1, bounds.width - sideMargin * 2)
         let hasUsableSize = captureWidth > UX.minimumUsableSide && availableHeight > UX.minimumUsableSide
         let isRenderable = hasUsableSize && image != nil
-        for view in [captureContainer, thumbnailContainer, brightWindowContainer, highlightView] {
+        for view in [scrollView, thumbnailContainer, brightWindowContainer, highlightView] {
             view.isHidden = !isRenderable
         }
-        guard isRenderable else {
-            highlightGeometry = nil
-            return
-        }
+        guard isRenderable else { return }
 
         let pageHeight = max(1, captureWidth * imageAspect)
-        captureContainer.frame = CGRect(x: sideMargin, y: contentTop, width: captureWidth, height: availableHeight)
-        scrollView.frame = captureContainer.bounds
+        scrollView.frame = CGRect(x: sideMargin, y: contentTop, width: captureWidth, height: availableHeight)
         pageImageView.frame = CGRect(x: 0, y: 0, width: captureWidth, height: pageHeight)
         scrollView.contentSize = CGSize(width: captureWidth, height: pageHeight)
 
         thumbnailContainer.frame = CGRect(
-            x: bounds.width - WebCompatReporterUX.Spacing.screenHorizontal - thumbnailWidth,
+            x: bounds.width - WebCompatReporterUX.Spacing.screenHorizontal - UX.thumbnailWidth,
             y: contentTop,
-            width: thumbnailWidth,
+            width: UX.thumbnailWidth,
             height: thumbnailHeight
         )
         thumbnailImageView.frame = thumbnailContainer.bounds
-        highlightGeometry = HighlightGeometry(
-            thumbnailHeight: thumbnailHeight,
-            viewportHeight: availableHeight,
-            pageHeight: pageHeight
-        )
         layoutViewportHighlight()
     }
 
     private func layoutViewportHighlight() {
-        guard let geometry = highlightGeometry else { return }
         let thumbnailFrame = thumbnailContainer.frame
-        let width = thumbnailFrame.width
-        let visibleFraction = min(1, geometry.viewportHeight / geometry.pageHeight)
-        let highlightHeight = max(UX.minimumHighlightHeight, geometry.thumbnailHeight * visibleFraction)
-        let travel = max(0, geometry.thumbnailHeight - highlightHeight)
+        let pageHeight = scrollView.contentSize.height
+        guard !thumbnailContainer.isHidden, pageHeight > 0 else { return }
+
+        let visibleFraction = min(1, scrollView.bounds.height / pageHeight)
+        let highlightHeight = max(UX.minimumHighlightHeight, thumbnailFrame.height * visibleFraction)
+        let travel = max(0, thumbnailFrame.height - highlightHeight)
         let highlightTop = scrollFraction * travel
 
         let windowFrame = CGRect(
             x: thumbnailFrame.minX,
             y: thumbnailFrame.minY + highlightTop,
-            width: width,
+            width: thumbnailFrame.width,
             height: highlightHeight
         )
         highlightView.frame = windowFrame
         // Shift the bright copy so its visible slice registers with the dimmed page underneath.
         brightWindowContainer.frame = windowFrame
-        brightWindowImageView.frame = CGRect(x: 0, y: -highlightTop, width: width, height: geometry.thumbnailHeight)
+        brightWindowImageView.frame = CGRect(
+            x: 0,
+            y: -highlightTop,
+            width: thumbnailFrame.width,
+            height: thumbnailFrame.height
+        )
     }
 
     // MARK: - Scroll sync
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let maximumOffset = max(1, scrollView.contentSize.height - scrollView.bounds.height)
-        let fraction = scrollView.contentOffset.y / maximumOffset
-        scrollFraction = min(max(fraction.isFinite ? fraction : 0, 0), 1)
         layoutViewportHighlight()
     }
 

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotViewController.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import UIKit
+
+/// What the viewer reports back. The coordinator does the dismissing.
+@MainActor
+public protocol WebCompatFullPageScreenshotDelegate: AnyObject {
+    func webCompatFullPageScreenshotDidTapClose()
+}
+
+/// Full-screen page viewer, shown over the Report Preview sheet.
+public final class WebCompatFullPageScreenshotViewController: UIViewController, ThemeApplicable {
+    public weak var delegate: WebCompatFullPageScreenshotDelegate?
+
+    let screenshotView: WebCompatFullPageScreenshotView
+
+    public init(image: UIImage?, closeButtonViewModel: CloseButtonViewModel, theme: Theme) {
+        screenshotView = WebCompatFullPageScreenshotView(image: image, closeButtonViewModel: closeButtonViewModel)
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        // The scrim is translucent and the sheet underneath stays mounted, so
+        // without this VoiceOver swipes straight through into it.
+        screenshotView.accessibilityViewIsModal = true
+        screenshotView.onClose = { [weak self] in
+            self?.delegate?.webCompatFullPageScreenshotDidTapClose()
+        }
+        screenshotView.applyTheme(theme: theme)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override public func loadView() {
+        view = screenshotView
+    }
+
+    // MARK: - ThemeApplicable
+
+    public func applyTheme(theme: Theme) {
+        screenshotView.applyTheme(theme: theme)
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 /// What the viewer reports back. The coordinator does the dismissing.
 @MainActor
 public protocol WebCompatFullPageScreenshotDelegate: AnyObject {
-    func webCompatFullPageScreenshotDidTapClose()
+    func webCompatFullPageScreenshotDidRequestDismiss()
 }
 
 /// Full-screen page viewer, shown over the Report Preview sheet.
@@ -25,7 +25,7 @@ public final class WebCompatFullPageScreenshotViewController: UIViewController, 
         // The sheet underneath stays mounted, so without this VoiceOver swipes into it.
         screenshotView.accessibilityViewIsModal = true
         screenshotView.onClose = { [weak self] in
-            self?.delegate?.webCompatFullPageScreenshotDidTapClose()
+            self?.delegate?.webCompatFullPageScreenshotDidRequestDismiss()
         }
         screenshotView.applyTheme(theme: theme)
     }
@@ -36,6 +36,20 @@ public final class WebCompatFullPageScreenshotViewController: UIViewController, 
 
     override public func loadView() {
         view = screenshotView
+    }
+
+    // MARK: - Accessibility
+
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIAccessibility.post(notification: .screenChanged, argument: screenshotView.closeButton)
+    }
+
+    /// The two-finger scrub. Without it the only way out is the close button.
+    override public func accessibilityPerformEscape() -> Bool {
+        guard let delegate else { return false }
+        delegate.webCompatFullPageScreenshotDidRequestDismiss()
+        return true
     }
 
     // MARK: - ThemeApplicable

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotViewController.swift
@@ -16,7 +16,7 @@ public protocol WebCompatFullPageScreenshotDelegate: AnyObject {
 public final class WebCompatFullPageScreenshotViewController: UIViewController, ThemeApplicable {
     public weak var delegate: WebCompatFullPageScreenshotDelegate?
 
-    let screenshotView: WebCompatFullPageScreenshotView
+    private let screenshotView: WebCompatFullPageScreenshotView
 
     public init(image: UIImage?, closeButtonViewModel: CloseButtonViewModel, theme: Theme) {
         screenshotView = WebCompatFullPageScreenshotView(image: image, closeButtonViewModel: closeButtonViewModel)
@@ -34,6 +34,8 @@ public final class WebCompatFullPageScreenshotViewController: UIViewController, 
         fatalError("init(coder:) has not been implemented")
     }
 
+    // Deliberately no `super` call: UIKit's implementation would build a plain `UIView` and
+    // assign it over ours.
     override public func loadView() {
         view = screenshotView
     }
@@ -42,7 +44,7 @@ public final class WebCompatFullPageScreenshotViewController: UIViewController, 
 
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        UIAccessibility.post(notification: .screenChanged, argument: screenshotView.closeButton)
+        screenshotView.moveAccessibilityFocusToFirstElement()
     }
 
     /// The two-finger scrub. Without it the only way out is the close button.

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotViewController.swift
@@ -12,14 +12,35 @@ public protocol WebCompatFullPageScreenshotDelegate: AnyObject {
     func webCompatFullPageScreenshotDidRequestDismiss()
 }
 
+/// Describes the capture to assistive tech and to UI automation. Both values are supplied by the
+/// caller because the package can reach neither Client's strings nor its `AccessibilityIdentifiers`.
+public struct WebCompatFullPageScreenshotViewModel: Equatable, Sendable {
+    public let captureAccessibilityLabel: String
+    public let captureAccessibilityIdentifier: String
+
+    public init(captureAccessibilityLabel: String, captureAccessibilityIdentifier: String) {
+        self.captureAccessibilityLabel = captureAccessibilityLabel
+        self.captureAccessibilityIdentifier = captureAccessibilityIdentifier
+    }
+}
+
 /// Full-screen page viewer, shown over the Report Preview sheet.
 public final class WebCompatFullPageScreenshotViewController: UIViewController, ThemeApplicable {
     public weak var delegate: WebCompatFullPageScreenshotDelegate?
 
     private let screenshotView: WebCompatFullPageScreenshotView
 
-    public init(image: UIImage?, closeButtonViewModel: CloseButtonViewModel, theme: Theme) {
-        screenshotView = WebCompatFullPageScreenshotView(image: image, closeButtonViewModel: closeButtonViewModel)
+    public init(
+        image: UIImage?,
+        viewModel: WebCompatFullPageScreenshotViewModel,
+        closeButtonViewModel: CloseButtonViewModel,
+        theme: Theme
+    ) {
+        screenshotView = WebCompatFullPageScreenshotView(
+            image: image,
+            viewModel: viewModel,
+            closeButtonViewModel: closeButtonViewModel
+        )
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .overFullScreen
         // The sheet underneath stays mounted, so without this VoiceOver swipes into it.
@@ -44,7 +65,7 @@ public final class WebCompatFullPageScreenshotViewController: UIViewController, 
 
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        screenshotView.moveAccessibilityFocusToFirstElement()
+        screenshotView.moveAccessibilityFocusToCloseButton()
     }
 
     /// The two-finger scrub. Without it the only way out is the close button.

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatFullPageScreenshotViewController.swift
@@ -22,8 +22,7 @@ public final class WebCompatFullPageScreenshotViewController: UIViewController, 
         screenshotView = WebCompatFullPageScreenshotView(image: image, closeButtonViewModel: closeButtonViewModel)
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .overFullScreen
-        // The scrim is translucent and the sheet underneath stays mounted, so
-        // without this VoiceOver swipes straight through into it.
+        // The sheet underneath stays mounted, so without this VoiceOver swipes into it.
         screenshotView.accessibilityViewIsModal = true
         screenshotView.onClose = { [weak self] in
             self?.delegate?.webCompatFullPageScreenshotDidTapClose()

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
@@ -11,9 +11,12 @@ import XCTest
 final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
     private enum UX {
         static let presentationSize = CGSize(width: 390, height: 844)
+        static let landscapeSize = CGSize(width: 852, height: 393)
         /// What the view is handed at the start of the presentation transition.
         static let transitionSize = CGSize(width: 1, height: 1)
         static let pageWidth: CGFloat = 320
+        /// Short enough to fit the space the capture is given.
+        static let shortPageHeight: CGFloat = 400
         static let tallPageHeight: CGFloat = 2400
         static let veryTallPageHeight: CGFloat = 40000
         /// Mirrors `WebCompatFullPageScreenshotView.UX.minimumHighlightHeight`, which is private.
@@ -29,9 +32,24 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
         subject.delegate = delegate
         subject.loadViewIfNeeded()
 
-        fireActions(firstSubview(ofType: CloseButton.self, in: subject.view), for: .touchUpInside)
+        fireActions(subject.screenshotView.closeButton, for: .touchUpInside)
 
-        XCTAssertEqual(delegate.didTapCloseCallCount, 1)
+        XCTAssertEqual(delegate.didRequestDismissCallCount, 1)
+    }
+
+    // The two-finger scrub is the expected way out of a modal.
+    func testAccessibilityEscape_notifiesDelegate() {
+        let delegate = MockWebCompatFullPageScreenshotDelegate()
+        let subject = createSubject()
+        subject.delegate = delegate
+
+        XCTAssertTrue(subject.accessibilityPerformEscape())
+        XCTAssertEqual(delegate.didRequestDismissCallCount, 1)
+    }
+
+    // Reporting the gesture as handled with nobody listening would swallow it silently.
+    func testAccessibilityEscape_withoutDelegate_isNotHandled() {
+        XCTAssertFalse(createSubject().accessibilityPerformEscape())
     }
 
     // MARK: - Content gating
@@ -121,6 +139,39 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
         )
     }
 
+    // A page wider than it is tall makes the rail short. The highlight's minimum height used
+    // to exceed it, so it overhung the rail and stopped tracking the scroll entirely.
+    func testHighlight_onWideLandscapePage_staysInsideTheRailAndTracksScroll() {
+        let subject = createSubject(
+            image: sampleImage(width: UX.landscapeSize.width, height: UX.landscapeSize.height)
+        )
+        layout(subject, in: UX.landscapeSize)
+        let view = subject.screenshotView
+        let topOffset = view.highlightView.frame.minY
+
+        scroll(subject, toFractionOfMaximumOffset: 1)
+
+        XCTAssertLessThanOrEqual(
+            view.highlightView.frame.maxY,
+            view.thumbnailContainer.frame.maxY + UX.frameAccuracy,
+            "The highlight must not overhang the rail"
+        )
+        XCTAssertGreaterThan(view.highlightView.frame.minY, topOffset, "The highlight must track the scroll")
+    }
+
+    // MARK: - Capture sizing
+
+    // Stretching a short page to the full height would round the top corners over scrim and
+    // leave the image's bottom edge square.
+    func testLayout_shortPage_sizesTheCaptureToThePage() {
+        let subject = createSubject(image: sampleImage(height: UX.shortPageHeight))
+
+        layout(subject, in: UX.presentationSize)
+
+        let scrollView = subject.screenshotView.scrollView
+        XCTAssertEqual(scrollView.frame.height, scrollView.contentSize.height, accuracy: UX.frameAccuracy)
+    }
+
     // A drifting bright slice spotlights a different part of the page than the capture shows.
     func testHighlight_brightSliceTracksTheHighlightOffset() {
         let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
@@ -167,12 +218,17 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
     ) {
         let view = subject.screenshotView
         XCTAssertEqual(view.scrollView.isHidden, expected, "scrollView", file: file, line: line)
+        XCTAssertEqual(view.brightWindowContainer.isHidden, expected, "brightWindowContainer", file: file, line: line)
         XCTAssertEqual(view.thumbnailContainer.isHidden, expected, "thumbnailContainer", file: file, line: line)
         XCTAssertEqual(view.highlightView.isHidden, expected, "highlightView", file: file, line: line)
+        XCTAssertFalse(view.closeButton.isHidden, "The close button must stay reachable", file: file, line: line)
     }
 
+    // Scale 1, or the 40000pt fixture allocates hundreds of megabytes at device scale.
     private func sampleImage(width: CGFloat = UX.pageWidth, height: CGFloat) -> UIImage {
-        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height))
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height), format: format)
         return renderer.image { context in
             UIColor.systemBlue.setFill()
             context.fill(CGRect(x: 0, y: 0, width: width, height: height))
@@ -180,8 +236,7 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
     }
 
     // No UIApplication in logic tests, so `sendActions` does nothing.
-    private func fireActions(_ control: UIControl?, for event: UIControl.Event) {
-        guard let control else { return }
+    private func fireActions(_ control: UIControl, for event: UIControl.Event) {
         for target in control.allTargets {
             let object = target as NSObject
             control.actions(forTarget: target, forControlEvent: event)?.forEach {
@@ -189,21 +244,12 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
             }
         }
     }
-
-    private func firstSubview<T: UIView>(ofType type: T.Type, in view: UIView?) -> T? {
-        guard let view else { return nil }
-        for subview in view.subviews {
-            if let match = subview as? T { return match }
-            if let match = firstSubview(ofType: type, in: subview) { return match }
-        }
-        return nil
-    }
 }
 
 private final class MockWebCompatFullPageScreenshotDelegate: WebCompatFullPageScreenshotDelegate {
-    var didTapCloseCallCount = 0
+    var didRequestDismissCallCount = 0
 
-    func webCompatFullPageScreenshotDidTapClose() {
-        didTapCloseCallCount += 1
+    func webCompatFullPageScreenshotDidRequestDismiss() {
+        didRequestDismissCallCount += 1
     }
 }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
@@ -9,6 +9,18 @@ import XCTest
 
 @MainActor
 final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
+    private enum UX {
+        static let presentationSize = CGSize(width: 390, height: 844)
+        /// What the view is handed at the start of the presentation transition.
+        static let transitionSize = CGSize(width: 1, height: 1)
+        static let pageWidth: CGFloat = 320
+        static let tallPageHeight: CGFloat = 2400
+        static let veryTallPageHeight: CGFloat = 40000
+        /// Mirrors `WebCompatFullPageScreenshotView.UX.minimumHighlightHeight`, which is private.
+        static let minimumHighlightHeight: CGFloat = 24
+        static let frameAccuracy: CGFloat = 0.5
+    }
+
     func testCloseButton_notifiesDelegate() {
         let delegate = MockWebCompatFullPageScreenshotDelegate()
         let subject = createSubject()
@@ -22,21 +34,20 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
 
     // MARK: - Content gating
 
-    // Presentation starts near zero size, so everything hides until the size is
-    // real. The part worth pinning is that it comes back afterwards.
+    // Presentation starts near zero size, so everything hides until the size is real.
     func testLayout_atTransitionSize_hidesGeometryDrivenViews() {
-        let subject = createSubject(image: sampleImage(height: 2400))
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
 
-        layout(subject, in: CGSize(width: 1, height: 1))
+        layout(subject, in: UX.transitionSize)
 
         assertGeometryViewsHidden(subject, expected: true)
     }
 
     func testLayout_recoveringFromTransitionSize_showsGeometryDrivenViews() {
-        let subject = createSubject(image: sampleImage(height: 2400))
-        layout(subject, in: CGSize(width: 1, height: 1))
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        layout(subject, in: UX.transitionSize)
 
-        layout(subject, in: presentationSize)
+        layout(subject, in: UX.presentationSize)
 
         assertGeometryViewsHidden(subject, expected: false)
     }
@@ -44,7 +55,7 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
     func testLayout_withoutImage_hidesGeometryDrivenViews() {
         let subject = createSubject(image: nil)
 
-        layout(subject, in: presentationSize)
+        layout(subject, in: UX.presentationSize)
 
         assertGeometryViewsHidden(subject, expected: true)
     }
@@ -52,61 +63,57 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
     // MARK: - Viewport highlight
 
     func testHighlight_atTopOfPage_sitsAtTopOfThumbnail() {
-        let subject = createSubject(image: sampleImage(height: 2400))
-        layout(subject, in: presentationSize)
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        layout(subject, in: UX.presentationSize)
 
         let view = subject.screenshotView
-        XCTAssertEqual(view.highlightView.frame.minY, view.thumbnailContainer.frame.minY, accuracy: 0.5)
+        XCTAssertEqual(view.highlightView.frame.minY, view.thumbnailContainer.frame.minY, accuracy: UX.frameAccuracy)
     }
 
     func testHighlight_scrolledToBottom_sitsAtBottomOfThumbnail() {
-        let subject = createSubject(image: sampleImage(height: 2400))
-        layout(subject, in: presentationSize)
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        layout(subject, in: UX.presentationSize)
 
         scroll(subject, toFractionOfMaximumOffset: 1)
 
         let view = subject.screenshotView
-        XCTAssertEqual(view.highlightView.frame.maxY, view.thumbnailContainer.frame.maxY, accuracy: 0.5)
+        XCTAssertEqual(view.highlightView.frame.maxY, view.thumbnailContainer.frame.maxY, accuracy: UX.frameAccuracy)
     }
 
     // Rubber-banding pushes the offset past both ends. The highlight has to stay put.
     func testHighlight_whenOverScrolled_staysWithinThumbnail() {
-        let subject = createSubject(image: sampleImage(height: 2400))
-        layout(subject, in: presentationSize)
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        layout(subject, in: UX.presentationSize)
         let view = subject.screenshotView
 
         scroll(subject, toFractionOfMaximumOffset: 1.4)
-        XCTAssertLessThanOrEqual(view.highlightView.frame.maxY, view.thumbnailContainer.frame.maxY + 0.5)
+        XCTAssertLessThanOrEqual(view.highlightView.frame.maxY, view.thumbnailContainer.frame.maxY + UX.frameAccuracy)
 
         scroll(subject, toFractionOfMaximumOffset: -0.4)
-        XCTAssertGreaterThanOrEqual(view.highlightView.frame.minY, view.thumbnailContainer.frame.minY - 0.5)
+        XCTAssertGreaterThanOrEqual(view.highlightView.frame.minY, view.thumbnailContainer.frame.minY - UX.frameAccuracy)
     }
 
     func testHighlight_onVeryTallPage_keepsAGrabbableMinimumHeight() {
-        let subject = createSubject(image: sampleImage(height: 40000))
-        layout(subject, in: presentationSize)
+        let subject = createSubject(image: sampleImage(height: UX.veryTallPageHeight))
+        layout(subject, in: UX.presentationSize)
 
-        XCTAssertGreaterThanOrEqual(subject.screenshotView.highlightView.frame.height, minimumHighlightHeight)
+        XCTAssertGreaterThanOrEqual(subject.screenshotView.highlightView.frame.height, UX.minimumHighlightHeight)
     }
 
-    // If the bright slice drifts out of register, the spotlight shows a different
-    // part of the page than the capture does.
+    // A drifting bright slice spotlights a different part of the page than the capture shows.
     func testHighlight_brightSliceTracksTheHighlightOffset() {
-        let subject = createSubject(image: sampleImage(height: 2400))
-        layout(subject, in: presentationSize)
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        layout(subject, in: UX.presentationSize)
 
         scroll(subject, toFractionOfMaximumOffset: 0.5)
 
         let view = subject.screenshotView
         let offsetFromThumbnailTop = view.highlightView.frame.minY - view.thumbnailContainer.frame.minY
         XCTAssertGreaterThan(offsetFromThumbnailTop, 0, "Expected the highlight to have moved down the rail")
-        XCTAssertEqual(view.brightWindowImageView.frame.minY, -offsetFromThumbnailTop, accuracy: 0.5)
+        XCTAssertEqual(view.brightWindowImageView.frame.minY, -offsetFromThumbnailTop, accuracy: UX.frameAccuracy)
     }
 
     // MARK: - Helpers
-
-    private let presentationSize = CGSize(width: 390, height: 844)
-    private let minimumHighlightHeight: CGFloat = 24
 
     private func createSubject(image: UIImage? = nil) -> WebCompatFullPageScreenshotViewController {
         return WebCompatFullPageScreenshotViewController(
@@ -143,7 +150,7 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
         XCTAssertEqual(view.highlightView.isHidden, expected, "highlightView", file: file, line: line)
     }
 
-    private func sampleImage(width: CGFloat = 320, height: CGFloat) -> UIImage {
+    private func sampleImage(width: CGFloat = UX.pageWidth, height: CGFloat) -> UIImage {
         let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height))
         return renderer.image { context in
             UIColor.systemBlue.setFill()
@@ -151,8 +158,7 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
         }
     }
 
-    // No UIApplication in logic tests, so UIControl.sendActions does nothing.
-    // Call the registered selectors directly instead.
+    // No UIApplication in logic tests, so `sendActions` does nothing.
     private func fireActions(_ control: UIControl?, for event: UIControl.Event) {
         guard let control else { return }
         for target in control.allTargets {

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
@@ -18,6 +18,8 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
         static let veryTallPageHeight: CGFloat = 40000
         /// Mirrors `WebCompatFullPageScreenshotView.UX.minimumHighlightHeight`, which is private.
         static let minimumHighlightHeight: CGFloat = 24
+        /// Mirrors `WebCompatFullPageScreenshotView.UX.thumbnailWidth`, which is private.
+        static let railWidth: CGFloat = 44
         static let frameAccuracy: CGFloat = 0.5
     }
 
@@ -100,6 +102,25 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(subject.screenshotView.highlightView.frame.height, UX.minimumHighlightHeight)
     }
 
+    // The rail used to back-solve its width from the capped height, so a tall enough page
+    // collapsed it to a sliver and widened the capture along with it.
+    func testLayout_onVeryTallPage_keepsRailWidthAndCaptureWidth() {
+        let tallSubject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        let veryTallSubject = createSubject(image: sampleImage(height: UX.veryTallPageHeight))
+
+        layout(tallSubject, in: UX.presentationSize)
+        layout(veryTallSubject, in: UX.presentationSize)
+
+        let veryTallView = veryTallSubject.screenshotView
+        XCTAssertEqual(veryTallView.thumbnailContainer.frame.width, UX.railWidth, accuracy: UX.frameAccuracy)
+        XCTAssertEqual(
+            veryTallView.scrollView.frame.width,
+            tallSubject.screenshotView.scrollView.frame.width,
+            accuracy: UX.frameAccuracy,
+            "Page length must not change the capture width"
+        )
+    }
+
     // A drifting bright slice spotlights a different part of the page than the capture shows.
     func testHighlight_brightSliceTracksTheHighlightOffset() {
         let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
@@ -145,7 +166,7 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
         line: UInt = #line
     ) {
         let view = subject.screenshotView
-        XCTAssertEqual(view.captureContainer.isHidden, expected, "captureContainer", file: file, line: line)
+        XCTAssertEqual(view.scrollView.isHidden, expected, "scrollView", file: file, line: line)
         XCTAssertEqual(view.thumbnailContainer.isHidden, expected, "thumbnailContainer", file: file, line: line)
         XCTAssertEqual(view.highlightView.isHidden, expected, "highlightView", file: file, line: line)
     }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
@@ -9,15 +9,24 @@ import XCTest
 
 @MainActor
 final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
-    func testCloseCallback_notifiesDelegate() {
+    func testCloseCallback_notifiesDelegate() throws {
         let delegate = MockWebCompatFullPageScreenshotDelegate()
         let subject = createSubject()
         subject.delegate = delegate
         subject.loadViewIfNeeded()
 
-        screenshotView(of: subject)?.onClose?()
+        try screenshotView(of: subject).onClose?()
 
         XCTAssertEqual(delegate.didRequestDismissCallCount, 1)
+    }
+
+    // The report sheet underneath stays mounted, so without this VoiceOver swipes straight into it.
+    func testLoadView_marksTheScreenshotViewAsModal() throws {
+        let subject = createSubject()
+
+        let screenshotView = try screenshotView(of: subject)
+
+        XCTAssertTrue(screenshotView.accessibilityViewIsModal)
     }
 
     // The two-finger scrub is the expected way out of a modal.
@@ -40,6 +49,10 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
     private func createSubject() -> WebCompatFullPageScreenshotViewController {
         return WebCompatFullPageScreenshotViewController(
             image: nil,
+            viewModel: WebCompatFullPageScreenshotViewModel(
+                captureAccessibilityLabel: "Screenshot of the page",
+                captureAccessibilityIdentifier: "capture"
+            ),
             closeButtonViewModel: CloseButtonViewModel(a11yLabel: "Close", a11yIdentifier: "close"),
             theme: LightTheme()
         )
@@ -49,8 +62,8 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
     /// rather than through a property on the controller.
     private func screenshotView(
         of subject: WebCompatFullPageScreenshotViewController
-    ) -> WebCompatFullPageScreenshotView? {
-        return subject.view as? WebCompatFullPageScreenshotView
+    ) throws -> WebCompatFullPageScreenshotView {
+        return try XCTUnwrap(subject.view as? WebCompatFullPageScreenshotView)
     }
 }
 

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
@@ -9,30 +9,13 @@ import XCTest
 
 @MainActor
 final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
-    private enum UX {
-        static let presentationSize = CGSize(width: 390, height: 844)
-        static let landscapeSize = CGSize(width: 852, height: 393)
-        /// What the view is handed at the start of the presentation transition.
-        static let transitionSize = CGSize(width: 1, height: 1)
-        static let pageWidth: CGFloat = 320
-        /// Short enough to fit the space the capture is given.
-        static let shortPageHeight: CGFloat = 400
-        static let tallPageHeight: CGFloat = 2400
-        static let veryTallPageHeight: CGFloat = 40000
-        /// Mirrors `WebCompatFullPageScreenshotView.UX.minimumHighlightHeight`, which is private.
-        static let minimumHighlightHeight: CGFloat = 24
-        /// Mirrors `WebCompatFullPageScreenshotView.UX.thumbnailWidth`, which is private.
-        static let railWidth: CGFloat = 44
-        static let frameAccuracy: CGFloat = 0.5
-    }
-
-    func testCloseButton_notifiesDelegate() {
+    func testCloseCallback_notifiesDelegate() {
         let delegate = MockWebCompatFullPageScreenshotDelegate()
         let subject = createSubject()
         subject.delegate = delegate
         subject.loadViewIfNeeded()
 
-        fireActions(subject.screenshotView.closeButton, for: .touchUpInside)
+        screenshotView(of: subject)?.onClose?()
 
         XCTAssertEqual(delegate.didRequestDismissCallCount, 1)
     }
@@ -52,197 +35,22 @@ final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
         XCTAssertFalse(createSubject().accessibilityPerformEscape())
     }
 
-    // MARK: - Content gating
-
-    // Presentation starts near zero size, so everything hides until the size is real.
-    func testLayout_atTransitionSize_hidesGeometryDrivenViews() {
-        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
-
-        layout(subject, in: UX.transitionSize)
-
-        assertGeometryViewsHidden(subject, expected: true)
-    }
-
-    func testLayout_recoveringFromTransitionSize_showsGeometryDrivenViews() {
-        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
-        layout(subject, in: UX.transitionSize)
-
-        layout(subject, in: UX.presentationSize)
-
-        assertGeometryViewsHidden(subject, expected: false)
-    }
-
-    func testLayout_withoutImage_hidesGeometryDrivenViews() {
-        let subject = createSubject(image: nil)
-
-        layout(subject, in: UX.presentationSize)
-
-        assertGeometryViewsHidden(subject, expected: true)
-    }
-
-    // MARK: - Viewport highlight
-
-    func testHighlight_atTopOfPage_sitsAtTopOfThumbnail() {
-        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
-        layout(subject, in: UX.presentationSize)
-
-        let view = subject.screenshotView
-        XCTAssertEqual(view.highlightView.frame.minY, view.thumbnailContainer.frame.minY, accuracy: UX.frameAccuracy)
-    }
-
-    func testHighlight_scrolledToBottom_sitsAtBottomOfThumbnail() {
-        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
-        layout(subject, in: UX.presentationSize)
-
-        scroll(subject, toFractionOfMaximumOffset: 1)
-
-        let view = subject.screenshotView
-        XCTAssertEqual(view.highlightView.frame.maxY, view.thumbnailContainer.frame.maxY, accuracy: UX.frameAccuracy)
-    }
-
-    // Rubber-banding pushes the offset past both ends. The highlight has to stay put.
-    func testHighlight_whenOverScrolled_staysWithinThumbnail() {
-        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
-        layout(subject, in: UX.presentationSize)
-        let view = subject.screenshotView
-
-        scroll(subject, toFractionOfMaximumOffset: 1.4)
-        XCTAssertLessThanOrEqual(view.highlightView.frame.maxY, view.thumbnailContainer.frame.maxY + UX.frameAccuracy)
-
-        scroll(subject, toFractionOfMaximumOffset: -0.4)
-        XCTAssertGreaterThanOrEqual(view.highlightView.frame.minY, view.thumbnailContainer.frame.minY - UX.frameAccuracy)
-    }
-
-    func testHighlight_onVeryTallPage_keepsAGrabbableMinimumHeight() {
-        let subject = createSubject(image: sampleImage(height: UX.veryTallPageHeight))
-        layout(subject, in: UX.presentationSize)
-
-        XCTAssertGreaterThanOrEqual(subject.screenshotView.highlightView.frame.height, UX.minimumHighlightHeight)
-    }
-
-    // The rail used to back-solve its width from the capped height, so a tall enough page
-    // collapsed it to a sliver and widened the capture along with it.
-    func testLayout_onVeryTallPage_keepsRailWidthAndCaptureWidth() {
-        let tallSubject = createSubject(image: sampleImage(height: UX.tallPageHeight))
-        let veryTallSubject = createSubject(image: sampleImage(height: UX.veryTallPageHeight))
-
-        layout(tallSubject, in: UX.presentationSize)
-        layout(veryTallSubject, in: UX.presentationSize)
-
-        let veryTallView = veryTallSubject.screenshotView
-        XCTAssertEqual(veryTallView.thumbnailContainer.frame.width, UX.railWidth, accuracy: UX.frameAccuracy)
-        XCTAssertEqual(
-            veryTallView.scrollView.frame.width,
-            tallSubject.screenshotView.scrollView.frame.width,
-            accuracy: UX.frameAccuracy,
-            "Page length must not change the capture width"
-        )
-    }
-
-    // A page wider than it is tall makes the rail short. The highlight's minimum height used
-    // to exceed it, so it overhung the rail and stopped tracking the scroll entirely.
-    func testHighlight_onWideLandscapePage_staysInsideTheRailAndTracksScroll() {
-        let subject = createSubject(
-            image: sampleImage(width: UX.landscapeSize.width, height: UX.landscapeSize.height)
-        )
-        layout(subject, in: UX.landscapeSize)
-        let view = subject.screenshotView
-        let topOffset = view.highlightView.frame.minY
-
-        scroll(subject, toFractionOfMaximumOffset: 1)
-
-        XCTAssertLessThanOrEqual(
-            view.highlightView.frame.maxY,
-            view.thumbnailContainer.frame.maxY + UX.frameAccuracy,
-            "The highlight must not overhang the rail"
-        )
-        XCTAssertGreaterThan(view.highlightView.frame.minY, topOffset, "The highlight must track the scroll")
-    }
-
-    // MARK: - Capture sizing
-
-    // Stretching a short page to the full height would round the top corners over scrim and
-    // leave the image's bottom edge square.
-    func testLayout_shortPage_sizesTheCaptureToThePage() {
-        let subject = createSubject(image: sampleImage(height: UX.shortPageHeight))
-
-        layout(subject, in: UX.presentationSize)
-
-        let scrollView = subject.screenshotView.scrollView
-        XCTAssertEqual(scrollView.frame.height, scrollView.contentSize.height, accuracy: UX.frameAccuracy)
-    }
-
-    // A drifting bright slice spotlights a different part of the page than the capture shows.
-    func testHighlight_brightSliceTracksTheHighlightOffset() {
-        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
-        layout(subject, in: UX.presentationSize)
-
-        scroll(subject, toFractionOfMaximumOffset: 0.5)
-
-        let view = subject.screenshotView
-        let offsetFromThumbnailTop = view.highlightView.frame.minY - view.thumbnailContainer.frame.minY
-        XCTAssertGreaterThan(offsetFromThumbnailTop, 0, "Expected the highlight to have moved down the rail")
-        XCTAssertEqual(view.brightWindowImageView.frame.minY, -offsetFromThumbnailTop, accuracy: UX.frameAccuracy)
-    }
-
     // MARK: - Helpers
 
-    private func createSubject(image: UIImage? = nil) -> WebCompatFullPageScreenshotViewController {
+    private func createSubject() -> WebCompatFullPageScreenshotViewController {
         return WebCompatFullPageScreenshotViewController(
-            image: image,
+            image: nil,
             closeButtonViewModel: CloseButtonViewModel(a11yLabel: "Close", a11yIdentifier: "close"),
             theme: LightTheme()
         )
     }
 
-    private func layout(_ subject: WebCompatFullPageScreenshotViewController, in size: CGSize) {
-        subject.loadViewIfNeeded()
-        subject.view.frame = CGRect(origin: .zero, size: size)
-        subject.view.layoutIfNeeded()
-    }
-
-    private func scroll(
-        _ subject: WebCompatFullPageScreenshotViewController,
-        toFractionOfMaximumOffset fraction: CGFloat
-    ) {
-        let scrollView = subject.screenshotView.scrollView
-        let maximumOffset = max(1, scrollView.contentSize.height - scrollView.bounds.height)
-        scrollView.contentOffset = CGPoint(x: 0, y: maximumOffset * fraction)
-    }
-
-    private func assertGeometryViewsHidden(
-        _ subject: WebCompatFullPageScreenshotViewController,
-        expected: Bool,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) {
-        let view = subject.screenshotView
-        XCTAssertEqual(view.scrollView.isHidden, expected, "scrollView", file: file, line: line)
-        XCTAssertEqual(view.brightWindowContainer.isHidden, expected, "brightWindowContainer", file: file, line: line)
-        XCTAssertEqual(view.thumbnailContainer.isHidden, expected, "thumbnailContainer", file: file, line: line)
-        XCTAssertEqual(view.highlightView.isHidden, expected, "highlightView", file: file, line: line)
-        XCTAssertFalse(view.closeButton.isHidden, "The close button must stay reachable", file: file, line: line)
-    }
-
-    // Scale 1, or the 40000pt fixture allocates hundreds of megabytes at device scale.
-    private func sampleImage(width: CGFloat = UX.pageWidth, height: CGFloat) -> UIImage {
-        let format = UIGraphicsImageRendererFormat.default()
-        format.scale = 1
-        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height), format: format)
-        return renderer.image { context in
-            UIColor.systemBlue.setFill()
-            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
-        }
-    }
-
-    // No UIApplication in logic tests, so `sendActions` does nothing.
-    private func fireActions(_ control: UIControl, for event: UIControl.Event) {
-        for target in control.allTargets {
-            let object = target as NSObject
-            control.actions(forTarget: target, forControlEvent: event)?.forEach {
-                object.perform(Selector($0))
-            }
-        }
+    /// `loadView` assigns the screenshot view as the root view, so the tests reach it from there
+    /// rather than through a property on the controller.
+    private func screenshotView(
+        of subject: WebCompatFullPageScreenshotViewController
+    ) -> WebCompatFullPageScreenshotView? {
+        return subject.view as? WebCompatFullPageScreenshotView
     }
 }
 

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewControllerTests.swift
@@ -1,0 +1,182 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import XCTest
+@testable import WebCompatReporterKit
+
+@MainActor
+final class WebCompatFullPageScreenshotViewControllerTests: XCTestCase {
+    func testCloseButton_notifiesDelegate() {
+        let delegate = MockWebCompatFullPageScreenshotDelegate()
+        let subject = createSubject()
+        subject.delegate = delegate
+        subject.loadViewIfNeeded()
+
+        fireActions(firstSubview(ofType: CloseButton.self, in: subject.view), for: .touchUpInside)
+
+        XCTAssertEqual(delegate.didTapCloseCallCount, 1)
+    }
+
+    // MARK: - Content gating
+
+    // Presentation starts near zero size, so everything hides until the size is
+    // real. The part worth pinning is that it comes back afterwards.
+    func testLayout_atTransitionSize_hidesGeometryDrivenViews() {
+        let subject = createSubject(image: sampleImage(height: 2400))
+
+        layout(subject, in: CGSize(width: 1, height: 1))
+
+        assertGeometryViewsHidden(subject, expected: true)
+    }
+
+    func testLayout_recoveringFromTransitionSize_showsGeometryDrivenViews() {
+        let subject = createSubject(image: sampleImage(height: 2400))
+        layout(subject, in: CGSize(width: 1, height: 1))
+
+        layout(subject, in: presentationSize)
+
+        assertGeometryViewsHidden(subject, expected: false)
+    }
+
+    func testLayout_withoutImage_hidesGeometryDrivenViews() {
+        let subject = createSubject(image: nil)
+
+        layout(subject, in: presentationSize)
+
+        assertGeometryViewsHidden(subject, expected: true)
+    }
+
+    // MARK: - Viewport highlight
+
+    func testHighlight_atTopOfPage_sitsAtTopOfThumbnail() {
+        let subject = createSubject(image: sampleImage(height: 2400))
+        layout(subject, in: presentationSize)
+
+        let view = subject.screenshotView
+        XCTAssertEqual(view.highlightView.frame.minY, view.thumbnailContainer.frame.minY, accuracy: 0.5)
+    }
+
+    func testHighlight_scrolledToBottom_sitsAtBottomOfThumbnail() {
+        let subject = createSubject(image: sampleImage(height: 2400))
+        layout(subject, in: presentationSize)
+
+        scroll(subject, toFractionOfMaximumOffset: 1)
+
+        let view = subject.screenshotView
+        XCTAssertEqual(view.highlightView.frame.maxY, view.thumbnailContainer.frame.maxY, accuracy: 0.5)
+    }
+
+    // Rubber-banding pushes the offset past both ends. The highlight has to stay put.
+    func testHighlight_whenOverScrolled_staysWithinThumbnail() {
+        let subject = createSubject(image: sampleImage(height: 2400))
+        layout(subject, in: presentationSize)
+        let view = subject.screenshotView
+
+        scroll(subject, toFractionOfMaximumOffset: 1.4)
+        XCTAssertLessThanOrEqual(view.highlightView.frame.maxY, view.thumbnailContainer.frame.maxY + 0.5)
+
+        scroll(subject, toFractionOfMaximumOffset: -0.4)
+        XCTAssertGreaterThanOrEqual(view.highlightView.frame.minY, view.thumbnailContainer.frame.minY - 0.5)
+    }
+
+    func testHighlight_onVeryTallPage_keepsAGrabbableMinimumHeight() {
+        let subject = createSubject(image: sampleImage(height: 40000))
+        layout(subject, in: presentationSize)
+
+        XCTAssertGreaterThanOrEqual(subject.screenshotView.highlightView.frame.height, minimumHighlightHeight)
+    }
+
+    // If the bright slice drifts out of register, the spotlight shows a different
+    // part of the page than the capture does.
+    func testHighlight_brightSliceTracksTheHighlightOffset() {
+        let subject = createSubject(image: sampleImage(height: 2400))
+        layout(subject, in: presentationSize)
+
+        scroll(subject, toFractionOfMaximumOffset: 0.5)
+
+        let view = subject.screenshotView
+        let offsetFromThumbnailTop = view.highlightView.frame.minY - view.thumbnailContainer.frame.minY
+        XCTAssertGreaterThan(offsetFromThumbnailTop, 0, "Expected the highlight to have moved down the rail")
+        XCTAssertEqual(view.brightWindowImageView.frame.minY, -offsetFromThumbnailTop, accuracy: 0.5)
+    }
+
+    // MARK: - Helpers
+
+    private let presentationSize = CGSize(width: 390, height: 844)
+    private let minimumHighlightHeight: CGFloat = 24
+
+    private func createSubject(image: UIImage? = nil) -> WebCompatFullPageScreenshotViewController {
+        return WebCompatFullPageScreenshotViewController(
+            image: image,
+            closeButtonViewModel: CloseButtonViewModel(a11yLabel: "Close", a11yIdentifier: "close"),
+            theme: LightTheme()
+        )
+    }
+
+    private func layout(_ subject: WebCompatFullPageScreenshotViewController, in size: CGSize) {
+        subject.loadViewIfNeeded()
+        subject.view.frame = CGRect(origin: .zero, size: size)
+        subject.view.layoutIfNeeded()
+    }
+
+    private func scroll(
+        _ subject: WebCompatFullPageScreenshotViewController,
+        toFractionOfMaximumOffset fraction: CGFloat
+    ) {
+        let scrollView = subject.screenshotView.scrollView
+        let maximumOffset = max(1, scrollView.contentSize.height - scrollView.bounds.height)
+        scrollView.contentOffset = CGPoint(x: 0, y: maximumOffset * fraction)
+    }
+
+    private func assertGeometryViewsHidden(
+        _ subject: WebCompatFullPageScreenshotViewController,
+        expected: Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let view = subject.screenshotView
+        XCTAssertEqual(view.captureContainer.isHidden, expected, "captureContainer", file: file, line: line)
+        XCTAssertEqual(view.thumbnailContainer.isHidden, expected, "thumbnailContainer", file: file, line: line)
+        XCTAssertEqual(view.highlightView.isHidden, expected, "highlightView", file: file, line: line)
+    }
+
+    private func sampleImage(width: CGFloat = 320, height: CGFloat) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height))
+        return renderer.image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        }
+    }
+
+    // No UIApplication in logic tests, so UIControl.sendActions does nothing.
+    // Call the registered selectors directly instead.
+    private func fireActions(_ control: UIControl?, for event: UIControl.Event) {
+        guard let control else { return }
+        for target in control.allTargets {
+            let object = target as NSObject
+            control.actions(forTarget: target, forControlEvent: event)?.forEach {
+                object.perform(Selector($0))
+            }
+        }
+    }
+
+    private func firstSubview<T: UIView>(ofType type: T.Type, in view: UIView?) -> T? {
+        guard let view else { return nil }
+        for subview in view.subviews {
+            if let match = subview as? T { return match }
+            if let match = firstSubview(ofType: type, in: subview) { return match }
+        }
+        return nil
+    }
+}
+
+private final class MockWebCompatFullPageScreenshotDelegate: WebCompatFullPageScreenshotDelegate {
+    var didTapCloseCallCount = 0
+
+    func webCompatFullPageScreenshotDidTapClose() {
+        didTapCloseCallCount += 1
+    }
+}

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewTests.swift
@@ -23,7 +23,34 @@ final class WebCompatFullPageScreenshotViewTests: XCTestCase {
         static let minimumHighlightHeight: CGFloat = 24
         /// Mirrors `WebCompatFullPageScreenshotView.UX.thumbnailWidth`, which is private.
         static let railWidth: CGFloat = 44
+        /// Mirrors `WebCompatFullPageScreenshotView.UX.minimumRailHeight`, which is private.
+        static let minimumRailHeight: CGFloat = 64
         static let frameAccuracy: CGFloat = 0.5
+        static let captureAccessibilityLabel = "Screenshot of the page"
+        static let captureAccessibilityIdentifier = "capture"
+    }
+
+    // MARK: - Accessibility
+
+    // The capture is the whole point of the screen, and VoiceOver reached nothing but the close
+    // button until it became an element in its own right.
+    func testCapture_isAnAccessibilityElementDescribingThePage() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+
+        XCTAssertTrue(subject.pageImageView.isAccessibilityElement)
+        XCTAssertEqual(subject.pageImageView.accessibilityLabel, UX.captureAccessibilityLabel)
+        XCTAssertEqual(subject.pageImageView.accessibilityIdentifier, UX.captureAccessibilityIdentifier)
+        XCTAssertEqual(subject.pageImageView.accessibilityTraits, .image)
+    }
+
+    // Three copies of the same page would otherwise be read as three separate elements.
+    func testRail_isHiddenFromVoiceOver() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+
+        XCTAssertFalse(subject.thumbnailContainer.isAccessibilityElement)
+        XCTAssertFalse(subject.brightWindowContainer.isAccessibilityElement)
+        XCTAssertFalse(subject.brightWindowImageView.isAccessibilityElement)
+        XCTAssertFalse(subject.highlightView.isAccessibilityElement)
     }
 
     func testCloseButton_invokesOnClose() {
@@ -109,12 +136,66 @@ final class WebCompatFullPageScreenshotViewTests: XCTestCase {
         )
     }
 
-    func testHighlight_onVeryTallPage_keepsAGrabbableMinimumHeight() {
+    // The window says how much of the page is on screen, so it has to be that fraction of the rail.
+    // Asserting only that it sits inside the rail passed while it was more than twice this size.
+    func testHighlight_tallPage_isTheVisibleFractionOfTheRail() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+
+        layout(subject, in: UX.presentationSize)
+
+        let visibleFraction = subject.scrollView.frame.height / subject.scrollView.contentSize.height
+        XCTAssertEqual(
+            subject.highlightView.frame.height,
+            subject.thumbnailContainer.frame.height * visibleFraction,
+            accuracy: UX.frameAccuracy
+        )
+    }
+
+    // A page that fits needs no window: the whole rail is on screen.
+    func testHighlight_shortPage_coversTheWholeRail() {
+        let subject = createSubject(image: sampleImage(height: UX.shortPageHeight))
+
+        layout(subject, in: UX.presentationSize)
+
+        XCTAssertEqual(
+            subject.highlightView.frame.height,
+            subject.thumbnailContainer.frame.height,
+            accuracy: UX.frameAccuracy
+        )
+        XCTAssertEqual(
+            subject.highlightView.frame.minY,
+            subject.thumbnailContainer.frame.minY,
+            accuracy: UX.frameAccuracy
+        )
+    }
+
+    // Exact, not a lower bound: `>=` also passed when the window filled the entire rail.
+    func testHighlight_onVeryTallPage_clampsToTheMinimumHeight() {
         let subject = createSubject(image: sampleImage(height: UX.veryTallPageHeight))
 
         layout(subject, in: UX.presentationSize)
 
-        XCTAssertGreaterThanOrEqual(subject.highlightView.frame.height, UX.minimumHighlightHeight)
+        XCTAssertEqual(
+            subject.highlightView.frame.height,
+            UX.minimumHighlightHeight,
+            accuracy: UX.frameAccuracy
+        )
+    }
+
+    // The offset is a transform precisely so it lands without waiting for another layout pass.
+    // Every other scroll test lays out afterwards, so they all pass with the handler gutted.
+    func testHighlight_onScroll_movesWithoutAnotherLayoutPass() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        layout(subject, in: UX.presentationSize)
+        let scrollView = subject.scrollView
+
+        scrollView.contentOffset = CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.height)
+
+        XCTAssertEqual(
+            subject.highlightView.frame.maxY,
+            subject.thumbnailContainer.frame.maxY,
+            accuracy: UX.frameAccuracy
+        )
     }
 
     // The rail used to back-solve its width from the capped height, so a tall enough page
@@ -151,12 +232,18 @@ final class WebCompatFullPageScreenshotViewTests: XCTestCase {
         )
     }
 
-    // The same stretch left a short page's rail taller than the capture beside it.
-    func testLayout_shortPage_keepsTheRailNoTallerThanTheCapture() {
+    // The same stretch left a short page's rail taller than the capture beside it. Exact, because
+    // `<= capture height` was satisfied by anything from nothing to the full 307pt.
+    func testLayout_shortPage_clampsTheRailToItsMinimumHeight() {
         let subject = createSubject(image: sampleImage(height: UX.shortPageHeight))
 
         layout(subject, in: UX.presentationSize)
 
+        XCTAssertEqual(
+            subject.thumbnailContainer.frame.height,
+            UX.minimumRailHeight,
+            accuracy: UX.frameAccuracy
+        )
         XCTAssertLessThanOrEqual(
             subject.thumbnailContainer.frame.maxY,
             subject.scrollView.frame.maxY + UX.frameAccuracy
@@ -191,9 +278,17 @@ final class WebCompatFullPageScreenshotViewTests: XCTestCase {
 
         let offsetFromThumbnailTop = subject.highlightView.frame.minY - subject.thumbnailContainer.frame.minY
         XCTAssertGreaterThan(offsetFromThumbnailTop, 0, "Expected the highlight to have moved down the rail")
+        // Asserting the raw offset just restates the implementation. What has to hold is that the
+        // bright copy still lines up with the dimmed page it is spotlighting, at the same size.
         XCTAssertEqual(
-            subject.brightWindowImageView.frame.minY,
-            -offsetFromThumbnailTop,
+            subject.brightWindowContainer.convert(subject.brightWindowImageView.frame, to: subject).minY,
+            subject.thumbnailContainer.frame.minY,
+            accuracy: UX.frameAccuracy,
+            "The bright copy must stay registered with the dimmed page"
+        )
+        XCTAssertEqual(
+            subject.brightWindowImageView.frame.height,
+            subject.thumbnailContainer.frame.height,
             accuracy: UX.frameAccuracy
         )
     }
@@ -219,6 +314,10 @@ final class WebCompatFullPageScreenshotViewTests: XCTestCase {
     private func createSubject(image: UIImage? = nil) -> WebCompatFullPageScreenshotView {
         return WebCompatFullPageScreenshotView(
             image: image,
+            viewModel: WebCompatFullPageScreenshotViewModel(
+                captureAccessibilityLabel: UX.captureAccessibilityLabel,
+                captureAccessibilityIdentifier: UX.captureAccessibilityIdentifier
+            ),
             closeButtonViewModel: CloseButtonViewModel(a11yLabel: "Close", a11yIdentifier: "close")
         )
     }
@@ -230,7 +329,7 @@ final class WebCompatFullPageScreenshotViewTests: XCTestCase {
 
     private func scroll(_ subject: WebCompatFullPageScreenshotView, toFractionOfMaximumOffset fraction: CGFloat) {
         let scrollView = subject.scrollView
-        let maximumOffset = max(1, scrollView.contentSize.height - scrollView.bounds.height)
+        let maximumOffset = max(0, scrollView.contentSize.height - scrollView.bounds.height)
         scrollView.contentOffset = CGPoint(x: 0, y: maximumOffset * fraction)
         subject.layoutIfNeeded()
     }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatFullPageScreenshotViewTests.swift
@@ -1,0 +1,277 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import XCTest
+@testable import WebCompatReporterKit
+
+@MainActor
+final class WebCompatFullPageScreenshotViewTests: XCTestCase {
+    private enum UX {
+        static let presentationSize = CGSize(width: 390, height: 844)
+        static let landscapeSize = CGSize(width: 852, height: 393)
+        /// What the view is handed at the start of the presentation transition.
+        static let transitionSize = CGSize(width: 1, height: 1)
+        static let pageWidth: CGFloat = 320
+        /// Short enough to fit the space the capture is given.
+        static let shortPageHeight: CGFloat = 400
+        static let tallPageHeight: CGFloat = 2400
+        static let veryTallPageHeight: CGFloat = 40000
+        /// Mirrors `WebCompatFullPageScreenshotView.UX.minimumHighlightHeight`, which is private.
+        static let minimumHighlightHeight: CGFloat = 24
+        /// Mirrors `WebCompatFullPageScreenshotView.UX.thumbnailWidth`, which is private.
+        static let railWidth: CGFloat = 44
+        static let frameAccuracy: CGFloat = 0.5
+    }
+
+    func testCloseButton_invokesOnClose() {
+        var closeCallCount = 0
+        let subject = createSubject()
+        subject.onClose = { closeCallCount += 1 }
+
+        fireActions(subject.closeButton, for: .touchUpInside)
+
+        XCTAssertEqual(closeCallCount, 1)
+    }
+
+    // MARK: - Content gating
+
+    // Presentation starts near zero size, so everything hides until the size is real.
+    func testLayout_atTransitionSize_hidesGeometryDrivenViews() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+
+        layout(subject, in: UX.transitionSize)
+
+        assertGeometryViewsHidden(subject, expected: true)
+    }
+
+    func testLayout_recoveringFromTransitionSize_showsGeometryDrivenViews() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        layout(subject, in: UX.transitionSize)
+
+        layout(subject, in: UX.presentationSize)
+
+        assertGeometryViewsHidden(subject, expected: false)
+    }
+
+    func testLayout_withoutImage_hidesGeometryDrivenViews() {
+        let subject = createSubject(image: nil)
+
+        layout(subject, in: UX.presentationSize)
+
+        assertGeometryViewsHidden(subject, expected: true)
+    }
+
+    // MARK: - Viewport highlight
+
+    func testHighlight_atTopOfPage_sitsAtTopOfThumbnail() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+
+        layout(subject, in: UX.presentationSize)
+
+        XCTAssertEqual(
+            subject.highlightView.frame.minY,
+            subject.thumbnailContainer.frame.minY,
+            accuracy: UX.frameAccuracy
+        )
+    }
+
+    func testHighlight_scrolledToBottom_sitsAtBottomOfThumbnail() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        layout(subject, in: UX.presentationSize)
+
+        scroll(subject, toFractionOfMaximumOffset: 1)
+
+        XCTAssertEqual(
+            subject.highlightView.frame.maxY,
+            subject.thumbnailContainer.frame.maxY,
+            accuracy: UX.frameAccuracy
+        )
+    }
+
+    // Rubber-banding pushes the offset past both ends. The highlight has to stay put.
+    func testHighlight_whenOverScrolled_staysWithinThumbnail() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        layout(subject, in: UX.presentationSize)
+
+        scroll(subject, toFractionOfMaximumOffset: 1.4)
+        XCTAssertLessThanOrEqual(
+            subject.highlightView.frame.maxY,
+            subject.thumbnailContainer.frame.maxY + UX.frameAccuracy
+        )
+
+        scroll(subject, toFractionOfMaximumOffset: -0.4)
+        XCTAssertGreaterThanOrEqual(
+            subject.highlightView.frame.minY,
+            subject.thumbnailContainer.frame.minY - UX.frameAccuracy
+        )
+    }
+
+    func testHighlight_onVeryTallPage_keepsAGrabbableMinimumHeight() {
+        let subject = createSubject(image: sampleImage(height: UX.veryTallPageHeight))
+
+        layout(subject, in: UX.presentationSize)
+
+        XCTAssertGreaterThanOrEqual(subject.highlightView.frame.height, UX.minimumHighlightHeight)
+    }
+
+    // The rail used to back-solve its width from the capped height, so a tall enough page
+    // collapsed it to a sliver and widened the capture along with it.
+    func testLayout_onVeryTallPage_keepsRailWidthAndCaptureWidth() {
+        let tallSubject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        let veryTallSubject = createSubject(image: sampleImage(height: UX.veryTallPageHeight))
+
+        layout(tallSubject, in: UX.presentationSize)
+        layout(veryTallSubject, in: UX.presentationSize)
+
+        XCTAssertEqual(veryTallSubject.thumbnailContainer.frame.width, UX.railWidth, accuracy: UX.frameAccuracy)
+        XCTAssertEqual(
+            veryTallSubject.scrollView.frame.width,
+            tallSubject.scrollView.frame.width,
+            accuracy: UX.frameAccuracy,
+            "Page length must not change the capture width"
+        )
+    }
+
+    // The rail shows the whole page at rail width, so its height follows the page ratio while
+    // that fits. The dimmed page filling it used to win against this and stretch the rail down
+    // the screen, which made the highlight far bigger than the fraction of the page on show.
+    func testLayout_tallPage_sizesTheRailToThePageRatio() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+
+        layout(subject, in: UX.presentationSize)
+
+        let pageRatio = UX.tallPageHeight / UX.pageWidth
+        XCTAssertEqual(
+            subject.thumbnailContainer.frame.height,
+            UX.railWidth * pageRatio,
+            accuracy: UX.frameAccuracy
+        )
+    }
+
+    // The same stretch left a short page's rail taller than the capture beside it.
+    func testLayout_shortPage_keepsTheRailNoTallerThanTheCapture() {
+        let subject = createSubject(image: sampleImage(height: UX.shortPageHeight))
+
+        layout(subject, in: UX.presentationSize)
+
+        XCTAssertLessThanOrEqual(
+            subject.thumbnailContainer.frame.maxY,
+            subject.scrollView.frame.maxY + UX.frameAccuracy
+        )
+    }
+
+    // A page wider than it is tall makes the rail short. The highlight's minimum height used
+    // to exceed it, so it overhung the rail and stopped tracking the scroll entirely.
+    func testHighlight_onWideLandscapePage_staysInsideTheRailAndTracksScroll() {
+        let subject = createSubject(
+            image: sampleImage(width: UX.landscapeSize.width, height: UX.landscapeSize.height)
+        )
+        layout(subject, in: UX.landscapeSize)
+        let topOffset = subject.highlightView.frame.minY
+
+        scroll(subject, toFractionOfMaximumOffset: 1)
+
+        XCTAssertLessThanOrEqual(
+            subject.highlightView.frame.maxY,
+            subject.thumbnailContainer.frame.maxY + UX.frameAccuracy,
+            "The highlight must not overhang the rail"
+        )
+        XCTAssertGreaterThan(subject.highlightView.frame.minY, topOffset, "The highlight must track the scroll")
+    }
+
+    // A drifting bright slice spotlights a different part of the page than the capture shows.
+    func testHighlight_brightSliceTracksTheHighlightOffset() {
+        let subject = createSubject(image: sampleImage(height: UX.tallPageHeight))
+        layout(subject, in: UX.presentationSize)
+
+        scroll(subject, toFractionOfMaximumOffset: 0.5)
+
+        let offsetFromThumbnailTop = subject.highlightView.frame.minY - subject.thumbnailContainer.frame.minY
+        XCTAssertGreaterThan(offsetFromThumbnailTop, 0, "Expected the highlight to have moved down the rail")
+        XCTAssertEqual(
+            subject.brightWindowImageView.frame.minY,
+            -offsetFromThumbnailTop,
+            accuracy: UX.frameAccuracy
+        )
+    }
+
+    // MARK: - Capture sizing
+
+    // Stretching a short page to the full height would round the top corners over scrim and
+    // leave the image's bottom edge square.
+    func testLayout_shortPage_sizesTheCaptureToThePage() {
+        let subject = createSubject(image: sampleImage(height: UX.shortPageHeight))
+
+        layout(subject, in: UX.presentationSize)
+
+        XCTAssertEqual(
+            subject.scrollView.frame.height,
+            subject.scrollView.contentSize.height,
+            accuracy: UX.frameAccuracy
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject(image: UIImage? = nil) -> WebCompatFullPageScreenshotView {
+        return WebCompatFullPageScreenshotView(
+            image: image,
+            closeButtonViewModel: CloseButtonViewModel(a11yLabel: "Close", a11yIdentifier: "close")
+        )
+    }
+
+    private func layout(_ subject: WebCompatFullPageScreenshotView, in size: CGSize) {
+        subject.frame = CGRect(origin: .zero, size: size)
+        subject.layoutIfNeeded()
+    }
+
+    private func scroll(_ subject: WebCompatFullPageScreenshotView, toFractionOfMaximumOffset fraction: CGFloat) {
+        let scrollView = subject.scrollView
+        let maximumOffset = max(1, scrollView.contentSize.height - scrollView.bounds.height)
+        scrollView.contentOffset = CGPoint(x: 0, y: maximumOffset * fraction)
+        subject.layoutIfNeeded()
+    }
+
+    private func assertGeometryViewsHidden(
+        _ subject: WebCompatFullPageScreenshotView,
+        expected: Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(subject.scrollView.isHidden, expected, "scrollView", file: file, line: line)
+        XCTAssertEqual(
+            subject.brightWindowContainer.isHidden,
+            expected,
+            "brightWindowContainer",
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(subject.thumbnailContainer.isHidden, expected, "thumbnailContainer", file: file, line: line)
+        XCTAssertEqual(subject.highlightView.isHidden, expected, "highlightView", file: file, line: line)
+        XCTAssertFalse(subject.closeButton.isHidden, "The close button must stay reachable", file: file, line: line)
+    }
+
+    // Scale 1, or the 40000pt fixture allocates hundreds of megabytes at device scale.
+    private func sampleImage(width: CGFloat = UX.pageWidth, height: CGFloat) -> UIImage {
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: width, height: height), format: format)
+        return renderer.image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        }
+    }
+
+    // No UIApplication in logic tests, so `sendActions` does nothing.
+    private func fireActions(_ control: UIControl, for event: UIControl.Event) {
+        for target in control.allTargets {
+            let object = target as NSObject
+            control.actions(forTarget: target, forControlEvent: event)?.forEach {
+                object.perform(Selector($0))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16186](https://mozilla-hub.atlassian.net/browse/FXIOS-16186)

## :bulb: Description
Adds the full-screen page-screenshot viewer that the Report Preview thumbnail opens. Also out of [#34610](https://github.com/mozilla-mobile/firefox-ios/pull/34610), rebuilt on `main` and independent of the preview screen.

It copies the native iOS Full Page screenshot preview. The capture scrolls in the centre, and a slim whole-page thumbnail in the right margin carries a viewport highlight that tracks the scroll.

The highlight is a full-brightness copy of the page clipped to the viewport window, floating over a dimmed base. That's how the native spotlight works, and it explains the hierarchy: the bright window is a sibling of the thumbnail, not a child, because a child would be clipped and lose its border and shadow.

The view never dismisses itself; `onClose` routes back to the caller.

Scales and frames derive from the image aspect and the view bounds, so bad geometry is what produces inf/NaN and kills rendering: mid-transition sizes, a nil image, a zero-width capture. Each is guarded explicitly.

Nothing presents this yet.

<img height="623" alt="Screenshot 2026-07-27 at 17 01 16" src="https://github.com/user-attachments/assets/d2dbb2e8-fcae-436d-9c2d-b8596b6b17e1" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
Open `WebCompatFullPageScreenshotPreview.swift` and run "Tall page" and "Short page".

- Tall page: scrolling the capture moves the highlight down the rail in step, and the highlight stays inside the rail rather than overhanging it
- Short page: the card takes the page's own height instead of stretching, so all four corners stay rounded
- Drag the highlight itself and the capture scrolls with it
- Rotate to landscape: the rail keeps its width and the highlight still tracks correctly
- Close returns to the caller

[FXIOS-16186]: https://mozilla-hub.atlassian.net/browse/FXIOS-16186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
