### PR TITLE
[5620] - add close private tabs toggle tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -267,6 +267,8 @@
         "PrivateBrowsingTest\/testLongPressLinkOptionsPrivateMode_tabTrayExperimentOn()",
         "PrivateBrowsingTest\/testMultipleTabsPrivateBrowsingCloseDisabled()",
         "PrivateBrowsingTest\/testMultipleTabsPrivateBrowsingCloseEnabled()",
+        "PrivateBrowsingTest\/testSwitchBetweenPrivateAndNormalBrowsingCloseTabsDisabled()",
+        "PrivateBrowsingTest\/testSwitchBetweenPrivateAndNormalBrowsingCloseTabsEnabled()",
         "PrivateBrowsingTest\/testSwitchBetweenPrivateTabsToastButton()",
         "PrivateBrowsingTest\/testiPadDirectAccessPrivateMode()",
         "PrivateBrowsingTest\/testiPadDirectAccessPrivateModeBrowserTab()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -299,6 +299,12 @@ final class BrowserScreen {
         XCTAssertTrue(hasFocus, "Expected the address bar to have keyboard focus, but it doesn't.")
     }
 
+    func tapWebLink(named name: String, timeout: TimeInterval = TIMEOUT) {
+        let link = sel.linkElement(named: name).element(in: app)
+        BaseTestCase().mozWaitForElementToExist(link, timeout: timeout)
+        link.waitAndTap()
+    }
+
     func longPressLink(named linkName: String, duration: TimeInterval = 2.0) {
         let link = sel.linkElement(named: linkName).element(in: app)
         BaseTestCase().mozWaitForElementToExist(link)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ContextMenuScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ContextMenuScreen.swift
@@ -58,6 +58,12 @@ final class ContextMenuScreen {
         ])
     }
 
+    func openInNewPrivateTab() {
+        let openPrivate = sel.OPEN_IN_NEW_PRIVATE_TAB.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(openPrivate)
+        openPrivate.waitAndTap()
+    }
+
     func openInNewPrivateTabAndSwitch() {
         let openPrivate = sel.OPEN_IN_NEW_PRIVATE_TAB.element(in: app)
         BaseTestCase().mozWaitForElementToExist(openPrivate)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -14,6 +14,12 @@ let url2Label = "Mozilla - Internet for people, not profit (US)"
 let url3Label = "Internet for people, not profit — Mozilla"
 let url4Label = "Form Autofill Demo: Basic @autocomplete"
 
+// Labels and text from the test-example-link.html local fixture
+let newTabLinkLabel = "Open Example Link Page"
+let sectionLinkLabel = "Go to Section Two"
+let exampleLinkPageTitle = "Example Link Page"
+let sectionLoadedText = "You are now in Section Two"
+
 class PrivateBrowsingTest: BaseTestCase {
     typealias HistoryPanelA11y = AccessibilityIdentifiers.LibraryPanels.HistoryPanel
     private var settingScreen: SettingScreen!
@@ -279,6 +285,69 @@ class PrivateBrowsingTest: BaseTestCase {
         openMultipleTabsInPrivateModeAndForceRestart(isClosePrivateTabEnabled: false)
         // All of the previously opened tabs are displayed
         tabTray.assertTabCount(2)
+    }
+
+    // Smoketest
+    // https://mozilla.testrail.io/index.php?/cases/view/3168539
+    func testSwitchBetweenPrivateAndNormalBrowsingCloseTabsDisabled() {
+        // Precondition: keep private tabs on exit so they persist across mode switches
+        navigator.goto(SettingsScreen)
+        settingScreen.disableClosePrivateTabs()
+
+        openPrivateTabsViaDeeplinksThenBrowseNormally()
+
+        // Step 4: Switch back to private browsing; the previously opened tabs persist and work
+        navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
+        tabTray.assertTabCount(2)
+        tabTray.tapTabAtIndex(index: 0)
+        navigator.nowAt(BrowserTab)
+        browserScreen.assertWebPageText(with: exampleLinkPageTitle)
+    }
+
+    // Smoketest
+    // https://mozilla.testrail.io/index.php?/cases/view/3168538
+    func testSwitchBetweenPrivateAndNormalBrowsingCloseTabsEnabled() {
+        // Precondition: close private tabs on exit so they are cleared when leaving private mode
+        navigator.goto(SettingsScreen)
+        settingScreen.enableClosePrivateTabs()
+
+        openPrivateTabsViaDeeplinksThenBrowseNormally()
+
+        // Step 4: Switch back to private browsing; the previous tabs are gone and the homepage is shown
+        navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
+        browserScreen.assertPrivateBrowsingLabelExist()
+    }
+
+    private func openPrivateTabsViaDeeplinksThenBrowseNormally() {
+        // Step 1: In private mode, open a website and open one of its links in a new tab
+        navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.nowAt(BrowserTab)
+        navigator.openURL(path(forTestPage: TestPages.exampleLink))
+        waitUntilPageLoad()
+        browserScreen.longPressLink(named: newTabLinkLabel)
+        contextMenuScreen.openInNewPrivateTab()
+        // Firefox opens a new tab; display it and confirm the correct website loaded
+        navigator.goto(TabTray)
+        tabTray.assertTabCount(2)
+        tabTray.tapTabAtIndex(index: 1)
+        navigator.nowAt(BrowserTab)
+        waitUntilPageLoad()
+        browserScreen.addressToolbarContainValue(value: "localhost")
+        browserScreen.assertWebPageText(with: exampleLinkPageTitle)
+
+        // Step 2: On the same tab, tap a deep link and confirm the new section loads in the same tab
+        browserScreen.tapWebLink(named: sectionLinkLabel)
+        browserScreen.assertWebPageText(with: sectionLoadedText)
+
+        // Step 3: Switch to normal browsing and access a website
+        navigator.toggleOff(userState.isPrivate, withAction: Action.ToggleExperimentRegularMode)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.nowAt(BrowserTab)
+        navigator.openURL(path(forTestPage: TestPages.exampleHTML))
+        waitUntilPageLoad()
+        browserScreen.addressToolbarContainValue(value: "localhost")
+        browserScreen.assertWebPageText(with: TestLabels.exampleDomain)
     }
 
     private func openMultipleTabsInPrivateModeAndForceRestart(isClosePrivateTabEnabled: Bool = true) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TestConstants.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TestConstants.swift
@@ -6,6 +6,7 @@ import Foundation
 
 enum TestPages {
     static let exampleHTML = "test-example.html"
+    static let exampleLink = "test-example-link.html"
     static let mozillaOrg = "test-mozilla-org.html"
     static let findInPage = "find-in-page-test.html"
     static let mozillaBook = "test-mozilla-book.html"

--- a/test-fixtures/test-example-link.html
+++ b/test-fixtures/test-example-link.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Example Link Page</title>
+</head>
+
+<body>
+    <h1 id="top">Example Link Page</h1>
+
+    <!-- Link opened in a new tab; loads this same local page -->
+    <p><a id="open-in-new-tab" href="test-example-link.html">Open Example Link Page</a></p>
+
+    <!-- In-page deep link to another section of the same page -->
+    <p><a id="go-to-section" href="#section-two"
+          onclick="document.getElementById('section-two-text').textContent = 'You are now in Section Two';">Go to Section Two</a></p>
+
+    <div style="height: 2000px"></div>
+
+    <h2 id="section-two">Section Two</h2>
+    <p id="section-two-text"></p>
+</body>
+</html>


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5619
https://mozilla-hub.atlassian.net/browse/MTE-5620

## :bulb: Description
https://mozilla.testrail.io/index.php?/cases/view/3168538
https://mozilla.testrail.io/index.php?/cases/view/3168539

Automated C3168538 and C3168539 — "Switch between Private and Normal browsing" (Close Private Tabs enabled/disabled) — as XCUITests, using a local fixture instead of live sites.

Files changed

- test-fixtures/test-example-link.html (new) — self-contained fixture with a new-tab link and an in-page anchor deeplink (JS-revealed section text). Served via the already-registered test-example-link handler in WebServerUtil.swift.
- XCUITests/PrivateBrowsingTest.swift — two tests (testSwitchBetweenPrivateAndNormalBrowsingCloseTabsDisabled, ...CloseTabsEnabled) sharing a private helper openPrivateTabsViaDeeplinksThenBrowseNormally() for the common Steps 1–3; fixture label/text constants.
- XCUITests/PageScreens/ContextMenuScreen.swift — openInNewPrivateTab() (cross-platform background open, no toast).
- XCUITests/PageScreens/BrowserScreen.swift — tapWebLink(named:).
- XCUITests/TestConstants.swift — TestPages.exampleLink.


