### PR TITLE
Bugfix [Lint] Exclude .claude/worktrees from SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -159,6 +159,8 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - MozillaRustComponents/
   - LocalizationTools
   - firefoxios-l10n
+  # Local git worktrees checked out alongside the repo, not part of the tracked source tree
+  - .claude/worktrees
 
 included:
   - /Users/vagrant/git


### PR DESCRIPTION
## :scroll: Tickets
No Jira ticket — small local dev-hygiene fix found while working on another PR.

## :bulb: Description
The pre-push SwiftLint hook runs `swiftlint --strict` over the whole tree, and it was picking up a pile of unrelated violations from `.claude/worktrees/`, a local dev-tooling directory that holds extra git worktrees for other in-progress work. Those aren't part of our source tree and shouldn't be linted. Added the path to `excluded` in `.swiftlint.yml`, same pattern as the other local-tooling exclusions already there (`build/`, `DerivedData/`, etc.).

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code