### PR TITLE
Refactor FXIOS-12557 [Technical Debt] Cleanup `JumpBackInSectionState` and improve readability

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/JumpBackInSectionState.swift
@@ -42,7 +42,7 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
     private init(
         windowUUID: WindowUUID,
         jumpBackInTabs: [JumpBackInTabConfiguration],
-        mostRecentSyncedTab: JumpBackInSyncedTabConfiguration? = nil,
+        mostRecentSyncedTab: JumpBackInSyncedTabConfiguration?,
         shouldShowSection: Bool
     ) {
         self.windowUUID = windowUUID
@@ -59,30 +59,19 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
     }
 
     static let legacyReducer: LegacyReducerMethod<Self> = { state, action in
-        // TODO: FXIOS-12557 We assume that we are isolated to the Main Actor
-        // because we dispatch to the main thread in the store. We will want to
-        // also isolate that to the @MainActor to remove this.
-        guard Thread.isMainThread else {
-            assertionFailure("JumpBackInSectionState reducer is not being called from the main thread!")
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else {
             return defaultState(from: state)
         }
 
-        return MainActor.assumeIsolated {
-            guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
-            else {
-                return defaultState(from: state)
-            }
-
-            switch action.actionType {
-            case TabManagerMiddlewareActionType.fetchedRecentTabs:
-                return handleInitializeAction(for: state, with: action)
-            case RemoteTabsMiddlewareActionType.fetchedMostRecentSyncedTab:
-                return handleRemoteTabsAction(for: state, with: action)
-            case JumpBackInActionType.toggleShowSectionSetting:
-                return handleToggleShowSectionSettingAction(action: action, state: state)
-            default:
-                return defaultState(from: state)
-            }
+        switch action.actionType {
+        case TabManagerMiddlewareActionType.fetchedRecentTabs:
+            return handleInitializeAction(for: state, with: action)
+        case RemoteTabsMiddlewareActionType.fetchedMostRecentSyncedTab:
+            return handleRemoteTabsAction(for: state, with: action)
+        case JumpBackInActionType.toggleShowSectionSetting:
+            return handleToggleShowSectionSettingAction(action: action, state: state)
+        default:
+            return defaultState(from: state)
         }
     }
 
@@ -97,18 +86,18 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
             return defaultState(from: state)
         }
 
-        return state.copy(
-            jumpBackInTabs: recentTabs.compactMap { tab in
-                let itemURL = tab.lastKnownUrl?.absoluteString ?? ""
-                let site = Site.createBasicSite(url: itemURL, title: tab.displayTitle)
-                return JumpBackInTabConfiguration(
-                    tab: tab,
-                    titleText: site.title,
-                    descriptionText: site.tileURL.shortDisplayString.capitalized,
-                    siteURL: itemURL
-                )
-            }
-        )
+        let tabConfigurations = recentTabs.compactMap { tab in
+            let itemURL = tab.lastKnownUrl?.absoluteString ?? ""
+            let site = Site.createBasicSite(url: itemURL, title: tab.displayTitle)
+            return JumpBackInTabConfiguration(
+                tab: tab,
+                titleText: site.title,
+                descriptionText: site.tileURL.shortDisplayString.capitalized,
+                siteURL: itemURL
+            )
+        }
+
+        return state.copy(jumpBackInTabs: tabConfigurations)
     }
 
     private static func handleRemoteTabsAction(
@@ -116,8 +105,7 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
         with action: Action
     ) -> JumpBackInSectionState {
         guard let tabManagerAction = action as? RemoteTabsAction,
-              let mostRecentSyncedTab = tabManagerAction.mostRecentSyncedTab
-        else {
+              let mostRecentSyncedTab = tabManagerAction.mostRecentSyncedTab else {
             return defaultState(from: state)
         }
 
@@ -125,25 +113,22 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
         let site = Site.createBasicSite(url: itemURL, title: mostRecentSyncedTab.tab.title)
         let descriptionText = mostRecentSyncedTab.client.name
 
-        return state.copy(
-            mostRecentSyncedTab: JumpBackInSyncedTabConfiguration(
-                titleText: site.title,
-                descriptionText: descriptionText,
-                url: mostRecentSyncedTab.tab.URL
-            )
+        let syncedTabConfiguration = JumpBackInSyncedTabConfiguration(
+            titleText: site.title,
+            descriptionText: descriptionText,
+            url: mostRecentSyncedTab.tab.URL
         )
+
+        return state.copy(mostRecentSyncedTab: syncedTabConfiguration)
     }
 
     private static func handleToggleShowSectionSettingAction(action: Action, state: Self) -> JumpBackInSectionState {
         guard let jumpBackInAction = action as? JumpBackInAction,
-              let isEnabled = jumpBackInAction.isEnabled
-        else {
+              let isEnabled = jumpBackInAction.isEnabled else {
             return defaultState(from: state)
         }
 
-        return state.copy(
-            shouldShowSection: isEnabled
-        )
+        return state.copy(shouldShowSection: isEnabled)
     }
 
     static func defaultState(from state: JumpBackInSectionState) -> JumpBackInSectionState {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12557)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27353)

## :bulb: Description
Cleaned up a lingering main actor isolation check that should now be redundant (CC @Cramsden it was on one of your Done tickets). Also cleaned up some spacing and .copy usages.

@Foxbolts Do you know how to test JumpBackIn tabs, is that still present in the app? For some reason I feel like that is no longer on the homepage? (I could be wrong though)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

