### PR TITLE
Add FXIOS-16431 Update card background color for Nova PrivateMode

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/ShadowCardView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ShadowCardView.swift
@@ -52,7 +52,7 @@ public class ShadowCardView: UIView, ThemeApplicable {
     }
 
     public func applyTheme(theme: Theme) {
-        rootView.backgroundColor = theme.colors.layer2
+        rootView.backgroundColor = theme.isNova ? theme.colors.layer4 : theme.colors.layer2
         setupShadow(theme: theme)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16431)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34912)

## :bulb: Description
Card background in Nova PrivateMode should use layer3 token, based on Figma design.

<img width="551" height="550" alt="Screenshot 2026-08-03 at 16 44 15" src="https://github.com/user-attachments/assets/414e6c9e-4c57-470f-aad9-0c579a25f881" />



## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

