### PR TITLE
Add FXIOS-16186 [WebCompat] Add the Report Preview screen

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportPreviewPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportPreviewPreview.swift
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+#if DEBUG
+import Common
+import SwiftUI
+import UIKit
+
+/// Hosts the screen over sample sections matching the designed payload view. Plain literals, so
+/// the preview doesn't depend on the Client.
+private struct WebCompatReportPreviewHost: UIViewControllerRepresentable {
+    typealias PreviewRow = WebCompatReportPreviewViewModel.PreviewRow
+    typealias PreviewSection = WebCompatReportPreviewViewModel.PreviewSection
+    typealias PreviewValue = WebCompatReportPreviewViewModel.PreviewValue
+
+    let theme: Theme
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let viewModel = WebCompatReportPreviewViewModel(
+            title: "Report Preview",
+            closeAccessibilityLabel: "Close",
+            closeA11yIdentifier: "WebCompatReporter.Preview.Close",
+            sections: Self.sampleSections
+        )
+        let controller = WebCompatReportPreviewViewController(viewModel: viewModel, theme: theme)
+        return UINavigationController(rootViewController: controller)
+    }
+
+    func updateUIViewController(_ navigationController: UINavigationController, context: Context) {}
+
+    private static func section(_ key: String, _ fields: [(String, PreviewValue)]) -> PreviewSection {
+        return PreviewSection(
+            id: key,
+            title: key,
+            a11yIdentifier: "WebCompatReporter.Preview.Section.\(key)",
+            contentA11yIdentifier: "WebCompatReporter.Preview.Section.\(key).content",
+            rows: fields.map { PreviewRow(id: "\(key).\($0.0)", label: $0.0, value: $0.1) }
+        )
+    }
+
+    private static let sampleSections: [PreviewSection] = [
+        section("basic", [
+            ("url", .string("https://houseandhome.com/recipe/croque-monsieur")),
+            ("breakage_category", .string("images_not_loaded")),
+            ("description", .string("The recipe images never load on this page."))
+        ]),
+        section("tabInfo", [
+            ("languages", .list(["en-US"])),
+            ("useragent_string", .string("Mozilla/5.0 (iPhone; CPU iPhone OS 26_0…)"))
+        ]),
+        section("graphics", [
+            ("device_pixel_ratio", .quantity(3)),
+            ("has_touch_screen", .bool(true))
+        ]),
+        section("antiTracking", [
+            ("block_list", .string("basic")),
+            ("blocked_origins", .null),
+            ("etp_category", .string("standard")),
+            ("is_private_browsing", .bool(false))
+        ]),
+        section("frameworks", [
+            ("fastclick", .bool(false)),
+            ("marfeel", .bool(false)),
+            ("mobify", .bool(false))
+        ]),
+        section("browserInfo", [
+            ("is_tablet", .bool(false)),
+            ("memory", .quantity(6144))
+        ]),
+        section("app", [
+            ("default_locales", .list(["en-US"])),
+            ("default_useragent_string", .string("Mozilla/5.0 (iPhone…)"))
+        ])
+    ]
+}
+
+@available(iOS 17.0, *)
+#Preview("Raw payload") {
+    WebCompatReportPreviewHost(theme: LightTheme())
+        .ignoresSafeArea()
+}
+
+@available(iOS 17.0, *)
+#Preview("Raw payload (dark)") {
+    WebCompatReportPreviewHost(theme: DarkTheme())
+        .ignoresSafeArea()
+}
+#endif

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
@@ -15,7 +15,8 @@ public protocol WebCompatReportPreviewDelegate: AnyObject {
 /// The Technical Data screen: collapsible sections listing the raw payload as
 /// key/value pairs. Store-agnostic, so configure it with a view model.
 ///
-/// Named for the ticket. Report Preview is a separate screen that pushes to this one.
+/// TODO: FXIOS-16432 - Rename the `ReportPreview` types to `TechnicalData`. Report Preview is a
+/// separate screen that pushes to this one.
 public final class WebCompatReportPreviewViewController: UIViewController,
                                                          ThemeApplicable,
                                                          UICollectionViewDelegate {

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
@@ -1,0 +1,310 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import UIKit
+
+/// What the screen reports back. The coordinator owns dismissal.
+@MainActor
+public protocol WebCompatReportPreviewDelegate: AnyObject {
+    func webCompatReportPreviewDidRequestDismiss()
+}
+
+/// The Technical Data screen: collapsible sections listing the raw payload as
+/// key/value pairs. Store-agnostic, so configure it with a view model.
+///
+/// Named for the ticket. Report Preview is a separate screen that pushes to this one.
+public final class WebCompatReportPreviewViewController: UIViewController,
+                                                         ThemeApplicable,
+                                                         UICollectionViewDelegate {
+    private enum UX {
+        static let headerHorizontalInset: CGFloat = 20
+        static let headerVerticalInset: CGFloat = 10
+    }
+
+    /// Omits `rows` deliberately. Carrying them would mark the header changed on any value
+    /// edit, when it only renders the title.
+    private enum ItemKind: Equatable {
+        case header(title: String, a11yIdentifier: String)
+        case content(WebCompatReportPreviewViewModel.PreviewSection)
+    }
+
+    /// Suffixed so an item id can't collide with a section id in `itemsByID`.
+    private static func headerItemID(for sectionID: String) -> String {
+        return "\(sectionID).header"
+    }
+
+    private static func contentItemID(for sectionID: String) -> String {
+        return "\(sectionID).content"
+    }
+
+    public weak var delegate: WebCompatReportPreviewDelegate?
+
+    private var viewModel: WebCompatReportPreviewViewModel
+    private var theme: Theme
+
+    /// The data source keys on item ids, so the values themselves live here.
+    private var itemsByID: [String: ItemKind] = [:]
+
+    /// The first applyTheme runs inside `viewDidLoad`, where reconfiguring collapses the nav
+    /// bar's large title. Later changes do reconfigure.
+    private var hasAppliedThemeOnce = false
+
+    /// ComponentLibrary's button, not a bare `UIBarButtonItem`. It brings its own size
+    /// constraints, so it stays a round chip.
+    private lazy var closeButton: CloseButton = .build { button in
+        button.addTarget(self, action: #selector(self.didTapClose), for: .touchUpInside)
+    }
+
+    private lazy var closeBarButtonItem = UIBarButtonItem(customView: closeButton)
+
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeLayout())
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.delegate = self
+        return collectionView
+    }()
+
+    private(set) lazy var dataSource = makeDataSource()
+
+    public init(viewModel: WebCompatReportPreviewViewModel, theme: Theme) {
+        self.viewModel = viewModel
+        self.theme = theme
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigationItem()
+        setupLayout()
+        configure(with: viewModel)
+        applyTheme(theme: theme)
+    }
+
+    // MARK: - Configuration
+
+    /// Safe to call before or after the view loads.
+    public func configure(with viewModel: WebCompatReportPreviewViewModel) {
+        self.viewModel = viewModel
+        guard isViewLoaded else { return }
+        navigationItem.title = viewModel.title
+        closeButton.configure(
+            viewModel: CloseButtonViewModel(
+                a11yLabel: viewModel.closeAccessibilityLabel,
+                a11yIdentifier: viewModel.closeA11yIdentifier
+            )
+        )
+        updateSections()
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigationItem() {
+        // Trailing, so the leading slot stays free for the back button on a pushed screen.
+        navigationItem.rightBarButtonItem = closeBarButtonItem
+    }
+
+    private func setupLayout() {
+        view.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func makeLayout(backgroundColor: UIColor? = nil) -> UICollectionViewCompositionalLayout {
+        return UICollectionViewCompositionalLayout { _, environment in
+            var configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+            configuration.backgroundColor = backgroundColor
+            configuration.showsSeparators = false
+            return NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: environment)
+        }
+    }
+
+    // MARK: - Data source
+
+    // Registrations go here, not inside the provider: UIKit crashes on one built lazily per cell.
+    private func makeDataSource() -> UICollectionViewDiffableDataSource<String, String> {
+        let headerRegistration = UICollectionView.CellRegistration<
+            UICollectionViewListCell, ItemKind
+        > { [weak self] cell, _, item in
+            guard let self, case let .header(title, a11yIdentifier) = item else { return }
+            cell.backgroundConfiguration = UIBackgroundConfiguration.clear()
+            var content = cell.defaultContentConfiguration()
+            content.text = title
+            content.textProperties.font = FXFontStyles.Bold.subheadline.scaledFont()
+            content.textProperties.color = self.theme.colors.textPrimary
+            content.directionalLayoutMargins = NSDirectionalEdgeInsets(
+                top: UX.headerVerticalInset,
+                leading: UX.headerHorizontalInset,
+                bottom: UX.headerVerticalInset,
+                trailing: UX.headerHorizontalInset
+            )
+            cell.contentConfiguration = content
+            cell.accessibilityIdentifier = a11yIdentifier
+            cell.accessibilityTraits.insert(.header)
+            let options = UICellAccessory.OutlineDisclosureOptions(
+                style: .header,
+                tintColor: self.theme.colors.actionPrimary
+            )
+            cell.accessories = [.outlineDisclosure(options: options)]
+        }
+
+        let contentRegistration = UICollectionView.CellRegistration<
+            WebCompatPreviewSectionContentCell, WebCompatReportPreviewViewModel.PreviewSection
+        > { [weak self] cell, _, section in
+            guard let self else { return }
+            cell.configure(rows: section.rows, accessibilityIdentifier: section.contentA11yIdentifier)
+            cell.applyTheme(theme: self.theme)
+        }
+
+        let fallbackRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, String> { _, _, _ in }
+
+        return UICollectionViewDiffableDataSource<String, String>(
+            collectionView: collectionView
+        ) { [weak self] collectionView, indexPath, itemID in
+            guard let self else {
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: fallbackRegistration, for: indexPath, item: itemID
+                )
+            }
+            switch self.itemsByID[itemID] {
+            case let .header(title, a11yIdentifier):
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: headerRegistration,
+                    for: indexPath,
+                    item: .header(title: title, a11yIdentifier: a11yIdentifier)
+                )
+            case let .content(section):
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: contentRegistration, for: indexPath, item: section
+                )
+            case .none:
+                assertionFailure("No Technical Data item registered for id \(itemID)")
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: fallbackRegistration, for: indexPath, item: itemID
+                )
+            }
+        }
+    }
+
+    private func updateSections() {
+        let expandedHeaderIDs = currentlyExpandedHeaderIDs()
+        let previousItems = itemsByID
+
+        itemsByID = [:]
+        for section in viewModel.sections {
+            itemsByID[Self.headerItemID(for: section.id)] = .header(
+                title: section.title,
+                a11yIdentifier: section.a11yIdentifier
+            )
+            itemsByID[Self.contentItemID(for: section.id)] = .content(section)
+        }
+
+        // Items live in the per-section snapshots, so applying the top-level one drops them all.
+        // Only apply it when the sections themselves changed.
+        let sectionIDs = viewModel.sections.map { $0.id }
+        if dataSource.snapshot().sectionIdentifiers != sectionIDs {
+            var sectionsSnapshot = NSDiffableDataSourceSnapshot<String, String>()
+            sectionsSnapshot.appendSections(sectionIDs)
+            dataSource.apply(sectionsSnapshot, animatingDifferences: false)
+        }
+
+        for section in viewModel.sections where dataSource.snapshot(for: section.id).items.isEmpty {
+            let headerID = Self.headerItemID(for: section.id)
+            // A fresh section starts collapsed. `expand` only restores what the user opened.
+            var snapshot = NSDiffableDataSourceSectionSnapshot<String>()
+            snapshot.append([headerID])
+            snapshot.append([Self.contentItemID(for: section.id)], to: headerID)
+            if expandedHeaderIDs.contains(headerID) {
+                snapshot.expand([headerID])
+            }
+            dataSource.apply(snapshot, to: section.id, animatingDifferences: false)
+        }
+
+        reconfigureItems(changedFrom: previousItems)
+    }
+
+    /// A value can change under a stable id, which the snapshot diff can't see.
+    private func reconfigureItems(changedFrom previousItems: [String: ItemKind]) {
+        var snapshot = dataSource.snapshot()
+        let changedItemIDs = snapshot.itemIdentifiers.filter { itemID in
+            guard let previous = previousItems[itemID] else { return false }
+            return previous != itemsByID[itemID]
+        }
+        guard !changedItemIDs.isEmpty else { return }
+        snapshot.reconfigureItems(changedItemIDs)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+
+    private func currentlyExpandedHeaderIDs() -> Set<String> {
+        let existingSectionIDs = Set(dataSource.snapshot().sectionIdentifiers)
+        var expanded = Set<String>()
+        for section in viewModel.sections where existingSectionIDs.contains(section.id) {
+            let headerID = Self.headerItemID(for: section.id)
+            if dataSource.snapshot(for: section.id).isExpanded(headerID) {
+                expanded.insert(headerID)
+            }
+        }
+        return expanded
+    }
+
+    private func reconfigureAllItems() {
+        var snapshot = dataSource.snapshot()
+        guard !snapshot.itemIdentifiers.isEmpty else { return }
+        snapshot.reconfigureItems(snapshot.itemIdentifiers)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+
+    // MARK: - Actions
+
+    @objc
+    private func didTapClose() {
+        delegate?.webCompatReportPreviewDidRequestDismiss()
+    }
+
+    // MARK: - Accessibility
+
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // No argument, so UIKit announces the screen and its first element. Naming the close
+        // button instead makes VoiceOver open on "Close".
+        UIAccessibility.post(notification: .screenChanged, argument: nil)
+    }
+
+    /// The two-finger scrub, otherwise the close button is the only way out.
+    override public func accessibilityPerformEscape() -> Bool {
+        guard let delegate else { return false }
+        delegate.webCompatReportPreviewDidRequestDismiss()
+        return true
+    }
+
+    // MARK: - UICollectionViewDelegate
+
+    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.deselectItem(at: indexPath, animated: false)
+    }
+
+    // MARK: - ThemeApplicable
+
+    public func applyTheme(theme: Theme) {
+        self.theme = theme
+        guard isViewLoaded else { return }
+        view.backgroundColor = theme.colors.layer1
+        navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
+        collectionView.backgroundColor = theme.colors.layer1
+        collectionView.setCollectionViewLayout(makeLayout(backgroundColor: theme.colors.layer1), animated: false)
+        if hasAppliedThemeOnce { reconfigureAllItems() }
+        hasAppliedThemeOnce = true
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
@@ -60,14 +60,13 @@ public final class WebCompatReportPreviewViewController: UIViewController,
 
     private lazy var closeBarButtonItem = UIBarButtonItem(customView: closeButton)
 
-    private lazy var collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: makeLayout())
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
+    private lazy var collectionView: UICollectionView = .build({ collectionView in
         collectionView.delegate = self
-        return collectionView
-    }()
+    }) {
+        UICollectionView(frame: .zero, collectionViewLayout: self.makeLayout())
+    }
 
-    private(set) lazy var dataSource = makeDataSource()
+    private lazy var dataSource = makeDataSource()
 
     public init(viewModel: WebCompatReportPreviewViewModel, theme: Theme) {
         self.viewModel = viewModel
@@ -114,18 +113,15 @@ public final class WebCompatReportPreviewViewController: UIViewController,
 
     private func setupLayout() {
         view.addSubview(collectionView)
-        NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: view.topAnchor),
-            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
+        collectionView.pinToSuperview()
     }
 
-    private func makeLayout(backgroundColor: UIColor? = nil) -> UICollectionViewCompositionalLayout {
+    private func makeLayout() -> UICollectionViewCompositionalLayout {
         return UICollectionViewCompositionalLayout { _, environment in
             var configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
-            configuration.backgroundColor = backgroundColor
+            // Clear so the collection view's own themed background shows through. A theme change
+            // then repaints instead of having to rebuild the layout for its colour.
+            configuration.backgroundColor = .clear
             configuration.showsSeparators = false
             return NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: environment)
         }
@@ -303,7 +299,6 @@ public final class WebCompatReportPreviewViewController: UIViewController,
         view.backgroundColor = theme.colors.layer1
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
         collectionView.backgroundColor = theme.colors.layer1
-        collectionView.setCollectionViewLayout(makeLayout(backgroundColor: theme.colors.layer1), animated: false)
         if hasAppliedThemeOnce { reconfigureAllItems() }
         hasAppliedThemeOnce = true
     }

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -4,8 +4,7 @@
 
 import CoreGraphics
 
-/// Layout constants for the WebCompat "Report a Website Issue" bottom sheet,
-/// matching the iOS Figma source (Mobile Assembly File 2026, node 23608-71142).
+/// Layout constants for the WebCompat "Report a Website Issue" bottom sheet.
 enum WebCompatReporterUX {
     enum Spacing {
         static let screenHorizontal: CGFloat = 16

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
@@ -21,34 +21,23 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
         XCTAssertEqual(collectionView(in: subject)?.numberOfItems(inSection: 0), 1)
     }
 
-    func testExpandingSection_revealsItsValueRows() {
+    func testExpandingSection_revealsItsValueRows() throws {
         let subject = createSubject(sections: sampleSections)
         layout(subject)
 
-        expandFirstSection(in: subject)
+        try expandFirstSection(in: subject)
 
         let collectionView = collectionView(in: subject)
         XCTAssertEqual(collectionView?.numberOfItems(inSection: 0), 2)
         XCTAssertTrue(collectionView?.cellForItem(at: IndexPath(item: 1, section: 0)) is WebCompatPreviewSectionContentCell)
     }
 
-    // The Client re-configures on every state change. That must not close an open group.
-    func testConfigure_afterExpanding_keepsTheSectionExpanded() {
+    // The Client re-configures on every state change. An unchanged re-configure must skip the
+    // top-level apply, which would drop every item and close the open group.
+    func testConfigure_withUnchangedSections_keepsTheExistingCells() throws {
         let subject = createSubject(sections: sampleSections)
         layout(subject)
-        expandFirstSection(in: subject)
-
-        subject.configure(with: makeViewModel(sections: sampleSections))
-        subject.view.layoutIfNeeded()
-
-        XCTAssertEqual(collectionView(in: subject)?.numberOfItems(inSection: 0), 2)
-    }
-
-    // An unchanged re-configure should skip the top-level apply, which would drop every item.
-    func testConfigure_withUnchangedSections_keepsTheExistingCells() {
-        let subject = createSubject(sections: sampleSections)
-        layout(subject)
-        expandFirstSection(in: subject)
+        try expandFirstSection(in: subject)
         let contentIndexPath = IndexPath(item: 1, section: 0)
         let cellBeforeReconfigure = collectionView(in: subject)?.cellForItem(at: contentIndexPath)
         XCTAssertNotNil(cellBeforeReconfigure)
@@ -62,10 +51,10 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
         )
     }
 
-    func testApplyTheme_afterExpanding_keepsTheSectionExpanded() {
+    func testApplyTheme_afterExpanding_keepsTheSectionExpanded() throws {
         let subject = createSubject(sections: sampleSections)
         layout(subject)
-        expandFirstSection(in: subject)
+        try expandFirstSection(in: subject)
 
         subject.applyTheme(theme: DarkTheme())
         subject.view.layoutIfNeeded()
@@ -74,13 +63,13 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
     }
 
     // If a round-tripped snapshot omitted collapsed children, applying it would delete them.
-    func testApplyTheme_whileCollapsed_thenExpanding_stillRevealsRows() {
+    func testApplyTheme_whileCollapsed_thenExpanding_stillRevealsRows() throws {
         let subject = createSubject(sections: sampleSections)
         layout(subject)
 
         subject.applyTheme(theme: DarkTheme())
         subject.view.layoutIfNeeded()
-        expandFirstSection(in: subject)
+        try expandFirstSection(in: subject)
 
         XCTAssertEqual(collectionView(in: subject)?.numberOfItems(inSection: 0), 2)
     }
@@ -89,13 +78,13 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
     func testConfigure_withAnAddedSection_keepsTheOpenSectionExpanded() throws {
         let subject = createSubject(sections: sampleSections)
         layout(subject)
-        expandFirstSection(in: subject)
+        try expandFirstSection(in: subject)
 
         subject.configure(with: makeViewModel(sections: [addedSection] + sampleSections))
         subject.view.layoutIfNeeded()
 
         let basicSection = try XCTUnwrap(
-            subject.dataSource.snapshot().sectionIdentifiers.firstIndex(of: "basic"),
+            sectionIndex(ofHeader: "section.basic", in: subject),
             "The pre-existing section should survive the added one"
         )
         XCTAssertEqual(basicSection, 1, "The added section should sort ahead of it")
@@ -103,10 +92,10 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
     }
 
     // A value edited under a stable id still has to reach the cell; the diff can't see it.
-    func testConfigure_withChangedRowValue_updatesTheVisibleRow() {
+    func testConfigure_withChangedRowValue_updatesTheVisibleRow() throws {
         let subject = createSubject(sections: sampleSections)
         layout(subject)
-        expandFirstSection(in: subject)
+        try expandFirstSection(in: subject)
 
         subject.configure(with: makeViewModel(sections: [changedFirstSection, sampleSections[1]]))
         subject.view.layoutIfNeeded()
@@ -158,87 +147,7 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
         XCTAssertEqual(collectionView(in: subject)?.numberOfSections, 0)
     }
 
-    /// A `backgroundConfiguration` card renders square on top and round on the bottom, because a
-    /// list cell masks by group position. Only visible in the list, hence real pixels.
-    func testExpandedCard_isRoundedOnAllFourCorners() throws {
-        let cardRows = try cardRowExtents(in: try renderExpandedScreen())
-
-        let topRow = try XCTUnwrap(cardRows.first)
-        let bottomRow = try XCTUnwrap(cardRows.last)
-        let widestRow = try XCTUnwrap(cardRows.max(by: { $0.width < $1.width }))
-        XCTAssertLessThan(
-            topRow.width,
-            widestRow.width,
-            "The card's first scanline spans its full width, so the top corners are square"
-        )
-        XCTAssertLessThan(
-            bottomRow.width,
-            widestRow.width,
-            "The card's last scanline spans its full width, so the bottom corners are square"
-        )
-    }
-
     // MARK: - Helpers
-
-    private func renderExpandedScreen() throws -> UIImage {
-        let subject = createSubject(sections: sampleSections)
-        let window = UIWindow(frame: CGRect(origin: .zero, size: UX.presentationSize))
-        window.rootViewController = UINavigationController(rootViewController: subject)
-        window.isHidden = false
-        addTeardownBlock { window.rootViewController = nil }
-        window.layoutIfNeeded()
-        expandFirstSection(in: subject)
-        window.layoutIfNeeded()
-
-        return UIGraphicsImageRenderer(bounds: window.bounds).image { context in
-            window.layer.render(in: context.cgContext)
-        }
-    }
-
-    /// Every card scanline's horizontal extent, top to bottom. The card is the only `layer5` fill
-    /// wide enough to span most of the screen.
-    ///
-    /// Matched against a swatch from the same renderer, not against colour components: the buffer
-    /// is BGRA, so comparing components works only while the colour is channel-symmetric.
-    private func cardRowExtents(in image: UIImage) throws -> [(y: Int, width: Int)] {
-        let cgImage = try XCTUnwrap(image.cgImage)
-        let data = try XCTUnwrap(cgImage.dataProvider?.data)
-        let pointer = try XCTUnwrap(CFDataGetBytePtr(data))
-        let bytesPerPixel = cgImage.bitsPerPixel / 8
-        let cardPixel = try swatchBytes(of: LightTheme().colors.layer5, bytesPerPixel: bytesPerPixel)
-
-        var extents: [(y: Int, width: Int)] = []
-        for y in 0..<cgImage.height {
-            var longestRun = 0
-            var run = 0
-            for x in 0..<cgImage.width {
-                let offset = y * cgImage.bytesPerRow + x * bytesPerPixel
-                let isCard = (0..<bytesPerPixel).allSatisfy { pointer[offset + $0] == cardPixel[$0] }
-                if isCard {
-                    run += 1
-                    longestRun = max(longestRun, run)
-                } else {
-                    run = 0
-                }
-            }
-            // Wide enough to be the card rather than a glyph or the disclosure chevron.
-            if longestRun > cgImage.width / 2 { extents.append((y, longestRun)) }
-        }
-        XCTAssertFalse(extents.isEmpty, "Found no card in the render, so the scan proves nothing")
-        return extents
-    }
-
-    /// The colour's bytes as this renderer lays them out, so channel order can't matter.
-    private func swatchBytes(of color: UIColor, bytesPerPixel: Int) throws -> [UInt8] {
-        let swatch = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1)).image { context in
-            color.setFill()
-            context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
-        }
-        let cgImage = try XCTUnwrap(swatch.cgImage)
-        let data = try XCTUnwrap(cgImage.dataProvider?.data)
-        let pointer = try XCTUnwrap(CFDataGetBytePtr(data))
-        return (0..<bytesPerPixel).map { pointer[$0] }
-    }
 
     private func makeViewModel(
         sections: [WebCompatReportPreviewViewModel.PreviewSection] = []
@@ -266,13 +175,17 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
         subject.view.layoutIfNeeded()
     }
 
-    /// UIKit owns the disclosure gesture, so expand the way that gesture ends up doing.
-    private func expandFirstSection(in subject: WebCompatReportPreviewViewController) {
+    /// UIKit owns the disclosure gesture, so expand the way that gesture ends up doing. Reached
+    /// through the collection view, since the screen keeps its data source private.
+    private func expandFirstSection(in subject: WebCompatReportPreviewViewController) throws {
+        let dataSource = try XCTUnwrap(
+            collectionView(in: subject)?.dataSource as? UICollectionViewDiffableDataSource<String, String>
+        )
         let sectionID = sampleSections[0].id
-        var snapshot = subject.dataSource.snapshot(for: sectionID)
+        var snapshot = dataSource.snapshot(for: sectionID)
         // The header is the section snapshot's only root; its id format is private.
         snapshot.expand(snapshot.rootItems)
-        subject.dataSource.apply(snapshot, to: sectionID, animatingDifferences: false)
+        dataSource.apply(snapshot, to: sectionID, animatingDifferences: false)
         subject.view.layoutIfNeeded()
     }
 
@@ -337,6 +250,18 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
 
     private func collectionView(in subject: WebCompatReportPreviewViewController) -> UICollectionView? {
         return subject.view.subviews.compactMap { $0 as? UICollectionView }.first
+    }
+
+    /// A section is recognisable from outside by its header cell's identifier.
+    private func sectionIndex(
+        ofHeader accessibilityIdentifier: String,
+        in subject: WebCompatReportPreviewViewController
+    ) -> Int? {
+        guard let collectionView = collectionView(in: subject) else { return nil }
+        return (0..<collectionView.numberOfSections).first { section in
+            collectionView.cellForItem(at: IndexPath(item: 0, section: section))?
+                .accessibilityIdentifier == accessibilityIdentifier
+        }
     }
 }
 

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
@@ -1,0 +1,349 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ComponentLibrary
+import XCTest
+@testable import WebCompatReporterKit
+
+@MainActor
+final class WebCompatReportPreviewViewControllerTests: XCTestCase {
+    private enum UX {
+        static let presentationSize = CGSize(width: 390, height: 844)
+    }
+
+    func testSectionsStartCollapsed() {
+        let subject = createSubject(sections: sampleSections)
+        layout(subject)
+
+        // Collapsed means header only.
+        XCTAssertEqual(collectionView(in: subject)?.numberOfItems(inSection: 0), 1)
+    }
+
+    func testExpandingSection_revealsItsValueRows() {
+        let subject = createSubject(sections: sampleSections)
+        layout(subject)
+
+        expandFirstSection(in: subject)
+
+        let collectionView = collectionView(in: subject)
+        XCTAssertEqual(collectionView?.numberOfItems(inSection: 0), 2)
+        XCTAssertTrue(collectionView?.cellForItem(at: IndexPath(item: 1, section: 0)) is WebCompatPreviewSectionContentCell)
+    }
+
+    // The Client re-configures on every state change. That must not close an open group.
+    func testConfigure_afterExpanding_keepsTheSectionExpanded() {
+        let subject = createSubject(sections: sampleSections)
+        layout(subject)
+        expandFirstSection(in: subject)
+
+        subject.configure(with: makeViewModel(sections: sampleSections))
+        subject.view.layoutIfNeeded()
+
+        XCTAssertEqual(collectionView(in: subject)?.numberOfItems(inSection: 0), 2)
+    }
+
+    // An unchanged re-configure should skip the top-level apply, which would drop every item.
+    func testConfigure_withUnchangedSections_keepsTheExistingCells() {
+        let subject = createSubject(sections: sampleSections)
+        layout(subject)
+        expandFirstSection(in: subject)
+        let contentIndexPath = IndexPath(item: 1, section: 0)
+        let cellBeforeReconfigure = collectionView(in: subject)?.cellForItem(at: contentIndexPath)
+        XCTAssertNotNil(cellBeforeReconfigure)
+
+        subject.configure(with: makeViewModel(sections: sampleSections))
+        subject.view.layoutIfNeeded()
+
+        XCTAssertIdentical(
+            cellBeforeReconfigure,
+            collectionView(in: subject)?.cellForItem(at: contentIndexPath)
+        )
+    }
+
+    func testApplyTheme_afterExpanding_keepsTheSectionExpanded() {
+        let subject = createSubject(sections: sampleSections)
+        layout(subject)
+        expandFirstSection(in: subject)
+
+        subject.applyTheme(theme: DarkTheme())
+        subject.view.layoutIfNeeded()
+
+        XCTAssertEqual(collectionView(in: subject)?.numberOfItems(inSection: 0), 2)
+    }
+
+    // If a round-tripped snapshot omitted collapsed children, applying it would delete them.
+    func testApplyTheme_whileCollapsed_thenExpanding_stillRevealsRows() {
+        let subject = createSubject(sections: sampleSections)
+        layout(subject)
+
+        subject.applyTheme(theme: DarkTheme())
+        subject.view.layoutIfNeeded()
+        expandFirstSection(in: subject)
+
+        XCTAssertEqual(collectionView(in: subject)?.numberOfItems(inSection: 0), 2)
+    }
+
+    // A changed section set forces the apply that drops items, so expansion is restored by hand.
+    func testConfigure_withAnAddedSection_keepsTheOpenSectionExpanded() throws {
+        let subject = createSubject(sections: sampleSections)
+        layout(subject)
+        expandFirstSection(in: subject)
+
+        subject.configure(with: makeViewModel(sections: [addedSection] + sampleSections))
+        subject.view.layoutIfNeeded()
+
+        let basicSection = try XCTUnwrap(
+            subject.dataSource.snapshot().sectionIdentifiers.firstIndex(of: "basic"),
+            "The pre-existing section should survive the added one"
+        )
+        XCTAssertEqual(basicSection, 1, "The added section should sort ahead of it")
+        XCTAssertEqual(collectionView(in: subject)?.numberOfItems(inSection: basicSection), 2)
+    }
+
+    // A value edited under a stable id still has to reach the cell; the diff can't see it.
+    func testConfigure_withChangedRowValue_updatesTheVisibleRow() {
+        let subject = createSubject(sections: sampleSections)
+        layout(subject)
+        expandFirstSection(in: subject)
+
+        subject.configure(with: makeViewModel(sections: [changedFirstSection, sampleSections[1]]))
+        subject.view.layoutIfNeeded()
+
+        let cell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 1, section: 0))
+        XCTAssertTrue(cell?.accessibilityLabel?.contains("https://changed.example") == true)
+    }
+
+    func testConfigure_withDifferentSections_replacesTheList() {
+        let subject = createSubject(sections: sampleSections)
+        layout(subject)
+
+        subject.configure(with: makeViewModel(sections: [sampleSections[1]]))
+        subject.view.layoutIfNeeded()
+
+        let collectionView = collectionView(in: subject)
+        XCTAssertEqual(collectionView?.numberOfSections, 1)
+        let header = collectionView?.cellForItem(at: IndexPath(item: 0, section: 0))
+        XCTAssertEqual(header?.accessibilityIdentifier, "section.system")
+    }
+
+    func testCloseTap_notifiesDelegate() throws {
+        let delegate = MockWebCompatReportPreviewDelegate()
+        let subject = createSubject(sections: sampleSections)
+        subject.delegate = delegate
+        subject.loadViewIfNeeded()
+
+        let closeButton = try XCTUnwrap(
+            subject.navigationItem.rightBarButtonItem?.customView as? CloseButton,
+            "The close button should be the bar button item's custom view"
+        )
+        fireActions(on: closeButton, for: .touchUpInside)
+
+        XCTAssertEqual(delegate.didRequestDismissCallCount, 1)
+    }
+
+    // Reporting the gesture as handled with nobody listening would swallow it silently.
+    func testAccessibilityEscape_withoutDelegate_isNotHandled() {
+        XCTAssertFalse(createSubject(sections: sampleSections).accessibilityPerformEscape())
+    }
+
+    func testConfigure_fromSectionsToEmpty_clearsTheList() {
+        let subject = createSubject(sections: sampleSections)
+        layout(subject)
+
+        subject.configure(with: makeViewModel())
+        subject.view.layoutIfNeeded()
+
+        XCTAssertEqual(collectionView(in: subject)?.numberOfSections, 0)
+    }
+
+    /// A `backgroundConfiguration` card renders square on top and round on the bottom, because a
+    /// list cell masks by group position. Only visible in the list, hence real pixels.
+    func testExpandedCard_isRoundedOnAllFourCorners() throws {
+        let cardRows = try cardRowExtents(in: try renderExpandedScreen())
+
+        let topRow = try XCTUnwrap(cardRows.first)
+        let bottomRow = try XCTUnwrap(cardRows.last)
+        let widestRow = try XCTUnwrap(cardRows.max(by: { $0.width < $1.width }))
+        XCTAssertLessThan(
+            topRow.width,
+            widestRow.width,
+            "The card's first scanline spans its full width, so the top corners are square"
+        )
+        XCTAssertLessThan(
+            bottomRow.width,
+            widestRow.width,
+            "The card's last scanline spans its full width, so the bottom corners are square"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func renderExpandedScreen() throws -> UIImage {
+        let subject = createSubject(sections: sampleSections)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: UX.presentationSize))
+        window.rootViewController = UINavigationController(rootViewController: subject)
+        window.isHidden = false
+        addTeardownBlock { window.rootViewController = nil }
+        window.layoutIfNeeded()
+        expandFirstSection(in: subject)
+        window.layoutIfNeeded()
+
+        return UIGraphicsImageRenderer(bounds: window.bounds).image { context in
+            window.layer.render(in: context.cgContext)
+        }
+    }
+
+    /// Every card scanline's horizontal extent, top to bottom. The card is the only `layer5` fill
+    /// wide enough to span most of the screen.
+    ///
+    /// Matched against a swatch from the same renderer, not against colour components: the buffer
+    /// is BGRA, so comparing components works only while the colour is channel-symmetric.
+    private func cardRowExtents(in image: UIImage) throws -> [(y: Int, width: Int)] {
+        let cgImage = try XCTUnwrap(image.cgImage)
+        let data = try XCTUnwrap(cgImage.dataProvider?.data)
+        let pointer = try XCTUnwrap(CFDataGetBytePtr(data))
+        let bytesPerPixel = cgImage.bitsPerPixel / 8
+        let cardPixel = try swatchBytes(of: LightTheme().colors.layer5, bytesPerPixel: bytesPerPixel)
+
+        var extents: [(y: Int, width: Int)] = []
+        for y in 0..<cgImage.height {
+            var longestRun = 0
+            var run = 0
+            for x in 0..<cgImage.width {
+                let offset = y * cgImage.bytesPerRow + x * bytesPerPixel
+                let isCard = (0..<bytesPerPixel).allSatisfy { pointer[offset + $0] == cardPixel[$0] }
+                if isCard {
+                    run += 1
+                    longestRun = max(longestRun, run)
+                } else {
+                    run = 0
+                }
+            }
+            // Wide enough to be the card rather than a glyph or the disclosure chevron.
+            if longestRun > cgImage.width / 2 { extents.append((y, longestRun)) }
+        }
+        XCTAssertFalse(extents.isEmpty, "Found no card in the render, so the scan proves nothing")
+        return extents
+    }
+
+    /// The colour's bytes as this renderer lays them out, so channel order can't matter.
+    private func swatchBytes(of color: UIColor, bytesPerPixel: Int) throws -> [UInt8] {
+        let swatch = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1)).image { context in
+            color.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+        }
+        let cgImage = try XCTUnwrap(swatch.cgImage)
+        let data = try XCTUnwrap(cgImage.dataProvider?.data)
+        let pointer = try XCTUnwrap(CFDataGetBytePtr(data))
+        return (0..<bytesPerPixel).map { pointer[$0] }
+    }
+
+    private func makeViewModel(
+        sections: [WebCompatReportPreviewViewModel.PreviewSection] = []
+    ) -> WebCompatReportPreviewViewModel {
+        return WebCompatReportPreviewViewModel(
+            title: "Report Preview",
+            closeAccessibilityLabel: "Close",
+            closeA11yIdentifier: "close",
+            sections: sections
+        )
+    }
+
+    private func createSubject(
+        sections: [WebCompatReportPreviewViewModel.PreviewSection] = []
+    ) -> WebCompatReportPreviewViewController {
+        return WebCompatReportPreviewViewController(
+            viewModel: makeViewModel(sections: sections),
+            theme: LightTheme()
+        )
+    }
+
+    private func layout(_ subject: WebCompatReportPreviewViewController) {
+        subject.view.frame = CGRect(origin: .zero, size: UX.presentationSize)
+        subject.loadViewIfNeeded()
+        subject.view.layoutIfNeeded()
+    }
+
+    /// UIKit owns the disclosure gesture, so expand the way that gesture ends up doing.
+    private func expandFirstSection(in subject: WebCompatReportPreviewViewController) {
+        let sectionID = sampleSections[0].id
+        var snapshot = subject.dataSource.snapshot(for: sectionID)
+        // The header is the section snapshot's only root; its id format is private.
+        snapshot.expand(snapshot.rootItems)
+        subject.dataSource.apply(snapshot, to: sectionID, animatingDifferences: false)
+        subject.view.layoutIfNeeded()
+    }
+
+    private let sampleSections: [WebCompatReportPreviewViewModel.PreviewSection] = [
+        WebCompatReportPreviewViewModel.PreviewSection(
+            id: "basic",
+            title: "basic",
+            a11yIdentifier: "section.basic",
+            contentA11yIdentifier: "section.basic.content",
+            rows: [
+                WebCompatReportPreviewViewModel.PreviewRow(
+                    id: "basic.url", label: "url", value: .string("https://example.com")
+                ),
+                WebCompatReportPreviewViewModel.PreviewRow(
+                    id: "basic.breakage_category", label: "breakage_category", value: .string("no_audio")
+                )
+            ]
+        ),
+        WebCompatReportPreviewViewModel.PreviewSection(
+            id: "system",
+            title: "system",
+            a11yIdentifier: "section.system",
+            contentA11yIdentifier: "section.system.content",
+            rows: [
+                WebCompatReportPreviewViewModel.PreviewRow(
+                    id: "system.is_tablet", label: "is_tablet", value: .bool(false)
+                )
+            ]
+        )
+    ]
+
+    private var addedSection: WebCompatReportPreviewViewModel.PreviewSection {
+        return WebCompatReportPreviewViewModel.PreviewSection(
+            id: "graphics",
+            title: "graphics",
+            a11yIdentifier: "section.graphics",
+            contentA11yIdentifier: "section.graphics.content",
+            rows: [
+                WebCompatReportPreviewViewModel.PreviewRow(
+                    id: "graphics.has_touch_screen", label: "has_touch_screen", value: .bool(true)
+                )
+            ]
+        )
+    }
+
+    /// `sampleSections[0]` with one value changed and every id the same, which the diff misses.
+    private var changedFirstSection: WebCompatReportPreviewViewModel.PreviewSection {
+        let section = sampleSections[0]
+        return WebCompatReportPreviewViewModel.PreviewSection(
+            id: section.id,
+            title: section.title,
+            a11yIdentifier: section.a11yIdentifier,
+            contentA11yIdentifier: section.contentA11yIdentifier,
+            rows: [
+                WebCompatReportPreviewViewModel.PreviewRow(
+                    id: "basic.url", label: "url", value: .string("https://changed.example")
+                ),
+                section.rows[1]
+            ]
+        )
+    }
+
+    private func collectionView(in subject: WebCompatReportPreviewViewController) -> UICollectionView? {
+        return subject.view.subviews.compactMap { $0 as? UICollectionView }.first
+    }
+}
+
+private final class MockWebCompatReportPreviewDelegate: WebCompatReportPreviewDelegate {
+    var didRequestDismissCallCount = 0
+
+    func webCompatReportPreviewDidRequestDismiss() {
+        didRequestDismissCallCount += 1
+    }
+}

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -113,7 +113,7 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         )
     }
 
-    func testSendButton_whenTapped_notifiesDelegateWithRowID() {
+    func testSendButton_whenTapped_notifiesDelegateWithRowID() throws {
         let delegate = MockWebCompatReportSheetDelegate()
         let subject = createSubject()
         subject.delegate = delegate
@@ -123,7 +123,8 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         subject.view.layoutIfNeeded()
 
         let cell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 0))
-        fireActions(firstSubview(ofType: UIButton.self, in: cell), for: .touchUpInside)
+        let sendButton = try XCTUnwrap(firstSubview(ofType: UIButton.self, in: cell))
+        fireActions(on: sendButton, for: .touchUpInside)
 
         XCTAssertEqual(delegate.tappedButtonIDs, ["send"])
     }
@@ -152,7 +153,7 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         )
     }
 
-    func testToggleCell_activation_notifiesDelegateWithRowIDAndValue() {
+    func testToggleCell_activation_notifiesDelegateWithRowIDAndValue() throws {
         let delegate = MockWebCompatReportSheetDelegate()
         let subject = createSubject()
         subject.delegate = delegate
@@ -162,9 +163,9 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
         subject.view.layoutIfNeeded()
 
         let toggleCell = collectionView(in: subject)?.cellForItem(at: IndexPath(item: 0, section: 0))
-        let toggle = firstSubview(ofType: UISwitch.self, in: toggleCell)
-        toggle?.isOn = true
-        fireActions(toggle, for: .valueChanged)
+        let toggle = try XCTUnwrap(firstSubview(ofType: UISwitch.self, in: toggleCell))
+        toggle.isOn = true
+        fireActions(on: toggle, for: .valueChanged)
 
         XCTAssertEqual(delegate.toggles.map(\.id), ["screenshot"])
         XCTAssertEqual(delegate.toggles.map(\.isOn), [true])
@@ -273,18 +274,6 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
 
     private func collectionView(in subject: WebCompatReportSheetViewController) -> UICollectionView? {
         return subject.view.subviews.compactMap { $0 as? UICollectionView }.first
-    }
-
-    // UIControl.sendActions needs a running UIApplication, which logic tests lack,
-    // so invoke each registered target/action selector directly.
-    private func fireActions(_ control: UIControl?, for event: UIControl.Event) {
-        guard let control else { return }
-        for target in control.allTargets {
-            let object = target as NSObject
-            control.actions(forTarget: target, forControlEvent: event)?.forEach {
-                object.perform(Selector($0))
-            }
-        }
     }
 
     private func sendSections(isEnabled: Bool) -> [WebCompatReportViewModel.Section] {

--- a/BrowserKit/Tests/WebCompatReporterKitTests/XCTestCase+TestHelpers.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/XCTestCase+TestHelpers.swift
@@ -16,4 +16,17 @@ extension XCTestCase {
         }
         return nil
     }
+
+    /// `UIControl.sendActions` needs a running `UIApplication`, which logic tests lack, and it
+    /// fails silently. Invoke each registered target/action directly instead. The control is
+    /// non-optional so a nil lookup fails at the caller's `XCTUnwrap`, not quietly here.
+    @MainActor
+    func fireActions(on control: UIControl, for event: UIControl.Event) {
+        for target in control.allTargets {
+            let object = target as NSObject
+            control.actions(forTarget: target, forControlEvent: event)?.forEach {
+                object.perform(Selector($0))
+            }
+        }
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16186](https://mozilla-hub.atlassian.net/browse/FXIOS-16186)

## :bulb: Description
Adds the Report Preview screen to `WebCompatReporterKit`: collapsible sections listing the report payload as `key: value` lines. Out of [#34610](https://github.com/mozilla-mobile/firefox-ios/pull/34610).

Stacked on the payload model and card cell it renders, so review that one first.

Configured with a `WebCompatReportPreviewViewModel`, reports intents through `WebCompatReportPreviewDelegate`, never navigates itself.

Sections start collapsed. Expanding one shows its lines in a single rounded card.

Two choices a reviewer might question:

- Re-configuring applies the top-level snapshot only when the section set changes, because applying it drops every item; otherwise changed values are reconfigured in place.
- `ItemKind.header` carries only the title, so editing a value doesn't reconfigure the header alongside it.

Nothing presents this yet. The thumbnail is [#34868](https://github.com/mozilla-mobile/firefox-ios/pull/34868) and the full-screen viewer is [#34864](https://github.com/mozilla-mobile/firefox-ios/pull/34864).

<img height="600" alt="Screenshot 2026-07-28 at 15 00 41" src="https://github.com/user-attachments/assets/e70acd5a-4b38-48e3-94d6-beb78e5eb8b8" />


<img height="600" alt="Screenshot 2026-07-28 at 15 00 53" src="https://github.com/user-attachments/assets/e1f9433c-3378-4127-9a18-e560bbdd702e" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
Open `WebCompatReportPreviewPreview.swift` and run "Raw payload" and "Raw payload (dark)".

Expect seven collapsed headers with blue chevrons. Tapping one reveals a card of `key: value` lines, rounded on all four corners, with JSON punctuation intact. The Close glyph is blank in the preview canvas because the acorn asset lives in the app bundle, not the package.

At AX5 the card grows and long values wrap instead of truncating.

[FXIOS-16186]: https://mozilla-hub.atlassian.net/browse/FXIOS-16186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
