### PR TITLE
Add FXIOS-16339 Add new GroupedEditBookmarkViewModel to be used for the new Bookmarks UI

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2250,6 +2250,7 @@
 		ECD8E56C2FF7EB69002092C6 /* WaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E56B2FF7EB64002092C6 /* WaybackService.swift */; };
 		ECD8E56E2FF7ED79002092C6 /* WaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E56D2FF7ED75002092C6 /* WaybackServiceTests.swift */; };
 		ECD8E8062FFBE6A2002092C6 /* WaybackCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E8052FFBE69E002092C6 /* WaybackCodes.swift */; };
+		ECF75D3C301930E2008183CA /* MockGroupedParentFolderSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF75D3B301930D8008183CA /* MockGroupedParentFolderSelector.swift */; };
 		ED07C0EB2CCADCD5006C0627 /* SearchEngineSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0E92CCADCD5006C0627 /* SearchEngineSelectionState.swift */; };
 		ED07C0ED2CCAE745006C0627 /* SearchEngineSelectionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0EC2CCAE745006C0627 /* SearchEngineSelectionAction.swift */; };
 		ED07C0EF2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0EE2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift */; };
@@ -11862,6 +11863,7 @@
 		ECD8E56D2FF7ED75002092C6 /* WaybackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaybackServiceTests.swift; sourceTree = "<group>"; };
 		ECD8E8052FFBE69E002092C6 /* WaybackCodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaybackCodes.swift; sourceTree = "<group>"; };
 		ECDA4593850BA4E08FDAC5AF /* kk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kk; path = kk.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
+		ECF75D3B301930D8008183CA /* MockGroupedParentFolderSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGroupedParentFolderSelector.swift; sourceTree = "<group>"; };
 		ED07C0E92CCADCD5006C0627 /* SearchEngineSelectionState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionState.swift; sourceTree = "<group>"; };
 		ED07C0EC2CCAE745006C0627 /* SearchEngineSelectionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionAction.swift; sourceTree = "<group>"; };
 		ED07C0EE2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionMiddleware.swift; sourceTree = "<group>"; };
@@ -16009,6 +16011,7 @@
 		C889D7D22858C85200121E1D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				ECF75D3B301930D8008183CA /* MockGroupedParentFolderSelector.swift */,
 				EC82F42E3017B02D00194A83 /* MockGroupedFolderHierarchyFetcher.swift */,
 				617D8AC12FC8D5B700E1C7A5 /* MockConversionValueUpdater.swift */,
 				C2E4F4C52F62F959002A8524 /* MockMainMenuCoordinatorDelegate.swift */,
@@ -20991,6 +20994,7 @@
 				03D9946A2EE821190081D209 /* TermsOfUseLinkTypeTests.swift in Sources */,
 				ED7A08E12CF679CE0035EC8F /* MockShareTab.swift in Sources */,
 				1D4D79462BF2F4E7007C6796 /* SimpleTab.swift in Sources */,
+				ECF75D3C301930E2008183CA /* MockGroupedParentFolderSelector.swift in Sources */,
 				8A3F08B02FB40BDC001F5DE9 /* MockTabRestorerDelegate.swift in Sources */,
 				21E78A7028F9A8C500F8D687 /* MockUIDevice.swift in Sources */,
 				C27EF6152EBA2EE500BED719 /* LanguageDetectorTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2242,6 +2242,8 @@
 		EC4F28143011A62600BAD351 /* CertificatesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4F28133011A61D00BAD351 /* CertificatesHandlerTests.swift */; };
 		EC4F28163011A64900BAD351 /* CertificateTestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4F28153011A64400BAD351 /* CertificateTestFactory.swift */; };
 		EC4F28183011A6BF00BAD351 /* CertificatesFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4F28173011A6B900BAD351 /* CertificatesFetcherTests.swift */; };
+		EC71F4E130190C9300A84FB9 /* GroupedEditBookmarkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC71F4E030190C8000A84FB9 /* GroupedEditBookmarkViewModel.swift */; };
+		EC7BFBF230190EB000254E9A /* BookmarkItemData+Copy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7BFBF130190EAA00254E9A /* BookmarkItemData+Copy.swift */; };
 		EC82F42B3013C75300194A83 /* GroupedEditFolderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC82F42A3013C74D00194A83 /* GroupedEditFolderViewController.swift */; };
 		EC82F42D3017AEC200194A83 /* GroupedEditFolderViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC82F42C3017AEB200194A83 /* GroupedEditFolderViewControllerTests.swift */; };
 		EC82F42F3017B03B00194A83 /* MockGroupedFolderHierarchyFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC82F42E3017B02D00194A83 /* MockGroupedFolderHierarchyFetcher.swift */; };
@@ -11848,8 +11850,10 @@
 		EC4F28133011A61D00BAD351 /* CertificatesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatesHandlerTests.swift; sourceTree = "<group>"; };
 		EC4F28153011A64400BAD351 /* CertificateTestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateTestFactory.swift; sourceTree = "<group>"; };
 		EC4F28173011A6B900BAD351 /* CertificatesFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatesFetcherTests.swift; sourceTree = "<group>"; };
+		EC71F4E030190C8000A84FB9 /* GroupedEditBookmarkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditBookmarkViewModel.swift; sourceTree = "<group>"; };
 		EC724CF0B0021AE49EDC95DC /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		EC734AD49E5483F11375E891 /* zh-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/AuthenticationManager.strings"; sourceTree = "<group>"; };
+		EC7BFBF130190EAA00254E9A /* BookmarkItemData+Copy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookmarkItemData+Copy.swift"; sourceTree = "<group>"; };
 		EC82F42A3013C74D00194A83 /* GroupedEditFolderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditFolderViewController.swift; sourceTree = "<group>"; };
 		EC82F42C3017AEB200194A83 /* GroupedEditFolderViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditFolderViewControllerTests.swift; sourceTree = "<group>"; };
 		EC82F42E3017B02D00194A83 /* MockGroupedFolderHierarchyFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGroupedFolderHierarchyFetcher.swift; sourceTree = "<group>"; };
@@ -12548,6 +12552,8 @@
 		0B8BF3732CA2EB3300E9812D /* Edit Bookmark */ = {
 			isa = PBXGroup;
 			children = (
+				EC7BFBF130190EAA00254E9A /* BookmarkItemData+Copy.swift */,
+				EC71F4E030190C8000A84FB9 /* GroupedEditBookmarkViewModel.swift */,
 				0B8BF3712CA2DA4600E9812D /* EditBookmarkViewController.swift */,
 				0B8A39EE2D3514C100853E47 /* EditBookmarkDiffableDataSource.swift */,
 				0B8BF3742CA2EFC000E9812D /* EditBookmarkCell.swift */,
@@ -20430,6 +20436,7 @@
 				D5D0532E2645B3A700759F85 /* ExperimentsTableView.swift in Sources */,
 				8A832A9029DC96C50025D5DD /* LaunchScreenView.swift in Sources */,
 				8C2FB1E62FF3D67900C9A803 /* WebCompatReporterState.swift in Sources */,
+				EC71F4E130190C9300A84FB9 /* GroupedEditBookmarkViewModel.swift in Sources */,
 				8AAAB05B2C1B7268008830B3 /* ClientTabsSearchWrapper.swift in Sources */,
 				214EF4152AC5D5D0005BCCDA /* TabDisplayView.swift in Sources */,
 				8A2D593E27DC0AA100713EC9 /* TopSite.swift in Sources */,
@@ -20534,6 +20541,7 @@
 				F605DD582CC73469009A671B /* TabDisplayDiffableDataSource.swift in Sources */,
 				8A7892052CF91FEF00490CA4 /* UnifiedAdsCallbackTelemetry.swift in Sources */,
 				8A454D292CB7078D009436D9 /* MerinoState.swift in Sources */,
+				EC7BFBF230190EB000254E9A /* BookmarkItemData+Copy.swift in Sources */,
 				21E77E502AA8BAEC00FABA10 /* TabTrayState.swift in Sources */,
 				C2D3A8C22FDFF686008D5689 /* WorldCupLottieView.swift in Sources */,
 				8C2447E82DFADF3D00BD2C91 /* ActivityEventHelper.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2251,6 +2251,7 @@
 		ECD8E56E2FF7ED79002092C6 /* WaybackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E56D2FF7ED75002092C6 /* WaybackServiceTests.swift */; };
 		ECD8E8062FFBE6A2002092C6 /* WaybackCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD8E8052FFBE69E002092C6 /* WaybackCodes.swift */; };
 		ECF75D3C301930E2008183CA /* MockGroupedParentFolderSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF75D3B301930D8008183CA /* MockGroupedParentFolderSelector.swift */; };
+		ECF75D3E30193E9A008183CA /* GroupedEditBookmarkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF75D3D30193E8A008183CA /* GroupedEditBookmarkViewModelTests.swift */; };
 		ED07C0EB2CCADCD5006C0627 /* SearchEngineSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0E92CCADCD5006C0627 /* SearchEngineSelectionState.swift */; };
 		ED07C0ED2CCAE745006C0627 /* SearchEngineSelectionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0EC2CCAE745006C0627 /* SearchEngineSelectionAction.swift */; };
 		ED07C0EF2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED07C0EE2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift */; };
@@ -11864,6 +11865,7 @@
 		ECD8E8052FFBE69E002092C6 /* WaybackCodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaybackCodes.swift; sourceTree = "<group>"; };
 		ECDA4593850BA4E08FDAC5AF /* kk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kk; path = kk.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		ECF75D3B301930D8008183CA /* MockGroupedParentFolderSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGroupedParentFolderSelector.swift; sourceTree = "<group>"; };
+		ECF75D3D30193E8A008183CA /* GroupedEditBookmarkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditBookmarkViewModelTests.swift; sourceTree = "<group>"; };
 		ED07C0E92CCADCD5006C0627 /* SearchEngineSelectionState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionState.swift; sourceTree = "<group>"; };
 		ED07C0EC2CCAE745006C0627 /* SearchEngineSelectionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionAction.swift; sourceTree = "<group>"; };
 		ED07C0EE2CCAE856006C0627 /* SearchEngineSelectionMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineSelectionMiddleware.swift; sourceTree = "<group>"; };
@@ -12533,6 +12535,7 @@
 		0B7CF8852CAC1BFB00DC02F8 /* Bookmarks */ = {
 			isa = PBXGroup;
 			children = (
+				ECF75D3D30193E8A008183CA /* GroupedEditBookmarkViewModelTests.swift */,
 				EC82F42C3017AEB200194A83 /* GroupedEditFolderViewControllerTests.swift */,
 				EC407901300AA88F0003DE07 /* GroupedEditFolderViewModelTests.swift */,
 				EC4078FF300AA7EF0003DE07 /* GroupedDefaultFolderHierarchyFetcherTests.swift */,
@@ -20996,6 +20999,7 @@
 				1D4D79462BF2F4E7007C6796 /* SimpleTab.swift in Sources */,
 				ECF75D3C301930E2008183CA /* MockGroupedParentFolderSelector.swift in Sources */,
 				8A3F08B02FB40BDC001F5DE9 /* MockTabRestorerDelegate.swift in Sources */,
+				ECF75D3E30193E9A008183CA /* GroupedEditBookmarkViewModelTests.swift in Sources */,
 				21E78A7028F9A8C500F8D687 /* MockUIDevice.swift in Sources */,
 				C27EF6152EBA2EE500BED719 /* LanguageDetectorTests.swift in Sources */,
 				81DAB2F92C8901AC00F4BE98 /* MainMenuStateTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -19,7 +19,8 @@ protocol BookmarksCoordinatorDelegate: AnyObject, LibraryPanelCoordinatorDelegat
     func showBookmarkDetail(
         bookmarkType: BookmarkNodeType,
         parentBookmarkFolder: FxBookmarkNode,
-        parentFolderSelector: ParentFolderSelector?
+        parentFolderSelector: ParentFolderSelector?,
+        groupedParentFolderSelector: GroupedParentFolderSelector?
     )
 
     @MainActor
@@ -35,12 +36,14 @@ extension BookmarksCoordinatorDelegate {
     func showBookmarkDetail(
         bookmarkType: BookmarkNodeType,
         parentBookmarkFolder: FxBookmarkNode,
-        parentFolderSelector: ParentFolderSelector? = nil
+        parentFolderSelector: ParentFolderSelector? = nil,
+        groupedParentFolderSelector: GroupedParentFolderSelector? = nil
     ) {
         showBookmarkDetail(
             bookmarkType: bookmarkType,
             parentBookmarkFolder: parentBookmarkFolder,
-            parentFolderSelector: parentFolderSelector
+            parentFolderSelector: parentFolderSelector,
+            groupedParentFolderSelector: groupedParentFolderSelector
         )
     }
 }
@@ -105,11 +108,13 @@ class BookmarksCoordinator: BaseCoordinator,
     func showBookmarkDetail(
         bookmarkType: BookmarkNodeType,
         parentBookmarkFolder: FxBookmarkNode,
-        parentFolderSelector: ParentFolderSelector? = nil
+        parentFolderSelector: ParentFolderSelector? = nil,
+        groupedParentFolderSelector: GroupedParentFolderSelector? = nil
     ) {
         let detailController = makeDetailController(for: bookmarkType,
                                                     parentFolder: parentBookmarkFolder,
-                                                    parentFolderSelector: parentFolderSelector)
+                                                    parentFolderSelector: parentFolderSelector,
+                                                    groupedParentFolderSelector: groupedParentFolderSelector)
         router.push(detailController)
     }
 
@@ -159,7 +164,8 @@ class BookmarksCoordinator: BaseCoordinator,
 
     private func makeDetailController(for type: BookmarkNodeType,
                                       parentFolder: FxBookmarkNode,
-                                      parentFolderSelector: ParentFolderSelector?) -> UIViewController {
+                                      parentFolderSelector: ParentFolderSelector?,
+                                      groupedParentFolderSelector: GroupedParentFolderSelector?) -> UIViewController {
         if type == .bookmark {
             return makeEditBookmarkController(for: nil, folder: parentFolder)
         }
@@ -167,7 +173,7 @@ class BookmarksCoordinator: BaseCoordinator,
             if featureFlagsProvider.isEnabled(.newBookmarkFolderTree) {
                 return makeGroupedEditFolderController(for: nil,
                                                        folder: parentFolder,
-                                                       parentFolderSelector: parentFolderSelector)
+                                                       parentFolderSelector: groupedParentFolderSelector)
             }
             return makeEditFolderController(for: nil, folder: parentFolder, parentFolderSelector: parentFolderSelector)
         }
@@ -231,7 +237,7 @@ class BookmarksCoordinator: BaseCoordinator,
 
     private func makeGroupedEditFolderController(for node: FxBookmarkNode?,
                                                  folder: FxBookmarkNode,
-                                                 parentFolderSelector: ParentFolderSelector?) -> UIViewController {
+                                                 parentFolderSelector: GroupedParentFolderSelector?) -> UIViewController {
         let viewModel = GroupedEditFolderViewModel(profile: profile,
                                                    parentFolder: folder,
                                                    folder: node)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/BookmarkItemData+Copy.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/BookmarkItemData+Copy.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MozillaAppServices
+
+extension BookmarkItemData {
+    func copy(with title: String, url: String) -> BookmarkItemData {
+        return BookmarkItemData(guid: guid,
+                                dateAdded: dateAdded,
+                                lastModified: lastModified,
+                                parentGUID: parentGUID,
+                                position: position,
+                                url: url,
+                                title: title)
+    }
+}

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewModel.swift
@@ -7,31 +7,32 @@ import Foundation
 import MozillaAppServices
 import Shared
 
-// This typealias should probably move somewhere else possibly its own file since eventually this file
-// will be removed and this alias which is used all over the app will be gone
-typealias VoidReturnCallback = @MainActor () -> Void
-
-protocol ParentFolderSelector: AnyObject {
+protocol GroupedParentFolderSelector: AnyObject {
     /// In some cases, a child `EditFolderViewController` needs to pass information to a parent `EditBookmarkViewController`
     /// to select the folder that was just created
     /// - Parameter folder: The folder that was created in the `EditFolderViewController`
     @MainActor
-    func selectFolderCreatedFromChild(folder: Folder)
+    func selectFolderCreatedFromChild(folder: GroupedFolder)
 }
 
 // FIXME: FXIOS-14161 Make EditBookmarkViewModel actually Sendable
-class EditBookmarkViewModel: ParentFolderSelector, @unchecked Sendable {
+class GroupedEditBookmarkViewModel: GroupedParentFolderSelector, @unchecked Sendable {
+    static let mobileHeaderPlaceholderGuid = "EditBookmarkViewModel.mobileHeaderPlaceholder"
+    static let desktopHeaderPlaceholderGuid = "EditBookmarkViewModel.desktopHeaderPlaceholder"
+
+    private static let placeholderIndentation = 0
+
     private let parentFolder: FxBookmarkNode
     private var node: BookmarkItemData?
     private let profile: Profile
     private let logger: Logger
-    private let folderFetcher: FolderHierarchyFetcher
+    private let folderFetcher: GroupedFolderHierarchyFetcher
     private let bookmarksSaver: BookmarksSaver
     weak var bookmarkCoordinatorDelegate: BookmarksCoordinatorDelegate?
 
     private(set) var isFolderCollapsed = true
-    private(set) var folderStructures: [Folder] = []
-    private(set) var selectedFolder: Folder?
+    private(set) var folderStructures: [GroupedFolder] = []
+    private(set) var selectedFolder: GroupedFolder?
 
     var bookmarkTitle: String {
         return node?.title ?? ""
@@ -40,8 +41,8 @@ class EditBookmarkViewModel: ParentFolderSelector, @unchecked Sendable {
         return node?.url ?? ""
     }
 
-    var onFolderStatusUpdate: VoidReturnCallback?
-    var onBookmarkSaved: VoidReturnCallback?
+    var onFolderStatusUpdate: (@MainActor () -> Void)?
+    var onBookmarkSaved: (@MainActor () -> Void)?
 
     var getBackNavigationButtonTitle: String {
         if parentFolder.guid == BookmarkRoots.MobileFolderGUID {
@@ -55,25 +56,25 @@ class EditBookmarkViewModel: ParentFolderSelector, @unchecked Sendable {
          profile: Profile,
          logger: Logger = DefaultLogger.shared,
          bookmarksSaver: BookmarksSaver? = nil,
-         folderFetcher: FolderHierarchyFetcher? = nil) {
+         folderFetcher: GroupedFolderHierarchyFetcher? = nil) {
         self.parentFolder = parentFolder
         self.node = node as? BookmarkItemData
         self.profile = profile
         self.logger = logger
         self.bookmarksSaver = bookmarksSaver ?? DefaultBookmarksSaver(profile: profile)
-        self.folderFetcher = folderFetcher ?? DefaultFolderHierarchyFetcher(profile: profile,
-                                                                            rootFolderGUID: BookmarkRoots.RootGUID)
-        let folder = Folder(title: parentFolder.title, guid: parentFolder.guid, indentation: 0)
+        self.folderFetcher = folderFetcher ?? GroupedDefaultFolderHierarchyFetcher(profile: profile,
+                                                                                   rootFolderGUID: BookmarkRoots.RootGUID)
+        let folder = GroupedFolder(title: parentFolder.title, guid: parentFolder.guid, indentation: 0)
         folderStructures = [folder]
         selectedFolder = folder
     }
 
-    func shouldShowDisclosureIndicatorForFolder(_ folder: Folder) -> Bool {
+    func shouldShowDisclosureIndicatorForFolder(_ folder: GroupedFolder) -> Bool {
         let shouldShowDisclosureIndicator = folder.guid == selectedFolder?.guid
         return shouldShowDisclosureIndicator && !isFolderCollapsed
     }
 
-    func indentationForFolder(_ folder: Folder) -> Int {
+    func indentationForFolder(_ folder: GroupedFolder) -> Int {
         if isFolderCollapsed {
             return 0
         }
@@ -81,7 +82,7 @@ class EditBookmarkViewModel: ParentFolderSelector, @unchecked Sendable {
     }
 
     @MainActor
-    func selectFolder(_ folder: Folder) {
+    func selectFolder(_ folder: GroupedFolder) {
         isFolderCollapsed.toggle()
         selectedFolder = folder
         if isFolderCollapsed {
@@ -97,16 +98,30 @@ class EditBookmarkViewModel: ParentFolderSelector, @unchecked Sendable {
         bookmarkCoordinatorDelegate?.showBookmarkDetail(
             bookmarkType: .folder,
             parentBookmarkFolder: parentFolder,
-            parentFolderSelector: self)
+            groupedParentFolderSelector: self)
     }
 
-    private func getFolderStructure(_ selectedFolder: Folder) {
+    private func getFolderStructure(_ selectedFolder: GroupedFolder) {
         Task { @MainActor [weak self] in
             let folders = await self?.folderFetcher.fetchFolders()
             guard let folders else { return }
-            self?.folderStructures = folders
+            self?.folderStructures = Self.insertSectionPlaceholders(into: folders)
             self?.onFolderStatusUpdate?()
         }
+    }
+
+    private static func insertSectionPlaceholders(into folders: [GroupedFolder]) -> [GroupedFolder] {
+        let mobileFolders = folders.filter { !$0.isDesktopRoot }
+        let desktopFolders = folders.filter { $0.isDesktopRoot }
+        guard !desktopFolders.isEmpty else { return mobileFolders }
+
+        let mobilePlaceholder = GroupedFolder(title: "",
+                                              guid: mobileHeaderPlaceholderGuid,
+                                              indentation: placeholderIndentation)
+        let desktopPlaceholder = GroupedFolder(title: "",
+                                               guid: desktopHeaderPlaceholderGuid,
+                                               indentation: placeholderIndentation)
+        return [mobilePlaceholder] + mobileFolders + [desktopPlaceholder] + desktopFolders
     }
 
     func setUpdatedTitle(_ title: String) {
@@ -148,7 +163,7 @@ class EditBookmarkViewModel: ParentFolderSelector, @unchecked Sendable {
 
     // MARK: ParentFolderSelector
 
-    func selectFolderCreatedFromChild(folder: Folder) {
+    func selectFolderCreatedFromChild(folder: GroupedFolder) {
         isFolderCollapsed = true
         selectedFolder = folder
         folderStructures = [folder]

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewModel.swift
@@ -15,7 +15,7 @@ protocol GroupedParentFolderSelector: AnyObject {
     func selectFolderCreatedFromChild(folder: GroupedFolder)
 }
 
-// FIXME: FXIOS-14161 Make GroupedEditBookmarkViewModel actually Sendable
+// FIXME: FXIOS-16473 Make GroupedEditBookmarkViewModel actually Sendable
 class GroupedEditBookmarkViewModel: GroupedParentFolderSelector, @unchecked Sendable {
     static let mobileHeaderPlaceholderGuid = "EditBookmarkViewModel.mobileHeaderPlaceholder"
     static let desktopHeaderPlaceholderGuid = "EditBookmarkViewModel.desktopHeaderPlaceholder"

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewModel.swift
@@ -8,14 +8,14 @@ import MozillaAppServices
 import Shared
 
 protocol GroupedParentFolderSelector: AnyObject {
-    /// In some cases, a child `EditFolderViewController` needs to pass information to a parent `EditBookmarkViewController`
-    /// to select the folder that was just created
-    /// - Parameter folder: The folder that was created in the `EditFolderViewController`
+    /// In some cases, a child `GroupedEditFolderViewController` needs to pass information
+    /// to a parent `GroupedEditBookmarkViewController` to select the folder that was just created
+    /// - Parameter folder: The folder that was created in the `GroupedEditFolderViewController`
     @MainActor
     func selectFolderCreatedFromChild(folder: GroupedFolder)
 }
 
-// FIXME: FXIOS-14161 Make EditBookmarkViewModel actually Sendable
+// FIXME: FXIOS-14161 Make GroupedEditBookmarkViewModel actually Sendable
 class GroupedEditBookmarkViewModel: GroupedParentFolderSelector, @unchecked Sendable {
     static let mobileHeaderPlaceholderGuid = "EditBookmarkViewModel.mobileHeaderPlaceholder"
     static let desktopHeaderPlaceholderGuid = "EditBookmarkViewModel.desktopHeaderPlaceholder"
@@ -136,7 +136,7 @@ class GroupedEditBookmarkViewModel: GroupedParentFolderSelector, @unchecked Send
     func saveBookmark() -> Task<Void, Never>? {
         guard let selectedFolder, let node else { return nil }
         return Task { @MainActor [weak self] in
-            // There is no way to access the EditBookmarkViewController without the bookmark already existing,
+            // There is no way to access the GroupedEditBookmarkViewController without the bookmark already existing,
             // so this call will always try to update an existing bookmark
             let result = await self?.bookmarksSaver.save(bookmark: node,
                                                          parentFolderGUID: selectedFolder.guid)
@@ -161,7 +161,7 @@ class GroupedEditBookmarkViewModel: GroupedParentFolderSelector, @unchecked Send
         bookmarkCoordinatorDelegate?.didFinish()
     }
 
-    // MARK: ParentFolderSelector
+    // MARK: GroupedParentFolderSelector
 
     func selectFolderCreatedFromChild(folder: GroupedFolder) {
         isFolderCollapsed = true

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewModel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewModel.swift
@@ -28,7 +28,7 @@ class GroupedEditFolderViewModel: @unchecked Sendable {
     var onFolderStatusUpdate: VoidReturnCallback?
     var onGroupExpansionUpdate: ((Int) -> Void)?
     var onBookmarkSaved: VoidReturnCallback?
-    weak var parentFolderSelector: ParentFolderSelector?
+    weak var parentFolderSelector: GroupedParentFolderSelector?
 
     var controllerTitle: String {
         return isNewFolderView ? .BookmarksNewFolder : .BookmarksEditFolder
@@ -128,7 +128,7 @@ class GroupedEditFolderViewModel: @unchecked Sendable {
 
                 // When the folder edit view is a child of the edit bookmark view, the newly created folder
                 // should be selected
-                let folderCreated = Folder(title: folder.title, guid: guid, indentation: 0)
+                let folderCreated = GroupedFolder(title: folder.title, guid: guid, indentation: 0)
                 parentFolderSelector?.selectFolderCreatedFromChild(folder: folderCreated)
             case .failure(let error):
                 self.logger.log("Failed to save folder: \(error)", level: .warning, category: .library)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditBookmarkViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditBookmarkViewModelTests.swift
@@ -1,0 +1,260 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import MozillaAppServices
+import Shared
+
+@testable import Client
+
+@MainActor
+class GroupedEditBookmarkViewModelTests: XCTestCase {
+    let folder = MockFxBookmarkNode(type: .folder,
+                                    guid: "1235",
+                                    position: 1,
+                                    isRoot: false,
+                                    title: "Hello")
+    var parentFolder = MockFxBookmarkNode(type: .folder,
+                                          guid: "5678",
+                                          position: 0,
+                                          isRoot: false,
+                                          title: "Parent")
+    var folderBookmarkItemData = BookmarkItemData(guid: "Hello",
+                                                  dateAdded: 0,
+                                                  lastModified: 0,
+                                                  parentGUID: nil,
+                                                  position: 0,
+                                                  url: "",
+                                                  title: "Hello")
+    var folderFetcher: MockGroupedFolderHierarchyFetcher!
+    var bookmarksSaver: MockBookmarksSaver!
+    var profile: MockProfile!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        folderFetcher = MockGroupedFolderHierarchyFetcher()
+        bookmarksSaver = MockBookmarksSaver()
+        profile = MockProfile()
+    }
+
+    override func tearDown() async throws {
+        folderFetcher = nil
+        bookmarksSaver = nil
+        profile = nil
+        try await super.tearDown()
+    }
+
+    func testInit() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+
+        XCTAssertTrue(subject.isFolderCollapsed)
+        XCTAssertTrue(!subject.folderStructures.isEmpty)
+        XCTAssertEqual(subject.selectedFolder?.title, parentFolder.title)
+        XCTAssertEqual(subject.selectedFolder?.guid, parentFolder.guid)
+    }
+
+    func testShouldShowDisclosureIndicator_whenIsFolderSelected() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let folder = GroupedFolder(title: folder.title, guid: folder.guid, indentation: 0)
+
+        subject.selectFolder(folder)
+
+        XCTAssertTrue(subject.shouldShowDisclosureIndicatorForFolder(folder))
+    }
+
+    func testShouldShowDisclosureIndicator_whenIsNotFolderSelected() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let folder = GroupedFolder(title: folder.title, guid: folder.guid, indentation: 0)
+
+        XCTAssertFalse(subject.shouldShowDisclosureIndicatorForFolder(folder))
+    }
+
+    func testShouldShowDisclosureIndicator_whenIsFolderCollapsed() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let folder = GroupedFolder(title: folder.title, guid: folder.guid, indentation: 0)
+
+        subject.selectFolder(folder)
+        // Double selecting a folder turns isFolderCollapsed to true
+        subject.selectFolder(folder)
+
+        XCTAssertFalse(subject.shouldShowDisclosureIndicatorForFolder(folder))
+        XCTAssertTrue(subject.isFolderCollapsed)
+    }
+
+    func testBackNavigationButtonTitle_whenIsMobileFolderGuid() {
+        parentFolder.guid = "mobile______"
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        XCTAssertEqual(subject.getBackNavigationButtonTitle, "All")
+    }
+
+    func testBackNavigationButtonTitle_whenIsNotMobileFolderGuid() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        XCTAssertEqual(subject.getBackNavigationButtonTitle, parentFolder.title)
+    }
+
+    func testSelectFolder_callsOnFolderStatusUpdate() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onFolderStatusUpdate should be called")
+        subject.onFolderStatusUpdate = {
+            expectation.fulfill()
+        }
+        subject.selectFolder(GroupedFolder(title: "Test", guid: "", indentation: 0))
+
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testSelectFolder_callsGetFolderStructure() {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onFolderStatusUpdate should be called")
+        subject.onFolderStatusUpdate = {
+            expectation.fulfill()
+        }
+
+        subject.selectFolder(GroupedFolder(title: "Test", guid: "", indentation: 0))
+
+        waitForExpectations(timeout: 0.1)
+        XCTAssertEqual(folderFetcher.fetchFoldersCalled, 1)
+    }
+
+    // MARK: - Folder structure / placeholder insertion
+
+    func testGetFolderStructure_insertsBothPlaceholders_whenDesktopAndMobileFoldersExist() {
+        folderFetcher.mockFolderStructures = [
+            GroupedFolder(title: "Mobile Bookmarks", guid: "mobile1", indentation: 0, isDesktopRoot: false),
+            GroupedFolder(title: "Desktop Bookmarks", guid: "desktop1", indentation: 0, isDesktopRoot: true)
+        ]
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onFolderStatusUpdate should be called")
+        subject.onFolderStatusUpdate = {
+            expectation.fulfill()
+        }
+
+        subject.selectFolder(GroupedFolder(title: "Test", guid: "", indentation: 0))
+
+        waitForExpectations(timeout: 0.1)
+        // mobile placeholder + mobile folder + desktop placeholder + desktop folder
+        XCTAssertEqual(subject.folderStructures.count, 4)
+        XCTAssertEqual(subject.folderStructures.first?.guid,
+                       GroupedEditBookmarkViewModel.mobileHeaderPlaceholderGuid)
+        XCTAssertEqual(subject.folderStructures[2].guid,
+                       GroupedEditBookmarkViewModel.desktopHeaderPlaceholderGuid)
+    }
+
+    func testGetFolderStructure_omitsPlaceholders_whenNoDesktopFoldersExist() {
+        folderFetcher.mockFolderStructures = [
+            GroupedFolder(title: "Mobile Bookmarks", guid: "mobile1", indentation: 0, isDesktopRoot: false)
+        ]
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+        let expectation = expectation(description: "onFolderStatusUpdate should be called")
+        subject.onFolderStatusUpdate = {
+            expectation.fulfill()
+        }
+
+        subject.selectFolder(GroupedFolder(title: "Test", guid: "", indentation: 0))
+
+        waitForExpectations(timeout: 0.1)
+        XCTAssertEqual(subject.folderStructures, folderFetcher.mockFolderStructures)
+    }
+
+    // MARK: - Save bookmark
+
+    func testSaveBookmark_whenHasNoUpdateDoesntSave() async throws {
+        let subject = createSubject(folder: folder, parentFolder: parentFolder)
+
+        let task = subject.saveBookmark()
+
+        XCTAssertNil(task)
+        XCTAssertEqual(bookmarksSaver.saveCalled, 0)
+    }
+
+    func testSaveBookmark_whenHasEmptyGuid_thenSetsRecentBookmarksPrefsString() async throws {
+        let subject = createSubject(folder: folderBookmarkItemData, parentFolder: parentFolder)
+        let expectation = expectation(description: "onBookmarkSaved should be called")
+        subject.onBookmarkSaved = {
+            expectation.fulfill()
+        }
+
+        subject.setUpdatedTitle("Hello test")
+        let task = subject.saveBookmark()
+        await task?.value
+
+        await fulfillment(of: [expectation])
+        let prefs = try XCTUnwrap(profile.prefs as? MockProfilePrefs)
+        let recentBookmark = try XCTUnwrap(prefs.things[PrefsKeys.RecentBookmarkFolder] as? String)
+        XCTAssertEqual(recentBookmark, "5678")
+        XCTAssertEqual(bookmarksSaver.saveCalled, 1)
+    }
+
+    func testSave_whenHasDifferentGuid_thenSetsRecentBookmarksPrefsString() async throws {
+        let expectedGuid = "09876"
+        bookmarksSaver.mockCreateGuid = expectedGuid
+        profile.prefs.setString(expectedGuid, forKey: PrefsKeys.RecentBookmarkFolder)
+
+        let subject = createSubject(folder: folderBookmarkItemData, parentFolder: parentFolder)
+        let expectation = expectation(description: "onBookmarkSaved should be called")
+        subject.onBookmarkSaved = {
+            expectation.fulfill()
+        }
+
+        subject.setUpdatedTitle("Hello test")
+        let task = subject.saveBookmark()
+        await task?.value
+
+        await fulfillment(of: [expectation])
+        let prefs = try XCTUnwrap(profile.prefs as? MockProfilePrefs)
+        let recentBookmark = try XCTUnwrap(prefs.things[PrefsKeys.RecentBookmarkFolder] as? String)
+        XCTAssertEqual(recentBookmark, "5678")
+        XCTAssertEqual(bookmarksSaver.saveCalled, 1)
+    }
+
+    // MARK: - GroupedParentFolderSelector
+
+    func testSelectFolderCreatedFromChild_ensureFolderIsCollapsed() {
+        let subject = createSubject(folder: folderBookmarkItemData, parentFolder: parentFolder)
+        let folderToSelect = GroupedFolder(title: folder.title, guid: folder.guid, indentation: 0)
+
+        subject.selectFolder(folderToSelect)
+        subject.selectFolderCreatedFromChild(folder: folderToSelect)
+
+        XCTAssertTrue(subject.isFolderCollapsed)
+    }
+
+    func testSelectFolderCreatedFromChild_ensureFolderSelectedUpdates() {
+        let subject = createSubject(folder: folderBookmarkItemData, parentFolder: parentFolder)
+        let folderToSelect = GroupedFolder(title: folder.title, guid: folder.guid, indentation: 0)
+
+        subject.selectFolderCreatedFromChild(folder: folderToSelect)
+
+        XCTAssertEqual(subject.selectedFolder, folderToSelect)
+        XCTAssertEqual(subject.folderStructures, [folderToSelect])
+    }
+
+    func testSelectFolderCreatedFromChild_ensureOnFolderStatusUpdateIsCalled() {
+        let subject = createSubject(folder: folderBookmarkItemData, parentFolder: parentFolder)
+        let folderToSelect = GroupedFolder(title: folder.title, guid: folder.guid, indentation: 0)
+        let expectation = expectation(description: "onFolderStatusUpdate should be called")
+        subject.onFolderStatusUpdate = {
+            expectation.fulfill()
+        }
+
+        subject.selectFolderCreatedFromChild(folder: folderToSelect)
+
+        waitForExpectations(timeout: 0.1)
+    }
+
+    // MARK: Helper function
+
+    func createSubject(folder: FxBookmarkNode,
+                       parentFolder: FxBookmarkNode,
+                       file: StaticString = #filePath,
+                       line: UInt = #line) -> GroupedEditBookmarkViewModel {
+        let subject = GroupedEditBookmarkViewModel(parentFolder: parentFolder,
+                                                   node: folder,
+                                                   profile: profile,
+                                                   bookmarksSaver: bookmarksSaver,
+                                                   folderFetcher: folderFetcher)
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewModelTests.swift
@@ -28,7 +28,7 @@ final class GroupedEditFolderViewModelTests: XCTestCase {
     var folderFetcher: MockGroupedFolderHierarchyFetcher!
     var bookmarksSaver: MockBookmarksSaver!
     var profile: MockProfile!
-    var parentFolderSelector: MockParentFolderSelector!
+    var parentFolderSelector: MockGroupedParentFolderSelector!
 
     override func setUp() async throws {
         try await super.setUp()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewModelTests.swift
@@ -35,7 +35,7 @@ final class GroupedEditFolderViewModelTests: XCTestCase {
         folderFetcher = MockGroupedFolderHierarchyFetcher()
         bookmarksSaver = MockBookmarksSaver()
         profile = MockProfile()
-        parentFolderSelector = MockParentFolderSelector()
+        parentFolderSelector = MockGroupedParentFolderSelector()
     }
 
     override func tearDown() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGroupedParentFolderSelector.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGroupedParentFolderSelector.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+class MockGroupedParentFolderSelector: GroupedParentFolderSelector {
+    var selectedFolder: GroupedFolder?
+    func selectFolderCreatedFromChild(folder: GroupedFolder) {
+        selectedFolder = folder
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16339)

## :bulb: Description
This PR adds the new GroupedEditBookmarkViewModel which mimics the current EditBookmarkViewModel but utilizes the GroupedFolders and other related grouped counterparts.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

