### PR TITLE
Add FXIOS-16185 [WebCompat] Submit the broken-site-report ping

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1376,6 +1376,7 @@
 		8CB4742330011A9900BB0119 /* WebCompatReportPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB4742230011A9900BB0119 /* WebCompatReportPayloadTests.swift */; };
 		8CC033FA2BA476840033449E /* FormAutofillHelper.js in Resources */ = {isa = PBXBuildFile; fileRef = 8CC033F92BA476840033449E /* FormAutofillHelper.js */; };
 		8CC185F72FF6A0D1004A124F /* WebCompatReporterKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8CC185F62FF6A0D1004A124F /* WebCompatReporterKit */; };
+		8CC6023F301C89A80041B7D0 /* WebCompatReportRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC6023E301C89A80041B7D0 /* WebCompatReportRecorderTests.swift */; };
 		8CC617092C35463B001C7688 /* AddressModifiedStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC617082C35463B001C7688 /* AddressModifiedStatus.swift */; };
 		8CCD74732B90A945008F919B /* LoginListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CCD74722B90A945008F919B /* LoginListViewModelTests.swift */; };
 		8CE1E4322B8C76AE0026530B /* LoginStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1E4312B8C76AE0026530B /* LoginStorage.swift */; };
@@ -10101,6 +10102,7 @@
 		8CB4742030011A9900BB0119 /* WebCompatReportDataCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportDataCollectorTests.swift; sourceTree = "<group>"; };
 		8CB4742230011A9900BB0119 /* WebCompatReportPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportPayloadTests.swift; sourceTree = "<group>"; };
 		8CC033F92BA476840033449E /* FormAutofillHelper.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = FormAutofillHelper.js; sourceTree = "<group>"; };
+		8CC6023E301C89A80041B7D0 /* WebCompatReportRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportRecorderTests.swift; sourceTree = "<group>"; };
 		8CC617082C35463B001C7688 /* AddressModifiedStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressModifiedStatus.swift; sourceTree = "<group>"; };
 		8CCA45EFA01D41F54715FBCC /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		8CCD74722B90A945008F919B /* LoginListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginListViewModelTests.swift; sourceTree = "<group>"; };
@@ -15239,6 +15241,7 @@
 				8C2FB1EC2FF3D6CA00C9A803 /* WebCompatReporterMiddlewareTests.swift */,
 				8CB4742030011A9900BB0119 /* WebCompatReportDataCollectorTests.swift */,
 				8CB4742230011A9900BB0119 /* WebCompatReportPayloadTests.swift */,
+				8CC6023E301C89A80041B7D0 /* WebCompatReportRecorderTests.swift */,
 			);
 			path = WebCompatReporter;
 			sourceTree = "<group>";
@@ -21382,6 +21385,7 @@
 				8A4EA0D42C01100200E4E4F1 /* MicrosurveySurfaceManagerTests.swift in Sources */,
 				C24E2D2A2ECF960000BBCFA7 /* MockTranslationsTelemetry.swift in Sources */,
 				8ADEC6832A40F208002D2ED8 /* AppSettingsTableViewControllerTests.swift in Sources */,
+				8CC6023F301C89A80041B7D0 /* WebCompatReportRecorderTests.swift in Sources */,
 				5A475E8E29DB89C7009C13FD /* TabManagerTests.swift in Sources */,
 				0B5CAF0D2E40DA89008B5D5A /* MockSummarizationChecker.swift in Sources */,
 				E16E1C9628BFB2E600EE2EF5 /* WallpaperSettingsViewModelTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -638,6 +638,16 @@ final class BrowserCoordinator: BaseCoordinator,
         router.dismiss(animated: true, completion: nil)
     }
 
+    func webCompatReportViewControllerDidSubmit() {
+        // Dismiss first, otherwise the toast is covered by the sheet.
+        router.dismiss(animated: true, completion: { [weak self] in
+            // TODO: FXIOS-16468 swap in the dedicated "Report sent" string once l10n exports it.
+            self?.browserViewController.showPlainToast(
+                message: String.Microsurvey.Survey.ConfirmationPage.ConfirmationLabel
+            )
+        })
+    }
+
     func webCompatReportViewControllerDidTapLearnMore(url: URL) {
         // Dismiss first, otherwise the explainer loads in a tab hidden behind the sheet.
         router.dismiss(animated: true, completion: { [weak self] in

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
@@ -31,7 +31,7 @@ struct WebCompatDeviceInfoProvider: WebCompatDeviceInfoProviding {
 /// Tab inputs as a plain value, so tests don't need a live `Tab`/`WKWebView`. Nil
 /// `blockingStrength` means no content blocker; `blockedOrigins` is filled only on opt-in.
 struct WebCompatTabSnapshot: Equatable {
-    var isPrivate: Bool
+    var isPrivate: Bool?
     var pageUserAgent: String?
     var displayScale: CGFloat?
     var blockingStrength: BlockingStrength?
@@ -47,9 +47,15 @@ enum WebCompatReportDataCollector {
         _ payload: WebCompatReportPayload,
         tab: Tab,
         includeBlockedList: Bool,
+        includeTabSpecificInfo: Bool = true,
         device: WebCompatDeviceInfoProviding = WebCompatDeviceInfoProvider()
     ) -> WebCompatReportPayload {
-        return enrich(payload, device: device, tab: makeSnapshot(from: tab, includeBlockedList: includeBlockedList))
+        let snapshot = makeSnapshot(
+            from: tab,
+            includeBlockedList: includeBlockedList,
+            includeTabSpecificInfo: includeTabSpecificInfo
+        )
+        return enrich(payload, device: device, tab: snapshot)
     }
 
     /// Pure mapping: no UIKit, no `Tab`, so tests can drive it with fakes.
@@ -67,8 +73,6 @@ enum WebCompatReportDataCollector {
         payload.hasTouchScreen = true
         payload.defaultUserAgentString = device.defaultUserAgent
 
-        // Only set when something overrode the User Agent, so a nil here is distinguishable from a
-        // page that matched the default. The real value is navigator.userAgent (FXIOS-16184).
         payload.userAgentString = tab.pageUserAgent.flatMap { $0.isEmpty ? nil : $0 }
         // An off-screen web view reports a display scale of 0, not nil.
         let pageScale = tab.displayScale ?? 0
@@ -77,7 +81,7 @@ enum WebCompatReportDataCollector {
 
         if let blockingStrength = tab.blockingStrength {
             payload.blockList = blockingStrength.rawValue
-            payload.etpCategory = blockingStrength.rawValue
+            payload.etpCategory = etpCategory(for: blockingStrength)
             payload.blockedOrigins = tab.blockedOrigins
         }
         return payload
@@ -87,7 +91,7 @@ enum WebCompatReportDataCollector {
     /// opt-out is testable without a live `Tab`.
     static func blockedOrigins(from stats: TPPageStats, includeBlockedList: Bool) -> [String]? {
         guard includeBlockedList else { return nil }
-        return stats.domains.values.flatMap { $0 }.sorted()
+        return Set(stats.domains.values.flatMap { $0 }).sorted()
     }
 
     /// The page as one tall image, via the same PDF route as Save as PDF. WebKit
@@ -127,8 +131,21 @@ enum WebCompatReportDataCollector {
         }
     }
 
+    /// Not `block_list`'s basic/strict: this is the cross-platform standard/strict vocabulary.
+    private static func etpCategory(for blockingStrength: BlockingStrength) -> String {
+        switch blockingStrength {
+        case .basic: return "standard"
+        case .strict: return "strict"
+        }
+    }
+
     @MainActor
-    private static func makeSnapshot(from tab: Tab, includeBlockedList: Bool) -> WebCompatTabSnapshot {
+    private static func makeSnapshot(
+        from tab: Tab,
+        includeBlockedList: Bool,
+        includeTabSpecificInfo: Bool
+    ) -> WebCompatTabSnapshot {
+        guard includeTabSpecificInfo else { return WebCompatTabSnapshot() }
         let blocker = tab.contentBlocker
         return WebCompatTabSnapshot(
             isPrivate: tab.isPrivate,

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -40,7 +40,8 @@ struct WebCompatReportPayload: Equatable {
         var payload = WebCompatReportPayload()
         payload.url = state.url.isEmpty ? nil : state.url
         payload.breakageCategory = state.selectedSubOptionID ?? state.selectedCategory?.rawValue
-        payload.description = state.additionalDetails.isEmpty ? nil : state.additionalDetails
+        let details = state.additionalDetails.trimmingCharacters(in: .whitespacesAndNewlines)
+        payload.description = details.isEmpty ? nil : details
         return payload
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportRecorder.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportRecorder.swift
@@ -1,0 +1,119 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Glean
+
+struct WebCompatReportRecorder {
+    private let gleanWrapper: GleanWrapper
+    private let logger: Logger
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper(),
+         logger: Logger = DefaultLogger.shared) {
+        self.gleanWrapper = gleanWrapper
+        self.logger = logger
+    }
+
+    func submit(_ payload: WebCompatReportPayload) {
+        recordBasic(payload)
+        recordTabInfo(payload)
+        recordAntitracking(payload)
+        recordFrameworks(payload)
+        recordBrowserInfo(payload)
+        gleanWrapper.submit(ping: GleanMetrics.Pings.shared.brokenSiteReport)
+    }
+
+    private func recordBasic(_ payload: WebCompatReportPayload) {
+        // `URL(string:)` accepts scheme-less input like "asdf", so parseability is not enough.
+        if let urlString = payload.url {
+            if let url = URL(string: urlString), url.scheme != nil, url.host != nil {
+                gleanWrapper.recordUrl(for: GleanMetrics.BrokenSiteReport.url, value: url)
+            } else {
+                logger.log("WebCompat report URL is not an absolute URL, omitting it from the ping",
+                           level: .warning,
+                           category: .webview)
+            }
+        }
+        if let breakageCategory = payload.breakageCategory {
+            gleanWrapper.recordString(for: GleanMetrics.BrokenSiteReport.breakageCategory,
+                                      value: breakageCategory)
+        }
+        if let description = payload.description {
+            gleanWrapper.recordText(for: GleanMetrics.BrokenSiteReport.description, value: description)
+        }
+    }
+
+    private func recordTabInfo(_ payload: WebCompatReportPayload) {
+        if let languages = payload.languages {
+            gleanWrapper.recordStringList(for: GleanMetrics.BrokenSiteReportTabInfo.languages,
+                                          value: languages)
+        }
+        if let userAgentString = payload.userAgentString {
+            gleanWrapper.recordText(for: GleanMetrics.BrokenSiteReportTabInfo.useragentString,
+                                    value: userAgentString)
+        }
+    }
+
+    private func recordAntitracking(_ payload: WebCompatReportPayload) {
+        if let blockList = payload.blockList {
+            gleanWrapper.recordString(for: GleanMetrics.BrokenSiteReportTabInfoAntitracking.blockList,
+                                      value: blockList)
+        }
+        if let blockedOrigins = payload.blockedOrigins {
+            gleanWrapper.recordStringList(for: GleanMetrics.BrokenSiteReportTabInfoAntitracking.blockedOrigins,
+                                          value: blockedOrigins)
+        }
+        if let etpCategory = payload.etpCategory {
+            gleanWrapper.recordString(for: GleanMetrics.BrokenSiteReportTabInfoAntitracking.etpCategory,
+                                      value: etpCategory)
+        }
+        if let isPrivateBrowsing = payload.isPrivateBrowsing {
+            gleanWrapper.setBoolean(for: GleanMetrics.BrokenSiteReportTabInfoAntitracking.isPrivateBrowsing,
+                                    value: isPrivateBrowsing)
+        }
+    }
+
+    private func recordFrameworks(_ payload: WebCompatReportPayload) {
+        if let fastclick = payload.fastclick {
+            gleanWrapper.setBoolean(for: GleanMetrics.BrokenSiteReportTabInfoFrameworks.fastclick,
+                                    value: fastclick)
+        }
+        if let marfeel = payload.marfeel {
+            gleanWrapper.setBoolean(for: GleanMetrics.BrokenSiteReportTabInfoFrameworks.marfeel,
+                                    value: marfeel)
+        }
+        if let mobify = payload.mobify {
+            gleanWrapper.setBoolean(for: GleanMetrics.BrokenSiteReportTabInfoFrameworks.mobify,
+                                    value: mobify)
+        }
+    }
+
+    private func recordBrowserInfo(_ payload: WebCompatReportPayload) {
+        if let defaultLocales = payload.defaultLocales {
+            gleanWrapper.recordStringList(for: GleanMetrics.BrokenSiteReportBrowserInfoApp.defaultLocales,
+                                          value: defaultLocales)
+        }
+        if let defaultUserAgentString = payload.defaultUserAgentString {
+            gleanWrapper.recordText(for: GleanMetrics.BrokenSiteReportBrowserInfoApp.defaultUseragentString,
+                                    value: defaultUserAgentString)
+        }
+        if let devicePixelRatio = payload.devicePixelRatio {
+            gleanWrapper.recordString(for: GleanMetrics.BrokenSiteReportBrowserInfoGraphics.devicePixelRatio,
+                                      value: devicePixelRatio)
+        }
+        if let hasTouchScreen = payload.hasTouchScreen {
+            gleanWrapper.setBoolean(for: GleanMetrics.BrokenSiteReportBrowserInfoGraphics.hasTouchScreen,
+                                    value: hasTouchScreen)
+        }
+        if let isTablet = payload.isTablet {
+            gleanWrapper.setBoolean(for: GleanMetrics.BrokenSiteReportBrowserInfoSystem.isTablet,
+                                    value: isTablet)
+        }
+        if let memory = payload.memory {
+            gleanWrapper.recordQuantity(for: GleanMetrics.BrokenSiteReportBrowserInfoSystem.memory,
+                                        value: Int64(memory))
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -12,6 +12,8 @@ import WebCompatReporterKit
 protocol WebCompatReportCoordinatorDelegate: AnyObject {
     /// Sheet asked to finish; the coordinator owns the dismissal.
     func webCompatReportViewControllerDidFinish()
+    /// Report was sent; the coordinator dismisses and confirms it.
+    func webCompatReportViewControllerDidSubmit()
     /// User tapped the "Learn More…" link; the coordinator dismisses the sheet and opens the explainer page.
     func webCompatReportViewControllerDidTapLearnMore(url: URL)
 }
@@ -103,6 +105,10 @@ final class WebCompatReportViewController: UINavigationController,
     }
 
     func newState(state: WebCompatReporterState) {
+        guard !state.shouldDismiss else {
+            reportCoordinator?.webCompatReportViewControllerDidSubmit()
+            return
+        }
         sheetViewController.configure(with: WebCompatReportViewController.makeViewModel(from: state))
     }
 

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatIssueCategory.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatIssueCategory.swift
@@ -5,12 +5,12 @@
 import Foundation
 
 /// Issue categories for the "Report a Website Issue" form — a grouping for the
-/// sub-options, not display copy. The Glean `broken-site-report` reason keys
-/// live on `WebCompatSubOption.rawValue`.
+/// sub-options, not display copy. Raw values are Glean `broken-site-report` reason
+/// keys too: a report sent without a sub-option carries the category instead.
 enum WebCompatIssueCategory: String, CaseIterable, Identifiable {
-    case siteNotUsable
-    case designBroken
-    case videoOrAudio
+    case siteNotUsable = "site_not_usable"
+    case designBroken = "design_broken"
+    case videoOrAudio = "video_or_audio"
     case other
 
     var id: String { rawValue }

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterAction.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterAction.swift
@@ -63,4 +63,5 @@ enum WebCompatReporterViewActionType: ActionType {
 
 enum WebCompatReporterMiddlewareActionType: ActionType {
     case didLoadInitialDraft
+    case didSubmit
 }

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
@@ -7,6 +7,15 @@ import Redux
 
 @MainActor
 final class WebCompatReporterMiddleware {
+    private let windowManager: WindowManager
+    private let recorder: WebCompatReportRecorder
+
+    init(windowManager: WindowManager = AppContainer.shared.resolve(),
+         recorder: WebCompatReportRecorder = WebCompatReportRecorder()) {
+        self.windowManager = windowManager
+        self.recorder = recorder
+    }
+
     lazy var webCompatReporterProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
     lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
@@ -21,8 +30,7 @@ final class WebCompatReporterMiddleware {
     private func handleAction(_ action: WebCompatReporterViewAction, state: AppState) {
         switch action.actionType {
         case WebCompatReporterViewActionType.viewDidLoad:
-            // The presenting layer passes the current tab URL. Payload collection
-            // for the Glean ping is FXIOS-16177.
+            // The presenting layer passes the current tab URL.
             store.dispatch(WebCompatReporterMiddlewareAction(
                 url: action.url,
                 windowUUID: action.windowUUID,
@@ -30,11 +38,42 @@ final class WebCompatReporterMiddleware {
             ))
 
         case WebCompatReporterViewActionType.submit:
-            // TODO: FXIOS-16177 collect the payload and send the broken-site-report ping.
-            break
+            submitReport(windowUUID: action.windowUUID, state: state)
 
         default:
             break
         }
+    }
+
+    private func submitReport(windowUUID: WindowUUID, state: AppState) {
+        let reporterState = WebCompatReporterState(appState: state, uuid: windowUUID)
+        var payload = WebCompatReportPayload.make(from: reporterState)
+        if let tab = selectedTab(for: windowUUID) {
+            payload = WebCompatReportDataCollector.enrich(
+                payload,
+                tab: tab,
+                includeBlockedList: reporterState.includeBlockedList,
+                includeTabSpecificInfo: isReporting(reporterState.url, on: tab)
+            )
+        }
+        recorder.submit(payload)
+
+        store.dispatch(WebCompatReporterMiddlewareAction(
+            windowUUID: windowUUID,
+            actionType: WebCompatReporterMiddlewareActionType.didSubmit
+        ))
+    }
+
+    private func selectedTab(for windowUUID: WindowUUID) -> Tab? {
+        return windowManager.tabManager(for: windowUUID)?.selectedTab
+    }
+
+    /// Origin and path, as desktop does.
+    private func isReporting(_ reportedURL: String, on tab: Tab) -> Bool {
+        guard let reported = URL(string: reportedURL), let current = tab.url else { return false }
+        return reported.scheme == current.scheme
+            && reported.host == current.host
+            && reported.port == current.port
+            && reported.path == current.path
     }
 }

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
@@ -16,11 +16,17 @@ struct WebCompatReporterState: ScreenState, Equatable {
     var additionalDetails: String
     var includeScreenshot: Bool
     var includeBlockedList: Bool
+    var shouldDismiss: Bool
 
-    /// Preview and Send stay disabled, and the details field stays hidden, until the user picks a category.
-    var canSubmit: Bool { selectedCategory != nil }
+    /// Preview stays disabled, and the details field stays hidden, until the user picks a category.
     var canPreview: Bool { selectedCategory != nil }
     var showsAdditionalDetails: Bool { selectedCategory != nil }
+
+    /// Send needs a sub-option too, except for "Other", which has none.
+    var canSubmit: Bool {
+        guard let selectedCategory else { return false }
+        return selectedCategory.subOptions.isEmpty || selectedSubOptionID != nil
+    }
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let state = appState.componentState(
@@ -38,7 +44,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
             selectedSubOptionID: state.selectedSubOptionID,
             additionalDetails: state.additionalDetails,
             includeScreenshot: state.includeScreenshot,
-            includeBlockedList: state.includeBlockedList
+            includeBlockedList: state.includeBlockedList,
+            shouldDismiss: state.shouldDismiss
         )
     }
 
@@ -50,7 +57,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
             selectedSubOptionID: nil,
             additionalDetails: "",
             includeScreenshot: true,
-            includeBlockedList: false
+            includeBlockedList: false,
+            shouldDismiss: false
         )
     }
 
@@ -60,7 +68,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
          selectedSubOptionID: String? = nil,
          additionalDetails: String = "",
          includeScreenshot: Bool = true,
-         includeBlockedList: Bool = false) {
+         includeBlockedList: Bool = false,
+         shouldDismiss: Bool = false) {
         self.windowUUID = windowUUID
         self.url = url
         self.selectedCategory = selectedCategory
@@ -68,6 +77,7 @@ struct WebCompatReporterState: ScreenState, Equatable {
         self.additionalDetails = additionalDetails
         self.includeScreenshot = includeScreenshot
         self.includeBlockedList = includeBlockedList
+        self.shouldDismiss = shouldDismiss
     }
 
     static let reducer: Reducer<Self> = (legacyReducer, modernReducer)
@@ -81,6 +91,9 @@ struct WebCompatReporterState: ScreenState, Equatable {
         guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else {
             return defaultState(from: state)
         }
+
+        // shouldDismiss is a one-shot signal, so it never survives into the next state.
+        let state = state.copy(shouldDismiss: false)
 
         switch action {
         case let action as WebCompatReporterMiddlewareAction:
@@ -101,6 +114,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
         switch action.actionType {
         case WebCompatReporterMiddlewareActionType.didLoadInitialDraft:
             return state.copy(url: action.url ?? state.url)
+        case WebCompatReporterMiddlewareActionType.didSubmit:
+            return state.copy(shouldDismiss: true)
         default:
             return defaultState(from: state)
         }
@@ -148,16 +163,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
             selectedSubOptionID: state.selectedSubOptionID,
             additionalDetails: state.additionalDetails,
             includeScreenshot: state.includeScreenshot,
-            includeBlockedList: state.includeBlockedList
+            includeBlockedList: state.includeBlockedList,
+            shouldDismiss: false
         )
-    }
-
-    static func == (lhs: WebCompatReporterState, rhs: WebCompatReporterState) -> Bool {
-        return lhs.url == rhs.url
-            && lhs.selectedCategory == rhs.selectedCategory
-            && lhs.selectedSubOptionID == rhs.selectedSubOptionID
-            && lhs.additionalDetails == rhs.additionalDetails
-            && lhs.includeScreenshot == rhs.includeScreenshot
-            && lhs.includeBlockedList == rhs.includeBlockedList
     }
 }

--- a/firefox-ios/Client/Glean/gleanProbes.xcfilelist
+++ b/firefox-ios/Client/Glean/gleanProbes.xcfilelist
@@ -9,6 +9,7 @@ $(PROJECT_DIR)/Client/Glean/probes/autofill.credit_cards.yaml
 $(PROJECT_DIR)/Client/Glean/probes/autofill.email_mask.yaml
 $(PROJECT_DIR)/Client/Glean/probes/autofill.password_generator.yaml
 $(PROJECT_DIR)/Client/Glean/probes/autofill.passwords.yaml
+$(PROJECT_DIR)/Client/Glean/probes/broken_site_report.yaml
 $(PROJECT_DIR)/Client/Glean/probes/google_lens.yaml
 $(PROJECT_DIR)/Client/Glean/probes/history.yaml
 $(PROJECT_DIR)/Client/Glean/probes/homepage.shortcuts_library.yaml

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -170,7 +170,9 @@ broken_site_report.tab_info.antitracking:
   etp_category:
     type: string
     description: |
-      The user's tracking-protection strength setting ("basic" or "strict").
+      The user's tracking-protection strength in the cross-platform ETP vocabulary:
+      "standard" (iOS calls this basic) or "strict". iOS has no "custom" equivalent.
+      `block_list` reports the same setting in iOS's own basic/strict wording.
     data_sensitivity:
       - technical
     lifetime: ping

--- a/firefox-ios/Client/Telemetry/GleanWrapper.swift
+++ b/firefox-ios/Client/Telemetry/GleanWrapper.swift
@@ -17,6 +17,8 @@ protocol GleanWrapper: Sendable {
     func recordEvent<NoExtras>(for metric: EventMetricType<NoExtras>) where NoExtras: EventExtras
     func incrementCounter(for metric: CounterMetricType)
     func recordString(for metric: StringMetricType, value: String)
+    func recordText(for metric: TextMetricType, value: String)
+    func recordStringList(for metric: StringListMetricType, value: [String])
     func incrementLabeledCounter(for metric: LabeledMetricType<CounterMetricType>, label: String)
     func setBoolean(for metric: BooleanMetricType, value: Bool)
     func recordQuantity(for metric: QuantityMetricType, value: Int64)
@@ -79,6 +81,14 @@ struct DefaultGleanWrapper: GleanWrapper {
     }
 
     func recordString(for metric: StringMetricType, value: String) {
+        metric.set(value)
+    }
+
+    func recordText(for metric: TextMetricType, value: String) {
+        metric.set(value)
+    }
+
+    func recordStringList(for metric: StringListMetricType, value: [String]) {
         metric.set(value)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -299,10 +299,15 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
 
 private final class MockWebCompatReportCoordinatorDelegate: WebCompatReportCoordinatorDelegate {
     var didFinishCallCount = 0
+    var didSubmitCallCount = 0
     var didTapLearnMoreURLs: [URL] = []
 
     func webCompatReportViewControllerDidFinish() {
         didFinishCallCount += 1
+    }
+
+    func webCompatReportViewControllerDidSubmit() {
+        didSubmitCallCount += 1
     }
 
     func webCompatReportViewControllerDidTapLearnMore(url: URL) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanWrapper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanWrapper.swift
@@ -13,6 +13,8 @@ class MockGleanWrapper: GleanWrapper, @unchecked Sendable {
     var recordEventNoExtraCalled = 0
     var incrementCounterCalled = 0
     var recordStringCalled = 0
+    var recordTextCalled = 0
+    var recordStringListCalled = 0
     var incrementLabeledCounterCalled = 0
     var setBooleanCalled = 0
     var recordQuantityCalled = 0
@@ -26,6 +28,8 @@ class MockGleanWrapper: GleanWrapper, @unchecked Sendable {
     var savedEvents: [Any] = []
     var savedExtras: [Any] = []
     var savedValues: [Any] = []
+    var savedBooleans: [Bool] = []
+    var savedQuantities: [Int64] = []
     var savedLabel: Any?
     var savedPing: Any?
 
@@ -70,6 +74,18 @@ class MockGleanWrapper: GleanWrapper, @unchecked Sendable {
         recordStringCalled += 1
     }
 
+    func recordText(for metric: TextMetricType, value: String) {
+        savedEvents.append(metric)
+        savedValues.append(value)
+        recordTextCalled += 1
+    }
+
+    func recordStringList(for metric: StringListMetricType, value: [String]) {
+        savedEvents.append(metric)
+        savedValues.append(value)
+        recordStringListCalled += 1
+    }
+
     func incrementLabeledCounter(
         for metric: LabeledMetricType<CounterMetricType>,
         label: String
@@ -81,11 +97,13 @@ class MockGleanWrapper: GleanWrapper, @unchecked Sendable {
 
     func setBoolean(for metric: BooleanMetricType, value: Bool) {
         savedEvents.append(metric)
+        savedBooleans.append(value)
         setBooleanCalled += 1
     }
 
     func recordQuantity(for metric: QuantityMetricType, value: Int64) {
         savedEvents.append(metric)
+        savedQuantities.append(value)
         recordQuantityCalled += 1
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
@@ -9,6 +9,16 @@ import XCTest
 
 @MainActor
 final class WebCompatReportDataCollectorTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() async throws {
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
     // MARK: - Device fields
 
     // The native locale list must only reach `defaultLocales`. `languages` is page
@@ -91,7 +101,7 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         XCTAssertEqual(payload.etpCategory, "strict")
     }
 
-    func test_enrich_basicBlocking_mapsToBasicCategory() {
+    func test_enrich_basicBlocking_mapsToStandardCategoryButKeepsBasicBlockList() {
         let snapshot = makeSnapshot(blockingStrength: .basic)
 
         let payload = WebCompatReportDataCollector.enrich(
@@ -101,7 +111,23 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         )
 
         XCTAssertEqual(payload.blockList, "basic")
-        XCTAssertEqual(payload.etpCategory, "basic")
+        XCTAssertEqual(payload.etpCategory, "standard")
+    }
+
+    func test_enrich_emptyTabSnapshot_keepsDeviceFieldsButDropsTabFields() {
+        let payload = WebCompatReportDataCollector.enrich(
+            WebCompatReportPayload(),
+            device: FakeDeviceInfoProvider(),
+            tab: WebCompatTabSnapshot()
+        )
+
+        XCTAssertNil(payload.isPrivateBrowsing)
+        XCTAssertNil(payload.blockList)
+        XCTAssertNil(payload.etpCategory)
+        XCTAssertNil(payload.blockedOrigins)
+        XCTAssertNil(payload.userAgentString)
+        XCTAssertEqual(payload.defaultLocales, FakeDeviceInfoProvider().preferredLanguages)
+        XCTAssertEqual(payload.memory, FakeDeviceInfoProvider().physicalMemoryMegabytes)
     }
 
     func test_enrich_noBlocker_leavesBlockListAndCategoryNil() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportRecorderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportRecorderTests.swift
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+final class WebCompatReportRecorderTests: XCTestCase {
+    private var gleanWrapper: MockGleanWrapper!
+
+    override func setUp() {
+        super.setUp()
+        gleanWrapper = MockGleanWrapper()
+    }
+
+    override func tearDown() {
+        gleanWrapper = nil
+        super.tearDown()
+    }
+
+    func testSubmit_recordsEveryPopulatedFieldOnce() {
+        createSubject().submit(makeFullPayload())
+
+        XCTAssertEqual(gleanWrapper.recordStringCalled, 4)
+        XCTAssertEqual(gleanWrapper.recordTextCalled, 3)
+        XCTAssertEqual(gleanWrapper.recordStringListCalled, 3)
+        XCTAssertEqual(gleanWrapper.setBooleanCalled, 6)
+        XCTAssertEqual(gleanWrapper.recordQuantityCalled, 1)
+        XCTAssertEqual(gleanWrapper.recordUrlCalled, 1)
+        XCTAssertEqual(gleanWrapper.savedEvents.count, 18)
+        XCTAssertEqual(gleanWrapper.submitPingCalled, 1)
+    }
+
+    func testSubmit_recordsTheValuesItWasGiven() {
+        var payload = WebCompatReportPayload()
+        payload.breakageCategory = "media"
+        payload.description = "Video does not play"
+        payload.languages = ["en-CA", "fr"]
+        payload.memory = 4096
+        payload.isPrivateBrowsing = true
+
+        createSubject().submit(payload)
+
+        XCTAssertEqual(gleanWrapper.savedValues.count, 3)
+        XCTAssertEqual(gleanWrapper.savedValues[0] as? String, "media")
+        XCTAssertEqual(gleanWrapper.savedValues[1] as? String, "Video does not play")
+        XCTAssertEqual(gleanWrapper.savedValues[2] as? [String], ["en-CA", "fr"])
+        XCTAssertEqual(gleanWrapper.savedBooleans, [true])
+        XCTAssertEqual(gleanWrapper.savedQuantities, [4096])
+    }
+
+    func testSubmit_withSchemelessURL_skipsTheURLButStillSubmits() {
+        var payload = WebCompatReportPayload()
+        payload.url = "asdf"
+        payload.breakageCategory = "media"
+
+        createSubject().submit(payload)
+
+        XCTAssertEqual(gleanWrapper.recordUrlCalled, 0)
+        XCTAssertEqual(gleanWrapper.recordStringCalled, 1)
+        XCTAssertEqual(gleanWrapper.submitPingCalled, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject() -> WebCompatReportRecorder {
+        return WebCompatReportRecorder(gleanWrapper: gleanWrapper)
+    }
+
+    private func makeFullPayload() -> WebCompatReportPayload {
+        var payload = WebCompatReportPayload()
+        payload.url = "https://example.com"
+        payload.breakageCategory = "media"
+        payload.description = "Video does not play"
+        payload.languages = ["en-CA"]
+        payload.userAgentString = "page UA"
+        payload.blockList = "strict"
+        payload.blockedOrigins = ["tracker.example"]
+        payload.etpCategory = "strict"
+        payload.isPrivateBrowsing = false
+        payload.fastclick = true
+        payload.marfeel = false
+        payload.mobify = false
+        payload.defaultLocales = ["en-CA"]
+        payload.defaultUserAgentString = "app UA"
+        payload.devicePixelRatio = "3"
+        payload.hasTouchScreen = true
+        payload.isTablet = false
+        payload.memory = 4096
+        return payload
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -12,15 +12,18 @@ import XCTest
 @MainActor
 final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
     private var mockStore: MockStoreForMiddleware<AppState>!
+    private var gleanWrapper: MockGleanWrapper!
 
     override func setUp() async throws {
         try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
+        gleanWrapper = MockGleanWrapper()
         setupStore()
     }
 
     override func tearDown() async throws {
         DependencyHelperMock().reset()
+        gleanWrapper = nil
         resetStore()
         try await super.tearDown()
     }
@@ -48,16 +51,41 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
 
     // MARK: - submit
 
-    func test_submit_doesNotDispatch() {
+    func test_submit_submitsThePingAndDispatchesDidSubmit() throws {
         let subject = createSubject()
-        let action = WebCompatReporterViewAction(
-            windowUUID: .XCTestDefaultUUID,
-            actionType: WebCompatReporterViewActionType.submit
-        )
 
-        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, action)
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
 
-        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertEqual(gleanWrapper.submitPingCalled, 1)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WebCompatReporterMiddlewareAction)
+        let dispatchedType = try XCTUnwrap(dispatched.actionType as? WebCompatReporterMiddlewareActionType)
+        XCTAssertEqual(dispatchedType, WebCompatReporterMiddlewareActionType.didSubmit)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    // MARK: - Tab-specific info
+
+    func test_submit_whenURLStillMatchesTheTab_includesTabFields() {
+        let subject = createSubject(selectedTab: makeTab(url: "https://example.com/page"))
+        setReportedURL("https://example.com/page")
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
+
+        // is_private_browsing on top of the device's has_touch_screen and is_tablet.
+        XCTAssertEqual(gleanWrapper.setBooleanCalled, 3)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func test_submit_whenURLNoLongerMatchesTheTab_dropsTabFields() {
+        let subject = createSubject(selectedTab: makeTab(url: "https://example.com/page"))
+        setReportedURL("https://different.example/other")
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
+
+        XCTAssertEqual(gleanWrapper.setBooleanCalled, 2)
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
@@ -118,8 +146,41 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
 
     // MARK: - Helpers
 
-    private func createSubject() -> WebCompatReporterMiddleware {
-        let subject = WebCompatReporterMiddleware()
+    private func submitAction() -> WebCompatReporterViewAction {
+        return WebCompatReporterViewAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.submit
+        )
+    }
+
+    private func makeTab(url: String) -> Tab {
+        let tab = Tab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.url = URL(string: url)
+        return tab
+    }
+
+    private func setReportedURL(_ url: String) {
+        mockStore.state = AppState(
+            presentedComponents: PresentedComponentsState(
+                components: [
+                    .webCompatReporter(
+                        WebCompatReporterState(windowUUID: .XCTestDefaultUUID, url: url)
+                    )
+                ]
+            )
+        )
+    }
+
+    private func createSubject(selectedTab: Tab? = nil) -> WebCompatReporterMiddleware {
+        let tabManager = MockTabManager()
+        tabManager.selectedTab = selectedTab
+        let subject = WebCompatReporterMiddleware(
+            windowManager: MockWindowManager(
+                wrappedManager: WindowManagerImplementation(),
+                tabManager: tabManager
+            ),
+            recorder: WebCompatReportRecorder(gleanWrapper: gleanWrapper)
+        )
         trackForMemoryLeaks(subject)
         return subject
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
@@ -24,18 +24,24 @@ final class WebCompatReporterStateTests: XCTestCase {
         XCTAssertFalse(subject.includeBlockedList)
     }
 
-    func test_canSubmitAndCanPreview_falseUntilCategorySelected() {
-        let withoutCategory = createSubject()
-        XCTAssertFalse(withoutCategory.canSubmit)
-        XCTAssertFalse(withoutCategory.canPreview)
+    func test_canPreview_falseUntilCategorySelected() {
+        XCTAssertFalse(createSubject().canPreview)
 
         let withCategory = WebCompatReporterState(
             windowUUID: .XCTestDefaultUUID,
             url: "https://example.com",
             selectedCategory: .siteNotUsable
         )
-        XCTAssertTrue(withCategory.canSubmit)
         XCTAssertTrue(withCategory.canPreview)
+    }
+
+    func test_canSubmit_needsASubOptionUnlessTheCategoryHasNone() {
+        XCTAssertFalse(createSubject().canSubmit)
+        XCTAssertFalse(makeState(category: .siteNotUsable).canSubmit)
+        XCTAssertTrue(
+            makeState(category: .siteNotUsable, subOption: .pageNotLoading).canSubmit
+        )
+        XCTAssertTrue(makeState(category: .other).canSubmit)
     }
 
     // MARK: - Reducer - didLoadInitialDraft
@@ -227,6 +233,37 @@ final class WebCompatReporterStateTests: XCTestCase {
         XCTAssertTrue(newState.includeBlockedList)
     }
 
+    // MARK: - didSubmit
+
+    func test_didSubmit_setsShouldDismiss() {
+        let initialState = createSubject()
+        let reducer = WebCompatReporterState.reducer
+
+        let action = WebCompatReporterMiddlewareAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterMiddlewareActionType.didSubmit
+        )
+
+        let newState = reducer.legacyReducer(initialState, action)
+
+        XCTAssertTrue(newState.shouldDismiss)
+    }
+
+    func test_actionAfterDidSubmit_clearsShouldDismiss() {
+        let reducer = WebCompatReporterState.reducer
+        let submitted = reducer.legacyReducer(createSubject(), WebCompatReporterMiddlewareAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterMiddlewareActionType.didSubmit
+        ))
+
+        let newState = reducer.legacyReducer(submitted, WebCompatReporterViewAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.toggleBlockedList
+        ))
+
+        XCTAssertFalse(newState.shouldDismiss)
+    }
+
     // MARK: - Edge Cases
 
     func test_unknownAction_returnsDefaultState() {
@@ -307,6 +344,18 @@ final class WebCompatReporterStateTests: XCTestCase {
     }
 
     // MARK: - Private Helpers
+
+    private func makeState(
+        category: WebCompatIssueCategory,
+        subOption: WebCompatSubOption? = nil
+    ) -> WebCompatReporterState {
+        return WebCompatReporterState(
+            windowUUID: .XCTestDefaultUUID,
+            url: "https://example.com",
+            selectedCategory: category,
+            selectedSubOptionID: subOption?.rawValue
+        )
+    }
 
     private func createSubject() -> WebCompatReporterState {
         return WebCompatReporterState(windowUUID: .XCTestDefaultUUID)


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16185](https://mozilla-hub.atlassian.net/browse/FXIOS-16185)

## :bulb: Description
Send now assembles the payload, records the `broken_site_report` metrics, submits the ping, then dismisses with a confirmation toast. Send requires a sub-option first, except for "Other" which has none.

`broken_site_report.yaml` was in `glean_index.yaml` but missing from `gleanProbes.xcfilelist`, so `GleanMetrics.BrokenSiteReport*` never generated and the metrics from [#34309](https://github.com/mozilla-mobile/firefox-ios/pull/34309) were uncompilable. No metrics change here, despite Danger flagging the path.

Four data fixes that only start mattering now the ping ships: `etp_category` uses the cross-platform standard/strict vocabulary rather than `block_list`'s basic/strict; tab-derived fields drop when the URL no longer matches the tab; category raw values are snake_case to match the sub-option keys; and the description is trimmed. The toast borrows a translated Microsurvey string until [FXIOS-16468](https://mozilla-hub.atlassian.net/browse/FXIOS-16468) exports a dedicated one.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
In Safari, load `fennec://glean?logPings=true&debugViewTag=<your-tag>`. "Send technical data" must be on.

Enable `reportBrokenSite`, open a page, then main menu → More → Report Broken Site. Pick a category and stop: Send stays disabled. Pick a sub-option, add details, tap Send. Expect the sheet to close, a "Thanks for your feedback!" toast, and a `broken-site-report` ping under your tag at https://debug-ping-preview.firebaseapp.com/ with no client id. Tapping X instead shows no toast.

Send again with the URL field edited to a different site. `default_locales`, `memory` and `is_tablet` stay; `is_private_browsing`, `block_list` and `etp_category` drop.


[FXIOS-16185]: https://mozilla-hub.atlassian.net/browse/FXIOS-16185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-16468]: https://mozilla-hub.atlassian.net/browse/FXIOS-16468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ