### PR TITLE
Refactor FXIOS-16474 - [Hang] Paste & Go in LocationView blocks the main thread

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/UIPasteboardExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/UIPasteboardExtension.swift
@@ -10,7 +10,7 @@ extension UIPasteboard {
     /// fetch, so it is never done on the main thread.
     ///
     /// - Parameter completion: Called off the main thread. Hop back to it before touching UI.
-    public nonisolated func asyncString(completion: @Sendable @escaping (String?) -> Void) {
+    nonisolated public func asyncString(completion: @Sendable @escaping (String?) -> Void) {
         Task(priority: .medium) { completion(self.string) }
     }
 }

--- a/BrowserKit/Sources/Common/Extensions/UIPasteboardExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/UIPasteboardExtension.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+extension UIPasteboard {
+    /// Preferred way to read the pasteboard's string contents. Reading `string` blocks the calling
+    /// thread on an IPC (Inter-process communication) call that can wait on the paste consent alert or a Universal Clipboard
+    /// fetch, so it is never done on the main thread.
+    ///
+    /// - Parameter completion: Called off the main thread. Hop back to it before touching UI.
+    public nonisolated func asyncString(completion: @Sendable @escaping (String?) -> Void) {
+        Task(priority: .medium) { completion(self.string) }
+    }
+}

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -682,10 +682,12 @@ final class LocationView: UIView,
     }
 
     func menuHelperPasteAndGo() {
-        ensureMainThread {
-            guard let pasteboardContents = UIPasteboard.general.string else { return }
-            self.urlTextField.text = pasteboardContents
-            self.delegate?.locationViewDidSubmitText(pasteboardContents)
+        UIPasteboard.general.asyncString { [weak self] contents in
+            guard let contents else { return }
+            ensureMainThread {
+                self?.urlTextField.text = contents
+                self?.delegate?.locationViewDidSubmitText(contents)
+            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16574)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34976)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### Root Cause
`LocationView.menuHelperPasteAndGo()` read `UIPasteboard.general.string` synchronously on the
main thread, which froze the UI. That getter is a blockin call to the pasteboard.

### The Fix

Fixed by adding `UIPasteboard.asyncString(completion:)` to `Common`, which performs the read off
the main thread. `menuHelperPasteAndGo()` now hops back via `ensureMainThread` before touching
the text field and delegate. The helper is documented so the indirection isn't optimized away
later.

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

### Before

https://github.com/user-attachments/assets/62b9c354-3bf3-47f5-8c1e-9a9e83739edf

### After

https://github.com/user-attachments/assets/5b49f000-d525-4276-b48a-03259958b278


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

