### PR TITLE
Bugfix FXIOS-16449 Tab preview not hidden when app switcher opens during gesture

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
@@ -202,7 +202,7 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
             let translation = gesture.translation(in: gesture.view)
             let fingerLocation = gesture.location(in: tabPreview)
             tabPreview.translate(translation, fingerLocation: fingerLocation)
-        case .ended:
+        case .ended, .cancelled:
             handleGestureEnded(gesture: gesture)
         default:
             break


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16449)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34957)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Fixed an issue where the pan up gesture on the address bar was not being completed when the app switcher is opened mid-gesture. This was fixed by ensuring a function call to clean up after the gesture is still made when the gesture is cancelled.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/6ba796dd-377d-4e79-9530-9e7d9c3522b2

</details>
<details>
<summary>After</summary>

https://github.com/user-attachments/assets/a4d4dd74-6f31-44f3-8f3a-13b807e7ffe1

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

