### PR TITLE
Bugfix FXIOS-15600 Fix SiteDataClearable for domain-specific removal

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Clearables.swift
+++ b/firefox-ios/Client/Frontend/Settings/Clearables.swift
@@ -15,8 +15,9 @@ protocol Clearable {
     @MainActor
     func clear() -> Success
     /// Clears data scoped to a single domain (eTLD+1).
-    /// Default implementation is a no-op for clearables where domain scoping is not meaningful
-    /// (e.g. history, downloads, spotlight).
+    /// Default implementation in production is a no-op for clearables where domain scoping is not meaningful
+    /// but will assert in debug builds since we currently do not expect to call this on Clearables where
+    /// it is unsupported. (e.g. history, downloads, spotlight).
     @MainActor
     func clear(forDomain domain: String) async
     var label: String { get }
@@ -24,7 +25,9 @@ protocol Clearable {
 
 extension Clearable {
     @MainActor
-    func clear(forDomain domain: String) async { }
+    func clear(forDomain domain: String) async {
+        assertionFailure("clear(forDomain:) called on Clearable '\(String(describing: type(of: self)))' that does not support it.")
+    }
 }
 
 // TODO: FXIOS-14152 - HistoryClearable shouldn't be @unchecked Sendable
@@ -131,25 +134,38 @@ class SpotlightClearable: Clearable {
 class SiteDataClearable: Clearable {
     var label: String { .ClearableOfflineData }
     private let logger: Logger
+    private let dataTypes = Set([
+        WKWebsiteDataTypeLocalStorage,
+        WKWebsiteDataTypeSessionStorage,
+        WKWebsiteDataTypeWebSQLDatabases,
+        WKWebsiteDataTypeIndexedDBDatabases,
+        WKWebsiteDataTypeFetchCache,
+    ])
 
     init(logger: Logger = DefaultLogger.shared) {
         self.logger = logger
     }
 
     func clear() -> Success {
-        let dataTypes = Set([
-            WKWebsiteDataTypeLocalStorage,
-            WKWebsiteDataTypeSessionStorage,
-            WKWebsiteDataTypeWebSQLDatabases,
-            WKWebsiteDataTypeIndexedDBDatabases,
-            WKWebsiteDataTypeFetchCache,
-        ])
         WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: .distantPast, completionHandler: {})
 
         logger.log("SiteDataClearable succeeded.",
                    level: .debug,
                    category: .storage)
         return succeed()
+    }
+
+    @MainActor
+    func clear(forDomain domain: String) async {
+        let dataStore = WKWebsiteDataStore.default()
+        let records = await dataStore.dataRecords(ofTypes: dataTypes)
+        let targets = records.filter { $0.displayName == domain.lowercased() }
+        guard !targets.isEmpty else { return }
+        await dataStore.removeData(ofTypes: dataTypes, for: targets)
+        logger.log(
+            "SiteDataClearable removed domain-scoped data for \(domain).",
+            level: .debug,
+            category: .storage)
     }
 }
 
@@ -158,6 +174,7 @@ class CookiesClearable: Clearable {
     var label: String { .ClearableCookies }
     private let logger: Logger
     private let dataStore: WKWebsiteDataStore
+    private let dataTypes = Set([WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage])
 
     @MainActor
     init(logger: Logger = DefaultLogger.shared,
@@ -168,7 +185,7 @@ class CookiesClearable: Clearable {
 
     func clear() -> Success {
         dataStore.removeData(
-            ofTypes: [WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage],
+            ofTypes: dataTypes,
             modifiedSince: .distantPast,
             completionHandler: {}
         )
@@ -181,10 +198,10 @@ class CookiesClearable: Clearable {
 
     @MainActor
     func clear(forDomain domain: String) async {
-        let records = await dataStore.dataRecords(ofTypes: [WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage])
+        let records = await dataStore.dataRecords(ofTypes: dataTypes)
         let targets = records.filter { $0.displayName == domain.lowercased() }
         guard !targets.isEmpty else { return }
-        await dataStore.removeData(ofTypes: [WKWebsiteDataTypeCookies, WKWebsiteDataTypeLocalStorage], for: targets)
+        await dataStore.removeData(ofTypes: dataTypes, for: targets)
         logger.log(
             "CookiesClearable removed domain-scoped data for \(domain).",
             level: .debug,

--- a/firefox-ios/Client/Frontend/Settings/Clearables.swift
+++ b/firefox-ios/Client/Frontend/Settings/Clearables.swift
@@ -134,6 +134,7 @@ class SpotlightClearable: Clearable {
 class SiteDataClearable: Clearable {
     var label: String { .ClearableOfflineData }
     private let logger: Logger
+    private let dataStore: WKWebsiteDataStore
     private let dataTypes = Set([
         WKWebsiteDataTypeLocalStorage,
         WKWebsiteDataTypeSessionStorage,
@@ -142,12 +143,15 @@ class SiteDataClearable: Clearable {
         WKWebsiteDataTypeFetchCache,
     ])
 
-    init(logger: Logger = DefaultLogger.shared) {
+    @MainActor
+    init(logger: Logger = DefaultLogger.shared,
+         dataStore: WKWebsiteDataStore = .default()) {
         self.logger = logger
+        self.dataStore = dataStore
     }
 
     func clear() -> Success {
-        WKWebsiteDataStore.default().removeData(ofTypes: dataTypes, modifiedSince: .distantPast, completionHandler: {})
+        dataStore.removeData(ofTypes: dataTypes, modifiedSince: .distantPast, completionHandler: {})
 
         logger.log("SiteDataClearable succeeded.",
                    level: .debug,
@@ -157,7 +161,6 @@ class SiteDataClearable: Clearable {
 
     @MainActor
     func clear(forDomain domain: String) async {
-        let dataStore = WKWebsiteDataStore.default()
         let records = await dataStore.dataRecords(ofTypes: dataTypes)
         let targets = records.filter { $0.displayName == domain.lowercased() }
         guard !targets.isEmpty else { return }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ClearablesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/ClearablesTests.swift
@@ -67,6 +67,21 @@ struct CookiesClearableTests {
         #expect(after.first?.domain == "other.com")
     }
 
+    // Ensure clear(forDomain:) dynamically dispatches to CookiesClearable implementation,
+    // not the Clearable extension default (which asserts).
+    @MainActor
+    @Test
+    func test_clearForDomain_calledViaClearableProtocol_runsCustomImplementation() async {
+        let store = WKWebsiteDataStore.nonPersistent()
+        await store.httpCookieStore.setCookie(makeCookie(domain: "example.com"))
+
+        let clearable: Clearable = makeSubject(dataStore: store)
+        await clearable.clear(forDomain: "example.com")
+
+        let after = await store.httpCookieStore.allCookies()
+        #expect(after.isEmpty)
+    }
+
     @MainActor
     private func makeSubject(dataStore: WKWebsiteDataStore = .nonPersistent()) -> CookiesClearable {
         CookiesClearable(logger: MockLogger(), dataStore: dataStore)
@@ -79,5 +94,49 @@ struct CookiesClearableTests {
             .domain: domain,
             .path: "/"
         ])!
+    }
+}
+
+@Suite("SiteDataClearable")
+struct SiteDataClearableTests {
+    @MainActor
+    @Test
+    func test_clear_returnsSuccess() async {
+        let result: Maybe<Void> = await withCheckedContinuation { continuation in
+            makeSubject().clear().upon { continuation.resume(returning: $0) }
+        }
+        #expect(result.isSuccess)
+    }
+
+    @MainActor
+    @Test
+    func test_clearForDomain_withEmptyStore_storeRemainsEmpty() async {
+        let store = WKWebsiteDataStore.nonPersistent()
+        await makeSubject(dataStore: store).clear(forDomain: "example.com")
+        let records = await store.dataRecords(ofTypes: [WKWebsiteDataTypeLocalStorage])
+        #expect(records.isEmpty)
+    }
+
+    // Ensure clear(forDomain:) dynamically dispatches to SiteDataClearable implementation,
+    // not the Clearable extension default (which asserts).
+    @MainActor
+    @Test
+    func test_clearForDomain_calledViaClearableProtocol_doesNotHitAssertingDefault() async {
+        let store = WKWebsiteDataStore.nonPersistent()
+        let clearable: Clearable = makeSubject(dataStore: store)
+        await clearable.clear(forDomain: "example.com")
+        let records = await store.dataRecords(ofTypes: [WKWebsiteDataTypeLocalStorage])
+        #expect(records.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func test_label_isOfflineData() {
+        #expect(makeSubject().label == .ClearableOfflineData)
+    }
+
+    @MainActor
+    private func makeSubject(dataStore: WKWebsiteDataStore = .nonPersistent()) -> SiteDataClearable {
+        SiteDataClearable(logger: MockLogger(), dataStore: dataStore)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15600)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33416)

## :bulb: Description

Previously our call into `SiteDataClearables.clear(forDomain:)` was calling into an empty default extension function. I believe this is the root issue captured by 15600, but in addition it's worth noting that our UI for the Website Data does not display the same record types that we clear for individual sites. Specifically, clearing an individual domain only clears records for the Cookies and SiteData clearables, while the Website Data UI shows records of all types, which I believe can create potential confusion for users. This latter issue is more of a UX question however and not really a bug (AFAICS), so I have not changed the UI for now but have solicited feedback on the Jira.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

