### PR TITLE
Bugfix [Build] Quote script phase paths so they survive spaces in the repo path

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -19117,7 +19117,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "bash $PWD/bin/sdk_generator.sh -g Glean -o $SRCROOT/Storage/Generated\n";
+			shellScript = "bash \"$PWD/bin/sdk_generator.sh\" -g Glean -o \"$SRCROOT/Storage/Generated\"\n";
 		};
 		5FA2232B27F6FA00005B3D87 /* Glean SDK Generator Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -19139,7 +19139,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "OUTPUT_DIR=\"${SRCROOT}/Client/Generated/Metrics/\"\n# remove old Metrics file if present\nrm \"${SRCROOT}/Client/Generated/Metrics/Metrics.swift\"\nbash $PWD/bin/sdk_generator.sh -g Glean -o $OUTPUT_DIR\n";
+			shellScript = "OUTPUT_DIR=\"${SRCROOT}/Client/Generated/Metrics/\"\n# remove old Metrics file if present\nrm \"${SRCROOT}/Client/Generated/Metrics/Metrics.swift\"\nbash \"$PWD/bin/sdk_generator.sh\" -g Glean -o \"$OUTPUT_DIR\"\n";
 		};
 		5FA2232C27F6FA69005B3D87 /* Nimbus Feature Manifest Generator Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -19161,7 +19161,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$ACTION\" != \"indexbuild\" ]; then\n    /usr/bin/env -i HOME=$HOME PROJECT=$PROJECT CONFIGURATION=$CONFIGURATION SOURCE_ROOT=$SOURCE_ROOT bash \"$SOURCE_ROOT/bin/nimbus-fml.sh\" --verbose\nfi\n\n";
+			shellScript = "if [ \"$ACTION\" != \"indexbuild\" ]; then\n    /usr/bin/env -i HOME=\"$HOME\" PROJECT=\"$PROJECT\" CONFIGURATION=\"$CONFIGURATION\" SOURCE_ROOT=\"$SOURCE_ROOT\" bash \"$SOURCE_ROOT/bin/nimbus-fml.sh\" --verbose\nfi\n\n";
 		};
 		C2A1EA152F4383FE00DD202A /* Run Periphery */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## :scroll: Tickets
No Jira ticket — build issue found incidentally while getting Periphery running for #33128.

## :bulb: Description
The "Glean SDK Generator Script" and "Nimbus Feature Manifest Generator Script" build phases in `Client.xcodeproj` interpolate `$PWD`, `$SRCROOT`, and `$SOURCE_ROOT` unquoted. If the checkout path contains a space (e.g. a macOS account name like "Faris's MacBook Air"), `bash`/`env` word-split the path and the build fails with `No such file or directory` before it ever reaches user code.

Quoted each of these expansions. No behavior change for anyone whose path doesn't contain a space — this only fixes the build for people who hit it.

## :movie_camera: Demos
Not applicable — build-phase script fix, no UI change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code