### PR TITLE
Bugfix FXIOS-16479 [Nova] Update toast colors

### DIFF
--- a/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
@@ -65,7 +65,7 @@ private struct NovaLightColourPalette: ThemeColourPalette {
     var textOnDark: UIColor = NovaColors.VioletDesaturated0
     var textOnLight: UIColor = NovaColors.VioletDesaturated90
     var textOnColorPrimary: UIColor = NovaColors.VioletDesaturated0
-    var textToast: UIColor = NovaColors.Violet50
+    var textToast: UIColor = NovaColors.Violet30
 
     // MARK: - Icon
 

--- a/firefox-ios/Client/Frontend/Browser/Toasts/Toast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/Toast.swift
@@ -149,7 +149,7 @@ class Toast: UIView, ThemeApplicable, Notifiable {
         let effectView = UIVisualEffectView()
 
         let glassEffect = UIGlassEffect()
-        glassEffect.tintColor = theme.isNova ? theme.colors.layerGlassTintNova : theme.colors.actionPrimary
+        glassEffect.tintColor = theme.isNova ? theme.colors.layerInverse : theme.colors.actionPrimary
         effectView.effect = glassEffect
 
         effectView.layer.cornerRadius = UX.toastCornerRadius


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16479)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34998)

## :bulb: Description
This PR updates toast design based on [Figma requirements ](https://www.figma.com/design/XrQf2Lqhpi2s5N03lTtJ5h/2026-03-31-nova?node-id=12524-334347&m=dev)
Also, it solves small bug for` textToast `token value on light mode - it should be Violet30, not Violet50.

<img width="1028" height="616" alt="Screenshot 2026-08-03 at 11 08 36" src="https://github.com/user-attachments/assets/75a20f35-d2ac-41f9-8cfb-77a7a5481912" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

