### PR TITLE
Refactor FXIOS-15352 Use Copyable macro for TermsOfUseState

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
@@ -96,10 +96,8 @@ struct TermsOfUseState: ScreenState {
             return state
                 .copy(wasDismissed: true)
 
-        case .learnMoreLinkTapped,
-             .privacyLinkTapped,
-             .termsLinkTapped:
-            return state
+        default:
+            return defaultState(from: state)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/TermsOfUseState.swift
@@ -3,8 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import ModifiedCopy
 import Redux
 
+@Copyable
 struct TermsOfUseState: ScreenState {
     let windowUUID: WindowUUID
     var hasAccepted: Bool
@@ -61,8 +63,7 @@ struct TermsOfUseState: ScreenState {
 
     private static func handleReducer(state: TermsOfUseState, action: Action) -> TermsOfUseState {
         // Only process actions for the current window
-        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
-        else {
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID else {
             return defaultState(from: state)
         }
 
@@ -81,24 +82,24 @@ struct TermsOfUseState: ScreenState {
 
         switch type {
         case .termsShown:
-            return TermsOfUseState(windowUUID: state.windowUUID,
-                                   hasAccepted: false,
-                                   wasDismissed: false)
+            return state
+                .copy(hasAccepted: false)
+                .copy(wasDismissed: false)
+
         case .termsAccepted:
-            return TermsOfUseState(windowUUID: state.windowUUID,
-                                   hasAccepted: true,
-                                   wasDismissed: false)
+            return state
+                .copy(hasAccepted: true)
+                .copy(wasDismissed: false)
+
         case .gestureDismiss,
              .remindMeLaterTapped:
-            return TermsOfUseState(windowUUID: state.windowUUID,
-                                   hasAccepted: state.hasAccepted,
-                                   wasDismissed: true)
+            return state
+                .copy(wasDismissed: true)
+
         case .learnMoreLinkTapped,
              .privacyLinkTapped,
              .termsLinkTapped:
-            return TermsOfUseState(windowUUID: state.windowUUID,
-                                   hasAccepted: state.hasAccepted,
-                                   wasDismissed: state.wasDismissed)
+            return state
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15352)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32939)

## :bulb: Description
- Refactors `TermsOfUseState` to use the `@Copyable` macro from `ModifiedCopy`

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

