### PR TITLE
Bugfix FXIOS-16405 Fix save GIF main actor crash

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/WebContextMenuActionsProvider.swift
@@ -182,10 +182,7 @@ class WebContextMenuActionsProvider {
         ) { _ in
             getImageData(url) { data in
                 if url.pathExtension.lowercased() == "gif" {
-                    PHPhotoLibrary.shared().performChanges {
-                        let creationRequest = PHAssetCreationRequest.forAsset()
-                        creationRequest.addResource(with: .photo, data: data, options: nil)
-                    }
+                    Self.saveGIFToPhotoLibrary(data: data)
                 } else {
                     ensureMainThread {
                         guard let image = UIImage(data: data) else { return }
@@ -195,6 +192,16 @@ class WebContextMenuActionsProvider {
             }
             Self.recordOptionSelectedTelemetry(option: .saveImage, originExtra: origin)
         })
+    }
+
+    /// Photos invokes the change block on its own private queue, so the block has to be formed in a nonisolated
+    /// context. Running it inside a `@MainActor` context makes it inherit main actor isolation,
+    /// and the runtime executor check then traps as soon as Photos runs it off the main thread.
+    nonisolated private static func saveGIFToPhotoLibrary(data: Data) {
+        PHPhotoLibrary.shared().performChanges {
+            let creationRequest = PHAssetCreationRequest.forAsset()
+            creationRequest.addResource(with: .photo, data: data, options: nil)
+        }
     }
 
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16405)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34870)

## :bulb: Description
This issue fixes the crash. I want to isolate just the fix for the backport so will follow up with a second PR to address the error message and unit test concerns in the ticket. 

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

