### PR TITLE
Bugfix FXIOS-16509 [Bookmarks] Prevent New Folder navigation bar shift

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -93,7 +93,7 @@ class EditFolderViewController: UIViewController,
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationController?.setNavigationBarHidden(false, animated: false)
         navigationController?.interactivePopGestureRecognizer?.isEnabled = false
         setTheme(theme)
         onViewWillAppear?()
@@ -110,7 +110,7 @@ class EditFolderViewController: UIViewController,
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if let isDraggingDown = transitionCoordinator?.isInteractive, !isDraggingDown {
-            navigationController?.setNavigationBarHidden(true, animated: true)
+            navigationController?.setNavigationBarHidden(true, animated: false)
         }
         onViewWillDisappear?()
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
@@ -93,7 +93,7 @@ final class GroupedEditFolderViewController: UIViewController,
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationController?.setNavigationBarHidden(false, animated: false)
         navigationController?.interactivePopGestureRecognizer?.isEnabled = false
         setTheme(theme)
         onViewWillAppear?()
@@ -110,7 +110,7 @@ final class GroupedEditFolderViewController: UIViewController,
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if let isDraggingDown = transitionCoordinator?.isInteractive, !isDraggingDown {
-            navigationController?.setNavigationBarHidden(true, animated: true)
+            navigationController?.setNavigationBarHidden(true, animated: false)
         }
         onViewWillDisappear?()
 


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16509)  
[GitHub issue](https://github.com/mozilla-mobile/firefox-ios/issues/35044)

## :bulb: Description

Fixes a vertical shift in the New Folder navigation bar when opening the screen from Bookmarks.

The navigation controller was animating the navigation bar’s visibility at the same time as the New Folder push transition. These overlapping animations caused the back button, title, and Save button to initially appear too high and then shift downward.

This change disables the additional navigation-bar animation when showing and hiding the New Folder screen. It matches the existing behavior in `EditBookmarkViewController`, which previously received the same fix for a similar animation issue.

Validation:

- Fennec build completed successfully
- SwiftLint passed
- Manually verified on an iPhone 17 Simulator running iOS 26.5
- Verified both forward and back navigation transitions
- Confirmed the navigation-bar shift no longer occurs

## :movie_camera: Demos

### Before

The navigation controls shift downward as the push transition completes.

https://github.com/user-attachments/assets/d9b9f9cf-d023-4b17-a086-31406254514e

### After

The navigation controls remain at their final vertical position throughout the transition.

https://github.com/user-attachments/assets/11234ef2-7368-473a-8334-6eaa85495708

## :pencil: Checklist

- [ ] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review — N/A, no telemetry changes
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n — N/A, no string changes
- [x] If needed, I updated documentation and added comments to complex code — N/A, no documentation changes required

## Notes
- This PR is related to https://github.com/mozilla-mobile/firefox-ios/issues/34896