### PR TITLE
Remove FXIOS-16364 [Periphery] Remove dead OnboardingTelemetry protoc…

### DIFF
--- a/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingTelemetryUtility.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Models/OnboardingTelemetryUtility.swift
@@ -159,29 +159,6 @@ final class OnboardingTelemetryUtility: OnboardingTelemetryProtocol {
         gleanWrapper.recordEvent(for: GleanMetrics.Onboarding.wallpaperSelectorSelected, extras: extras)
     }
 
-    func sendWallpaperSelectedTelemetry(wallpaperName: String, wallpaperType: String) {
-        let extras = GleanMetrics.Onboarding.WallpaperSelectedExtra(
-            onboardingReason: onboardingReason.rawValue,
-            wallpaperName: wallpaperName,
-            wallpaperType: wallpaperType
-        )
-        gleanWrapper.recordEvent(for: GleanMetrics.Onboarding.wallpaperSelected, extras: extras)
-    }
-
-    func sendEngagementNotificationTappedTelemetry() {
-        let extras = GleanMetrics.Onboarding.EngagementNotificationTappedExtra(
-            onboardingReason: onboardingReason.rawValue
-        )
-        gleanWrapper.recordEvent(for: GleanMetrics.Onboarding.engagementNotificationTapped, extras: extras)
-    }
-
-    func sendEngagementNotificationCancelTelemetry() {
-        let extras = GleanMetrics.Onboarding.EngagementNotificationCancelExtra(
-            onboardingReason: onboardingReason.rawValue
-        )
-        gleanWrapper.recordEvent(for: GleanMetrics.Onboarding.engagementNotificationCancel, extras: extras)
-    }
-
     private struct BaseExtras {
         let cardType: String
         let flowType: String

--- a/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingTelemetryProtocol.swift
+++ b/firefox-ios/Client/Frontend/Onboarding/Protocols/OnboardingTelemetryProtocol.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import OnboardingKit
 
 enum OnboardingReason: String {
     case newUser = "new_user"
@@ -11,25 +10,9 @@ enum OnboardingReason: String {
 }
 
 protocol OnboardingTelemetryProtocol: AnyObject {
-    func sendCardViewTelemetry(from cardName: String)
-    func sendButtonActionTelemetry(from cardName: String,
-                                   with action: OnboardingActions,
-                                   and primaryButton: Bool)
-    func sendMultipleChoiceButtonActionTelemetry(
-        from cardName: String,
-        with action: OnboardingMultipleChoiceAction
-    )
-    func sendDismissOnboardingTelemetry(from cardName: String)
     func sendGoToSettingsButtonTappedTelemetry()
     func sendDismissButtonTappedTelemetry()
-    /// Records `onboarding.shown` and submits the `onboarding` ping.
-    func sendOnboardingShownTelemetry()
-    /// Records `onboarding.dismissed` with the given method and submits the `onboarding` ping.
-    func sendOnboardingDismissedTelemetry(outcome: OnboardingFlowOutcome)
     func sendWallpaperSelectorViewTelemetry()
     func sendWallpaperSelectorCloseTelemetry()
     func sendWallpaperSelectorSelectedTelemetry(wallpaperName: String, wallpaperType: String)
-    func sendWallpaperSelectedTelemetry(wallpaperName: String, wallpaperType: String)
-    func sendEngagementNotificationTappedTelemetry()
-    func sendEngagementNotificationCancelTelemetry()
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingServiceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OnboardingTests/OnboardingServiceTests.swift
@@ -101,45 +101,8 @@ class MockSearchBarLocationSaver: SearchBarLocationSaverProtocol {
 }
 
 class MockOnboardingTelemetryUtility: OnboardingTelemetryProtocol {
-    var sendCardViewTelemetryCalled = false
-    var sendButtonActionTelemetryCalled = false
-    var sendMultipleChoiceButtonActionTelemetryCalled = false
-    var sendDismissOnboardingTelemetryCalled = false
     var sendGoToSettingsButtonTappedTelemetryCalled = false
     var sendDismissButtonTappedTelemetryCalled = false
-
-    var cardName: String?
-    var action: OnboardingActions?
-    var primaryButton: Bool?
-    var multipleChoiceAction: OnboardingMultipleChoiceAction?
-
-    func sendCardViewTelemetry(from cardName: String) {
-        sendCardViewTelemetryCalled = true
-        self.cardName = cardName
-    }
-
-    func sendButtonActionTelemetry(from cardName: String,
-                                   with action: OnboardingActions,
-                                   and primaryButton: Bool) {
-        sendButtonActionTelemetryCalled = true
-        self.cardName = cardName
-        self.action = action
-        self.primaryButton = primaryButton
-    }
-
-    func sendMultipleChoiceButtonActionTelemetry(
-        from cardName: String,
-        with action: OnboardingMultipleChoiceAction
-    ) {
-        sendMultipleChoiceButtonActionTelemetryCalled = true
-        self.cardName = cardName
-        self.multipleChoiceAction = action
-    }
-
-    func sendDismissOnboardingTelemetry(from cardName: String) {
-        sendDismissOnboardingTelemetryCalled = true
-        self.cardName = cardName
-    }
 
     func sendGoToSettingsButtonTappedTelemetry() {
         sendGoToSettingsButtonTappedTelemetryCalled = true
@@ -149,24 +112,9 @@ class MockOnboardingTelemetryUtility: OnboardingTelemetryProtocol {
         sendDismissButtonTappedTelemetryCalled = true
     }
 
-    var sendOnboardingShownTelemetryCalled = false
-    func sendOnboardingShownTelemetry() {
-        sendOnboardingShownTelemetryCalled = true
-    }
-
-    var sendOnboardingDismissedTelemetryCalled = false
-    var lastDismissedOutcome: OnboardingFlowOutcome?
-    func sendOnboardingDismissedTelemetry(outcome: OnboardingFlowOutcome) {
-        sendOnboardingDismissedTelemetryCalled = true
-        lastDismissedOutcome = outcome
-    }
-
     func sendWallpaperSelectorViewTelemetry() {}
     func sendWallpaperSelectorCloseTelemetry() {}
     func sendWallpaperSelectorSelectedTelemetry(wallpaperName: String, wallpaperType: String) {}
-    func sendWallpaperSelectedTelemetry(wallpaperName: String, wallpaperType: String) {}
-    func sendEngagementNotificationTappedTelemetry() {}
-    func sendEngagementNotificationCancelTelemetry() {}
 }
 
 class MockActivityEventHelper: ActivityEventHelper {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperSelectorViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Wallpaper/WallpaperSelectorViewModelTests.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import OnboardingKit
 import XCTest
 
 @testable import Client
@@ -13,14 +12,8 @@ private class MockWallpaperTelemetryUtility: OnboardingTelemetryProtocol {
     var wallpaperSelectorSelectedName: String?
     var wallpaperSelectorSelectedType: String?
 
-    func sendCardViewTelemetry(from cardName: String) {}
-    func sendButtonActionTelemetry(from cardName: String, with action: OnboardingActions, and primaryButton: Bool) {}
-    func sendMultipleChoiceButtonActionTelemetry(from cardName: String, with action: OnboardingMultipleChoiceAction) {}
-    func sendDismissOnboardingTelemetry(from cardName: String) {}
     func sendGoToSettingsButtonTappedTelemetry() {}
     func sendDismissButtonTappedTelemetry() {}
-    func sendOnboardingShownTelemetry() {}
-    func sendOnboardingDismissedTelemetry(outcome: OnboardingFlowOutcome) {}
 
     func sendWallpaperSelectorViewTelemetry() { wallpaperSelectorViewCalled = true }
     func sendWallpaperSelectorCloseTelemetry() { wallpaperSelectorCloseCalled = true }
@@ -28,9 +21,6 @@ private class MockWallpaperTelemetryUtility: OnboardingTelemetryProtocol {
         wallpaperSelectorSelectedName = wallpaperName
         wallpaperSelectorSelectedType = wallpaperType
     }
-    func sendWallpaperSelectedTelemetry(wallpaperName: String, wallpaperType: String) {}
-    func sendEngagementNotificationTappedTelemetry() {}
-    func sendEngagementNotificationCancelTelemetry() {}
 }
 
 @MainActor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16364)  
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34794)

## :bulb: Description
Removes unused requirements from `OnboardingTelemetryProtocol` and deletes the telemetry implementations that have no callers.

This also removes the corresponding obsolete test mock methods and unused imports. Concrete telemetry methods that still have active call sites remain unchanged.

Verified by:
- Building the `Periphery` scheme
- Running the relevant onboarding and wallpaper unit tests
- Running SwiftLint

Closes #34794

## :movie_camera: Demos
Not applicable — there are no UI changes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass; no new tests were required for this cleanup
- [x] Not applicable — there are no UI or accessibility changes
- [x] Not applicable — no telemetry was added
- [x] Not applicable — no strings were added or modified
- [x] No documentation changes were needed