### PR TITLE
Bugfix FXIOS-16223 Fix truncated label in microsuvery alert

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptView.swift
@@ -176,15 +176,17 @@ final class MicrosurveyPromptView: UIView, ThemeApplicable, Notifiable {
 
             toastView.topAnchor.constraint(equalTo: topBorderView.bottomAnchor, constant: UX.padding.top),
             toastView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: UX.padding.bottom),
-
-            headerView.widthAnchor.constraint(equalTo: toastView.widthAnchor),
-            titleLabel.heightAnchor.constraint(equalTo: headerView.heightAnchor),
         ])
     }
 
     override func updateConstraints() {
         super.updateConstraints()
         updatePadding()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        titleLabel.preferredMaxLayoutWidth = titleLabel.bounds.width
     }
 
     private func updatePadding() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16223)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34526)

## :bulb: Description
- Fixed microsurvey alert title truncation
- Allow the microsurvey title label to span multiple lines by updating its preferred maximum layout width during layout.
- Remove the fixed header width and title height constraints that prevented the alert from expanding vertically when displaying longer text.
- Screenshots added to verify the updated layout.


## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 21 51 43" src="https://github.com/user-attachments/assets/902823e1-e819-439a-9194-374c78905ae4" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 21 43 04" src="https://github.com/user-attachments/assets/77a7b8dc-74d6-453b-a3d5-d7ea75aef817" /> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

