### PR TITLE
Bugfix FXIOS-16433 Fix states for wayback button

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -947,7 +947,7 @@ struct AccessibilityIdentifiers {
         static let waybackButton = "NativeErrorPage.waybackButton"
         static let waybackErrorCard = "NativeErrorPage.waybackErrorCard"
         static let waybackErrorLabel = "NativeErrorPage.waybackErrorLabel"
-        static let waybackRetryButton = "NativeErrorPage.waybackRetryButton"
+        static let waybackErrorButton = "NativeErrorPage.waybackRetryButton"
         static let goBackButton = "NativeErrorPage.goBackButton"
         static let proceedButton = "NativeErrorPage.proceedButton"
         static let advancedSectionHeader = "NativeErrorPage.advancedSectionHeader"

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -454,9 +454,8 @@ final class NativeErrorPageViewController: UIViewController,
 
         let query = "\"\(failingURL.absoluteString)\""
         guard let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let searchURL = URL(string: "https://www.google.com/search?q=\(encodedQuery)") else {
-            return
-        }
+              let searchURL = URL(string: "https://www.google.com/search?q=\(encodedQuery)")
+        else { return }
 
         store.dispatch(
             GeneralBrowserAction(

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -430,7 +430,7 @@ final class NativeErrorPageViewController: UIViewController,
             do {
                 let snapshot = try await WaybackService.fetchSnapshot(for: failingURL.absoluteString)
                 guard let snapshot, snapshot.available, let archivedURL = URL(string: snapshot.url) else {
-                    await MainActor.run { self.regularContentView.configureWaybackButton(state: .failed) }
+                    await MainActor.run { self.regularContentView.configureWaybackButton(state: .failed(.notFound)) }
                     return
                 }
                 await MainActor.run {
@@ -444,9 +444,28 @@ final class NativeErrorPageViewController: UIViewController,
                     )
                 }
             } catch {
-                await MainActor.run { self.regularContentView.configureWaybackButton(state: .failed) }
+                await MainActor.run { self.regularContentView.configureWaybackButton(state: .failed(.networkError)) }
             }
         }
+    }
+
+    func regularContentViewDidTapSearchWeb() {
+        guard let failingURL = model?.url?.baseURLWithPath else { return }
+
+        let query = "\"\(failingURL.absoluteString)\""
+        guard let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let searchURL = URL(string: "https://www.google.com/search?q=\(encodedQuery)") else {
+            return
+        }
+
+        store.dispatch(
+            GeneralBrowserAction(
+                destinationURL: searchURL,
+                isNativeErrorPage: true,
+                windowUUID: self.windowUUID,
+                actionType: GeneralBrowserActionType.loadWaybackURL
+            )
+        )
     }
 
     // MARK: - NativeErrorBadCertContentViewDelegate

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -151,11 +151,14 @@ final class NativeErrorPageViewController: UIViewController,
         }
     }
 
+    private let searchEnginesManager: SearchEnginesManagerProvider
+
     init(
         windowUUID: WindowUUID,
         tabManager: TabManager,
         themeManager: ThemeManager = AppContainer.shared.resolve(),
         overlayManager: OverlayModeManager,
+        searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(SearchEnginesManager.self),
         notificationCenter: NotificationProtocol = NotificationCenter.default,
         logger: Logger = DefaultLogger.shared
     ) {
@@ -163,6 +166,7 @@ final class NativeErrorPageViewController: UIViewController,
         self.tabManager = tabManager
         self.themeManager = themeManager
         self.overlayManager = overlayManager
+        self.searchEnginesManager = searchEnginesManager
         self.notificationCenter = notificationCenter
         self.logger = logger
         nativeErrorPageState = NativeErrorPageState(windowUUID: windowUUID)
@@ -450,12 +454,11 @@ final class NativeErrorPageViewController: UIViewController,
     }
 
     func regularContentViewDidTapSearchWeb() {
-        guard let failingURL = model?.url?.baseURLWithPath else { return }
+        guard let failingURL = model?.url?.baseURLWithPath,
+              let defaultEngine = searchEnginesManager.defaultEngine else { return }
 
         let query = "\"\(failingURL.absoluteString)\""
-        guard let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-              let searchURL = URL(string: "https://www.google.com/search?q=\(encodedQuery)")
-        else { return }
+        guard let searchURL = defaultEngine.searchURLForQuery(query) else { return }
 
         store.dispatch(
             GeneralBrowserAction(

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
@@ -10,12 +10,18 @@ import Shared
 protocol NativeErrorRegularContentViewDelegate: AnyObject {
     func regularContentViewDidTapReload()
     func regularContentViewDidTapSearchWayback()
+    func regularContentViewDidTapSearchWeb()
 }
 
 enum WaybackButtonState: Equatable {
     case idle
     case loading
-    case failed
+    case failed(Reason)
+
+    enum Reason: Equatable {
+        case networkError
+        case notFound
+    }
 }
 
 /// Encapsulates the "no internet / generic error" action area: a reload button,
@@ -60,10 +66,9 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable {
         stackView.spacing = 6
     }
 
-    private lazy var waybackRetryButton: UIButton = .build { button in
-        button.addTarget(self, action: #selector(self.didTapWayback), for: .touchUpInside)
+    private lazy var waybackErrorButton: UIButton = .build { button in
         button.contentHorizontalAlignment = .leading
-        button.accessibilityIdentifier = AccessibilityIdentifiers.NativeErrorPage.waybackRetryButton
+        button.accessibilityIdentifier = AccessibilityIdentifiers.NativeErrorPage.waybackErrorButton
     }
 
     private lazy var waybackErrorContentStack: UIStackView = .build { stackView in
@@ -101,7 +106,7 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable {
         waybackErrorMessageRow.addArrangedSubview(waybackErrorIcon)
         waybackErrorMessageRow.addArrangedSubview(waybackErrorLabel)
         waybackErrorContentStack.addArrangedSubview(waybackErrorMessageRow)
-        waybackErrorContentStack.addArrangedSubview(waybackRetryButton)
+        waybackErrorContentStack.addArrangedSubview(waybackErrorButton)
 
         waybackErrorCard.addSubview(waybackErrorContentStack)
         NSLayoutConstraint.activate([
@@ -162,10 +167,10 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable {
             waybackButton.isHidden = false
             waybackErrorCard.isHidden = true
             applyWaybackTitle(.NativeErrorPage.Wayback.CheckingLabel, enabled: false, showsSpinner: true)
-        case .failed:
+        case .failed(let reason):
             waybackButton.isHidden = true
             waybackErrorCard.isHidden = false
-            configureRetryButtonTitle()
+            configureWaybackErrorCard(reason: reason)
         }
     }
 
@@ -182,13 +187,23 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable {
         waybackButton.accessibilityHint = enabled ? .NativeErrorPage.Wayback.WaybackButtonA11yHint : nil
     }
 
-    private func configureRetryButtonTitle() {
+    private func configureWaybackErrorCard(reason: WaybackButtonState.Reason) {
         let attributes: [NSAttributedString.Key: Any] = [
             .underlineStyle: NSUnderlineStyle.single.rawValue,
             .font: FXFontStyles.Regular.footnote.scaledFont()
         ]
-        let title = NSAttributedString(string: .NativeErrorPage.Wayback.RetryButton, attributes: attributes)
-        waybackRetryButton.setAttributedTitle(title, for: .normal)
+        switch reason {
+        case .notFound:
+            let title = NSAttributedString(string: .NativeErrorPage.Wayback.SearchButton, attributes: attributes)
+            waybackErrorButton.setAttributedTitle(title, for: .normal)
+            waybackErrorLabel.text = String.NativeErrorPage.Wayback.NotFoundLabel
+            waybackErrorButton.addTarget(self, action: #selector(self.didTapSearchWeb), for: .touchUpInside)
+        case .networkError:
+            let title = NSAttributedString(string: .NativeErrorPage.Wayback.RetryButton, attributes: attributes)
+            waybackErrorButton.setAttributedTitle(title, for: .normal)
+            waybackErrorLabel.text = String.NativeErrorPage.Wayback.CouldNotReachLabel
+            waybackErrorButton.addTarget(self, action: #selector(self.didTapWayback), for: .touchUpInside)
+        }
     }
 
     @objc
@@ -201,6 +216,11 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable {
         delegate?.regularContentViewDidTapSearchWayback()
     }
 
+    @objc
+    private func didTapSearchWeb() {
+        delegate?.regularContentViewDidTapSearchWeb()
+    }
+
     // MARK: - ThemeApplicable
     func applyTheme(theme: any Theme) {
         reloadButton.applyTheme(theme: theme)
@@ -208,6 +228,6 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable {
         waybackErrorCard.backgroundColor = theme.colors.layerWarning
         waybackErrorLabel.textColor = theme.colors.textPrimary
         waybackErrorIcon.tintColor = theme.colors.actionWarning
-        waybackRetryButton.setTitleColor(theme.colors.textPrimary, for: .normal)
+        waybackErrorButton.setTitleColor(theme.colors.textPrimary, for: .normal)
     }
 }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2171,7 +2171,7 @@ extension String {
                 key: "NativeErrorPage.Wayback.Error.Search.v155",
                 tableName: "NativeErrorPage",
                 value: "Search the web",
-                comment: "Button label allowing the user to retry searching the Wayback Machine after a failed attempt.")
+                comment: "Button label allowing the use their default search engine to search for the page.")
         }
     }
 }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2171,7 +2171,7 @@ extension String {
                 key: "NativeErrorPage.Wayback.Error.Search.v155",
                 tableName: "NativeErrorPage",
                 value: "Search the web",
-                comment: "Button label allowing the use their default search engine to search for the page.")
+                comment: "Button label displayed when there is no archived version of a webpage, allowing the user to search for the page URL using their default search engine.")
         }
     }
 }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2158,7 +2158,7 @@ extension String {
                 value: "Couldn’t reach Wayback Machine",
                 comment: "Label shown when the app fails to reach the Wayback Machine while searching for an earlier version of a page.")
             public static let NotFoundLabel = MZLocalizedString(
-                key: "NativeErrorPage.Wayback.Error.NotFound.v154",
+                key: "NativeErrorPage.Wayback.Error.NotFound.v155",
                 tableName: "NativeErrorPage",
                 value: "No archived version found.",
                 comment: "Label shown when wayback responds and says no snapshot was found.")
@@ -2168,7 +2168,7 @@ extension String {
                 value: "Retry",
                 comment: "Button label allowing the user to retry searching the Wayback Machine after a failed attempt.")
             public static let SearchButton = MZLocalizedString(
-                key: "NativeErrorPage.Wayback.Error.Search.v154",
+                key: "NativeErrorPage.Wayback.Error.Search.v155",
                 tableName: "NativeErrorPage",
                 value: "Search the web",
                 comment: "Button label allowing the user to retry searching the Wayback Machine after a failed attempt.")

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2157,16 +2157,16 @@ extension String {
                 tableName: "NativeErrorPage",
                 value: "Couldn’t reach Wayback Machine",
                 comment: "Label shown when the app fails to reach the Wayback Machine while searching for an earlier version of a page.")
-            public static let NotFoundLabel = MZLocalizedString(
-                key: "NativeErrorPage.Wayback.Error.NotFound.v155",
-                tableName: "NativeErrorPage",
-                value: "No archived version found",
-                comment: "Label shown when wayback responds and says no snapshot was found.")
             public static let RetryButton = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Retry.v154",
                 tableName: "NativeErrorPage",
                 value: "Retry",
                 comment: "Button label allowing the user to retry searching the Wayback Machine after a failed attempt.")
+            public static let NotFoundLabel = MZLocalizedString(
+                key: "NativeErrorPage.Wayback.Error.NotFound.v155",
+                tableName: "NativeErrorPage",
+                value: "No archived version found",
+                comment: "Label shown when wayback responds and says no snapshot was found.")
             public static let SearchButton = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Search.v155",
                 tableName: "NativeErrorPage",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2157,10 +2157,20 @@ extension String {
                 tableName: "NativeErrorPage",
                 value: "Couldn’t reach Wayback Machine",
                 comment: "Label shown when the app fails to reach the Wayback Machine while searching for an earlier version of a page.")
+            public static let NotFoundLabel = MZLocalizedString(
+                key: "NativeErrorPage.Wayback.Error.NotFound.v154",
+                tableName: "NativeErrorPage",
+                value: "No archived version found.",
+                comment: "Label shown when wayback responds and says no snapshot was found.")
             public static let RetryButton = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Retry.v154",
                 tableName: "NativeErrorPage",
                 value: "Retry",
+                comment: "Button label allowing the user to retry searching the Wayback Machine after a failed attempt.")
+            public static let SearchButton = MZLocalizedString(
+                key: "NativeErrorPage.Wayback.Error.Search.v154",
+                tableName: "NativeErrorPage",
+                value: "Search the web",
                 comment: "Button label allowing the user to retry searching the Wayback Machine after a failed attempt.")
         }
     }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2160,7 +2160,7 @@ extension String {
             public static let NotFoundLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.NotFound.v155",
                 tableName: "NativeErrorPage",
-                value: "No archived version found.",
+                value: "No archived version found",
                 comment: "Label shown when wayback responds and says no snapshot was found.")
             public static let RetryButton = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Retry.v154",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorRegularContentViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorRegularContentViewTests.swift
@@ -37,10 +37,18 @@ final class NativeErrorRegularContentViewTests: XCTestCase {
         XCTAssertFalse(subject.waybackButton.isEnabled)
     }
 
-    func test_configureWaybackButton_failedState_hidesButtonShowsCard() {
+    func test_configureWaybackButton_failedNotFoundState_hidesButtonShowsCard() {
         let subject = createSubject()
         subject.configure(showWaybackButton: true)
-        subject.configureWaybackButton(state: .failed)
+        subject.configureWaybackButton(state: .failed(.notFound))
+        XCTAssertTrue(subject.waybackButton.isHidden)
+        XCTAssertFalse(subject.waybackErrorCard.isHidden)
+    }
+
+    func test_configureWaybackButton_failedNetworkErrorState_hidesButtonShowsCard() {
+        let subject = createSubject()
+        subject.configure(showWaybackButton: true)
+        subject.configureWaybackButton(state: .failed(.networkError))
         XCTAssertTrue(subject.waybackButton.isHidden)
         XCTAssertFalse(subject.waybackErrorCard.isHidden)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16433)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34917)

## :bulb: Description
The failing state after clicking the button should have 3 main states
1. initial state
2. searching state
3. failing state

The failing state should have 2 sub cases, failure due to cannot reach Wayback, and failure due to no snapshot found

This PR adds the missing subcases to the failing state which before used to just be one state

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

