### PR TITLE
Add FXIOS-16469 [Content Blocker] Update rules when RS finishes syncing

### DIFF
--- a/BrowserKit/Sources/Common/Constants/NotificationConstants.swift
+++ b/BrowserKit/Sources/Common/Constants/NotificationConstants.swift
@@ -97,4 +97,8 @@ extension Notification.Name {
     public static let DefaultSearchEngineUpdated = Notification.Name("DefaultSearchEngineUpdated")
     public static let SearchSettingsDidUpdateDefaultSearchEngine =
     Notification.Name("SearchSettingsDidUpdateDefaultSearchEngine")
+
+    // MARK: Remote Settings
+
+    public static let remoteSettingsDidSync = Notification.Name("remoteSettingsDidSync")
 }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1235,6 +1235,8 @@
 		8ABE9F1A2CB45B4B0080E1DF /* RemotePasswordRules.json in Resources */ = {isa = PBXBuildFile; fileRef = 8AF4E7702C45B98F00BAD91C /* RemotePasswordRules.json */; };
 		8ABE9F1B2CB4620A0080E1DF /* RemoteSettingsFetchConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 8AF4E76D2C41D86100BAD91C /* RemoteSettingsFetchConfig.json */; };
 		8ABE9F1D2CB462730080E1DF /* RemoteSettingsFetchConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABE9F1C2CB462730080E1DF /* RemoteSettingsFetchConfigTests.swift */; };
+		C7F5683DC329455783CCB143 /* RemoteSettingsServiceSyncCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F5683DC329455783CCB141 /* RemoteSettingsServiceSyncCoordinatorTests.swift */; };
+		C7F5683DC329455783CCB144 /* MockRemoteSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F5683DC329455783CCB142 /* MockRemoteSettingsService.swift */; };
 		8ABE9F1E2CB462CA0080E1DF /* RemoteSettingsFetchConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 8AF4E76D2C41D86100BAD91C /* RemoteSettingsFetchConfig.json */; };
 		8AC0B1C02D1D935C004237FD /* ContextMenuConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC0B1BF2D1D9356004237FD /* ContextMenuConfiguration.swift */; };
 		8AC1065F28D0CD700013263A /* OpenQLPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */; };
@@ -9903,6 +9905,8 @@
 		8ABB15C82D5A4E3900A4635C /* RemoteTabsMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabsMiddlewareTests.swift; sourceTree = "<group>"; };
 		8ABDBAA52CB6BF6600B51F63 /* HomepageHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageHeaderCell.swift; sourceTree = "<group>"; };
 		8ABE9F1C2CB462730080E1DF /* RemoteSettingsFetchConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSettingsFetchConfigTests.swift; sourceTree = "<group>"; };
+		C7F5683DC329455783CCB141 /* RemoteSettingsServiceSyncCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSettingsServiceSyncCoordinatorTests.swift; sourceTree = "<group>"; };
+		C7F5683DC329455783CCB142 /* MockRemoteSettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteSettingsService.swift; sourceTree = "<group>"; };
 		8AC0B1BF2D1D9356004237FD /* ContextMenuConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuConfiguration.swift; sourceTree = "<group>"; };
 		8AC1065E28D0CD700013263A /* OpenQLPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenQLPreviewHelper.swift; sourceTree = "<group>"; };
 		8AC5D55E28BFE6C8001F6F7F /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
@@ -15114,11 +15118,13 @@
 			isa = PBXGroup;
 			children = (
 				AAB5AF372EDDCF5A0051EF6E /* MockLocaleProvider.swift */,
+				C7F5683DC329455783CCB142 /* MockRemoteSettingsService.swift */,
 				8AFC4E462CAF53E100C54B43 /* RemoteDataTypeTests.swift */,
 				1D3564532D9329FA00F52F12 /* SearchPrefsMigrationTests.swift */,
 				1DA3E4B12DB1C86A0065F7E7 /* ASSearchEngineUtilitiesTests.swift */,
 				8ABE9F1C2CB462730080E1DF /* RemoteSettingsFetchConfigTests.swift */,
 				AA07F1C2CB462730080E1DF0 /* RemoteSettingsGleanTelemetryTests.swift */,
+				C7F5683DC329455783CCB141 /* RemoteSettingsServiceSyncCoordinatorTests.swift */,
 			);
 			path = RemoteSettings;
 			sourceTree = "<group>";
@@ -21282,6 +21288,8 @@
 				C78FC19E2E62448400B077DA /* ShortcutsLibraryViewControllerTests.swift in Sources */,
 				8ABE9F1D2CB462730080E1DF /* RemoteSettingsFetchConfigTests.swift in Sources */,
 				AA06F1D2CB462730080E1DF0 /* RemoteSettingsGleanTelemetryTests.swift in Sources */,
+				C7F5683DC329455783CCB143 /* RemoteSettingsServiceSyncCoordinatorTests.swift in Sources */,
+				C7F5683DC329455783CCB144 /* MockRemoteSettingsService.swift in Sources */,
 				8A106D632D416F82009AD7E4 /* MessageCardMiddlewareTests.swift in Sources */,
 				E1E425322B5A2E9700899550 /* DownloadTests.swift in Sources */,
 				5AB4237C28A1947A003BC40C /* MockNotificationCenter.swift in Sources */,

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsServiceSyncCoordinator.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/RemoteSettingsServiceSyncCoordinator.swift
@@ -15,13 +15,16 @@ final class RemoteSettingsServiceSyncCoordinator: @unchecked Sendable, Notifiabl
     private let logger: Logger
     private var syncTimer: Timer?
     private let maxSyncFrequency: Double = 60 * 60 * 24 // 24 hours
+    private let notificationCenter: NotificationProtocol
 
     init(service: RemoteSettingsService,
          prefs: Prefs,
-         logger: Logger = DefaultLogger.shared) {
+         logger: Logger = DefaultLogger.shared,
+         notificationCenter: NotificationProtocol = NotificationCenter.default) {
         self.service = service
         self.prefs = prefs
         self.logger = logger
+        self.notificationCenter = notificationCenter
 
         startObservingNotifications(
             withNotificationCenter: NotificationCenter.default,
@@ -96,6 +99,13 @@ final class RemoteSettingsServiceSyncCoordinator: @unchecked Sendable, Notifiabl
                 level: .info,
                 category: .remoteSettings
             )
+            if !syncResults.isEmpty {
+                notificationCenter.post(
+                    name: .remoteSettingsDidSync,
+                    withObject: nil,
+                    withUserInfo: ["updatedCollections": syncResults]
+                )
+            }
         } catch {
             logger.log(
                 "Remote Settings sync error: \(error)",

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -131,7 +131,7 @@ struct NoImageModeDefaults {
 }
 
 @MainActor
-class ContentBlocker {
+class ContentBlocker: Notifiable {
     var safelistedDomains = SafelistedDomains()
     let ruleStore = WKContentRuleListStore.default()
     var blockImagesRule: WKContentRuleList?
@@ -166,23 +166,26 @@ class ContentBlocker {
             }
         }
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(remoteSettingsDidSync(_:)),
-            name: .remoteSettingsDidSync,
-            object: nil
+        startObservingNotifications(
+            withNotificationCenter: NotificationCenter.default,
+            forObserver: self,
+            observing: [.remoteSettingsDidSync]
         )
     }
 
-    @objc
-    private func remoteSettingsDidSync(_ notification: Notification) {
-        guard let collections = notification.userInfo?["updatedCollections"] as? [String],
-              collections.contains(ASRemoteSettingsCollection.trackingProtectionLists.rawValue) else {
-            return
-        }
-        Task {
-            await reloadAdBlockerList()
-            prefsChanged()
+    nonisolated func handleNotifications(_ notification: Notification) {
+        switch notification.name {
+        case .remoteSettingsDidSync:
+            guard let collections = notification.userInfo?["updatedCollections"] as? [String],
+                  collections.contains(ASRemoteSettingsCollection.trackingProtectionLists.rawValue) else {
+                return
+            }
+            Task { @MainActor [weak self] in
+                await self?.reloadAdBlockerList()
+                self?.prefsChanged()
+            }
+        default:
+            break
         }
     }
 

--- a/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker.swift
@@ -165,6 +165,25 @@ class ContentBlocker {
                 }
             }
         }
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(remoteSettingsDidSync(_:)),
+            name: .remoteSettingsDidSync,
+            object: nil
+        )
+    }
+
+    @objc
+    private func remoteSettingsDidSync(_ notification: Notification) {
+        guard let collections = notification.userInfo?["updatedCollections"] as? [String],
+              collections.contains(ASRemoteSettingsCollection.trackingProtectionLists.rawValue) else {
+            return
+        }
+        Task {
+            await reloadAdBlockerList()
+            prefsChanged()
+        }
     }
 
     func prefsChanged() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/MockRemoteSettingsService.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/MockRemoteSettingsService.swift
@@ -4,7 +4,7 @@
 
 import MozillaAppServices
 
-final class MockRemoteSettingsService: RemoteSettingsService {
+final class MockRemoteSettingsService: RemoteSettingsService, @unchecked Sendable {
     private let syncResult: [String]
 
     init(syncResult: [String]) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/MockRemoteSettingsService.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/MockRemoteSettingsService.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MozillaAppServices
+
+final class MockRemoteSettingsService: RemoteSettingsService {
+    private let syncResult: [String]
+
+    init(syncResult: [String]) {
+        self.syncResult = syncResult
+        super.init(noHandle: NoHandle())
+    }
+
+    required init(unsafeFromHandle handle: UInt64) {
+        self.syncResult = []
+        super.init(unsafeFromHandle: handle)
+    }
+
+    override func sync() throws -> [String] {
+        return syncResult
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/RemoteSettingsServiceSyncCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/RemoteSettings/RemoteSettingsServiceSyncCoordinatorTests.swift
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MozillaAppServices
+import Shared
+import TestKit
+import XCTest
+
+@testable import Client
+
+final class RemoteSettingsServiceSyncCoordinatorTests: XCTestCase {
+    private var mockNotificationCenter: MockNotificationCenter!
+
+    override func setUp() {
+        super.setUp()
+        mockNotificationCenter = MockNotificationCenter()
+    }
+
+    override func tearDown() {
+        mockNotificationCenter = nil
+        super.tearDown()
+    }
+
+    func test_performSync_withAdBlockerUpdate_postsNotification() {
+        let mockService = MockRemoteSettingsService(
+            syncResult: ["tracking-protection-lists-ios"]
+        )
+        let subject = RemoteSettingsServiceSyncCoordinator(
+            service: mockService,
+            prefs: MockProfilePrefs(),
+            notificationCenter: mockNotificationCenter
+        )
+
+        subject.forceImmediateSync()
+
+        XCTAssertEqual(mockNotificationCenter.postCallCount, 1)
+        XCTAssertEqual(mockNotificationCenter.savePostName, .remoteSettingsDidSync)
+        let collections = mockNotificationCenter.saveUserInfo as? [String: [String]]
+        XCTAssertEqual(
+            collections?["updatedCollections"],
+            ["tracking-protection-lists-ios"]
+        )
+    }
+
+    func test_performSync_withOtherCollectionUpdate_postsNotificationWithCorrectCollections() {
+        let mockService = MockRemoteSettingsService(
+            syncResult: ["search-config-icons"]
+        )
+        let subject = RemoteSettingsServiceSyncCoordinator(
+            service: mockService,
+            prefs: MockProfilePrefs(),
+            notificationCenter: mockNotificationCenter
+        )
+
+        subject.forceImmediateSync()
+
+        XCTAssertEqual(mockNotificationCenter.postCallCount, 1)
+        let collections = mockNotificationCenter.saveUserInfo as? [String: [String]]
+        XCTAssertEqual(collections?["updatedCollections"], ["search-config-icons"])
+    }
+
+    func test_performSync_withEmptyResults_doesNotPostNotification() {
+        let mockService = MockRemoteSettingsService(syncResult: [])
+        let subject = RemoteSettingsServiceSyncCoordinator(
+            service: mockService,
+            prefs: MockProfilePrefs(),
+            notificationCenter: mockNotificationCenter
+        )
+
+        subject.forceImmediateSync()
+
+        XCTAssertEqual(mockNotificationCenter.postCallCount, 0)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16469)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34964)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Adds notification when RS finishes syncing.
- Adds a `reloadAdBlockerList` call when RS sync finishes.
- Adds tests.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

