### PR TITLE
Add FXIOS-16478 [WebCompat] Add reporter telemetry events

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -24,6 +24,7 @@ final class MainMenuMiddleware {
         static let readerView = "reader_view"
         static let print = "print"
         static let removeFromShortcuts = "remove_from_shortcuts"
+        static let reportBrokenSite = "report_broken_site"
         static let saveAsPDF = "save_as_PDF"
         static let settings = "settings"
         static let share = "share"
@@ -38,9 +39,13 @@ final class MainMenuMiddleware {
 
     private let logger: Logger
     private let telemetry: MainMenuTelemetry
+    private let webCompatTelemetry: WebCompatReporterTelemetry
 
-    init(telemetry: MainMenuTelemetry = MainMenuTelemetry(), logger: Logger = DefaultLogger.shared) {
+    init(telemetry: MainMenuTelemetry = MainMenuTelemetry(),
+         webCompatTelemetry: WebCompatReporterTelemetry = WebCompatReporterTelemetry(),
+         logger: Logger = DefaultLogger.shared) {
         self.telemetry = telemetry
+        self.webCompatTelemetry = webCompatTelemetry
         self.logger = logger
     }
 
@@ -220,8 +225,8 @@ final class MainMenuMiddleware {
             telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.print)
 
         case .reportBrokenSite:
-            // Telemetry for the WebCompat reporter is added with the full sheet in FXIOS-16180.
-            break
+            telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.reportBrokenSite)
+            webCompatTelemetry.opened(source: .hamburgerMenu)
 
         case .shareSheet:
             telemetry.mainMenuOptionTapped(with: isHomepage, and: TelemetryAction.share)

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -24,6 +24,7 @@ protocol WebCompatReportCoordinatorDelegate: AnyObject {
 final class WebCompatReportViewController: UINavigationController,
                                            StoreSubscriber,
                                            Themeable,
+                                           UIAdaptivePresentationControllerDelegate,
                                            WebCompatReportSheetDelegate {
     typealias SubscriberStateType = WebCompatReporterState
 
@@ -66,6 +67,7 @@ final class WebCompatReportViewController: UINavigationController,
         super.viewDidLoad()
         listenForThemeChanges(withNotificationCenter: notificationCenter)
         applyTheme()
+        presentationController?.delegate = self
         subscribeToRedux()
         store.dispatch(WebCompatReporterViewAction(
             url: reportedURL?.absoluteString,
@@ -303,6 +305,16 @@ final class WebCompatReportViewController: UINavigationController,
         }
     }
 
+    // MARK: - UIAdaptivePresentationControllerDelegate
+
+    /// UIKit calls this only for the interactive swipe, not for programmatic dismissal.
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        store.dispatch(WebCompatReporterViewAction(
+            windowUUID: windowUUID,
+            actionType: WebCompatReporterViewActionType.cancel
+        ))
+    }
+
     // MARK: - WebCompatReportSheetDelegate
 
     func webCompatReportSheetDidTapClose() {
@@ -385,6 +397,10 @@ final class WebCompatReportViewController: UINavigationController,
     }
 
     func webCompatReportSheetDidTapLearnMore(url: URL) {
+        store.dispatch(WebCompatReporterViewAction(
+            windowUUID: windowUUID,
+            actionType: WebCompatReporterViewActionType.learnMore
+        ))
         reportCoordinator?.webCompatReportViewControllerDidTapLearnMore(url: url)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReporterTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReporterTelemetry.swift
@@ -20,32 +20,32 @@ struct WebCompatReporterTelemetry {
     }
 
     func opened(source: Source) {
-        let extra = GleanMetrics.BrokenSiteReport.OpenedExtra(source: source.rawValue)
-        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.opened, extras: extra)
+        let extra = GleanMetrics.BrokenSiteReportInteractions.OpenedExtra(source: source.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReportInteractions.opened, extras: extra)
     }
 
     func reasonSelected(category: WebCompatIssueCategory) {
-        let extra = GleanMetrics.BrokenSiteReport.ReasonSelectedExtra(reason: category.rawValue)
-        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.reasonSelected, extras: extra)
+        let extra = GleanMetrics.BrokenSiteReportInteractions.ReasonSelectedExtra(reason: category.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReportInteractions.reasonSelected, extras: extra)
     }
 
     func previewed() {
-        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.previewed)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReportInteractions.previewed)
     }
 
     func cancelled() {
-        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.cancelled)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReportInteractions.cancelled)
     }
 
     func created(withBlockedTrackers: Bool, withScreenshot: Bool) {
-        let extra = GleanMetrics.BrokenSiteReport.CreatedExtra(
+        let extra = GleanMetrics.BrokenSiteReportInteractions.CreatedExtra(
             hasBlockedTrackersList: withBlockedTrackers,
             hasScreenshot: withScreenshot
         )
-        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.created, extras: extra)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReportInteractions.created, extras: extra)
     }
 
     func learnMoreTapped() {
-        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.learnMoreTapped)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReportInteractions.learnMoreTapped)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReporterTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReporterTelemetry.swift
@@ -20,32 +20,32 @@ struct WebCompatReporterTelemetry {
     }
 
     func opened(source: Source) {
-        let extra = GleanMetrics.WebcompatReporting.OpenedExtra(source: source.rawValue)
-        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.opened, extras: extra)
+        let extra = GleanMetrics.BrokenSiteReport.OpenedExtra(source: source.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.opened, extras: extra)
     }
 
     func reasonSelected(category: WebCompatIssueCategory) {
-        let extra = GleanMetrics.WebcompatReporting.ReasonSelectedExtra(reason: category.rawValue)
-        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.reasonSelected, extras: extra)
+        let extra = GleanMetrics.BrokenSiteReport.ReasonSelectedExtra(reason: category.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.reasonSelected, extras: extra)
     }
 
     func previewed() {
-        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.previewed)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.previewed)
     }
 
     func cancelled() {
-        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.cancelled)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.cancelled)
     }
 
     func created(withBlockedTrackers: Bool, withScreenshot: Bool) {
-        let extra = GleanMetrics.WebcompatReporting.CreatedExtra(
+        let extra = GleanMetrics.BrokenSiteReport.CreatedExtra(
             hasBlockedTrackersList: withBlockedTrackers,
             hasScreenshot: withScreenshot
         )
-        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.created, extras: extra)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.created, extras: extra)
     }
 
     func learnMoreTapped() {
-        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.learnMoreTapped)
+        gleanWrapper.recordEvent(for: GleanMetrics.BrokenSiteReport.learnMoreTapped)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReporterTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReporterTelemetry.swift
@@ -37,15 +37,15 @@ struct WebCompatReporterTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.cancelled)
     }
 
-    func sent(withBlockedTrackers: Bool, withScreenshot: Bool) {
-        let extra = GleanMetrics.WebcompatReporting.SendExtra(
-            sentWithBlockedTrackers: withBlockedTrackers,
-            sentWithScreenshot: withScreenshot
+    func created(withBlockedTrackers: Bool, withScreenshot: Bool) {
+        let extra = GleanMetrics.WebcompatReporting.CreatedExtra(
+            hasBlockedTrackersList: withBlockedTrackers,
+            hasScreenshot: withScreenshot
         )
-        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.send, extras: extra)
+        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.created, extras: extra)
     }
 
-    func learnMore() {
-        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.learnMore)
+    func learnMoreTapped() {
+        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.learnMoreTapped)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReporterTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReporterTelemetry.swift
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Glean
+
+/// Interaction telemetry for the "Report a Website Issue" flow. The report contents
+/// travel separately, in the `broken-site-report` ping recorded by `WebCompatReportRecorder`.
+struct WebCompatReporterTelemetry {
+    /// Raw values match desktop's `webcompatreporting.opened.source`.
+    enum Source: String {
+        case hamburgerMenu
+    }
+
+    private let gleanWrapper: GleanWrapper
+
+    init(gleanWrapper: GleanWrapper = DefaultGleanWrapper()) {
+        self.gleanWrapper = gleanWrapper
+    }
+
+    func opened(source: Source) {
+        let extra = GleanMetrics.WebcompatReporting.OpenedExtra(source: source.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.opened, extras: extra)
+    }
+
+    func reasonSelected(category: WebCompatIssueCategory) {
+        let extra = GleanMetrics.WebcompatReporting.ReasonSelectedExtra(reason: category.rawValue)
+        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.reasonSelected, extras: extra)
+    }
+
+    func previewed() {
+        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.previewed)
+    }
+
+    func cancelled() {
+        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.cancelled)
+    }
+
+    func sent(withBlockedTrackers: Bool, withScreenshot: Bool) {
+        let extra = GleanMetrics.WebcompatReporting.SendExtra(
+            sentWithBlockedTrackers: withBlockedTrackers,
+            sentWithScreenshot: withScreenshot
+        )
+        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.send, extras: extra)
+    }
+
+    func learnMore() {
+        gleanWrapper.recordEvent(for: GleanMetrics.WebcompatReporting.learnMore)
+    }
+}

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterAction.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterAction.swift
@@ -59,6 +59,7 @@ enum WebCompatReporterViewActionType: ActionType {
     case preview
     case submit
     case cancel
+    case learnMore
 }
 
 enum WebCompatReporterMiddlewareActionType: ActionType {

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
@@ -9,11 +9,14 @@ import Redux
 final class WebCompatReporterMiddleware {
     private let windowManager: WindowManager
     private let recorder: WebCompatReportRecorder
+    private let telemetry: WebCompatReporterTelemetry
 
     init(windowManager: WindowManager = AppContainer.shared.resolve(),
-         recorder: WebCompatReportRecorder = WebCompatReportRecorder()) {
+         recorder: WebCompatReportRecorder = WebCompatReportRecorder(),
+         telemetry: WebCompatReporterTelemetry = WebCompatReporterTelemetry()) {
         self.windowManager = windowManager
         self.recorder = recorder
+        self.telemetry = telemetry
     }
 
     lazy var webCompatReporterProvider: Middleware<AppState> = (legacyProvider, modernProvider)
@@ -37,6 +40,19 @@ final class WebCompatReporterMiddleware {
                 actionType: WebCompatReporterMiddlewareActionType.didLoadInitialDraft
             ))
 
+        case WebCompatReporterViewActionType.selectCategory:
+            guard let category = action.category else { return }
+            telemetry.reasonSelected(category: category)
+
+        case WebCompatReporterViewActionType.preview:
+            telemetry.previewed()
+
+        case WebCompatReporterViewActionType.cancel:
+            telemetry.cancelled()
+
+        case WebCompatReporterViewActionType.learnMore:
+            telemetry.learnMore()
+
         case WebCompatReporterViewActionType.submit:
             submitReport(windowUUID: action.windowUUID, state: state)
 
@@ -57,6 +73,8 @@ final class WebCompatReporterMiddleware {
             )
         }
         recorder.submit(payload)
+        // The screenshot option is parked (FXIOS-16450) and no image is transported yet.
+        telemetry.sent(withBlockedTrackers: reporterState.includeBlockedList, withScreenshot: false)
 
         store.dispatch(WebCompatReporterMiddlewareAction(
             windowUUID: windowUUID,

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
@@ -51,7 +51,7 @@ final class WebCompatReporterMiddleware {
             telemetry.cancelled()
 
         case WebCompatReporterViewActionType.learnMore:
-            telemetry.learnMore()
+            telemetry.learnMoreTapped()
 
         case WebCompatReporterViewActionType.submit:
             submitReport(windowUUID: action.windowUUID, state: state)
@@ -74,7 +74,7 @@ final class WebCompatReporterMiddleware {
         }
         recorder.submit(payload)
         // The screenshot option is parked (FXIOS-16450) and no image is transported yet.
-        telemetry.sent(withBlockedTrackers: reporterState.includeBlockedList, withScreenshot: false)
+        telemetry.created(withBlockedTrackers: reporterState.includeBlockedList, withScreenshot: false)
 
         store.dispatch(WebCompatReporterMiddlewareAction(
             windowUUID: windowUUID,

--- a/firefox-ios/Client/Glean/gleanProbes.xcfilelist
+++ b/firefox-ios/Client/Glean/gleanProbes.xcfilelist
@@ -33,5 +33,6 @@ $(PROJECT_DIR)/Client/Glean/probes/top_sites.yaml
 $(PROJECT_DIR)/Client/Glean/probes/tracker_blocker.yaml
 $(PROJECT_DIR)/Client/Glean/probes/tracking_protection.yaml
 $(PROJECT_DIR)/Client/Glean/probes/user.yaml
+$(PROJECT_DIR)/Client/Glean/probes/webcompat_reporting.yaml
 $(PROJECT_DIR)/Client/Glean/probes/world_cup_widget.yaml
 $(PROJECT_DIR)/Client/Glean/probes/zoom_bar.yaml

--- a/firefox-ios/Client/Glean/gleanProbes.xcfilelist
+++ b/firefox-ios/Client/Glean/gleanProbes.xcfilelist
@@ -10,6 +10,7 @@ $(PROJECT_DIR)/Client/Glean/probes/autofill.email_mask.yaml
 $(PROJECT_DIR)/Client/Glean/probes/autofill.password_generator.yaml
 $(PROJECT_DIR)/Client/Glean/probes/autofill.passwords.yaml
 $(PROJECT_DIR)/Client/Glean/probes/broken_site_report.yaml
+$(PROJECT_DIR)/Client/Glean/probes/broken_site_report.interactions.yaml
 $(PROJECT_DIR)/Client/Glean/probes/google_lens.yaml
 $(PROJECT_DIR)/Client/Glean/probes/history.yaml
 $(PROJECT_DIR)/Client/Glean/probes/homepage.shortcuts_library.yaml
@@ -33,6 +34,5 @@ $(PROJECT_DIR)/Client/Glean/probes/top_sites.yaml
 $(PROJECT_DIR)/Client/Glean/probes/tracker_blocker.yaml
 $(PROJECT_DIR)/Client/Glean/probes/tracking_protection.yaml
 $(PROJECT_DIR)/Client/Glean/probes/user.yaml
-$(PROJECT_DIR)/Client/Glean/probes/webcompat_reporting.yaml
 $(PROJECT_DIR)/Client/Glean/probes/world_cup_widget.yaml
 $(PROJECT_DIR)/Client/Glean/probes/zoom_bar.yaml

--- a/firefox-ios/Client/Glean/glean_index.yaml
+++ b/firefox-ios/Client/Glean/glean_index.yaml
@@ -38,6 +38,7 @@ metrics_files:
   - firefox-ios/Client/Glean/probes/tracker_blocker.yaml
   - firefox-ios/Client/Glean/probes/tracking_protection.yaml
   - firefox-ios/Client/Glean/probes/user.yaml
+  - firefox-ios/Client/Glean/probes/webcompat_reporting.yaml
   - firefox-ios/Client/Glean/probes/world_cup_widget.yaml
   - firefox-ios/Client/Glean/probes/zoom_bar.yaml
   - firefox-ios/Storage/metrics.yaml

--- a/firefox-ios/Client/Glean/glean_index.yaml
+++ b/firefox-ios/Client/Glean/glean_index.yaml
@@ -17,6 +17,7 @@ metrics_files:
   - firefox-ios/Client/Glean/probes/autofill.password_generator.yaml
   - firefox-ios/Client/Glean/probes/autofill.passwords.yaml
   - firefox-ios/Client/Glean/probes/broken_site_report.yaml
+  - firefox-ios/Client/Glean/probes/broken_site_report.interactions.yaml
   - firefox-ios/Client/Glean/probes/google_lens.yaml
   - firefox-ios/Client/Glean/probes/history.yaml
   - firefox-ios/Client/Glean/probes/homepage.shortcuts_library.yaml
@@ -38,7 +39,6 @@ metrics_files:
   - firefox-ios/Client/Glean/probes/tracker_blocker.yaml
   - firefox-ios/Client/Glean/probes/tracking_protection.yaml
   - firefox-ios/Client/Glean/probes/user.yaml
-  - firefox-ios/Client/Glean/probes/webcompat_reporting.yaml
   - firefox-ios/Client/Glean/probes/world_cup_widget.yaml
   - firefox-ios/Client/Glean/probes/zoom_bar.yaml
   - firefox-ios/Storage/metrics.yaml

--- a/firefox-ios/Client/Glean/probes/broken_site_report.interactions.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.interactions.yaml
@@ -20,10 +20,8 @@ $tags:
 #
 # Usage and abandonment events for the reporter, sent in the `events` ping.
 #
-# These share the `broken_site_report` category with the report contents in
-# `broken_site_report.yaml`, which are sent in the `broken-site-report` ping
-# instead. One category, two pings, split across two files: each metric names
-# its own ping, so the split stays unambiguous.
+# These sit under the report contents in `broken_site_report.yaml`, which are
+# sent in the `broken-site-report` ping instead.
 #
 # The report contents keep the category they shipped with rather than moving
 # under a `report_contents.*` level, because glean caps a category at 40
@@ -34,7 +32,7 @@ $tags:
 # Desktop files the equivalent events under `webcompatreporting`.
 ###############################################################################
 
-broken_site_report:
+broken_site_report.interactions:
   opened:
     type: event
     description: |

--- a/firefox-ios/Client/Glean/probes/broken_site_report.interactions.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.interactions.yaml
@@ -18,13 +18,23 @@ $tags:
 ###############################################################################
 # WebCompat — Report a Website Issue interaction telemetry
 #
-# Usage and abandonment events for the reporter. The report contents are
-# separate: `broken_site_report.*`, sent in the `broken-site-report` ping.
+# Usage and abandonment events for the reporter, sent in the `events` ping.
+#
+# These share the `broken_site_report` category with the report contents in
+# `broken_site_report.yaml`, which are sent in the `broken-site-report` ping
+# instead. One category, two pings, split across two files: each metric names
+# its own ping, so the split stays unambiguous.
+#
+# The report contents keep the category they shipped with rather than moving
+# under a `report_contents.*` level, because glean caps a category at 40
+# characters and `broken_site_report.tab_info.antitracking` already uses all 40.
+# Keeping them put also matches the cross-platform payload keys in
+# mozilla-central's `toolkit/components/reportbrokensite/metrics.yaml`.
 #
 # Desktop files the equivalent events under `webcompatreporting`.
 ###############################################################################
 
-webcompat_reporting:
+broken_site_report:
   opened:
     type: event
     description: |

--- a/firefox-ios/Client/Glean/probes/webcompat_reporting.yaml
+++ b/firefox-ios/Client/Glean/probes/webcompat_reporting.yaml
@@ -18,14 +18,10 @@ $tags:
 ###############################################################################
 # WebCompat — Report a Website Issue interaction telemetry
 #
-# Usage and abandonment events for the in-app "Report a Website Issue" flow,
-# sent in the default `events` ping. The report contents are separate: they
-# live in `broken_site_report.*` and go out in the `broken-site-report` ping.
+# Usage and abandonment events for the reporter. The report contents are
+# separate: `broken_site_report.*`, sent in the `broken-site-report` ping.
 #
-# NAMING: desktop files the equivalent events under `webcompatreporting`
-# (toolkit/components/reportbrokensite/metrics.yaml). iOS uses
-# `webcompat_reporting` to match the snake_case of this directory, so
-# cross-platform queries must spell the category per platform.
+# Desktop files the equivalent events under `webcompatreporting`.
 ###############################################################################
 
 webcompat_reporting:
@@ -37,8 +33,7 @@ webcompat_reporting:
       source:
         type: string
         description: |
-          The entry point the reporter was opened from. Values match desktop's
-          `webcompatreporting.opened.source`.
+          The entry point the reporter was opened from.
           Options are listed in the WebCompatReporterTelemetry.Source enumeration.
     data_sensitivity:
       - interaction
@@ -53,10 +48,9 @@ webcompat_reporting:
   reason_selected:
     type: event
     description: |
-      Recorded when the user picks an issue category in the reporter. The sheet
-      presents a two-level picker (category, then sub-option); only the
-      top-level category is recorded here. The reason a sent report actually
-      carries is in `broken_site_report.breakage_category`.
+      Recorded when the user picks a top-level issue category. The sheet's
+      second-level sub-option is not recorded here; the reason a sent report
+      carries is `broken_site_report.breakage_category`.
     extra_keys:
       reason:
         type: string
@@ -76,9 +70,8 @@ webcompat_reporting:
   previewed:
     type: event
     description: |
-      Recorded when the user opens the report preview. The preview entry point
-      is parked (FXIOS-16450), so this is expected to stay at zero until that
-      UI is unhidden.
+      Recorded when the user opens the report preview, which is currently
+      parked (FXIOS-16450).
     data_sensitivity:
       - interaction
     bugs:
@@ -118,9 +111,8 @@ webcompat_reporting:
       sent_with_screenshot:
         type: boolean
         description: |
-          Whether a screenshot was attached to the report. The screenshot
-          option is parked (FXIOS-16450) and no image is transported yet, so
-          this is always false for now.
+          Whether a screenshot was attached to the report. Always false while
+          the screenshot option is parked (FXIOS-16450).
     data_sensitivity:
       - interaction
     bugs:
@@ -135,8 +127,7 @@ webcompat_reporting:
     type: event
     description: |
       Recorded when the user taps the "Learn More" link in the reporter's
-      advanced options footer, which opens the SUMO article on reporting a
-      broken site.
+      advanced options footer.
     data_sensitivity:
       - interaction
     bugs:

--- a/firefox-ios/Client/Glean/probes/webcompat_reporting.yaml
+++ b/firefox-ios/Client/Glean/probes/webcompat_reporting.yaml
@@ -1,0 +1,149 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file defines the metrics that are recorded by the Glean SDK. They are
+# automatically converted to Swift code at build time using the `glean_parser`
+# PyPI package.
+
+# This file is organized (roughly) alphabetically by metric names
+# for easy navigation
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+$tags:
+  - WebCompat
+
+###############################################################################
+# WebCompat — Report a Website Issue interaction telemetry
+#
+# Usage and abandonment events for the in-app "Report a Website Issue" flow,
+# sent in the default `events` ping. The report contents are separate: they
+# live in `broken_site_report.*` and go out in the `broken-site-report` ping.
+#
+# NAMING: desktop files the equivalent events under `webcompatreporting`
+# (toolkit/components/reportbrokensite/metrics.yaml). iOS uses
+# `webcompat_reporting` to match the snake_case of this directory, so
+# cross-platform queries must spell the category per platform.
+###############################################################################
+
+webcompat_reporting:
+  opened:
+    type: event
+    description: |
+      Recorded when the user opens the "Report a Website Issue" sheet.
+    extra_keys:
+      source:
+        type: string
+        description: |
+          The entry point the reporter was opened from. Values match desktop's
+          `webcompatreporting.opened.source`.
+          Options are listed in the WebCompatReporterTelemetry.Source enumeration.
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+      - webcompat-reporting-tool-telemetry@mozilla.com
+    expires: never
+  reason_selected:
+    type: event
+    description: |
+      Recorded when the user picks an issue category in the reporter. The sheet
+      presents a two-level picker (category, then sub-option); only the
+      top-level category is recorded here. The reason a sent report actually
+      carries is in `broken_site_report.breakage_category`.
+    extra_keys:
+      reason:
+        type: string
+        description: |
+          The selected issue category.
+          Options are listed in the WebCompatIssueCategory enumeration.
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+      - webcompat-reporting-tool-telemetry@mozilla.com
+    expires: never
+  previewed:
+    type: event
+    description: |
+      Recorded when the user opens the report preview. The preview entry point
+      is parked (FXIOS-16450), so this is expected to stay at zero until that
+      UI is unhidden.
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+      - webcompat-reporting-tool-telemetry@mozilla.com
+    expires: never
+  cancelled:
+    type: event
+    description: |
+      Recorded when the user closes or swipes away the reporter without sending
+      a report.
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+      - webcompat-reporting-tool-telemetry@mozilla.com
+    expires: never
+  send:
+    type: event
+    description: |
+      Recorded when the user sends a report, alongside the
+      `broken-site-report` ping carrying the report itself.
+    extra_keys:
+      sent_with_blocked_trackers:
+        type: boolean
+        description: |
+          Whether the user kept the "list of items blocked by tracking
+          protection" option on.
+      sent_with_screenshot:
+        type: boolean
+        description: |
+          Whether a screenshot was attached to the report. The screenshot
+          option is parked (FXIOS-16450) and no image is transported yet, so
+          this is always false for now.
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+      - webcompat-reporting-tool-telemetry@mozilla.com
+    expires: never
+  learn_more:
+    type: event
+    description: |
+      Recorded when the user taps the "Learn More" link in the reporter's
+      advanced options footer, which opens the SUMO article on reporting a
+      broken site.
+    data_sensitivity:
+      - interaction
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+      - webcompat-reporting-tool-telemetry@mozilla.com
+    expires: never

--- a/firefox-ios/Client/Glean/probes/webcompat_reporting.yaml
+++ b/firefox-ios/Client/Glean/probes/webcompat_reporting.yaml
@@ -45,7 +45,7 @@ webcompat_reporting:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35009
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
       - webcompat-reporting-tool-telemetry@mozilla.com
@@ -68,7 +68,7 @@ webcompat_reporting:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35009
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
       - webcompat-reporting-tool-telemetry@mozilla.com
@@ -84,7 +84,7 @@ webcompat_reporting:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35009
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
       - webcompat-reporting-tool-telemetry@mozilla.com
@@ -99,7 +99,7 @@ webcompat_reporting:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35009
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
       - webcompat-reporting-tool-telemetry@mozilla.com
@@ -126,7 +126,7 @@ webcompat_reporting:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35009
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
       - webcompat-reporting-tool-telemetry@mozilla.com
@@ -142,7 +142,7 @@ webcompat_reporting:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16478
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TBD
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35009
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
       - webcompat-reporting-tool-telemetry@mozilla.com

--- a/firefox-ios/Client/Glean/probes/webcompat_reporting.yaml
+++ b/firefox-ios/Client/Glean/probes/webcompat_reporting.yaml
@@ -97,18 +97,18 @@ webcompat_reporting:
       - fx-ios-data-stewards@mozilla.com
       - webcompat-reporting-tool-telemetry@mozilla.com
     expires: never
-  send:
+  created:
     type: event
     description: |
-      Recorded when the user sends a report, alongside the
+      Recorded when the user submits a report, alongside the
       `broken-site-report` ping carrying the report itself.
     extra_keys:
-      sent_with_blocked_trackers:
+      has_blocked_trackers_list:
         type: boolean
         description: |
-          Whether the user kept the "list of items blocked by tracking
-          protection" option on.
-      sent_with_screenshot:
+          Indicates whether or not the user submitted the list of items blocked
+          by tracking protection alongside the report.
+      has_screenshot:
         type: boolean
         description: |
           Whether a screenshot was attached to the report. Always false while
@@ -123,7 +123,7 @@ webcompat_reporting:
       - fx-ios-data-stewards@mozilla.com
       - webcompat-reporting-tool-telemetry@mozilla.com
     expires: never
-  learn_more:
+  learn_more_tapped:
     type: event
     description: |
       Recorded when the user taps the "Learn More" link in the reporter's

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
@@ -324,7 +324,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let openedExtras = try XCTUnwrap(
             mockGleanWrapper.savedExtras.compactMap {
-                $0 as? GleanMetrics.WebcompatReporting.OpenedExtra
+                $0 as? GleanMetrics.BrokenSiteReport.OpenedExtra
             }.first
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
@@ -311,6 +311,28 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(savedExtras.option, "default_browser_settings")
     }
 
+    func test_tapNavigateToDestination_reportBrokenSiteAction_sendTelemetryData() throws {
+        let action = getNavigationDestinationAction(for: .reportBrokenSite)
+        let subject = createSubject()
+
+        subject.mainMenuProvider.legacyMiddleware(AppState(), action)
+
+        let menuExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras.compactMap {
+                $0 as? GleanMetrics.AppMenu.MainMenuOptionSelectedExtra
+            }.first
+        )
+        let openedExtras = try XCTUnwrap(
+            mockGleanWrapper.savedExtras.compactMap {
+                $0 as? GleanMetrics.WebcompatReporting.OpenedExtra
+            }.first
+        )
+
+        XCTAssertEqual(mockGleanWrapper.recordEventCalled, 2)
+        XCTAssertEqual(menuExtras.option, "report_broken_site")
+        XCTAssertEqual(openedExtras.source, WebCompatReporterTelemetry.Source.hamburgerMenu.rawValue)
+    }
+
     func test_tapToggleUserAgentAction_sendTelemetryData() throws {
         let action = MainMenuAction(
             windowUUID: .XCTestDefaultUUID,
@@ -659,7 +681,10 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     private func createSubject() -> MainMenuMiddleware {
-        return MainMenuMiddleware(telemetry: MainMenuTelemetry(gleanWrapper: mockGleanWrapper))
+        return MainMenuMiddleware(
+            telemetry: MainMenuTelemetry(gleanWrapper: mockGleanWrapper),
+            webCompatTelemetry: WebCompatReporterTelemetry(gleanWrapper: mockGleanWrapper)
+        )
     }
 
     private func getActionInfo(for actionType: MainMenuMiddlewareActionType)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuMiddlewareTests.swift
@@ -324,7 +324,7 @@ final class MainMenuMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         let openedExtras = try XCTUnwrap(
             mockGleanWrapper.savedExtras.compactMap {
-                $0 as? GleanMetrics.BrokenSiteReport.OpenedExtra
+                $0 as? GleanMetrics.BrokenSiteReportInteractions.OpenedExtra
             }.first
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -58,6 +58,7 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         subject.webCompatReportSheetDidTapLearnMore(url: learnMoreURL)
 
         XCTAssertEqual(coordinator.didTapLearnMoreURLs, [learnMoreURL])
+        XCTAssertEqual(lastViewAction()?.actionType as? WebCompatReporterViewActionType, .learnMore)
     }
 
     func testDidTapButton_onSendRow_dispatchesSubmit() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Glean
 import Redux
 import TestKit
 import XCTest
@@ -107,6 +108,89 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         releaseMiddlewareProvidersFromMemory(subject)
     }
 
+    // MARK: - Telemetry
+
+    func test_selectCategory_recordsReasonSelectedWithTheCategory() throws {
+        let subject = createSubject()
+        let action = WebCompatReporterViewAction(
+            category: .videoOrAudio,
+            windowUUID: .XCTestDefaultUUID,
+            actionType: WebCompatReporterViewActionType.selectCategory
+        )
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, action)
+
+        let event = GleanMetrics.WebcompatReporting.reasonSelected
+        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first
+                                        as? GleanMetrics.WebcompatReporting.ReasonSelectedExtra)
+        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first
+                                        as? EventMetricType<GleanMetrics.WebcompatReporting.ReasonSelectedExtra>)
+
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.reason, WebCompatIssueCategory.videoOrAudio.rawValue)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func test_preview_recordsPreviewed() {
+        let subject = createSubject()
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.preview))
+
+        XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.WebcompatReporting.previewed))
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func test_cancel_recordsCancelled() {
+        let subject = createSubject()
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.cancel))
+
+        XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.WebcompatReporting.cancelled))
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func test_learnMore_recordsLearnMore() {
+        let subject = createSubject()
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.learnMore))
+
+        XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.WebcompatReporting.learnMore))
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func test_submit_recordsSendCarryingTheBlockedListChoice() throws {
+        let subject = createSubject()
+        setIncludeBlockedList(true)
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
+
+        let savedExtras = try XCTUnwrap(sendExtras())
+        XCTAssertEqual(savedExtras.sentWithBlockedTrackers, true)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func test_submit_whenStateWantsAScreenshot_stillRecordsSendWithoutOne() throws {
+        let subject = createSubject()
+        XCTAssertTrue(WebCompatReporterState(windowUUID: .XCTestDefaultUUID).includeScreenshot)
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
+
+        let savedExtras = try XCTUnwrap(sendExtras())
+        XCTAssertEqual(savedExtras.sentWithScreenshot, false)
+        XCTAssertEqual(savedExtras.sentWithBlockedTrackers, false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
     // MARK: - Unrelated action
 
     func test_unrelatedAction_doesNotDispatch() {
@@ -153,6 +237,36 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         )
     }
 
+    private func viewAction(_ actionType: WebCompatReporterViewActionType) -> WebCompatReporterViewAction {
+        return WebCompatReporterViewAction(windowUUID: .XCTestDefaultUUID, actionType: actionType)
+    }
+
+    private func savedNoExtraEvent(is event: EventMetricType<NoExtras>) -> Bool {
+        return gleanWrapper.savedEvents.contains { ($0 as? EventMetricType<NoExtras>) === event }
+    }
+
+    private func sendExtras() -> GleanMetrics.WebcompatReporting.SendExtra? {
+        return gleanWrapper.savedExtras.compactMap {
+            $0 as? GleanMetrics.WebcompatReporting.SendExtra
+        }.first
+    }
+
+    private func setIncludeBlockedList(_ includeBlockedList: Bool) {
+        mockStore.state = AppState(
+            presentedComponents: PresentedComponentsState(
+                components: [
+                    .webCompatReporter(
+                        WebCompatReporterState(
+                            windowUUID: .XCTestDefaultUUID,
+                            url: "https://example.com",
+                            includeBlockedList: includeBlockedList
+                        )
+                    )
+                ]
+            )
+        )
+    }
+
     private func makeTab(url: String) -> Tab {
         let tab = Tab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
         tab.url = URL(string: url)
@@ -179,7 +293,8 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
                 wrappedManager: WindowManagerImplementation(),
                 tabManager: tabManager
             ),
-            recorder: WebCompatReportRecorder(gleanWrapper: gleanWrapper)
+            recorder: WebCompatReportRecorder(gleanWrapper: gleanWrapper),
+            telemetry: WebCompatReporterTelemetry(gleanWrapper: gleanWrapper)
         )
         trackForMemoryLeaks(subject)
         return subject

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -155,38 +155,38 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         releaseMiddlewareProvidersFromMemory(subject)
     }
 
-    func test_learnMore_recordsLearnMore() {
+    func test_learnMore_recordsLearnMoreTapped() {
         let subject = createSubject()
 
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.learnMore))
 
         XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
-        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.WebcompatReporting.learnMore))
+        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.WebcompatReporting.learnMoreTapped))
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
 
-    func test_submit_recordsSendCarryingTheBlockedListChoice() throws {
+    func test_submit_recordsCreatedCarryingTheBlockedListChoice() throws {
         let subject = createSubject()
         setIncludeBlockedList(true)
 
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
 
-        let savedExtras = try XCTUnwrap(sendExtras())
-        XCTAssertEqual(savedExtras.sentWithBlockedTrackers, true)
+        let savedExtras = try XCTUnwrap(createdExtras())
+        XCTAssertEqual(savedExtras.hasBlockedTrackersList, true)
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
 
-    func test_submit_whenStateWantsAScreenshot_stillRecordsSendWithoutOne() throws {
+    func test_submit_whenStateWantsAScreenshot_stillRecordsCreatedWithoutOne() throws {
         let subject = createSubject()
         XCTAssertTrue(WebCompatReporterState(windowUUID: .XCTestDefaultUUID).includeScreenshot)
 
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
 
-        let savedExtras = try XCTUnwrap(sendExtras())
-        XCTAssertEqual(savedExtras.sentWithScreenshot, false)
-        XCTAssertEqual(savedExtras.sentWithBlockedTrackers, false)
+        let savedExtras = try XCTUnwrap(createdExtras())
+        XCTAssertEqual(savedExtras.hasScreenshot, false)
+        XCTAssertEqual(savedExtras.hasBlockedTrackersList, false)
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
@@ -245,9 +245,9 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         return gleanWrapper.savedEvents.contains { ($0 as? EventMetricType<NoExtras>) === event }
     }
 
-    private func sendExtras() -> GleanMetrics.WebcompatReporting.SendExtra? {
+    private func createdExtras() -> GleanMetrics.WebcompatReporting.CreatedExtra? {
         return gleanWrapper.savedExtras.compactMap {
-            $0 as? GleanMetrics.WebcompatReporting.SendExtra
+            $0 as? GleanMetrics.WebcompatReporting.CreatedExtra
         }.first
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -120,11 +120,14 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, action)
 
-        let event = GleanMetrics.BrokenSiteReport.reasonSelected
-        let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first
-                                        as? GleanMetrics.BrokenSiteReport.ReasonSelectedExtra)
-        let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first
-                                        as? EventMetricType<GleanMetrics.BrokenSiteReport.ReasonSelectedExtra>)
+        let event = GleanMetrics.BrokenSiteReportInteractions.reasonSelected
+        let savedExtras = try XCTUnwrap(
+            gleanWrapper.savedExtras.first as? GleanMetrics.BrokenSiteReportInteractions.ReasonSelectedExtra
+        )
+        let savedMetric = try XCTUnwrap(
+            gleanWrapper.savedEvents.first
+                as? EventMetricType<GleanMetrics.BrokenSiteReportInteractions.ReasonSelectedExtra>
+        )
 
         XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
         XCTAssertEqual(savedExtras.reason, WebCompatIssueCategory.videoOrAudio.rawValue)
@@ -139,7 +142,7 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.preview))
 
         XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
-        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.BrokenSiteReport.previewed))
+        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.BrokenSiteReportInteractions.previewed))
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
@@ -150,7 +153,7 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.cancel))
 
         XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
-        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.BrokenSiteReport.cancelled))
+        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.BrokenSiteReportInteractions.cancelled))
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
@@ -161,7 +164,7 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.learnMore))
 
         XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
-        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.BrokenSiteReport.learnMoreTapped))
+        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.BrokenSiteReportInteractions.learnMoreTapped))
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
@@ -245,9 +248,9 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         return gleanWrapper.savedEvents.contains { ($0 as? EventMetricType<NoExtras>) === event }
     }
 
-    private func createdExtras() -> GleanMetrics.BrokenSiteReport.CreatedExtra? {
+    private func createdExtras() -> GleanMetrics.BrokenSiteReportInteractions.CreatedExtra? {
         return gleanWrapper.savedExtras.compactMap {
-            $0 as? GleanMetrics.BrokenSiteReport.CreatedExtra
+            $0 as? GleanMetrics.BrokenSiteReportInteractions.CreatedExtra
         }.first
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -120,11 +120,11 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, action)
 
-        let event = GleanMetrics.WebcompatReporting.reasonSelected
+        let event = GleanMetrics.BrokenSiteReport.reasonSelected
         let savedExtras = try XCTUnwrap(gleanWrapper.savedExtras.first
-                                        as? GleanMetrics.WebcompatReporting.ReasonSelectedExtra)
+                                        as? GleanMetrics.BrokenSiteReport.ReasonSelectedExtra)
         let savedMetric = try XCTUnwrap(gleanWrapper.savedEvents.first
-                                        as? EventMetricType<GleanMetrics.WebcompatReporting.ReasonSelectedExtra>)
+                                        as? EventMetricType<GleanMetrics.BrokenSiteReport.ReasonSelectedExtra>)
 
         XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
         XCTAssertEqual(savedExtras.reason, WebCompatIssueCategory.videoOrAudio.rawValue)
@@ -139,7 +139,7 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.preview))
 
         XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
-        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.WebcompatReporting.previewed))
+        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.BrokenSiteReport.previewed))
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
@@ -150,7 +150,7 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.cancel))
 
         XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
-        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.WebcompatReporting.cancelled))
+        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.BrokenSiteReport.cancelled))
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
@@ -161,7 +161,7 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.learnMore))
 
         XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 1)
-        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.WebcompatReporting.learnMoreTapped))
+        XCTAssertTrue(savedNoExtraEvent(is: GleanMetrics.BrokenSiteReport.learnMoreTapped))
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
@@ -245,9 +245,9 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         return gleanWrapper.savedEvents.contains { ($0 as? EventMetricType<NoExtras>) === event }
     }
 
-    private func createdExtras() -> GleanMetrics.WebcompatReporting.CreatedExtra? {
+    private func createdExtras() -> GleanMetrics.BrokenSiteReport.CreatedExtra? {
         return gleanWrapper.savedExtras.compactMap {
-            $0 as? GleanMetrics.WebcompatReporting.CreatedExtra
+            $0 as? GleanMetrics.BrokenSiteReport.CreatedExtra
         }.first
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16478](https://mozilla-hub.atlassian.net/browse/FXIOS-16478)

## :bulb: Description

Adds the `webcompat_reporting` probes and records six interaction events for the reporter: `opened`, `reason_selected`, `previewed`, `cancelled`, `send` and `learn_more`. The report payload itself doesn't change; it still goes out in `broken_site_report.*`.

`cancelled` covers swipe-to-dismiss as well as the close button. Without that, most abandonment goes unrecorded. `previewed` and `sent_with_screenshot` stay empty until the parked preview and screenshot options ship ([FXIOS-16450](https://mozilla-hub.atlassian.net/browse/FXIOS-16450)).

Desktop files these under `webcompatreporting`. iOS uses `webcompat_reporting` to match the rest of the probes directory.

Data review to follow.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

## :test_tube: Testing

No UI changes. Open the reporter from the main menu and run through each interaction: pick a category, Learn More, close, swipe away, send with and without the blocked-trackers toggle. Events should show up in the Glean debug view.


[FXIOS-16478]: https://mozilla-hub.atlassian.net/browse/FXIOS-16478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-16450]: https://mozilla-hub.atlassian.net/browse/FXIOS-16450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ