### PR TITLE
Bugfix FXIOS-16471 [Content Blocker] Revalidate rules when data is cleared

### DIFF
--- a/firefox-ios/Client/ContentBlocker/ContentBlocker+Safelist.swift
+++ b/firefox-ios/Client/ContentBlocker/ContentBlocker+Safelist.swift
@@ -60,8 +60,11 @@ extension ContentBlocker {
     private func updateSafelist(completion: (() -> Void)?) {
         removeAllRulesInStore {
             self.compileListsNotInStore {
-                completion?()
-                NotificationCenter.default.post(name: .contentBlockerTabSetupRequired, object: nil)
+                Task {
+                    await self.reloadAdBlockerList()
+                    completion?()
+                    NotificationCenter.default.post(name: .contentBlockerTabSetupRequired, object: nil)
+                }
             }
         }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ContentBlockerTests.swift
@@ -140,6 +140,24 @@ final class ContentBlockerTests: XCTestCase {
         )
     }
 
+    func testClearSafelist_reloadsAdBlockerList() async {
+        let mock = MockAdBlockerListFetcher(jsonToReturn: Self.validRuleJSON)
+        ContentBlocker.shared.adBlockerListFetcher = mock
+
+        await ContentBlocker.shared.reloadAdBlockerList()
+        XCTAssertEqual(mock.fetchCallCount, 1)
+
+        let clearExpectation = XCTestExpectation(description: "clearSafelist completed")
+        ContentBlocker.shared.clearSafelist { clearExpectation.fulfill() }
+        await fulfillment(of: [clearExpectation], timeout: 5)
+
+        XCTAssertEqual(
+            mock.fetchCallCount,
+            2,
+            "clearSafelist should trigger reloadAdBlockerList"
+        )
+    }
+
     func testReloadAdBlockerList_differentJSON_recompiles() async {
         let mock = MockAdBlockerListFetcher(jsonToReturn: Self.validRuleJSON)
         ContentBlocker.shared.adBlockerListFetcher = mock


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16471)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34971)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Rebuilds rule list for content blocker when data is cleared.
- Adds test

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

