### PR TITLE
Refactor FXIOS-15361 [Technical Debt] Cleanup `PasswordGeneratorState` macro usage

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
@@ -48,8 +48,9 @@ struct PasswordGeneratorState: ScreenState {
     }
 
     static let legacyReducer: LegacyReducerMethod<Self> = { state, action in
-        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
-        else { return defaultState(from: state) }
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else {
+            return defaultState(from: state)
+        }
 
         switch action.actionType {
         case PasswordGeneratorActionType.updateGeneratedPassword:
@@ -57,18 +58,18 @@ struct PasswordGeneratorState: ScreenState {
             else {
                 return defaultState(from: state)
             }
-            return state.copy(windowUUID: action.windowUUID)
+            return state
+                .copy(windowUUID: action.windowUUID)
                 .copy(password: password)
-                .copy(passwordHidden: state.passwordHidden)
 
         case PasswordGeneratorActionType.hidePassword:
-            return state.copy(windowUUID: action.windowUUID)
-                .copy(password: state.password)
+            return state
+                .copy(windowUUID: action.windowUUID)
                 .copy(passwordHidden: true)
 
         case PasswordGeneratorActionType.showPassword:
-            return state.copy(windowUUID: action.windowUUID)
-                .copy(password: state.password)
+            return state
+                .copy(windowUUID: action.windowUUID)
                 .copy(passwordHidden: false)
 
         default:
@@ -77,8 +78,10 @@ struct PasswordGeneratorState: ScreenState {
     }
 
     static func defaultState(from state: PasswordGeneratorState) -> PasswordGeneratorState {
-        return state.copy(windowUUID: state.windowUUID)
-            .copy(password: state.password)
-            .copy(passwordHidden: state.passwordHidden)
+        return PasswordGeneratorState(
+            windowUUID: state.windowUUID,
+            password: state.password,
+            passwordHidden: state.passwordHidden
+        )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15361)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32948)

## :bulb: Description
Cleaning up some `@Copyable` usage consistency.

FYI There is no need to use a .copy call when the property is not changing (nothing to copy).

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

