### PR TITLE
Refactor MTE-5695 Implement missing step. Add "config" TestRail link.

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ModernKitOnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ModernKitOnboardingTests.swift
@@ -145,6 +145,7 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
 
         // Address bar choice is onboarding flow screen 2
         onboardingScreen.selectAddressBarPosition(position: .top)
+        onboardingScreen.assertAddressBarPositionSelected(position: .top)
         onboardingScreen.goToNextScreenViaPrimary()
         onboardingScreen.assertTitle()
 
@@ -164,7 +165,7 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
         XCTAssertTrue(toolbar.frame.origin.y < screenHeight / 2, "Toolbar is not near the top")
     }
 
-    // https://mozilla.testrail.io/index.php?/cases/view/4038428
+    // https://mozilla.testrail.io/index.php?/cases/view/4035645 [Config] nav:bottombar
     func testModernKitOnboardingToolbarPlacementBottom() throws {
         if iPad() {
             throw XCTSkip("Toolbar customization is not available on iPad")
@@ -182,6 +183,7 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
 
         // Address bar choice is onboarding flow screen 2
         onboardingScreen.selectAddressBarPosition(position: .bottom)
+        onboardingScreen.assertAddressBarPositionSelected(position: .bottom)
         onboardingScreen.goToNextScreenViaPrimary()
         onboardingScreen.assertTitle()
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/OnboardingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/OnboardingScreen.swift
@@ -211,6 +211,13 @@ final class OnboardingScreen {
         }
     }
 
+    /// Asserts the given address bar position button is selected on the modern flow's segmented control.
+    func assertAddressBarPositionSelected(position: AddressBarPosition) {
+        let button = sel.addressBarTopButton(rootId: rootA11yId, position: position).element(in: app)
+        BaseTestCase().mozWaitForElementToExist(button)
+        XCTAssertTrue(button.isSelected, "\(position.rawValue) address bar position button should be selected")
+    }
+
     /// Exercises the multiple choice buttons on the card to choose your theme.
     func selectThemeButtons() {
         var themes = ["Light", "Dark"]


### PR DESCRIPTION
## :scroll: Tickets
[MTE-5695](https://mozilla-hub.atlassian.net/browse/MTE-5695)
[MTE-5695](https://mozilla-hub.atlassian.net/browse/MTE-5696)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
* Added test names to https://mozilla.testrail.io/index.php?/cases/view/4035645
* Replace TestRail link for testModernKitOnboardingToolbarPlacementBottom()

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code



[MTE-5695]: https://mozilla-hub.atlassian.net/browse/MTE-5695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTE-5695]: https://mozilla-hub.atlassian.net/browse/MTE-5695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ