### PR TITLE
Add [Release Automation] Send a slack notification on merge automation success (bug 2057499)

### DIFF
--- a/taskcluster/ffios_taskgraph/actions/merge_automation.py
+++ b/taskcluster/ffios_taskgraph/actions/merge_automation.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from mozilla_version.ios import MobileIosVersion
 from taskgraph.parameters import Parameters
 
 from taskgraph.actions.registry import register_callback_action
@@ -45,11 +46,20 @@ def merge_automation_action(parameters, graph_config, input, task_group_id, task
     # make parameters read-write
     parameters = dict(parameters)
 
+    behavior = input.get("behavior", "major")
+
     parameters["target_tasks_method"] = "merge_automation"
     parameters["merge_config"] = {
         "force-dry-run": input.get("force-dry-run", False),
-        "behavior": input.get("behavior", "major"),
+        "behavior": behavior,
     }
+    version = MobileIosVersion.parse(parameters["version"])
+    if behavior == "major":
+        parameters["next_version"] = str(version.bump("major_number"))
+    elif behavior == "minor":
+        parameters["next_version"] = str(version.bump("minor_number"))
+    else:
+        raise Exception(f"Unknown merge-automation behavior: {behavior}")
 
     for field in [
         "merge-automation-id",

--- a/taskcluster/ffios_taskgraph/transforms/mark_as_merged.py
+++ b/taskcluster/ffios_taskgraph/transforms/mark_as_merged.py
@@ -17,14 +17,21 @@ def make_task_description(config, tasks):
         return
 
     for task in tasks:
-        resolve_keyed_by(
-            task,
-            "scopes",
-            item_name=task["name"],
-            level=config.params["level"],
-        )
+        for field in ("scopes", "slack-channel"):
+            resolve_keyed_by(
+                task,
+                field,
+                item_name=task["name"],
+                level=config.params["level"],
+            )
 
         task["worker"]["merge-automation-id"] = merge_automation_id
 
-        yield task
+        slack_channel = task.pop("slack-channel")
 
+        if slack_channel and not merge_config.get("force-dry-run"):
+            task.setdefault("routes", []).append(
+                f"notify.slack-channel.{slack_channel}.on-completed"
+            )
+
+        yield task

--- a/taskcluster/ffios_taskgraph/transforms/version_bump.py
+++ b/taskcluster/ffios_taskgraph/transforms/version_bump.py
@@ -5,32 +5,21 @@
 Add the right git branch configuration to the worker definition
 """
 
-from pathlib import Path
-from taskgraph.transforms.base import TransformSequence
 from mozilla_version.ios import MobileIosVersion
+from taskgraph.transforms.base import TransformSequence
 
 transforms = TransformSequence()
 
 @transforms.add
 def version_bump_task(config, tasks):
     for task in tasks:
-        versionfile = Path(__file__).parent.parent.parent.parent / "version.txt"
-        with open(versionfile) as fd:
-            version = MobileIosVersion.parse(fd.readline())
-
         if "create-branch-info" in task["worker"]:
-            # We need to default to major here so taskgraph full can produce a valid task
-            behavior = config.params.get("merge_config", {}).get("behavior", "major")
-            branch_name = f"release/v{version.major_number}.{version.minor_number}"
-            task["worker"]["create-branch-info"]["branch-name"] = branch_name
-            if behavior == "major":
-                version = version.bump("major_number")
-            elif behavior == "minor":
-                version = version.bump("minor_number")
-            else:
-                raise Exception(f"Unknown merge-automation behavior: {behavior}")
+            version = MobileIosVersion.parse(config.params["version"])
+            task["worker"]["create-branch-info"]["branch-name"] = (
+                f"release/v{version.major_number}.{version.minor_number}"
+            )
 
-        task["worker"]["next-version"] = str(version)
+        task["worker"]["next-version"] = config.params["next_version"] or config.params["version"]
         task["worker"].update(branch=config.params["head_ref"])
 
         if config.params.get("merge_config", {}).get("force-dry-run"):

--- a/taskcluster/kinds/mark-as-merged/kind.yml
+++ b/taskcluster/kinds/mark-as-merged/kind.yml
@@ -6,6 +6,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - ffios_taskgraph.transforms.mark_as_merged:transforms
+    - taskgraph.transforms.task_context:transforms
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
@@ -29,3 +30,18 @@ tasks:
                 default:
                     - project:mobile:releng:ship-it:server:staging
                     - project:mobile:releng:ship-it:action:mark-as-merged
+        slack-channel:
+            by-level:
+                '3': C03PKCHHSSD  # firefox-ios-releases
+                default: null
+        task-context:
+            from-parameters:
+                version: version
+                next_version: next_version
+            substitution-fields:
+                - extra.notify.slackText
+        extra:
+            notify:
+                slackText: >-
+                    firefox-ios release/v{version} branch has been created
+                    and the version has been bumped to {next_version} on main

--- a/taskcluster/test/params/cron-bitrise-performance.yml
+++ b/taskcluster/test/params/cron-bitrise-performance.yml
@@ -26,4 +26,4 @@ pushlog_id: '0'
 repository_type: git
 target_tasks_method: bitrise_performance_test
 tasks_for: cron
-version: null
+version: '154.0'

--- a/taskcluster/test/params/cron-firebase-performance.yml
+++ b/taskcluster/test/params/cron-firebase-performance.yml
@@ -26,4 +26,4 @@ pushlog_id: '0'
 repository_type: git
 target_tasks_method: firebase_performance_test
 tasks_for: cron
-version: null
+version: '154.0'

--- a/taskcluster/test/params/main-push.yml
+++ b/taskcluster/test/params/main-push.yml
@@ -27,4 +27,4 @@ pushlog_id: '0'
 repository_type: git
 target_tasks_method: default
 tasks_for: github-push
-version: null
+version: '154.0'

--- a/taskcluster/test/params/pull-request.yml
+++ b/taskcluster/test/params/pull-request.yml
@@ -27,4 +27,4 @@ pushlog_id: '0'
 repository_type: git
 target_tasks_method: default
 tasks_for: github-pull-request
-version: null
+version: '154.0'


### PR DESCRIPTION
## :scroll: Tickets

https://bugzilla.mozilla.org/show_bug.cgi?id=2057499


## :bulb: Description

Changed version to be read from params instead of the file in transforms. Added a slack notification on merge automation success. See commits for details

Ran a test [here](https://firefox-ci-tc.services.mozilla.com/tasks/groups/M_vAIcNTQvyWVLiksSLFXA) on staging. Had to force schedule mark-as-merged because I guess the token for treescript is wrong for the staging repo :shrug: