### PR TITLE
Refactor NO_TICKET [Technical Debt] Clean up `TabPeekState` initializers and incorrect reducer `return state`s

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -37,14 +37,25 @@ struct TabPeekState: ScreenState {
                   screenshot: tabPeekState.screenshot)
     }
 
+    init(windowUUID: WindowUUID) {
+        self.windowUUID = windowUUID
+        self.showAddToBookmarks = false
+        self.showRemoveBookmark = false
+        self.showSendToDevice = false
+        self.showCopyURL = true
+        self.showCloseTab = true
+        self.previewAccessibilityLabel = ""
+        self.screenshot = UIImage()
+    }
+
     init(windowUUID: WindowUUID,
-         showAddToBookmarks: Bool = false,
-         showRemoveBookmark: Bool = false,
-         showSendToDevice: Bool = false,
-         showCopyURL: Bool = true,
-         showCloseTab: Bool = true,
-         previewAccessibilityLabel: String = "",
-         screenshot: UIImage = UIImage()) {
+         showAddToBookmarks: Bool,
+         showRemoveBookmark: Bool,
+         showSendToDevice: Bool,
+         showCopyURL: Bool,
+         showCloseTab: Bool,
+         previewAccessibilityLabel: String,
+         screenshot: UIImage) {
         self.windowUUID = windowUUID
         self.showAddToBookmarks = showAddToBookmarks
         self.showRemoveBookmark = showRemoveBookmark
@@ -65,12 +76,14 @@ struct TabPeekState: ScreenState {
     static let legacyReducer: LegacyReducerMethod<Self> = { state, action in
         // Only process actions for the current window
         guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID,
-              let action = action as? TabPeekAction
-        else { return state }
+              let action = action as? TabPeekAction else {
+            return defaultState(from: state)
+        }
 
         switch action.actionType {
         case TabPeekActionType.loadTabPeek:
-            guard let tabPeekModel = action.tabPeekModel else { return state }
+            guard let tabPeekModel = action.tabPeekModel else { return defaultState(from: state) }
+
             return state
                 .copy(showAddToBookmarks: tabPeekModel.canTabBeSaved)
                 .copy(showRemoveBookmark: tabPeekModel.canTabBeRemoved)
@@ -79,7 +92,7 @@ struct TabPeekState: ScreenState {
                 .copy(previewAccessibilityLabel: tabPeekModel.accessiblityLabel)
                 .copy(screenshot: tabPeekModel.screenshot)
         default:
-            return state
+            return defaultState(from: state)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/WorldCup/WorldCupSectionState.swift
@@ -65,8 +65,9 @@ struct WorldCupSectionState: StateType, Equatable, Hashable {
 
     static let legacyReducer: LegacyReducerMethod<Self> = { state, action in
         guard let action = action as? WorldCupAction else {
-            return state
+            return defaultState(from: state)
         }
+
         switch action.actionType {
         case WorldCupMiddlewareActionType.didUpdate:
             return WorldCupSectionState(
@@ -81,7 +82,7 @@ struct WorldCupSectionState: StateType, Equatable, Hashable {
                 shouldShowConfetti: action.shouldShowConfetti
             )
         default:
-            return state
+            return defaultState(from: state)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
N/A

## :bulb: Description
- Fixes two reducers that should have used `return defaultState()` instead of `return state` (I guess I can't test the WorldCup one anymore 🤣 )
- Tweaks `TabPeekState` initializer. I want to make the default params more deliberate for any potentially transient data.

CC @PARAIPAN9 I'm pretty sure you flagged this `return state` issue in another PR 🙂  I audited the other states and only found one more file that had this issue.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

