### PR TITLE
BugFix FXIOS-14323 [Logins] Fix crash from concurrent addLogin/updateLogin/verifyLogins calls

### DIFF
--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -328,20 +328,27 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
             }
 
             self.getStoredKey { result in
-                switch result {
-                case .success:
-                    do {
-                        try self.storage?.deleteUndecryptableRecordsForRemoteReplacement()
-                        completionHandler(true)
-                    } catch let err as NSError {
-                        self.logger.log("Error verifying logins",
-                                        level: .warning,
-                                        category: .storage,
-                                        description: err.localizedDescription)
+                self.queue.async {
+                    guard self.isOpen else {
+                        completionHandler(false)
+                        return
+                    }
+
+                    switch result {
+                    case .success:
+                        do {
+                            try self.storage?.deleteUndecryptableRecordsForRemoteReplacement()
+                            completionHandler(true)
+                        } catch let err as NSError {
+                            self.logger.log("Error verifying logins",
+                                            level: .warning,
+                                            category: .storage,
+                                            description: err.localizedDescription)
+                            completionHandler(false)
+                        }
+                    case .failure:
                         completionHandler(false)
                     }
-                case .failure:
-                    completionHandler(false)
                 }
             }
         }
@@ -475,16 +482,24 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
             }
 
             self.getStoredKey { result in
-                switch result {
-                case .success:
-                    do {
-                        let login = try self.storage?.add(login: login)
-                        completionHandler(.success(login))
-                    } catch let err as NSError {
+                self.queue.async {
+                    guard self.isOpen else {
+                        let error = LoginsStoreError.UnexpectedLoginsApiError(reason: "Database is closed")
+                        completionHandler(.failure(error))
+                        return
+                    }
+
+                    switch result {
+                    case .success:
+                        do {
+                            let login = try self.storage?.add(login: login)
+                            completionHandler(.success(login))
+                        } catch let err as NSError {
+                            completionHandler(.failure(err))
+                        }
+                    case .failure(let err):
                         completionHandler(.failure(err))
                     }
-                case .failure(let err):
-                    completionHandler(.failure(err))
                 }
             }
         }
@@ -519,16 +534,24 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
                 }
 
                 self.getStoredKey { result in
-                    switch result {
-                    case .success:
-                        do {
-                            let updatedLogin = try self.storage?.update(id: id, login: login)
-                            completionHandler(.success(updatedLogin))
-                        } catch let error as NSError {
+                    self.queue.async {
+                        guard self.isOpen else {
+                            let error = LoginsStoreError.UnexpectedLoginsApiError(reason: "Database is closed")
                             completionHandler(.failure(error))
+                            return
                         }
-                    case .failure(let err):
-                        completionHandler(.failure(err))
+
+                        switch result {
+                        case .success:
+                            do {
+                                let updatedLogin = try self.storage?.update(id: id, login: login)
+                                completionHandler(.success(updatedLogin))
+                            } catch let error as NSError {
+                                completionHandler(.failure(error))
+                            }
+                        case .failure(let err):
+                            completionHandler(.failure(err))
+                        }
                     }
                 }
             }

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
@@ -23,6 +23,11 @@ class RustLoginsTests: XCTestCase, @unchecked Sendable {
         super.setUp()
         files = MockFiles()
 
+        // MockRustKeychain.shared is a process-wide singleton that otherwise leaks a
+        // cached logins key across test methods, masking the first-time-key-creation
+        // code path that testDeleteMultipleLogins depends on to reproduce FXIOS-14323.
+        MockRustKeychain.shared.removeAllKeys()
+
         if let rootDirectory = try? files.getAndEnsureDirectory() {
             let databasePath = URL(
                 fileURLWithPath: rootDirectory,
@@ -159,23 +164,24 @@ class RustLoginsTests: XCTestCase, @unchecked Sendable {
     func testDeleteMultipleLogins() {
         logins.rustKeychain.removeLoginsKeysForDebugMenuItem()
 
-        var addExpectations = [XCTestExpectation]()
+        // Add three logins back-to-back without waiting in between, regression test for
+        // a crash caused by concurrent Rust FFI calls (FXIOS-14323 / Github #31023).
+        let addExpectations = (0..<3).map { i in XCTestExpectation(description: "Add login \(i)") }
+
         for i in 0..<3 {
-            let expectation = XCTestExpectation(description: "Add login \(i)")
-            addExpectations.append(expectation)
             let login = RustLoginsTests.loginFactory(number: i)
 
             logins.addLogin(login: login) { result in
                 switch result {
                 case .success(let login):
                     XCTAssertNotNil(login)
-                    expectation.fulfill()
+                    addExpectations[i].fulfill()
                 case .failure:
                     XCTFail("Add login \(i) failed")
                 }
             }
         }
-        wait(for: addExpectations, timeout: 2)
+        wait(for: addExpectations, timeout: 5)
 
         let deleteExpectation = XCTestExpectation(description: "Deleting all entries")
 


### PR DESCRIPTION
### Jira
https://mozilla-hub.atlassian.net/browse/FXIOS-14323

### GitHub Issue
Fixes #31023

### What changed
`getStoredKey`'s completion can fire off `RustLogins`'s serial queue on the first-time-key-creation path (routed through `Deferred.upon`, which defaults to `DispatchQueue.global()`). This let concurrent `addLogin`/`updateLogin`/`verifyLogins` calls touch the Rust FFI storage object from different threads at once, corrupting it and crashing with "unrecognized selector sent to instance".

`verifyLogins`, `addLogin`, and `updateLogin` now re-dispatch onto the serial queue before touching storage, and re-check `isOpen` after the hop since `forceClose()` can now race the widened window.

### Why
Builds on the earlier serialized key-retrieval fix (#34773) by closing the remaining race at the three call sites that touch storage directly after key retrieval.

### Testing
Added/updated `RustLoginsTests.testDeleteMultipleLogins` to add three logins back-to-back without waiting in between, regressing the concurrent-call crash. Also reset the shared mock keychain in `setUp` so the first-time-key-creation path (needed to reproduce the crash) isn't masked by state leaking across test methods.