### PR TITLE
Refactor FXIOS-15901 [Technical Debt] [Redux] Clean up HomepageState `@Copyable` macro usage for transient properties

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -339,7 +339,6 @@ struct HomepageState: ScreenState, Equatable {
 
     // MARK: - Helper function to reset transient state
     private func resetTransientState() -> HomepageState {
-        return self
-            .copy(shouldTriggerImpression: false)
+        return Self.defaultState(from: self)
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -173,6 +173,7 @@ struct HomepageState: ScreenState, Equatable {
     @MainActor
     private static func handleInitializeAndViewWillTransitionAction(state: HomepageState, action: Action) -> HomepageState {
         return state
+            .resetTransientState()
             .copy(headerState: HeaderState.reducer.legacyReducer(state.headerState, action))
             .copy(messageState: MessageCardState.reducer.legacyReducer(state.messageState, action))
             .copy(topSitesState: TopSitesSectionState.reducer.legacyReducer(state.topSitesState, action))
@@ -184,7 +185,6 @@ struct HomepageState: ScreenState, Equatable {
             .copy(worldcupState: WorldCupSectionState.reducer.legacyReducer(state.worldcupState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
-            .copy(shouldTriggerImpression: false)
     }
 
     @MainActor
@@ -192,6 +192,7 @@ struct HomepageState: ScreenState, Equatable {
                                                      action: Action,
                                                      isZeroSearch: Bool) -> HomepageState {
         return state
+            .resetTransientState()
             .copy(headerState: HeaderState.reducer.legacyReducer(state.headerState, action))
             .copy(messageState: MessageCardState.reducer.legacyReducer(state.messageState, action))
             .copy(topSitesState: TopSitesSectionState.reducer.legacyReducer(state.topSitesState, action))
@@ -204,7 +205,6 @@ struct HomepageState: ScreenState, Equatable {
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
             .copy(isZeroSearch: isZeroSearch)
-            .copy(shouldTriggerImpression: false)
     }
 
     @MainActor
@@ -218,6 +218,7 @@ struct HomepageState: ScreenState, Equatable {
         let availableWallpaperHeight = homepageAction.availableWallpaperHeight ?? state.availableWallpaperHeight
 
         return state
+            .resetTransientState()
             .copy(headerState: HeaderState.reducer.legacyReducer(state.headerState, action))
             .copy(messageState: MessageCardState.reducer.legacyReducer(state.messageState, action))
             .copy(topSitesState: TopSitesSectionState.reducer.legacyReducer(state.topSitesState, action))
@@ -229,7 +230,6 @@ struct HomepageState: ScreenState, Equatable {
             .copy(worldcupState: WorldCupSectionState.reducer.legacyReducer(state.worldcupState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
-            .copy(shouldTriggerImpression: false)
             .copy(availableContentHeight: availableContentHeight)
             .copy(availableWallpaperHeight: availableWallpaperHeight)
     }
@@ -237,6 +237,7 @@ struct HomepageState: ScreenState, Equatable {
     @MainActor
     private static func handlePrivacyNoticeCloseButtonTappedAction(state: HomepageState, action: Action) -> HomepageState {
         return state
+            .resetTransientState()
             .copy(headerState: HeaderState.reducer.legacyReducer(state.headerState, action))
             .copy(messageState: MessageCardState.reducer.legacyReducer(state.messageState, action))
             .copy(topSitesState: TopSitesSectionState.reducer.legacyReducer(state.topSitesState, action))
@@ -248,13 +249,13 @@ struct HomepageState: ScreenState, Equatable {
             .copy(worldcupState: WorldCupSectionState.reducer.legacyReducer(state.worldcupState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
-            .copy(shouldTriggerImpression: false)
             .copy(shouldShowPrivacyNotice: false)
     }
 
     @MainActor
     private static func handleDidTabChangeToHomepageAction(state: HomepageState, action: Action) -> HomepageState {
         return state
+            .resetTransientState()
             .copy(headerState: HeaderState.reducer.legacyReducer(state.headerState, action))
             .copy(messageState: MessageCardState.reducer.legacyReducer(state.messageState, action))
             .copy(topSitesState: TopSitesSectionState.reducer.legacyReducer(state.topSitesState, action))
@@ -272,6 +273,7 @@ struct HomepageState: ScreenState, Equatable {
     @MainActor
     private static func handlePrivacyNoticeInitialization(action: Action, state: Self) -> HomepageState {
         return state
+            .resetTransientState()
             .copy(headerState: HeaderState.reducer.legacyReducer(state.headerState, action))
             .copy(messageState: MessageCardState.reducer.legacyReducer(state.messageState, action))
             .copy(topSitesState: TopSitesSectionState.reducer.legacyReducer(state.topSitesState, action))
@@ -283,13 +285,13 @@ struct HomepageState: ScreenState, Equatable {
             .copy(worldcupState: WorldCupSectionState.reducer.legacyReducer(state.worldcupState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
-            .copy(shouldTriggerImpression: false)
             .copy(shouldShowPrivacyNotice: true)
     }
 
     @MainActor
     private static func passthroughState(from state: HomepageState, action: Action) -> HomepageState {
         return state
+            .resetTransientState()
             .copy(headerState: HeaderState.reducer.legacyReducer(state.headerState, action))
             .copy(messageState: MessageCardState.reducer.legacyReducer(state.messageState, action))
             .copy(topSitesState: TopSitesSectionState.reducer.legacyReducer(state.topSitesState, action))
@@ -301,20 +303,43 @@ struct HomepageState: ScreenState, Equatable {
             .copy(worldcupState: WorldCupSectionState.reducer.legacyReducer(state.worldcupState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
-            .copy(shouldTriggerImpression: false)
     }
 
     static func defaultState(from state: HomepageState) -> HomepageState {
-        return state
-            .copy(messageState: MessageCardState.defaultState(from: state.messageState))
-            .copy(topSitesState: TopSitesSectionState.defaultState(from: state.topSitesState))
-            .copy(searchState: SearchBarState.defaultState(from: state.searchState))
-            .copy(jumpBackInState: JumpBackInSectionState.defaultState(from: state.jumpBackInState))
-            .copy(trackerBlockerModuleState: TrackerBlockerModuleState.defaultState(from: state.trackerBlockerModuleState))
-            .copy(bookmarkState: BookmarksSectionState.defaultState(from: state.bookmarkState))
-            .copy(worldcupState: WorldCupSectionState.defaultState(from: state.worldcupState))
-            .copy(merinoState: MerinoState.defaultState(from: state.merinoState))
-            .copy(wallpaperState: WallpaperState.defaultState(from: state.wallpaperState))
+        let headerState = HeaderState.defaultState(from: state.headerState)
+        let messageState = MessageCardState.defaultState(from: state.messageState)
+        let topSitesState = TopSitesSectionState.defaultState(from: state.topSitesState)
+        let searchState = SearchBarState.defaultState(from: state.searchState)
+        let jumpBackInState = JumpBackInSectionState.defaultState(from: state.jumpBackInState)
+        let trackerBlockerState = TrackerBlockerModuleState.defaultState(from: state.trackerBlockerModuleState)
+        let bookmarkState = BookmarksSectionState.defaultState(from: state.bookmarkState)
+        let worldCupState = WorldCupSectionState.defaultState(from: state.worldcupState)
+        let merinoState = MerinoState.defaultState(from: state.merinoState)
+        let wallpaperState = WallpaperState.defaultState(from: state.wallpaperState)
+
+        return HomepageState(
+            windowUUID: state.windowUUID,
+            headerState: headerState,
+            messageState: messageState,
+            topSitesState: topSitesState,
+            searchState: searchState,
+            jumpBackInState: jumpBackInState,
+            trackerBlockerModuleState: trackerBlockerState,
+            bookmarkState: bookmarkState,
+            worldcupState: worldCupState,
+            merinoState: merinoState,
+            wallpaperState: wallpaperState,
+            isZeroSearch: state.isZeroSearch,
+            shouldTriggerImpression: false, // Transient state
+            shouldShowPrivacyNotice: state.shouldShowPrivacyNotice,
+            availableContentHeight: state.availableContentHeight,
+            availableWallpaperHeight: state.availableWallpaperHeight
+        )
+    }
+
+    // MARK: - Helper function to reset transient state
+    private func resetTransientState() -> HomepageState {
+        return self
             .copy(shouldTriggerImpression: false)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15901)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33989)

## :bulb: Description
This tries to clean up the transient state inside the HomepageState using the same chaining as the `@Copyable`, as @Kiyo99 is doing in https://github.com/mozilla-mobile/firefox-ios/pull/34920 

There are no bugs to fix in this case, but this makes HomepageState cleaner.

I also made the defaultState method use the initializer for consistency.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

