### PR TITLE
MTE-5756 - remove jump back in test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
@@ -204,7 +204,6 @@
         "IpadOnlyTestCase",
         "IphoneOnlyTestCase",
         "JumpBackInTests",
-        "JumpBackInTests\/testJumpBackInSection()",
         "JumpBackInTests\/testLongTapOnJumpBackInLink()",
         "JumpBackInTests\/testPrivateTab_tabTrayExperimentOff()",
         "JumpBackInTests\/testPrivateTab_tabTrayExperimentOn()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -328,7 +328,6 @@
         "IpadOnlyTestCase",
         "IphoneOnlyTestCase",
         "JumpBackInTests",
-        "JumpBackInTests\/testJumpBackInSection()",
         "JumpBackInTests\/testLongTapOnJumpBackInLink()",
         "JumpBackInTests\/testPrivateTab()",
         "JumpBackInTests\/testPrivateTab_tabTrayExperimentOff()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/JumpBackInTests.swift
@@ -35,22 +35,6 @@ class JumpBackInTests: FeatureFlaggedTestBase {
         tabTrayScreen.tapOnNewTabButton()
     }
 
-    // https://mozilla.testrail.io/index.php?/cases/view/2306922
-    func testJumpBackInSection() {
-        prepareTest()
-        // Open a tab and visit a page
-        browserScreen.navigateToURL("https://www.example.com")
-        waitUntilPageLoad()
-
-        // Open a new tab
-        openNewTabFromTabTray()
-
-        // "Jump Back In" section is displayed
-        jumpBackInScreen.assertSectionExists()
-        // The contextual hint box is not displayed consistently, so
-        // I don't test for its existence.
-    }
-
     // https://mozilla.testrail.io/index.php?/cases/view/2306920
     func testPrivateTab() throws {
         prepareTest()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5756

## :bulb: Description
https://mozilla.testrail.io/index.php?/cases/view/2306922 test case has been deleted
Removing testJumpBackInSection() also
The test was already covered in https://mozilla.testrail.io/index.php?/cases/view/2307033 

