### PR TITLE
Bugfix FXIOS-13693 [Edit Bookmark][Edit folder] Fix sticky "Save in" header overlapping folder rows

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -36,11 +36,7 @@ class EditBookmarkViewController: UIViewController,
         view.tableHeaderView = headerSpacerView
         view.keyboardDismissMode = .onDrag
     }, {
-        if #available(iOS 26.0, *) {
-            UITableView(frame: .zero, style: .insetGrouped)
-        } else {
-            UITableView()
-        }
+        UITableView(frame: .zero, style: .insetGrouped)
     })
 
     private lazy var saveBarButton: UIBarButtonItem =  {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -43,11 +43,7 @@ class EditFolderViewController: UIViewController,
         view.tableHeaderView = headerSpacerView
         view.keyboardDismissMode = .onDrag
     }, {
-        if #available(iOS 26.0, *) {
-            UITableView(frame: .zero, style: .insetGrouped)
-        } else {
-            UITableView()
-        }
+        UITableView(frame: .zero, style: .insetGrouped)
     })
 
     private lazy var saveBarButton: UIBarButtonItem =  {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13693)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/29695)

## :bulb: Description
On the Edit Bookmark / Edit Folder screens, the "Save in" section header stays pinned to the top and overlaps the folder rows while scrolling.

Root cause: both view controllers gate their table view's style on iOS 26 availability — `.insetGrouped` on 26+, `.plain` everywhere else. `.plain`-style tables pin their section headers while scrolling, which is exactly this bug; `.insetGrouped`/`.grouped` headers scroll away with the content. iOS 26 got this fixed as a side effect of an unrelated rounded-corners change; everything below it kept the old pinning behavior.

Fix: drop the version gate and use `.insetGrouped` on all versions, matching what's already shipping on iOS 26. Pre-26 devices now pick up the same inset/rounded cell look as iOS 26 instead of the old edge-to-edge plain style — that's an intentional visual change and the direct fix for the overlap, not a side effect to work around.

## :movie_camera: Demos
Manual repro/verification pending on a physical device or simulator running iOS 15–25 (the bug doesn't reproduce on 26+, which already had the fix by accident).

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code