### PR TITLE
[MTE-5757] - improve iOS 18 test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -342,6 +342,7 @@
         "ToolbarTests\/testShowToolbarWhenScrollingDefaultOption()",
         "ToolbarTests\/testToolbarIsVisibleAfterTypingInWebPageTextField()",
         "TrackingProtectionTests\/testEnableDisableTPforSite()",
+        "TrackingProtectionTests\/testStandardProtectionLevel()",
         "TrackingProtectionTests\/testStandardProtectionLevel_TAE()",
         "TrackingProtectionTests\/testStandardProtectionLevel_tabTrayExperimentOff()",
         "TrackingProtectionTests\/testStandardProtectionLevel_tabTrayExperimentOn()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -107,7 +107,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
         navigator.performAction(Action.OpenEmailToSignIn)
         mozWaitForElementToExist(app.webViews.firstMatch, timeout: TIMEOUT_LONG)
         if #available(iOS 17, *) {
-            mozWaitForElementToExist(app.webViews.staticTexts["Continue to your ⁨Mozilla account⁩"])
+            mozWaitForElementToExist(app.webViews.staticTexts["Continue to your ⁨Mozilla account⁩"], timeout: TIMEOUT_LONG)
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5757

## :bulb: Description
Small improvement for testTapSignInShowsFxAFromTour by increasing the timeout. "Continue to your ⁨Mozilla account⁩" static text loads slower sometimes.
Also removed testStandardProtectionLevel from full functional test plan.
