### PR TITLE
[MTE-5735] - fixes for share and toolbar flaky tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
@@ -183,19 +183,14 @@ class ShareMenuTests: FeatureFlaggedTestBase {
         // The Markup tool opens. It can take a little longer to load, so wait longer.
         if #available(iOS 26, *) {
             if !iPad() {
-                // The navbar overflow label varies ("More" -> "View More", MTE-5253) and the
-                // palette sometimes opens without one; only tap the label that's actually present.
-                if !app.buttons["Markup"].mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) {
-                    let overflow = app.navigationBars.buttons["More"].exists
-                        ? app.navigationBars.buttons["More"]
-                        : app.navigationBars.buttons["View More"]
-                    if overflow.exists {
-                        overflow.waitAndTap()
-                    }
+                // Share "Markup" sometimes opens QuickLook in preview mode (a "Markup" pen button, no
+                // palette); tap it to enter markup, then verify the PencilKit Drawing-Palette + Pen.
+                let palette = app.otherElements["Drawing-Palette"]
+                if !palette.mozWaitForElementToExist(timeout: TIMEOUT_LONG, failOnTimeout: false) {
+                    app.switches["QLOverlayMarkupButtonAccessibilityIdentifier"].firstMatch.waitAndTap()
                 }
-                mozWaitForElementToExist(app.buttons["Markup"], timeout: TIMEOUT_LONG)
-                mozWaitForElementToExist(app.buttons["Close"], timeout: TIMEOUT_LONG)
-                mozWaitForElementToExist(app.otherElements["Drawing-Palette"], timeout: TIMEOUT_LONG)
+                mozWaitForElementToExist(palette, timeout: TIMEOUT_LONG)
+                mozWaitForElementToExist(app.buttons["Pen"], timeout: TIMEOUT_LONG)
             } else {
                 // On iPad the Markup palette renders inline with no navbar overflow button;
                 // the Markup control is a switch, not a button.

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -182,19 +182,14 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
         // The Markup tool opens
         if #available(iOS 26, *) {
             if !iPad() {
-                // The navbar overflow label varies ("More" -> "View More", MTE-5253) and the
-                // palette sometimes opens without one; only tap the label that's actually present.
-                if !app.buttons["Markup"].mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) {
-                    let overflow = app.navigationBars.buttons["More"].exists
-                        ? app.navigationBars.buttons["More"]
-                        : app.navigationBars.buttons["View More"]
-                    if overflow.exists {
-                        overflow.waitAndTap()
-                    }
+                // Share "Markup" sometimes opens QuickLook in preview mode (a "Markup" pen button, no
+                // palette); tap it to enter markup, then verify the PencilKit Drawing-Palette + Pen.
+                let palette = app.otherElements["Drawing-Palette"]
+                if !palette.mozWaitForElementToExist(timeout: TIMEOUT_LONG, failOnTimeout: false) {
+                    app.buttons["Markup"].waitAndTap()
                 }
-                mozWaitForElementToExist(app.buttons["Markup"])
-                mozWaitForElementToExist(app.buttons["Close"])
-                mozWaitForElementToExist(app.otherElements["Drawing-Palette"])
+                mozWaitForElementToExist(palette, timeout: TIMEOUT_LONG)
+                mozWaitForElementToExist(app.buttons["Pen"], timeout: TIMEOUT_LONG)
             } else {
                 mozWaitForElementToExist(app.switches["Markup"])
                 mozWaitForElementToExist(app.buttons["close"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -190,8 +190,14 @@ class ToolbarTests: FeatureFlaggedTestBase {
             mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
             mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton])
             if !isPrivate {
-                app.partialSwipeUp(distance: 0.2)
-                mozWaitForElementToExist(app.otherElements["News"])
+                // News scrolls in after the relaunch and loads async; retry the swipe.
+                let news = app.otherElements["News"]
+                var swipes = 3
+                repeat {
+                    app.partialSwipeUp(distance: 0.2)
+                    swipes -= 1
+                } while !news.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) && swipes > 0
+                mozWaitForElementToExist(news)
             }
             navigator.nowAt(BrowserTab)
             mozWaitElementHittable(element: app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton], timeout: TIMEOUT)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5735

## :bulb: Description
Fix flaky UITests testShareNormalWebsiteMarkup and testOpenNewTabButtonOnToolbar

- ShareToolbarTests / ShareMenuTests (validateMarkupTool, iOS 26 iPhone): the share "Markup" opens QuickLook in one of two alternating states, so the old single-state selectors were flaky. Now: if the PencilKit Drawing-Palette isn't already up (preview mode), tap the Markup toggle app.switches["QLOverlayMarkupButtonAccessibilityIdentifier"].firstMatch to enter markup mode, then assert Drawing-Palette + the Pen tool. (The pencil control is a switch, not a button — hence buttons["Markup"]/["Close"] never matched.)
- ToolbarTest (validateAddNewTabButtonOnToolbar): replaced the single swipe-then-wait for the async-loading News section with a swipe/wait retry loop plus a final assert.

