### PR TITLE
Disable testRequestDesktopSitePersistsAcrossDomainAndRestart

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -235,6 +235,7 @@
         "DesktopModeTestsIphone\/testPrivateModeOnHasNoAffectOnNormalMode()",
         "DesktopModeTestsIphone\/testPrivateModeOnHasNoAffectOnNormalMode_tabTrayExperimentOff()",
         "DesktopModeTestsIphone\/testPrivateModeOnHasNoAffectOnNormalMode_tabTrayExperimentOn()",
+        "DesktopModeTestsIphone\/testRequestDesktopSitePersistsAcrossDomainAndRestart()",
         "DesktopModeTestsIphone\/testSameHostInMultipleTabs()",
         "DisplaySettingTests",
         "DomainAutocompleteTests",


### PR DESCRIPTION
## :scroll: Tickets
No ticket

Temporarily disable this test until #34836 is merged


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

