### PR TITLE
FXIOS-16361 Remove dead PasswordManagerViewModel code

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -27,7 +27,6 @@ class PasswordManagerListViewController: SensitiveViewController,
     private let searchController = UISearchController(searchResultsController: nil)
     private let loadingView: SettingsLoadingView = .build()
     private var deleteAlert: UIAlertController?
-    private var selectedIndexPaths = [IndexPath]()
     private let tableView: UITableView
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { return windowUUID }

--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerViewModel.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerViewModel.swift
@@ -10,10 +10,6 @@ import Shared
 import struct MozillaAppServices.Login
 import struct MozillaAppServices.LoginEntry
 
-struct NewSearchInProgressError: MaybeErrorType {
-    public let description: String
-}
-
 // Login List View Model
 @MainActor
 final class PasswordManagerViewModel {
@@ -173,18 +169,8 @@ final class PasswordManagerViewModel {
         })
     }
 
-    func setBreachIndexPath(indexPath: IndexPath) {
-        self.breachIndexPath = [indexPath]
-    }
-
-    func setBreachAlertsManager(_ client: BreachAlertsClientProtocol) {
-        self.breachAlertsManager = BreachAlertsManager(client, profile: profile)
-    }
-
     // MARK: - UX Constants
     struct UX {
-        static let rowHeight: CGFloat = 58
-        static let searchHeight: CGFloat = 58
         static let selectionButtonFont = UIFont.systemFont(ofSize: 16)
         static let noResultsFont = UIFont.systemFont(ofSize: 16)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/PasswordManagerViewModelTests.swift
@@ -31,7 +31,6 @@ class PasswordManagerViewModelTests: XCTestCase {
         )
         self.mockDelegate = MockLoginViewModelDelegate()
         self.viewModel.delegate = mockDelegate
-        self.viewModel.setBreachAlertsManager(MockBreachAlertsClient())
     }
 
     override func tearDown() async throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16361)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34798)

## :bulb: Description

Dead code cleanup, removes unused code paths.

for #34798 

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

