### PR TITLE
Add FXIOS-16477 [WebCompat] Gate the reporter menu entry on telemetry consent

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -699,7 +699,9 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         )
     }
 
+    /// `Equatable` is only here because `MainMenuState` stores a configurator and `StateType`
+    /// requires it. The profile is deliberately left out: this is a stateless helper, not state.
     static func == (lhs: MainMenuConfigurationUtility, rhs: MainMenuConfigurationUtility) -> Bool {
-        return lhs.profile === rhs.profile
+        return true
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -28,12 +28,17 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         static let reportBrokenSite = StandardImageIdentifiers.Large.report
     }
 
+    private let profile: Profile
+
+    init(profile: Profile = AppContainer.shared.resolve()) {
+        self.profile = profile
+    }
+
     private var isReportBrokenSiteOn: Bool {
         featureFlagsProvider.isEnabled(.reportBrokenSite)
     }
 
     private var canSendTechnicalData: Bool {
-        let profile: Profile = AppContainer.shared.resolve()
         return profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
     }
 
@@ -692,5 +697,9 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                 )
             }
         )
+    }
+
+    static func == (lhs: MainMenuConfigurationUtility, rhs: MainMenuConfigurationUtility) -> Bool {
+        return lhs.profile === rhs.profile
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -32,6 +32,11 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         featureFlagsProvider.isEnabled(.reportBrokenSite)
     }
 
+    private var canSendTechnicalData: Bool {
+        let profile: Profile = AppContainer.shared.resolve()
+        return profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true
+    }
+
     private var isSummarizerOn: Bool {
         return DefaultSummarizerNimbusUtils().isSummarizeFeatureToggledOn
     }
@@ -351,6 +356,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         tabInfo: MainMenuTabInfo
     ) -> MenuElement? {
         guard isReportBrokenSiteOn,
+              canSendTechnicalData,
               tabInfo.url?.isWebPage(includeDataURIs: false) == true
         else { return nil }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
@@ -217,18 +217,15 @@ final class MainMenuConfigurationUtilityTests: XCTestCase {
     }
 
     private func hasReportBrokenSiteItem(isTelemetryEnabled: Bool) -> Bool {
-        let profile = MockProfile()
-        profile.prefs.setBool(isTelemetryEnabled, forKey: AppConstants.prefSendUsageData)
-
         let featureFlagProvider = MockNimbusFeatureFlags()
         featureFlagProvider.enabledFlags = [.reportBrokenSite]
+        DependencyHelperMock().bootstrapDependencies(injectedFeatureFlagProvider: featureFlagProvider)
 
-        DependencyHelperMock().bootstrapDependencies(
-            injectedProfile: profile,
-            injectedFeatureFlagProvider: featureFlagProvider
-        )
+        let profile = MockProfile()
+        profile.prefs.setBool(isTelemetryEnabled, forKey: AppConstants.prefSendUsageData)
+        let configurationUtility = MainMenuConfigurationUtility(profile: profile)
 
-        let sections = configUtility.generateMenuElements(
+        let sections = configurationUtility.generateMenuElements(
             with: getTabInfo(url: URL(string: "https://www.mozilla.org")),
             and: windowUUID,
             isExpanded: true

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
@@ -211,6 +211,31 @@ final class MainMenuConfigurationUtilityTests: XCTestCase {
         XCTAssertEqual(translateItem?.a11yHint, expectedHint)
     }
 
+    func test_reportBrokenSiteItem_isHidden_whenTelemetryIsDisabled() {
+        XCTAssertTrue(hasReportBrokenSiteItem(isTelemetryEnabled: true))
+        XCTAssertFalse(hasReportBrokenSiteItem(isTelemetryEnabled: false))
+    }
+
+    private func hasReportBrokenSiteItem(isTelemetryEnabled: Bool) -> Bool {
+        let profile = MockProfile()
+        profile.prefs.setBool(isTelemetryEnabled, forKey: AppConstants.prefSendUsageData)
+
+        let featureFlagProvider = MockNimbusFeatureFlags()
+        featureFlagProvider.enabledFlags = [.reportBrokenSite]
+
+        DependencyHelperMock().bootstrapDependencies(
+            injectedProfile: profile,
+            injectedFeatureFlagProvider: featureFlagProvider
+        )
+
+        let sections = configUtility.generateMenuElements(
+            with: getTabInfo(url: URL(string: "https://www.mozilla.org")),
+            and: windowUUID,
+            isExpanded: true
+        )
+        return sections.flatMap { $0.options }.contains { $0.title == .MainMenu.ToolsSection.ReportBrokenSite }
+    }
+
     private func setIsSummarizerLanguageExpansionEnabled(_ enabled: Bool) {
         FxNimbus.shared.features.summarizerLanguageExpansionFeature.with { _, _ in
             return SummarizerLanguageExpansionFeature(enabled: enabled)
@@ -219,11 +244,12 @@ final class MainMenuConfigurationUtilityTests: XCTestCase {
 
     private func getTabInfo(
         isHomepage: Bool = false,
+        url: URL? = nil,
         translationConfiguration: TranslationConfiguration? = nil
     ) -> MainMenuTabInfo {
         return MainMenuTabInfo(
             tabID: "uuid",
-            url: nil,
+            url: url,
             canonicalURL: nil,
             isHomepage: isHomepage,
             isDefaultUserAgentDesktop: false,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16477)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34994)

## :bulb: Description
The broken site report only ever leaves the device as a Glean ping, so the entry point shouldn't be there when the user has opted out of telemetry.

`configureReportBrokenSiteItem` now also guards on `settings.sendUsageData` (defaults to `true`), alongside the existing Nimbus flag and web-page URL checks. With the setting off the `MenuElement` is never built, so there's nothing to tap — no need to gate the submission path further down.

The menu is regenerated each time it opens, so toggling the setting takes effect on the next open.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

## :test_tube: Testing
1. Load any web page and open the main menu → Tools → More options. **Report Broken Site is listed.**
2. Settings → Support → Send Technical and Interaction Data → **off**.
3. Reopen the main menu on the same page. **Report Broken Site is gone.**
4. Turn the setting back on, reopen the menu. **The entry is back and still opens the reporter.**
