### PR TITLE
Refactor FXIOS-15361 Use copyable macro for password generator state

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
@@ -80,6 +80,5 @@ struct PasswordGeneratorState: ScreenState {
         return state.copy(windowUUID: state.windowUUID)
             .copy(password: state.password)
             .copy(passwordHidden: state.passwordHidden)
-        )
     }
 }

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
@@ -29,7 +29,7 @@ struct PasswordGeneratorState: ScreenState {
             passwordHidden: passwordGeneratorState.passwordHidden
         )
     }
-    
+
     init(
         windowUUID: WindowUUID,
         password: String = "",

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
@@ -5,7 +5,9 @@
 import Foundation
 import Redux
 import Common
+import ModifiedCopy
 
+@Copyable
 struct PasswordGeneratorState: ScreenState {
     var windowUUID: WindowUUID
     var password: String
@@ -27,7 +29,7 @@ struct PasswordGeneratorState: ScreenState {
             passwordHidden: passwordGeneratorState.passwordHidden
         )
     }
-
+    
     init(
         windowUUID: WindowUUID,
         password: String = "",
@@ -55,22 +57,19 @@ struct PasswordGeneratorState: ScreenState {
             else {
                 return defaultState(from: state)
             }
-            return PasswordGeneratorState(
-                windowUUID: action.windowUUID,
-                password: password,
-                passwordHidden: state.passwordHidden)
+            return state.copy(windowUUID: action.windowUUID)
+                .copy(password: password)
+                .copy(passwordHidden: state.passwordHidden)
 
         case PasswordGeneratorActionType.hidePassword:
-            return PasswordGeneratorState(
-                windowUUID: action.windowUUID,
-                password: state.password,
-                passwordHidden: true)
+            return state.copy(windowUUID: action.windowUUID)
+                .copy(password: state.password)
+                .copy(passwordHidden: true)
 
         case PasswordGeneratorActionType.showPassword:
-            return PasswordGeneratorState(
-                windowUUID: action.windowUUID,
-                password: state.password,
-                passwordHidden: false)
+            return state.copy(windowUUID: action.windowUUID)
+                .copy(password: state.password)
+                .copy(passwordHidden: false)
 
         default:
             return defaultState(from: state)
@@ -78,10 +77,9 @@ struct PasswordGeneratorState: ScreenState {
     }
 
     static func defaultState(from state: PasswordGeneratorState) -> PasswordGeneratorState {
-        return PasswordGeneratorState(
-            windowUUID: state.windowUUID,
-            password: state.password,
-            passwordHidden: state.passwordHidden
+        return state.copy(windowUUID: state.windowUUID)
+            .copy(password: state.password)
+            .copy(passwordHidden: state.passwordHidden)
         )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15361)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32948)

## :bulb: Description
- Refactors `PasswordGeneratorState` to use the `@Copyable` macro from `ModifiedCopy`
- Fixed related SwiftLint violations required by the pre-push check

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

