### PR TITLE
Refactor MTE-5586 Enhanced Tracking Protection testing

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -38,6 +38,23 @@ final class BrowserScreen {
         }
     }
 
+    // Reads the adblock-tester.com score banner (e.g. "38 points out of 100 (11 services, 22
+    // checks)") and returns the leading number. The score/service/check counts are dynamic
+    // (depend on ads/trackers live on the page at test time), so callers should compare scores
+    // relative to each other rather than against a fixed expected value.
+    func adblockTesterScore(timeout: TimeInterval = TIMEOUT) -> Int {
+        let scoreElement = app.webViews.otherElements.matching(
+            NSPredicate(format: "label CONTAINS[c] 'points out of 100'")
+        ).firstMatch
+        BaseTestCase().mozWaitForElementToExist(scoreElement, timeout: timeout)
+
+        guard let match = scoreElement.label.range(of: #"^\d+"#, options: .regularExpression) else {
+            XCTFail("Could not parse a leading score number from label: \(scoreElement.label)")
+            return 0
+        }
+        return Int(scoreElement.label[match]) ?? 0
+    }
+
     func tapBackButton() {
         let backButton = sel.BACK_BUTTON.element(in: app)
         backButton.waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -39,9 +39,7 @@ final class BrowserScreen {
     }
 
     // Reads the adblock-tester.com score banner (e.g. "38 points out of 100 (11 services, 22
-    // checks)") and returns the leading number. The score/service/check counts are dynamic
-    // (depend on ads/trackers live on the page at test time), so callers should compare scores
-    // relative to each other rather than against a fixed expected value.
+    // checks)") and returns the leading number.
     func adblockTesterScore(timeout: TimeInterval = TIMEOUT) -> Int {
         let scoreElement = app.webViews.otherElements.matching(
             NSPredicate(format: "label CONTAINS[c] 'points out of 100'")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -331,6 +331,11 @@ final class BrowserScreen {
         BaseTestCase().mozWaitForElementToExist(text)
     }
 
+    func assertWebPageTextDoesNotExist(with text: String) {
+        let text = sel.webPageElement(with: text).element(in: app)
+        BaseTestCase().mozWaitForElementToNotExist(text)
+    }
+
     func tapWebViewTextIfExists(text: String) {
         app.webViews.staticTexts[text].tapIfExists()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TrackingProtectionScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TrackingProtectionScreen.swift
@@ -27,4 +27,18 @@ final class TrackingProtectionScreen {
         BaseTestCase().mozWaitForElementToExist(toggle)
         XCTAssertFalse(toggle.isEnabled, "Expected Tracking Protection switch to be disabled")
     }
+
+    // assertTrackingProtectionSwitchIsEnabled/Disabled above check whether the switch control
+    // itself is interactable, not its on/off value. Use this to check the actual toggle state.
+    @MainActor
+    func assertTrackingProtectionSwitchValue(isOn: Bool) {
+        let toggle = sel.TRACKING_PROTECTION_SWITCH.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(toggle)
+        let expectedValue = isOn ? "1" : "0"
+        XCTAssertEqual(
+            toggle.value as? String,
+            expectedValue,
+            "Expected Tracking Protection switch value to be \(expectedValue)"
+        )
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -26,23 +26,6 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.performAction(Action.TrackingProtectionperSiteToggle)
     }
 
-    // Reads the adblock-tester.com score banner (e.g. "38 points out of 100 (11 services, 22
-    // checks)") and returns the leading number. The score/service/check counts are dynamic
-    // (depend on ads/trackers live on the page at test time), so callers should compare scores
-    // relative to each other rather than against a fixed expected value.
-    private func adblockTesterScore(timeout: TimeInterval = TIMEOUT) -> Int {
-        let scoreElement = app.webViews.otherElements.matching(
-            NSPredicate(format: "label CONTAINS[c] 'points out of 100'")
-        ).firstMatch
-        mozWaitForElementToExist(scoreElement, timeout: timeout)
-
-        guard let match = scoreElement.label.range(of: #"^\d+"#, options: .regularExpression) else {
-            XCTFail("Could not parse a leading score number from label: \(scoreElement.label)")
-            return 0
-        }
-        return Int(scoreElement.label[match]) ?? 0
-    }
-
     private func checkTrackingProtectionDisabledForSite() {
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon])
     }
@@ -119,7 +102,7 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.openURL(adblockTesterURL)
         waitUntilPageLoad()
         app.swipeUp()
-        let scoreWithETPOff = adblockTesterScore()
+        let scoreWithETPOff = browserScreen.adblockTesterScore()
 
         // Step 5: Enable "Enhanced Tracking Protection" and recheck adblock-tester.com ->
         // Tracking Protection is enabled, and the score increases (e.g. from 38 to 42 out of 100).
@@ -134,7 +117,7 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.openURL(adblockTesterURL)
         waitUntilPageLoad()
         app.swipeUp()
-        let scoreWithETPOn = adblockTesterScore()
+        let scoreWithETPOn = browserScreen.adblockTesterScore()
 
         XCTAssertGreaterThan(
             scoreWithETPOn,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -20,7 +20,6 @@ let secureTrackingProtectionOffLabel = "Secure connection. Enhanced Tracking Pro
 class TrackingProtectionTests: BaseTestCase {
     var browserScreen: BrowserScreen!
     var trackingProtectionScreen: TrackingProtectionScreen!
-    var toolbarScreen: ToolbarScreen!
     var settingsScreen: SettingScreen!
 
     private func disableEnableTrackingProtectionForSite() {
@@ -86,49 +85,57 @@ class TrackingProtectionTests: BaseTestCase {
     func testStandardProtectionLevel() {
         browserScreen = BrowserScreen(app: app)
         trackingProtectionScreen = TrackingProtectionScreen(app: app)
-        toolbarScreen = ToolbarScreen(app: app)
         settingsScreen = SettingScreen(app: app)
-        // issue 28625: iOS 15 may not open the menu fully.
-        if #unavailable(iOS 16) {
-            navigator.goto(BrowserTabMenu)
-            app.swipeUp()
-        }
+
+        let firstPartySimulatorURL = "https://firstpartysimulator.org/kcarter?try2=true&aat=1"
+
+        // Step 2: Go to Settings -> Tracking Protection -> Standard TP is enabled by default.
         navigator.goto(TrackingProtectionSettings)
+        trackingProtectionScreen.assertTrackingProtectionSwitchValue(isOn: true)
 
-        // Make sure ETP is enabled by default
-        trackingProtectionScreen.assertTrackingProtectionSwitchIsEnabled()
-
-        // Turn off ETP
+        // Step 3: Disable "Enhanced Tracking Protection" -> Tracking Protection is disabled.
         navigator.performAction(Action.SwitchETP)
+        trackingProtectionScreen.assertTrackingProtectionSwitchValue(isOn: false)
 
-        // Verify it is turned off
-        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
+        // Step 4: Visit firstpartysimulator.org and run the test -> a message reading "You have
+        // some protection against Web Tracking, but it has some gaps." is shown, with "Partial
+        // protection" displayed below it.
+        // NOTE(you): as of 2026-07-23 this site actually shows "Our tests indicate that you have
+        // strong protection against Web tracking" regardless of the ETP switch state above - the
+        // assertions below match the TestRail case as written, but haven't been confirmed to
+        // pass against the site's current real behavior. Re-verify on-device.
+        navigator.openURL(firstPartySimulatorURL)
         waitUntilPageLoad()
-
-        // The lock icon should still be there
-        browserScreen.assertAddressBar_LockIconOffExist()
-        toolbarScreen.assertSettingsButtonExists()
-
-        // Switch to Private Browsing
-        navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
-        navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
+        browserScreen.assertAddressBarContains(value: "coveryourtracks.eff.org")
+        browserScreen.assertWebPageTextDoesNotExist(with: "Testing your browser")
         waitUntilPageLoad()
+        app.partialSwipeUp(distance: 0.3)
+        browserScreen.assertWebPageText(with: "strong protection against Web tracking")
+        browserScreen.assertWebPageText(with: "your browser has a unique fingerprint")
+        // browserScreen.assertWebPageText(with: "your browser has a randomized fingerprint")
+        browserScreen.assertWebPageTextDoesNotExist(with: "partial protection against Web tracking")
+        // browserScreen.assertWebPageTextDoesNotExist(with: "your browser has a unique fingerprint")
 
-        // Make sure TP is also there in PBM
-        browserScreen.assertAddressBar_LockIconOffExist()
-        toolbarScreen.assertSettingsButtonExists()
-
+        // Step 5: Enable "Enhanced Tracking Protection" -> Tracking Protection is enabled.
+        app.swipeDown()
         navigator.goto(BrowserTabMenu)
-        // issue 28625: iOS 15 may not open the menu fully.
-        if #unavailable(iOS 16) {
-            app.swipeUp()
-        }
         navigator.goto(SettingsScreen)
         settingsScreen.swipeUpFromNewTabCell()
-        // Enable TP again
         navigator.goto(TrackingProtectionSettings)
-        // Turn on ETP
         navigator.performAction(Action.SwitchETP)
+        trackingProtectionScreen.assertTrackingProtectionSwitchValue(isOn: true)
+
+        // Step 6: Revisit firstpartysimulator.org and run the test -> Tracking Protection is
+        // enabled.
+        navigator.openURL(firstPartySimulatorURL)
+        waitUntilPageLoad()
+        browserScreen.assertAddressBarContains(value: "coveryourtracks.eff.org")
+        browserScreen.assertWebPageTextDoesNotExist(with: "Testing your browser")
+        app.partialSwipeUp(distance: 0.3)
+        browserScreen.assertWebPageText(with: "strong protection against Web tracking")
+        browserScreen.assertWebPageText(with: "your browser has a randomized fingerprint")
+        browserScreen.assertWebPageTextDoesNotExist(with: "partial protection against Web tracking")
+        browserScreen.assertWebPageTextDoesNotExist(with: "your browser has a unique fingerprint")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2318742

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -26,6 +26,23 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.performAction(Action.TrackingProtectionperSiteToggle)
     }
 
+    // Reads the adblock-tester.com score banner (e.g. "38 points out of 100 (11 services, 22
+    // checks)") and returns the leading number. The score/service/check counts are dynamic
+    // (depend on ads/trackers live on the page at test time), so callers should compare scores
+    // relative to each other rather than against a fixed expected value.
+    private func adblockTesterScore(timeout: TimeInterval = TIMEOUT) -> Int {
+        let scoreElement = app.webViews.otherElements.matching(
+            NSPredicate(format: "label CONTAINS[c] 'points out of 100'")
+        ).firstMatch
+        mozWaitForElementToExist(scoreElement, timeout: timeout)
+
+        guard let match = scoreElement.label.range(of: #"^\d+"#, options: .regularExpression) else {
+            XCTFail("Could not parse a leading score number from label: \(scoreElement.label)")
+            return 0
+        }
+        return Int(scoreElement.label[match]) ?? 0
+    }
+
     private func checkTrackingProtectionDisabledForSite() {
         mozWaitForElementToNotExist(app.buttons[AccessibilityIdentifiers.Browser.AddressToolbar.lockIcon])
     }
@@ -87,7 +104,7 @@ class TrackingProtectionTests: BaseTestCase {
         trackingProtectionScreen = TrackingProtectionScreen(app: app)
         settingsScreen = SettingScreen(app: app)
 
-        let firstPartySimulatorURL = "https://firstpartysimulator.org/kcarter?try2=true&aat=1"
+        let adblockTesterURL = "https://adblock-tester.com/"
 
         // Step 2: Go to Settings -> Tracking Protection -> Standard TP is enabled by default.
         navigator.goto(TrackingProtectionSettings)
@@ -97,26 +114,15 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.performAction(Action.SwitchETP)
         trackingProtectionScreen.assertTrackingProtectionSwitchValue(isOn: false)
 
-        // Step 4: Visit firstpartysimulator.org and run the test -> a message reading "You have
-        // some protection against Web Tracking, but it has some gaps." is shown, with "Partial
-        // protection" displayed below it.
-        // NOTE(you): as of 2026-07-23 this site actually shows "Our tests indicate that you have
-        // strong protection against Web tracking" regardless of the ETP switch state above - the
-        // assertions below match the TestRail case as written, but haven't been confirmed to
-        // pass against the site's current real behavior. Re-verify on-device.
-        navigator.openURL(firstPartySimulatorURL)
+        // Step 4: Go to https://adblock-tester.com/ and run the test -> a message shows the
+        // score out of 100 (e.g. "38 points out of 100") while ETP is disabled.
+        navigator.openURL(adblockTesterURL)
         waitUntilPageLoad()
-        browserScreen.assertAddressBarContains(value: "coveryourtracks.eff.org")
-        browserScreen.assertWebPageTextDoesNotExist(with: "Testing your browser")
-        waitUntilPageLoad()
-        app.partialSwipeUp(distance: 0.3)
-        browserScreen.assertWebPageText(with: "strong protection against Web tracking")
-        browserScreen.assertWebPageText(with: "your browser has a unique fingerprint")
-        // browserScreen.assertWebPageText(with: "your browser has a randomized fingerprint")
-        browserScreen.assertWebPageTextDoesNotExist(with: "partial protection against Web tracking")
-        // browserScreen.assertWebPageTextDoesNotExist(with: "your browser has a unique fingerprint")
+        app.swipeUp()
+        let scoreWithETPOff = adblockTesterScore()
 
-        // Step 5: Enable "Enhanced Tracking Protection" -> Tracking Protection is enabled.
+        // Step 5: Enable "Enhanced Tracking Protection" and recheck adblock-tester.com ->
+        // Tracking Protection is enabled, and the score increases (e.g. from 38 to 42 out of 100).
         app.swipeDown()
         navigator.goto(BrowserTabMenu)
         navigator.goto(SettingsScreen)
@@ -125,17 +131,16 @@ class TrackingProtectionTests: BaseTestCase {
         navigator.performAction(Action.SwitchETP)
         trackingProtectionScreen.assertTrackingProtectionSwitchValue(isOn: true)
 
-        // Step 6: Revisit firstpartysimulator.org and run the test -> Tracking Protection is
-        // enabled.
-        navigator.openURL(firstPartySimulatorURL)
+        navigator.openURL(adblockTesterURL)
         waitUntilPageLoad()
-        browserScreen.assertAddressBarContains(value: "coveryourtracks.eff.org")
-        browserScreen.assertWebPageTextDoesNotExist(with: "Testing your browser")
-        app.partialSwipeUp(distance: 0.3)
-        browserScreen.assertWebPageText(with: "strong protection against Web tracking")
-        browserScreen.assertWebPageText(with: "your browser has a randomized fingerprint")
-        browserScreen.assertWebPageTextDoesNotExist(with: "partial protection against Web tracking")
-        browserScreen.assertWebPageTextDoesNotExist(with: "your browser has a unique fingerprint")
+        app.swipeUp()
+        let scoreWithETPOn = adblockTesterScore()
+
+        XCTAssertGreaterThan(
+            scoreWithETPOn,
+            scoreWithETPOff,
+            "Enabling Enhanced Tracking Protection should improve the adblock-tester.com score"
+        )
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2318742


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5586)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The test site for the ETP feature is `adblock-tester.com` now. The steps in TestRail has been updated with the new test website.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

