### PR TITLE
Bugfix FXIOS-15447 [Menu] Fix Periphery warnings in MenuInfoCell, MenuMainView, MenuSquareView and MenuSquaresViewContentCell

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
@@ -57,7 +57,7 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
     // MARK: - Initializers
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupView(hasInfoTitle: model?.infoTitle != nil)
+        setupView()
     }
 
     required init?(coder: NSCoder) {
@@ -88,7 +88,7 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
         self.separatorInset = .zero
     }
 
-    private func setupView(hasInfoTitle: Bool) {
+    private func setupView() {
         self.addSubview(titleLabel)
         self.addSubview(infoLabelView)
         NSLayoutConstraint.activate([

--- a/BrowserKit/Sources/MenuKit/MenuMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuMainView.swift
@@ -99,6 +99,7 @@ public final class MenuMainView: UIView, ThemeApplicable {
                                               siteProtectionHeaderIdentifier: String,
                                               headerBannerCloseButtonA11yIdentifier: String,
                                               headerBannerCloseButtonA11yLabel: String) {
+        tableView.setupAccessibilityIdentifiers(menuA11yId: menuA11yId, menuA11yLabel: menuA11yLabel)
         headerBanner.setupAccessibility(closeButtonA11yLabel: headerBannerCloseButtonA11yLabel,
                                         closeButtonA11yId: headerBannerCloseButtonA11yIdentifier)
         siteProtectionHeader.setupAccessibility(closeButtonA11yLabel: closeButtonA11yLabel,
@@ -193,11 +194,6 @@ public final class MenuMainView: UIView, ThemeApplicable {
     }
 
     // MARK: - Callbacks
-    @objc
-    private func closeTapped() {
-        closeButtonCallback?()
-    }
-
     @objc
     private func bannerButtonTapped() {
         bannerButtonCallback?()

--- a/BrowserKit/Sources/MenuKit/MenuSquareCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSquareCell.swift
@@ -9,7 +9,6 @@ final class MenuSquareView: UIView, ThemeApplicable {
     private struct UX {
         static let iconSize: CGFloat = 24
         static let backgroundViewCornerRadius: CGFloat = 12
-        static let horizontalMargin: CGFloat = 6
         static let contentViewSpacing: CGFloat = 4
         static let contentViewTopMargin: CGFloat = 12
         static let contentViewBottomMargin: CGFloat = 8

--- a/BrowserKit/Sources/MenuKit/MenuSquaresViewContentCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSquaresViewContentCell.swift
@@ -8,7 +8,6 @@ import Common
 final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeApplicable {
     private struct UX {
         static let contentViewSpacing: CGFloat = 16
-        static let backgroundAlpha: CGFloat = 0.80
     }
 
     private var contentStackView: UIStackView = .build { stack in
@@ -20,7 +19,7 @@ final class MenuSquaresViewContentCell: UITableViewCell, ReusableCell, ThemeAppl
     private var menuData: [MenuSection]
     private var theme: Theme?
 
-    public var mainMenuHelper: MainMenuInterface = MainMenuHelper()
+    private var mainMenuHelper: MainMenuInterface = MainMenuHelper()
 
     private var horizontalTabsSection: MenuSection? {
         return menuData.first(where: { $0.isHorizontalTabsSection })


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15447)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33128)

## :bulb: Description
Cleans up the dead code Periphery flags in the four files named in the issue:

- **MenuInfoCell**: `setupView(hasInfoTitle:)` never used its `hasInfoTitle` parameter — dropped it.
- **MenuMainView**: `closeTapped()` had no `#selector` wiring anywhere in the repo (confirmed with a repo-wide search, careful to distinguish it from same-named-but-unrelated `closeTapped()` methods in `TermsOfUseLinkViewController` and `BottomSheetViewController`, which *are* wired) — removed it. Also noticed `setupAccessibilityIdentifiers`'s `menuA11yId`/`menuA11yLabel` params were accepted but silently dropped instead of applied — wired them through to the table view instead of just deleting them, since that was a real accessibility gap, not just an unused-parameter warning.
- **MenuSquareView** (`MenuSquareCell.swift`) and **MenuSquaresViewContentCell**: each had one unused `UX` constant (`horizontalMargin`, `backgroundAlpha`) — removed. `MenuSquaresViewContentCell.mainMenuHelper` was `public` on an otherwise-internal class with no external caller ever setting it (unlike the sibling `Menu*Cell` types, which all take a `mainMenuHelper` in their `configureCellWith`) — narrowed to `private`.

Left `MenuMainView.isPhoneLandscape` alone — it's write-only, but the setter (`setupMenuMenuOrientation`) is genuinely called from `MainMenuViewController`, and it's the kind of write-only property `retain_assign_only_properties: true` in `.periphery.yml` is meant to suppress.

**Caveat worth flagging to reviewers:** we couldn't get a live Periphery scan running locally (traced to an unrelated build-script bug, fixed separately in #35000), so these fixes are based on manual code reading plus repo-wide searches rather than the tool's own output. Everything here checked out safe under review, but there's a real chance the actual `Periphery` scheme reports a slightly different list — worth a CI run before merge to confirm nothing's missing. Also worth noting: `closeTapped()` was `@objc`, and `.periphery.yml` sets `retain_objc_accessible: true`, so Periphery may not have flagged that one at all — it's still correct to remove (no wiring exists), just maybe not literally what the tool reported.

Verified with `xcodebuild test -scheme MenuKit`: 13/13 tests pass (`MenuKitTests`, `MenuMainViewTests`, `MenuTableViewHelperTests`).

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code