### PR TITLE
Add FXIOS-16428 [PrivacyDashboard] Add Privacy Dashboard feature flag

### DIFF
--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -40,6 +40,7 @@ enum FeatureFlagID: String, CaseIterable {
     case newBookmarkFolderTree
     case novaDesign
     case noInternetConnectionErrorPage
+    case privacyDashboard
     case quickAnswers
     case recentSearches
     case relayIntegration
@@ -117,6 +118,7 @@ enum FeatureFlagID: String, CaseIterable {
                 .newBookmarkFolderTree,
                 .novaDesign,
                 .noInternetConnectionErrorPage,
+                .privacyDashboard,
                 .quickAnswers,
                 .recentSearches,
                 .relayIntegration,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -207,6 +207,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .privacyDashboard,
+                titleText: format(string: "Privacy Dashboard"),
+                statusText: format(string: "Toggle Privacy Dashboard")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .quickAnswers,
                 titleText: format(string: "Quick Answers"),
                 statusText: format(string: "Toggle to enable the Quick Answers feature")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -125,6 +125,9 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .noInternetConnectionErrorPage:
             return checkNICErrorPageFeature()
 
+        case .privacyDashboard:
+            return checkPrivacyDashboardFeature()
+
         case .quickAnswers:
             return checkQuickAnswersFeature()
 
@@ -478,5 +481,9 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
 
     private func checkVPNFeature() -> Bool {
         return nimbus.features.vpnFeature.value().enabled
+    }
+
+    private func checkPrivacyDashboardFeature() -> Bool {
+        return nimbus.features.privacyDashboardFeature.value().enabled
     }
 }

--- a/firefox-ios/nimbus-features/privacyDashboardFeature.yaml
+++ b/firefox-ios/nimbus-features/privacyDashboardFeature.yaml
@@ -1,0 +1,18 @@
+# The configuration for the privacyDashboardFeature feature
+features:
+  privacy-dashboard-feature:
+    description: >
+      The Privacy Dashboard feature from homepage
+    variables:
+      enabled:
+        description: >
+          Whether or not this feature is enabled
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -35,6 +35,7 @@ include:
   - nimbus-features/newBookmarkFolderTreeFeature.yaml
   - nimbus-features/novaDesignFeature.yaml
   - nimbus-features/onboardingFrameworkFeature.yaml
+  - nimbus-features/privacyDashboardFeature.yaml
   - nimbus-features/quickAnswersFeature.yaml
   - nimbus-features/recentSearchesFeature.yaml
   - nimbus-features/relayIntegrationFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16428)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34903)

## :bulb: Description
Title

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

