### PR TITLE
Test #34638 Add edit folder memory leak regression coverage

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
@@ -48,8 +48,13 @@ final class BookmarksCoordinatorTests: XCTestCase {
 
         subject.showBookmarkDetail(for: folder, folder: folder)
 
-        XCTAssertTrue(router.pushedViewController is EditFolderViewController)
+        let controller = router.pushedViewController as? EditFolderViewController
+        XCTAssertNotNil(controller)
+        trackForMemoryLeaks(controller)
         XCTAssertEqual(router.pushCalled, 1)
+        router.pushedViewController = nil
+        router.topViewController = nil
+        router.navigationController.setViewControllers([], animated: false)
     }
 
     func testShowBookmarkDetail_forBookmarkCreation() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
@@ -48,10 +48,20 @@ final class BookmarksCoordinatorTests: XCTestCase {
 
         subject.showBookmarkDetail(for: folder, folder: folder)
 
-        let controller = router.pushedViewController as? EditFolderViewController
-        XCTAssertNotNil(controller)
-        trackForMemoryLeaks(controller)
+        XCTAssertTrue(router.pushedViewController is EditFolderViewController)
         XCTAssertEqual(router.pushCalled, 1)
+    }
+
+    func testShowBookmarksDetail_forFolder_doesNotLeakController() {
+        let subject = createSubject()
+        let folder = LocalDesktopFolder()
+
+        subject.showBookmarkDetail(for: folder, folder: folder)
+
+        guard let controller = router.pushedViewController as? EditFolderViewController else {
+            return XCTFail("Expected EditFolderViewController to be pushed")
+        }
+        trackForMemoryLeaks(controller)
         router.pushedViewController = nil
         router.topViewController = nil
         router.navigationController.setViewControllers([], animated: false)


### PR DESCRIPTION
## :scroll: Tickets
[GitHub issue](https://github.com/mozilla-mobile/firefox-ios/issues/34638)

## :bulb: Description
Adds regression coverage for the `EditFolderViewController` retain cycle.

The test removes the controller from its navigation owners and verifies that it is deallocated. This protects the weak capture in `onViewWillDisappear` from being changed back to a strong capture.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code