### PR TITLE
Refactor FXIOS-16381 Replace gsutil with gcloud storage

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1918,7 +1918,7 @@ workflows:
                 --results-bucket="$GOOGLE_CLOUD_BUCKET" \
                 --results-dir="$RESULTS_DIR")
 
-            FIREBASE_XCRESULT_PATH=$("${HOME}/google-cloud-sdk/bin/gcloud" storage ls "$XCRESULT_PATH" | grep ".xcresult")
+            FIREBASE_XCRESULT_PATH=$("${HOME}/google-cloud-sdk/bin/gcloud" storage ls "$XCRESULT_PATH" | grep -F ".xcresult")
             envman add --key FIREBASE_XCRESULT_PATH --value "$FIREBASE_XCRESULT_PATH"
     - script@1:
         is_always_run: true

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1918,7 +1918,7 @@ workflows:
                 --results-bucket="$GOOGLE_CLOUD_BUCKET" \
                 --results-dir="$RESULTS_DIR")
 
-            FIREBASE_XCRESULT_PATH=$("${HOME}/google-cloud-sdk/bin/gsutil" ls "$XCRESULT_PATH" | grep ".xcresult")
+            FIREBASE_XCRESULT_PATH=$("${HOME}/google-cloud-sdk/bin/gcloud" storage ls "$XCRESULT_PATH" | grep ".xcresult")
             envman add --key FIREBASE_XCRESULT_PATH --value "$FIREBASE_XCRESULT_PATH"
     - script@1:
         is_always_run: true
@@ -1935,9 +1935,9 @@ workflows:
             # pull firebase xcresult and rename it to extract measurement data
             mkdir test_firebase_xcresult
 
-            $HOME/google-cloud-sdk/bin/gsutil -m cp -r "$FIREBASE_XCRESULT_PATH" ./test_firebase_xcresult &
+            $HOME/google-cloud-sdk/bin/gcloud storage cp -r "$FIREBASE_XCRESULT_PATH" ./test_firebase_xcresult &
 
-            # Get the process ID of the backgrounded gsutil command
+            # Get the process ID of the backgrounded gcloud storage command
             PID=$!
 
             TIMEOUT=60
@@ -1945,22 +1945,22 @@ workflows:
             ITERATIONS=$((TIMEOUT / CHECK_INTERVAL))
 
             for ((i = 0; i < ITERATIONS; i++)); do
-                echo "Waiting for gsutil to complete..."
+                echo "Waiting for gcloud storage to complete..."
                 sleep $CHECK_INTERVAL
                 if ! ps -p $PID > /dev/null; then
                     break
                 fi
             done
 
-            # if gsutil is still running after 60s, it is hanging and needs to be killed
+            # if gcloud storage is still running after 60s, it is hanging and needs to be killed
             if ps -p $PID > /dev/null; then
-                echo "The gsutil command exceeded the timeout. Stopping and removing contents..."
+                echo "The gcloud storage command exceeded the timeout. Stopping and removing contents..."
                 kill -9 $PID
 
                 rm -rf ./test_firebase_xcresult
                 mkdir ./test_firebase_xcresult
                 echo "Retrying xcresult copy without multi-processing..."
-                $HOME/google-cloud-sdk/bin/gsutil cp -r "$FIREBASE_XCRESULT_PATH" ./test_firebase_xcresult
+                CLOUDSDK_STORAGE_PROCESS_COUNT=1 CLOUDSDK_STORAGE_THREAD_COUNT=1 $HOME/google-cloud-sdk/bin/gcloud storage cp -r "$FIREBASE_XCRESULT_PATH" ./test_firebase_xcresult
             fi
 
             mv ./test_firebase_xcresult/*.xcresult ./test_firebase_xcresult/Test-Fennec-test.xcresult

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1948,6 +1948,12 @@ workflows:
                 echo "Waiting for gcloud storage to complete..."
                 sleep $CHECK_INTERVAL
                 if ! ps -p $PID > /dev/null; then
+                    wait $PID
+                    STATUS=$?
+                    if [ $STATUS -ne 0 ]; then
+                        echo "gcloud storage cp failed with exit code $STATUS"
+                        exit $STATUS
+                    fi
                     break
                 fi
             done


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16381)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34774)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
`gsutil` will be deprecated. The command is replaced by `gcloud storage`. I and Claude Code have been guessing if we can just replace the old command with the new.

`Firebase_Performance_Test` is the only workflow affected.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

Bitrise: https://app.bitrise.io/app/6c06d3a40422d10f/build/30f9e23a-0abb-423b-96c2-ef7f76e1749e
Firebase Testlab: https://console.firebase.google.com/u/0/project/moz-firefox-ios-230118/testlab/histories/bh.edf3c7143e2d5284/matrices/8340911305660816531/details?stepId=bs.6056ecdd8a26a6bb&testCaseId=1

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

