### PR TITLE
Bugfix FXIOS-16446 [App Icons Improvements] Prioritize "new tap" and "new private tab" above the "App Icon" option in quick actions

### DIFF
--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -185,15 +185,7 @@
 		</dict>
 	</dict>
 	<key>UIApplicationShortcutItems</key>
-	<array>
-		<dict>
-			<key>UIApplicationShortcutItemIconFile</key>
-			<string>logoFirefoxLarge</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>App Icon</string>
-			<key>UIApplicationShortcutItemType</key>
-			<string>$(PRODUCT_BUNDLE_IDENTIFIER).AppIcon</string>
-		</dict>
+	<array>		
 		<dict>
 			<key>UIApplicationShortcutItemIconFile</key>
 			<string>plusLarge</string>
@@ -209,6 +201,14 @@
 			<string>New Private Tab</string>
 			<key>UIApplicationShortcutItemType</key>
 			<string>$(PRODUCT_BUNDLE_IDENTIFIER).NewPrivateTab</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemIconFile</key>
+			<string>logoFirefoxLarge</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>App Icon</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER).AppIcon</string>
 		</dict>
 	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16446)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34950)

## :bulb: Description
The App Icon selection should be lower priority than the New Tab and New Private Tab options on the quick actions menu (long press of the app icon on the iOS home screen).
<img width="206" height="266" alt="Screenshot 2026-07-30 at 10 33 53 AM" src="https://github.com/user-attachments/assets/4fde0f37-0ed1-4611-99f2-9d377744041a" />
<img width="228" height="209" alt="Screenshot 2026-07-30 at 10 33 41 AM" src="https://github.com/user-attachments/assets/208a5e70-6e47-4af3-ad6d-cf686aa087a1" />



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

