### PR TITLE
Refactor FXIOS-16450 [WebCompat] Park the Preview button and screenshot toggle

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -99,6 +99,7 @@ public final class WebCompatReportSheetViewController: UIViewController,
         closeButton.accessibilityLabel = viewModel.closeButtonAccessibilityLabel
         previewButton.title = viewModel.previewButtonTitle
         previewButton.isEnabled = viewModel.isPreviewEnabled
+        navigationItem.rightBarButtonItem = viewModel.previewButtonTitle == nil ? nil : previewButton
         applySnapshot()
     }
 
@@ -107,7 +108,6 @@ public final class WebCompatReportSheetViewController: UIViewController,
     private func setupNavigationItem() {
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationItem.leftBarButtonItem = closeButton
-        navigationItem.rightBarButtonItem = previewButton
         navigationItem.largeTitleDisplayMode = .always
     }
 

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
@@ -79,14 +79,15 @@ public struct WebCompatReportViewModel: Equatable, Sendable {
 
     public let navigationTitle: String
     public let closeButtonAccessibilityLabel: String
-    public let previewButtonTitle: String
+    /// Nil hides the Preview bar button entirely. Preview is parked for v1 (FXIOS-16450).
+    public let previewButtonTitle: String?
     public let isPreviewEnabled: Bool
     public let sections: [Section]
 
     public init(navigationTitle: String,
                 closeButtonAccessibilityLabel: String,
-                previewButtonTitle: String,
-                isPreviewEnabled: Bool,
+                previewButtonTitle: String? = nil,
+                isPreviewEnabled: Bool = false,
                 sections: [Section] = []) {
         self.navigationTitle = navigationTitle
         self.closeButtonAccessibilityLabel = closeButtonAccessibilityLabel

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -112,8 +112,6 @@ final class WebCompatReportViewController: UINavigationController,
         return WebCompatReportViewModel(
             navigationTitle: .MainMenu.ToolsSection.ReportBrokenSite,
             closeButtonAccessibilityLabel: .WebCompatReporter.Sheet.CloseButtonAccessibilityLabel,
-            previewButtonTitle: .WebCompatReporter.Sheet.PreviewButton,
-            isPreviewEnabled: state.canPreview,
             sections: makeSections(from: state)
         )
     }
@@ -164,13 +162,8 @@ final class WebCompatReportViewController: UINavigationController,
             id: SectionID.advancedOptions.rawValue,
             title: .WebCompatReporter.AdditionalInfo.Title,
             footer: learnMoreFooter(),
+            // The screenshot row is parked (FXIOS-16450): the image has no transport yet.
             rows: [
-                WebCompatReportViewModel.Row(
-                    id: RowID.includeScreenshot.rawValue,
-                    title: .WebCompatReporter.AdditionalInfo.IncludeScreenshot,
-                    kind: .toggle(isOn: state.includeScreenshot),
-                    a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.includeScreenshot
-                ),
                 WebCompatReportViewModel.Row(
                     id: RowID.includeBlockedList.rawValue,
                     title: .WebCompatReporter.AdditionalInfo.IncludeBlockedList,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -193,7 +193,7 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(sections.map(\.id), ["url", "issueCategory", "advancedOptions", "send"])
 
         let advanced = sections.first { $0.id == "advancedOptions" }
-        XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: true), .toggle(isOn: false)])
+        XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: false)])
         XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: false)])
 
         guard case let .urlField(text, _) = sections.first?.rows.first?.kind else {
@@ -220,7 +220,7 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         )
 
         let advanced = sections.first { $0.id == "advancedOptions" }
-        XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: false), .toggle(isOn: true)])
+        XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: true)])
         XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: true)])
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16450](https://mozilla-hub.atlassian.net/browse/FXIOS-16450)

## :bulb: Description
V1 ships without the Report Preview screen. The Preview bar button has no destination, and the screenshot has no transport since Glean has no image metric type, so both come off the form.

Parked, not deleted — [FXIOS-16432](https://mozilla-hub.atlassian.net/browse/FXIOS-16432) brings them back. The two strings stay in place rather than being deleted and re-added under a new key.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
Enable `reportBrokenSite` (on by default on developer), open a web page, then main menu → More → Report Broken Site.

Expect the sheet's top right to be empty, with only the X on the left. Under "Additional Info" expect a single toggle, "Send list of items blocked by tracking protection". The URL field, issue picker, Learn More footer and Send button are unchanged.


[FXIOS-16450]: https://mozilla-hub.atlassian.net/browse/FXIOS-16450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-16432]: https://mozilla-hub.atlassian.net/browse/FXIOS-16432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ