### PR TITLE
remove: Unused RequestBody, delete func and dependent tests

### DIFF
--- a/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/UnifiedAds/UnifiedAdsProvider.swift
@@ -54,11 +54,6 @@ final class UnifiedAdsProvider: UnifiedAdsProviderInterface, Sendable {
         let count: Int
     }
 
-    private struct RequestBody: Codable {
-        let context_id: String
-        let placements: [AdPlacement]
-    }
-
     func fetchTiles(timestamp: Shared.Timestamp = Date.now(),
                     completion: @escaping @Sendable (UnifiedTileResult) -> Void) {
         logger.log("Fetching tiles with ads client", level: .debug, category: .homepage)

--- a/firefox-ios/Client/Utils/HistoryDeletionUtility.swift
+++ b/firefox-ios/Client/Utils/HistoryDeletionUtility.swift
@@ -16,7 +16,6 @@ enum HistoryDeletionUtilityDateOptions: String, CaseIterable {
 }
 
 protocol HistoryDeletionProtocol {
-    func delete(_ sites: [String], completion: @Sendable @escaping (Bool) -> Void)
     @MainActor
     func deleteHistoryFrom(_ dateOption: HistoryDeletionUtilityDateOptions,
                            completion: @Sendable @escaping @MainActor (HistoryDeletionUtilityDateOptions) -> Void)
@@ -32,16 +31,6 @@ final class HistoryDeletionUtility: HistoryDeletionProtocol, Sendable {
     }
 
     // MARK: Interface
-    func delete(
-        _ sites: [String],
-        completion: @Sendable @escaping (Bool) -> Void
-    ) {
-        deleteFromHistory(sites)
-        deleteMetadata(sites) { result in
-            completion(result)
-        }
-    }
-
     @MainActor
     func deleteHistoryFrom(
         _ dateOption: HistoryDeletionUtilityDateOptions,
@@ -60,28 +49,6 @@ final class HistoryDeletionUtility: HistoryDeletionProtocol, Sendable {
         deleteProfileMetadataSince(dateOption)
 
         HistoryDeletionUtilityTelemetry().clearedHistory(dateOption)
-    }
-
-    // MARK: URL based deletion functions
-    private func deleteFromHistory(_ sites: [String]) {
-        sites.forEach { _ = profile.places.deleteVisitsFor($0) }
-    }
-
-    private func deleteMetadata(
-        _ sites: [String],
-        completion: @Sendable @escaping (Bool) -> Void
-    ) {
-        sites.forEach { currentSite in
-            profile.places
-                .deleteVisitsFor(url: currentSite)
-                .uponQueue(.global()) { result in
-                    guard let lastSite = sites.last,
-                          lastSite == currentSite
-                    else { return }
-
-                    completion(result.isSuccess)
-                }
-        }
     }
 
     // MARK: - Date based deletion functions

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/HistoryDeletionUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/HistoryDeletionUtilityTests.swift
@@ -46,76 +46,6 @@ class HistoryDeletionUtilityTests: XCTestCase, @unchecked Sendable {
         assertDBStateFor(testSites, with: profile)
     }
 
-    // MARK: - Test url based deletion
-    @MainActor
-    func testDeletingSingleItem() {
-        let profile = profileSetup(named: "hsd_deleteSingleItem")
-        let testSites = [SiteElements(domain: "mozilla")]
-        populateDBHistory(with: testSites, using: profile)
-        let siteEntry = createWebsiteFor(domain: "mozilla", with: "")
-
-        deletionWithExpectation(for: [siteEntry.url], using: profile) { result in
-            XCTAssertTrue(result)
-            self.assertDBIsEmpty(with: profile)
-        }
-    }
-
-    @MainActor
-    func testDeletingMultipleItemsEmptyingDatabase() {
-        let profile = profileSetup(named: "hsd_deleteMultipleItemsEmptyingDB")
-        let sitesToDelete = [SiteElements(domain: "mozilla"),
-                             SiteElements(domain: "amazon"),
-                             SiteElements(domain: "google")]
-        populateDBHistory(with: sitesToDelete, using: profile)
-
-        let siteEntries = sitesToDelete
-            .map { self.createWebsiteFor(domain: $0.domain, with: $0.path) }
-            .map { $0.url }
-
-        deletionWithExpectation(for: siteEntries, using: profile) { result in
-            XCTAssertTrue(result)
-            self.assertDBIsEmpty(with: profile)
-        }
-    }
-
-    @MainActor
-    func testDeletingMultipleTopLevelItems() {
-        let profile = profileSetup(named: "hsd_deleteMultipleItemsTopLevelItems")
-        let sitesToRemain = [SiteElements(domain: "cnn")]
-        let sitesToDelete = [SiteElements(domain: "mozilla"),
-                             SiteElements(domain: "google"),
-                             SiteElements(domain: "amazon")]
-        populateDBHistory(with: (sitesToRemain + sitesToDelete).shuffled(), using: profile)
-
-        let siteEntries = sitesToDelete
-            .map { self.createWebsiteFor(domain: $0.domain, with: $0.path) }
-            .map { $0.url }
-
-        deletionWithExpectation(for: siteEntries, using: profile) { result in
-            XCTAssertTrue(result)
-            self.assertDBStateFor(sitesToRemain, with: profile)
-        }
-    }
-
-    @MainActor
-    func testDeletingMultipleSpecificItems() {
-        let profile = profileSetup(named: "hsd_deleteMultipleSpecificItems")
-        let sitesToRemain = [SiteElements(domain: "cnn", path: "newsOne/test1.html")]
-        let sitesToDelete = [SiteElements(domain: "cnn", path: "newsOne/test2.html"),
-                             SiteElements(domain: "cnn", path: "newsOne/test3.html"),
-                             SiteElements(domain: "cnn", path: "newsTwo/test1.html")]
-        populateDBHistory(with: (sitesToRemain + sitesToDelete).shuffled(), using: profile)
-
-        let siteEntries = sitesToDelete
-            .map { self.createWebsiteFor(domain: $0.domain, with: $0.path) }
-            .map { $0.url }
-
-        deletionWithExpectation(for: siteEntries, using: profile) { result in
-            XCTAssertTrue(result)
-            self.assertDBStateFor(sitesToRemain, with: profile)
-        }
-    }
-
     // MARK: - Test time based deletion
     // In these tests, we don't test the deletion of metadata. The assumption
     // is that A-S has its own testing. Furthermore, because we don't have an
@@ -366,26 +296,6 @@ class HistoryDeletionUtilityTests: XCTestCase, @unchecked Sendable {
         emptyDB(with: profile)
 
         return profile
-    }
-
-    @MainActor
-    func deletionWithExpectation(
-        for siteEntries: [String],
-        using profile: MockProfile,
-        file: StaticString = #filePath,
-        line: UInt = #line,
-        completion: @escaping @Sendable (Bool) -> Void
-    ) {
-        let deletionUtility = HistoryDeletionUtility(with: profile)
-        trackForMemoryLeaks(deletionUtility)
-        let expectation = expectation(description: "HistoryDeletionUtilityTest")
-
-        deletionUtility.delete(siteEntries) { result in
-            completion(result)
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 5, handler: nil)
     }
 
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)
Fixes #34804 

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
- Removed `RequestBody` from `UnifiedAdsProvider.swift`
- Removed `delete(_:completion:)`, `deleteFromHistory(_:)` and `deleteMetadata(_:completion:)` from `HistoryDeletionUtility.swift`
- Removed `deletionWithExpectation(for:using:file:line:completion:)` which calls the above `delete(_:completion:)` and its callers  -> `testDeletingSingleItem()`, `testDeletingMultipleItemsEmptyingDatabase()`, `testDeletingMultipleTopLevelItems()`, `testDeletingMultipleSpecificItems()` from `HistoryDeletionUtilityTests.swift`. 



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

