### PR TITLE
FXIOS-34796 - Remove unused import Storage statements 

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/DeleteAppAttestKeySetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/DeleteAppAttestKeySetting.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Storage
 import MLPAKit
 
 class DeleteAppAttestKeySetting: HiddenSetting {

--- a/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/AppStartupTelemetry.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import Glean
-import Storage
 import Common
 
 import class MozillaAppServices.BookmarkFolderData

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -7,7 +7,6 @@
 import Common
 import Glean
 import Shared
-import Storage
 import class MozillaAppServices.NimbusGleanPings
 
 protocol TelemetryWrapperProtocol {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16359)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34796)

## :bulb: Description

deleted unused `import Storage` statements.

many files listed in the issue were actually required in order to compile. removing the import would trigger build error

<details>

<summary>the full list of triggered error can be found in here</summary>

```
BrowserCoordinator.swift:895:48 Cannot find type 'UnencryptedCreditCardFields' in scope
```

```
BrowserNavigationHandler.swift:53:48 Cannot find type 'UnencryptedCreditCardFields' in scope
```

```
CredentialAutofillCoordinator.swift:45:48: Cannot find type 'UnencryptedCreditCardFields' in scope

CredentialAutofillCoordinator.swift:56:68: Cannot infer type of closure parameter 'error' without a type annotation

CredentialAutofillCoordinator.swift:87:77: Cannot infer type of closure parameter 'plainTextCard' without a type annotation
```

```
ShareSheetCoordinator.swift:179:34 Cannot find type 'RemoteDevice' in scope
```

```
UserActivityHandler.swift:75:56 Cannot find type 'PageMetadata' in scope
```
```
CanRemoveQuickActionBookmark.swift:12:27: Cannot find type 'BookmarksHandler' in scope

CanRemoveQuickActionBookmark.swift:16:48: Cannot find type 'BookmarksHandler' in scope

CanRemoveQuickActionBookmark.swift:25:48: Cannot find type 'BookmarksHandler' in scope
```
```
BackgroundTabLoader.swift:18:27: Cannot find type 'TabQueue' in scope

BackgroundTabLoader.swift:22:20: Cannot find type 'TabQueue' in scope

BackgroundTabLoader.swift:40:57: Cannot infer type of closure parameter 'urls' without a type annotation
```
```
SponsoredContentFilterUtility.swift:15:44 Cannot find type 'Site' in scope

SponsoredContentFilterUtility.swift:15:55 Cannot find type 'Site' in scope
```
```
PageZoomSettingsViewModel.swift:11:39 Cannot find type 'DomainZoomLevel' in scope
```
```
ZoomLevelCellView.swift:9:34 Cannot find type 'DomainZoomLevel' in scope

ZoomLevelCellView.swift:16:27 Cannot find type 'DomainZoomLevel' in scope
```
```
ZoomSiteListView.swift:10:37 Cannot find type 'DomainZoomLevel' in scope

ZoomSiteListView.swift:50:37 Cannot find type 'DomainZoomLevel' in scope
```
```
DeleteAutofillKeysSetting.swift:17:9 Cannot find 'KeychainManager' in scope
```
```
DeleteLoginsKeysSetting.swift:17:9 Cannot find 'KeychainManager' in scope
```
```
ScreenshotSetting.swift:10:29 Cannot find type 'DiskImageStore' in scope
```
```
ScreenshotSetting.swift:13:22 Cannot find type 'DiskImageStore' in scope
```
```
FxSuggestTelemetry.swift:26:36 Cannot find type 'RustFirefoxSuggestionTelemetryInfo' in scope

FxSuggestTelemetry.swift:75:41 Cannot find type 'RustFirefoxSuggestionTelemetryInfo' in scope
```
```
SearchTelemetry.swift:20:9 Cannot find type 'RustFirefoxSuggestionTelemetryInfo' in scope

SearchTelemetry.swift:166:37 Cannot call value of non-function type '[Element]'

SearchTelemetry.swift:166:38 Cannot find 'RustFirefoxSuggestion' in scope

SearchTelemetry.swift:169:23 Cannot call value of non-function type '[Element]'

SearchTelemetry.swift:169:24 Cannot find 'Site' in scope
```
```
SponsoredTileTelemetry.swift:11:44 Cannot find type 'Site' in scope

SponsoredTileTelemetry.swift:13:39 Cannot find type 'Site' in scope

SponsoredTileTelemetry.swift:30:44 Cannot find type 'Site' in scope

SponsoredTileTelemetry.swift:52:39 Cannot find type 'Site' in scope
```
```
LoginRecordExtension.swift:9:11 Cannot find type 'LoginRecord' in scope

LoginRecordExtension.swift:24:11 Cannot find type 'LoginRecord' in scope

LoginRecordExtension.swift:25:32 Cannot find type 'LoginRecord' in scope

LoginRecordExtension.swift:25:50 Cannot find type 'LoginRecord' in scope
```
```
Profile.swift:65:29 Cannot find type 'FileAccessor' in scope

Profile.swift:91:19 Cannot find type 'RustAutofill' in scope

Profile.swift:92:17 Cannot find type 'RustPlaces' in scope

Profile.swift:94:16 Cannot find type 'TabQueue' in scope

Profile.swift:95:16 Cannot find type 'FileAccessor' in scope

Profile.swift:96:22 Cannot find type 'PinnedSites' in scope

Profile.swift:97:17 Cannot find type 'RustLogins' in scope

Profile.swift:98:25 Cannot find type 'RustFirefoxSuggestProtocol' in scope

Profile.swift:100:20 Cannot find type 'CertStore' in scope

Profile.swift:101:29 Cannot find type 'ClosedTabsStore' in scope

Profile.swift:104:22 Cannot find type 'ReadingList' in scope

Profile.swift:131:49 Cannot find type 'ClientAndTabs' in scope

Profile.swift:132:55 Cannot find type 'ClientAndTabs' in scope

Profile.swift:134:62 Cannot find type 'ClientAndTabs' in scope

Profile.swift:135:68 Cannot find type 'ClientAndTabs' in scope

Profile.swift:140:36 Cannot find type 'RemoteTab' in scope

Profile.swift:145:27 Cannot find type 'ShareItem' in scope

Profile.swift:234:31 Cannot find type 'KeychainProtocol' in scope

Profile.swift:237:25 Cannot find type 'FileAccessor' in scope

Profile.swift:239:19 Cannot find type 'BrowserDB' in scope

Profile.swift:240:24 Cannot find type 'BrowserDB' in scope

Profile.swift:272:25 Cannot find 'KeychainManager' in scope

Profile.swift:295:25 Cannot find 'BrowserDB' in scope

Profile.swift:297:21 Cannot find 'BrowserSchema' in scope

Profile.swift:300:30 Cannot find 'BrowserDB' in scope

Profile.swift:302:21 Cannot find 'ReadingListSchema' in scope

Profile.swift:310:13 Cannot find 'RustKeychain' in scope

Profile.swift:380:21 Cannot find type 'TabQueue' in scope

Profile.swift:382:20 Cannot find 'SQLiteQueue' in scope

Profile.swift:390:36 Cannot find type 'PinnedSites' in scope

Profile.swift:391:16 Cannot find 'BrowserDBSQLite' in scope

Profile.swift:394:22 Cannot find type 'PinnedSites' in scope

Profile.swift:405:23 Cannot find 'RustPlaces' in scope

Profile.swift:431:21 Cannot find 'RustRemoteTabs' in scope

Profile.swift:438:25 Cannot find 'RustAutofill' in scope

Profile.swift:448:27 Cannot find type 'ReadingList' in scope

Profile.swift:449:16 Cannot find 'SQLiteReadingList' in scope

Profile.swift:452:25 Cannot find type 'CertStore' in scope

Profile.swift:453:16 Cannot find 'CertStore' in scope

Profile.swift:456:34 Cannot find type 'ClosedTabsStore' in scope

Profile.swift:457:16 Cannot find 'ClosedTabsStore' in scope

Profile.swift:460:47 Cannot find type 'ClientAndTabs' in scope

Profile.swift:478:56 Cannot find type 'ClientAndTabs' in scope

Profile.swift:490:69 Cannot find type 'ClientAndTabs' in scope

Profile.swift:497:75 Cannot find type 'ClientAndTabs' in scope

Profile.swift:504:62 Cannot find type 'ClientAndTabs' in scope

Profile.swift:530:36 Cannot find type 'RemoteTab' in scope

Profile.swift:543:42 Generic parameter 'U' could not be inferred

Profile.swift:553:34 Cannot find type 'ShareItem' in scope

Profile.swift:651:22 Cannot find type 'RustLogins' in scope

Profile.swift:656:16 Cannot find 'RustLogins' in scope

Profile.swift:687:30 Cannot find type 'RustFirefoxSuggestProtocol' in scope

Profile.swift:695:24 Cannot find 'RustFirefoxSuggest' in scope
```
```
AutofillProvider.swift:18:71 Cannot find type 'NSError' in scope

AutofillProvider.swift:24:11 Cannot find type 'RustAutofill' in scope
```
```
ProvidersLoginProvider.swift:22:11 Cannot find type 'RustLogins' in scope
```
```
PlacesProvider.swift:9:11 Cannot find type 'RustPlaces' in scope
```
```
TabsProvider.swift:9:11 Cannot find type 'RustRemoteTabs' in scope
```
```
RustSyncManager.swift:286:25 Cannot find 'RustKeychain' in scope
```
```
TopSitesProvider.swift:11:27 Cannot find type 'Site' in scope
```
```
TopSitesWidgetManager.swift:38:34 Cannot find type 'Site' in scope
```
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass 

