### PR TITLE
Bugfix NO-TICKET [Tests] Fix flaky UI test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/WebsiteDataScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/WebsiteDataScreen.swift
@@ -26,6 +26,8 @@ final class WebsiteDataScreen {
         okButton.waitAndTap()
         BaseTestCase().mozWaitForElementToNotExist(okButton)
 
+        // The table clears asynchronously; wait for the rows to be removed before asserting the count.
+        BaseTestCase().mozWaitForElementToNotExist(app.cells.buttons.images.firstMatch)
         XCTAssertEqual(app.cells.buttons.images.count, 0, "The Website data has not cleared correctly")
 
         // Add wait for back button to be enabled
@@ -37,6 +39,8 @@ final class WebsiteDataScreen {
     }
 
     func assertAllWebsiteDataCleared() {
+        // The table clears asynchronously; wait for the rows to be removed before asserting the count.
+        BaseTestCase().mozWaitForElementToNotExist(app.cells.buttons.images.firstMatch)
         XCTAssertEqual(app.cells.buttons.images.count, 0, "The Website data has not cleared correctly")
     }
 


### PR DESCRIPTION
## :bulb: Description
Fixes a flaky failure in the DataManagementTests UI tests, most visibly testWebSiteDataEnterFirstTime(), which intermittently fails on BR (especially on [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/34910) ) with `WebsiteDataScreen.swift:29: XCTAssertEqual failed: ("1") is not equal to ("0") - The Website data has not cleared correctly` even though that PR has nothing to do with this.

Fix is to removes async race by waiting for the residual cell images to be removed before asserting the count.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

