### PR TITLE
MTE-5561 Disable check for desktop site temporarily

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
@@ -286,8 +286,7 @@ class DesktopModeTestsIphone: BaseTestCase {
         browserScreen.navigateToURL(googleURL)
         waitUntilPageLoad()
         browserScreen.addressToolbarContainValue(value: "google.com")
-        // "I'm feeling lucky" may not show up intermittently
-        // browserScreen.assertLayout(.desktop)
+        browserScreen.assertLayout(.desktop, retries: 3)
 
         // Step 4: Visit amazon.com -> different domain, no desktop pref, mobile version loads.
         // NOTE: Amazon may show a region-redirect interstitial (e.g. "Deliver to Canada") on

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
@@ -286,7 +286,8 @@ class DesktopModeTestsIphone: BaseTestCase {
         browserScreen.navigateToURL(googleURL)
         waitUntilPageLoad()
         browserScreen.addressToolbarContainValue(value: "google.com")
-        browserScreen.assertLayout(.desktop)
+        // "I'm feeling lucky" may not show up intermittently
+        // browserScreen.assertLayout(.desktop)
 
         // Step 4: Visit amazon.com -> different domain, no desktop pref, mobile version loads.
         // NOTE: Amazon may show a region-redirect interstitial (e.g. "Deliver to Canada") on

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -20,6 +20,7 @@ final class BrowserScreen {
     private var bookText: XCUIElement { sel.BOOK_OF_MOZILLA_TEXT.element(in: app) }
     private var bookTextInTable: XCUIElement { sel.BOOK_OF_MOZILLA_TEXT_IN_TABLE.element(in: app) }
     private var clearButton: XCUIElement { sel.CLEAR_TEXT_BUTTON.element(in: app) }
+    private var reloadButton: XCUIElement { sel.RELOAD_BUTTON.element(in: app) }
 
     func assertAddressBarContains(value: String, timeout: TimeInterval = TIMEOUT) {
         let addressBar = sel.ADDRESS_BAR.element(in: app)
@@ -86,25 +87,59 @@ final class BrowserScreen {
         case mobile
     }
 
+    func reload() {
+        reloadButton.waitAndTap()
+    }
+
     // No one magic heuristic to determine desktop vs mobile layout, so we hardcode some
     // known characteristics of the test websites.
-    func assertLayout(_ mode: SiteLayoutMode, timeout: TimeInterval = TIMEOUT) {
-        let currentURL = (addressBar.value as? String) ?? ""
-        let element: XCUIElement
+    //
+    // `retries`: the custom UA can intermittently take an extra navigation to apply
+    // (WKWebView customUserAgent timing), so when > 1, a mismatch reloads the page and
+    // re-checks instead of failing immediately.
+    @discardableResult
+    func assertLayout(
+        _ mode: SiteLayoutMode,
+        timeout: TimeInterval = TIMEOUT,
+        failOnTimeout: Bool = true,
+        retries: Int = 1
+    ) -> Bool {
+        var isMatch = false
 
-        if mode == .desktop, currentURL.contains("google.com"), !currentURL.contains("news.google.com") {
-            element = app.webViews.buttons["I'm Feeling Lucky"]
-        } else if mode == .mobile, currentURL.contains("amazon.com") {
-            element = app.webViews.buttons["Open All Categories Menu"]
-        } else if mode == .desktop {
-            let pred = NSPredicate(format: "label BEGINSWITH 'Horizontal scroll bar,' AND NOT (label CONTAINS '1 page')")
-            element = app.webViews.descendants(matching: .any).matching(pred).firstMatch
-        } else {
-            element = app.webViews.descendants(matching: .any)
-                .matching(NSPredicate(format: "label == 'Horizontal scroll bar, 1 page'")).firstMatch
+        for attempt in 1...retries {
+            XCTContext.runActivity(named: "assertLayout(\(mode)) attempt \(attempt)/\(retries)") { activity in
+                if attempt > 1 {
+                    reload()
+                    BaseTestCase().waitUntilPageLoad()
+                }
+
+                let currentURL = (addressBar.value as? String) ?? ""
+                let element: XCUIElement
+
+                if mode == .desktop, currentURL.contains("google.com"), !currentURL.contains("news.google.com") {
+                    element = app.webViews.buttons["I'm Feeling Lucky"]
+                } else if mode == .mobile, currentURL.contains("amazon.com") {
+                    element = app.webViews.buttons["Open All Categories Menu"]
+                } else if mode == .desktop {
+                    let pred = NSPredicate(
+                        format: "label BEGINSWITH 'Horizontal scroll bar,' AND NOT (label CONTAINS '1 page')"
+                    )
+                    element = app.webViews.descendants(matching: .any).matching(pred).firstMatch
+                } else {
+                    element = app.webViews.descendants(matching: .any)
+                        .matching(NSPredicate(format: "label == 'Horizontal scroll bar, 1 page'")).firstMatch
+                }
+
+                isMatch = BaseTestCase().mozWaitForElementToExist(element, timeout: timeout, failOnTimeout: false)
+                activity.add(XCTAttachment(string: isMatch ? "\(mode) layout detected" : "\(mode) layout NOT detected"))
+            }
+            if isMatch { break }
         }
 
-        BaseTestCase().mozWaitForElementToExist(element, timeout: timeout)
+        if !isMatch, failOnTimeout {
+            XCTFail("\(mode) layout did not appear after \(retries) attempt(s)")
+        }
+        return isMatch
     }
 
     func tapDownloadsToastButton() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
@@ -9,6 +9,7 @@ protocol BrowserSelectorsSet {
     var SEARCH_ENGINE_LOGO: Selector { get }
     var DOWNLOADS_TOAST_BUTTON: Selector { get }
     var BACK_BUTTON: Selector { get }
+    var RELOAD_BUTTON: Selector { get }
     var MENU_BUTTON: Selector { get }
     var STATIC_TEXT_MOZILLA: Selector { get }
     var STATIC_TEXT_EXAMPLE_DOMAIN: Selector { get }
@@ -37,6 +38,7 @@ struct BrowserSelectors: BrowserSelectorsSet {
         static let addressBar = AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField
         static let searchEngineLogo = AccessibilityIdentifiers.Browser.AddressToolbar.searchEngine
         static let backButton = AccessibilityIdentifiers.Toolbar.backButton
+        static let reloadButton = AccessibilityIdentifiers.Toolbar.reloadButton
         static let menuButton = "Menu"
         static let clearTextLabel = "Clear text"
         static let downloadLabel = "Downloads"
@@ -74,6 +76,12 @@ struct BrowserSelectors: BrowserSelectorsSet {
     let BACK_BUTTON = Selector.buttonId(
         IDs.backButton,
         description: "Back button",
+        groups: ["browser"]
+    )
+
+    let RELOAD_BUTTON = Selector.buttonId(
+        IDs.reloadButton,
+        description: "Reload button",
         groups: ["browser"]
     )
 
@@ -203,7 +211,7 @@ struct BrowserSelectors: BrowserSelectorsSet {
         )
     }
 
-    var all: [Selector] { [ADDRESS_BAR, SEARCH_ENGINE_LOGO, DOWNLOADS_TOAST_BUTTON, BACK_BUTTON,
+    var all: [Selector] { [ADDRESS_BAR, SEARCH_ENGINE_LOGO, DOWNLOADS_TOAST_BUTTON, BACK_BUTTON, RELOAD_BUTTON,
                            MENU_BUTTON, STATIC_TEXT_MOZILLA, STATIC_TEXT_EXAMPLE_DOMAIN,
                            CLEAR_TEXT_BUTTON, CANCEL_BUTTON_URL_BAR, PRIVATE_BROWSING, CANCEL_BUTTON,
                            LINK_RFC_2606, BOOK_OF_MOZILLA_TEXT, ADDRESSTOOLBAR_LOCKICON, ADDRESSTOOLBAR_LOCKICON_OFF,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
`testRequestDesktopSitePersistsAcrossDomainAndRestart` fails intermittently because "I'm Feeling Lucky" button may not show up in google.com. Let me disable this step when I try to find a solution.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

