### PR TITLE
Refactor Use the same swiftlint version for all workflows

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,7 +1,16 @@
 #!/bin/sh
 
 echo "Starting Swiftlint Check..."
-swiftlint --strict --quiet
+
+# The version is pinned in .swiftlint-version
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SWIFTLINT=$("$REPO_ROOT/scripts/install-swiftlint.sh")
+if [ -z "$SWIFTLINT" ]; then
+    echo "Could not install the pinned SwiftLint version. Run ./bootstrap.sh from the repo root."
+    exit 1
+fi
+
+"$SWIFTLINT" --strict --quiet
 RESULT=$?
 
 if [ $RESULT -ne 0 ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,9 @@ shavar-*
 # Licenses.html generation
 LicensePlistTemp
 
+# Pinned developer tools installed by scripts/install-swiftlint.sh
+.tools/
+
 # Claude Code
 .claude/settings.local.json
 .mcp.json

--- a/.swiftlint-version
+++ b/.swiftlint-version
@@ -1,0 +1,10 @@
+# The SwiftLint version used by every local and CI lint run in this repo.
+# Installed by scripts/install-swiftlint.sh into .tools/swiftlint/<version>/.
+#
+# To upgrade, bump both fields together. The checksum is the SHA-256 of the
+# release's portable_swiftlint.zip asset:
+#
+#   curl -sL https://github.com/realm/SwiftLint/releases/download/<version>/portable_swiftlint.zip | shasum -a 256
+#
+version=0.65.0
+sha256=d6cb0aa7a2f5f1ef306fc9e37bcb54dc9a26facc8f7784ac0c3dd3eccf5c6ba6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ We add the "Contributor Fix" label on tasks that have a PR opened for it, or if 
 * Use 4-space indentation instead of 2  
 * Follow existing patterns in the codebase when in doubt  
 
-We use [Swiftlint rules](https://github.com/mozilla-mobile/firefox-ios/blob/main/.swiftlint.yml) in both local and CI builds to ensure conformance to accepted rules. You can run Swiftlint by installing it [locally with Homebrew](https://github.com/realm/SwiftLint#using-homebrew). Swiftlint will then be run through Xcode Build Phases on the Client target.
+We use [Swiftlint rules](https://github.com/mozilla-mobile/firefox-ios/blob/main/.swiftlint.yml) in both local and CI builds to ensure conformance to accepted rules. The version is pinned in `.swiftlint-version` so that every engineer and CI lint with the same version; `./bootstrap.sh` installs it into `.tools/` for you, and you can install it on its own with `./scripts/install-swiftlint.sh`. Don't install Swiftlint through Homebrew for this project — a Homebrew install is no longer used by the build. Swiftlint is then run through Xcode Build Phases on the Client target.
 
 ### Quality expectations for pull requests
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -765,10 +765,34 @@ workflows:
             brew install fxios
             fxios bootstrap
         title: Run bootstrap
-    - swiftlint-extended@1:
+    - script@1:
+        title: Run swiftlint
         inputs:
-        - linting_path: "$BITRISE_SOURCE_DIR"
-        - lint_config_file: ""  # Don't pass a config file to make use of nested configurations
+        - content: |-
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            cd "$BITRISE_SOURCE_DIR"
+
+            # Use the version pinned in .swiftlint-version rather than whichever
+            # version the stack happens to ship, so that CI and local runs match
+            SWIFTLINT=$(./scripts/install-swiftlint.sh)
+            "$SWIFTLINT" version
+
+            # Lint from the repo root and don't pass a config file, to make use
+            # of nested configurations. Violations are written to stdout, while
+            # progress and the summary go to stderr.
+            REPORT="$BITRISE_DEPLOY_DIR/swiftlint_report.txt"
+            set +e
+            "$SWIFTLINT" lint > "$REPORT"
+            set -e
+
+            cat "$REPORT"
+
+            # Left unset when there are no violations, which the next step reads
+            if [ -s "$REPORT" ]; then
+                envman add --key SWIFTLINT_REPORT --valuefile "$REPORT"
+            fi
     - deploy-to-bitrise-io@2: {}
     - script@1:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -789,6 +789,23 @@ workflows:
 
             cat "$REPORT"
 
+            # Publish the violations as a test report as well, so that swiftlint
+            # gets its own entry on the pull request alongside the UI test ones.
+            # SwiftLint takes a single reporter per run, so this is a second pass
+            # rather than a second output format; it hits SwiftLint's cache from
+            # the run above. A run with no violations still writes a test suite,
+            # which is what keeps the entry visible when linting passes.
+            if [ -n "${BITRISE_TEST_RESULT_DIR:-}" ]; then
+                RESULT_DIR="$BITRISE_TEST_RESULT_DIR/swiftlint"
+                mkdir -p "$RESULT_DIR"
+                set +e
+                "$SWIFTLINT" lint --reporter junit > "$RESULT_DIR/swiftlint.xml"
+                set -e
+                echo '{"test-name":"swiftlint"}' > "$RESULT_DIR/test-info.json"
+            else
+                echo "BITRISE_TEST_RESULT_DIR is unset, skipping the swiftlint test report"
+            fi
+
             # Left unset when there are no violations, which the next step reads
             if [ -s "$REPORT" ]; then
                 envman add --key SWIFTLINT_REPORT --valuefile "$REPORT"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,6 +11,9 @@
 # Default argument is "firefox"
 PRODUCT="${1:-firefox}"
 
+# Install the swiftlint version pinned in .swiftlint-version
+./scripts/install-swiftlint.sh > /dev/null
+
 if [[ "$PRODUCT" == "firefox" ]]; then
     echo "Running Firefox bootstrap..."
     

--- a/docs/xcode-upgrade.md
+++ b/docs/xcode-upgrade.md
@@ -171,3 +171,4 @@ xcodebuild test -scheme Fennec -testPlan Smoketest \
 
 - **Edge vs stable Bitrise stack.** The `-edge` stack ships new Xcode versions first but its simulator runtimes are sometimes incomplete. If parallel UI tests hang during the test launch phase (build succeeds, sims boot, but no `Test Case` output ever appears), switch to the non-edge stack.
 - **iOS version trailing Xcode version.** Apple sometimes ships e.g. Xcode 26.5 with an iOS 26.4.1 default simulator runtime. Check `xcrun simctl list runtimes` and pick the latest installed; the iOS version in destinations may lag by a patch.
+- **`Initialize CoreSimulator` warm-up steps.** Earlier upgrades added `xcrun simctl list` as a warm-up script before xcodebuild. These are usually safe to remove once the stack is stable.

--- a/docs/xcode-upgrade.md
+++ b/docs/xcode-upgrade.md
@@ -171,5 +171,3 @@ xcodebuild test -scheme Fennec -testPlan Smoketest \
 
 - **Edge vs stable Bitrise stack.** The `-edge` stack ships new Xcode versions first but its simulator runtimes are sometimes incomplete. If parallel UI tests hang during the test launch phase (build succeeds, sims boot, but no `Test Case` output ever appears), switch to the non-edge stack.
 - **iOS version trailing Xcode version.** Apple sometimes ships e.g. Xcode 26.5 with an iOS 26.4.1 default simulator runtime. Check `xcrun simctl list runtimes` and pick the latest installed; the iOS version in destinations may lag by a patch.
-- **SwiftLint pinning.** Past upgrades have required a `Pin swiftlint version` workaround step in `bitrise.yml`. Once the toolchain catches up, remove that workaround.
-- **`Initialize CoreSimulator` warm-up steps.** Earlier upgrades added `xcrun simctl list` as a warm-up script before xcodebuild. These are usually safe to remove once the stack is stable.

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -19206,7 +19206,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\nSWIFTLINT_ROOT=\"${SRCROOT}/..\"\n\nif which swiftlint > /dev/null; then\n    # Move to the location of the root Swiftlint config file in\n    # order to use nested configurations\n    cd ${SWIFTLINT_ROOT}\n\n    swiftlint lint ${MODIFIED_FILES}\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\" \nfi\n";
+			shellScript = "SWIFTLINT_ROOT=\"${SRCROOT}/..\"\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\n# The version is pinned in .swiftlint-version and installed by bootstrap.sh\nSWIFTLINT=$(\"${SWIFTLINT_ROOT}/scripts/install-swiftlint.sh\" --path-only)\n\nif [ -n \"${SWIFTLINT}\" ]; then\n    # Move to the location of the root Swiftlint config file in\n    # order to use nested configurations\n    cd ${SWIFTLINT_ROOT}\n\n    \"${SWIFTLINT}\" lint ${MODIFIED_FILES}\nelse\n    echo \"warning: pinned SwiftLint not installed, run ./bootstrap.sh from the repo root\"\nfi\n";
 		};
 		D48146712E26CB3300231244 /* Populate test-fixtures script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/focus-ios/Blockzilla.xcodeproj/project.pbxproj
+++ b/focus-ios/Blockzilla.xcodeproj/project.pbxproj
@@ -2550,7 +2550,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]; then\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\nSWIFTLINT_ROOT=\"${SRCROOT}/..\"\n\nif which swiftlint > /dev/null; then\n    # Move to the location of the root Swiftlint config file in\n    # order to use nested configurations\n    cd ${SWIFTLINT_ROOT}\n\n    swiftlint lint ${MODIFIED_FILES}\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\" \nfi\n";
+			shellScript = "SWIFTLINT_ROOT=\"${SRCROOT}/..\"\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\n# The version is pinned in .swiftlint-version and installed by bootstrap.sh\nSWIFTLINT=$(\"${SWIFTLINT_ROOT}/scripts/install-swiftlint.sh\" --path-only)\n\nif [ -n \"${SWIFTLINT}\" ]; then\n    # Move to the location of the root Swiftlint config file in\n    # order to use nested configurations\n    cd ${SWIFTLINT_ROOT}\n\n    \"${SWIFTLINT}\" lint ${MODIFIED_FILES}\nelse\n    echo \"warning: pinned SwiftLint not installed, run ./bootstrap.sh from the repo root\"\nfi\n";
 		};
 		D5D067F9252F939600C35227 /* Glean */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/scripts/install-swiftlint.sh
+++ b/scripts/install-swiftlint.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
+#
+
+#
+# Installs the SwiftLint version pinned in .swiftlint-version and prints the
+# path to the binary on stdout. Everything else goes to stderr, so callers can
+# do:
+#
+#   SWIFTLINT=$(scripts/install-swiftlint.sh)
+#   "$SWIFTLINT" lint
+#
+# Usage:
+#   scripts/install-swiftlint.sh              Install if missing, print path.
+#   scripts/install-swiftlint.sh --path-only  Print path if already installed,
+#                                             exit 1 without downloading. Used
+#                                             by the Xcode build phases so a
+#                                             build never blocks on a download.
+#
+
+set -eu
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+VERSION_FILE="$REPO_ROOT/.swiftlint-version"
+
+if [ ! -f "$VERSION_FILE" ]; then
+    echo "error: $VERSION_FILE not found" >&2
+    exit 1
+fi
+
+# Reads a `key=value` field from the version file, ignoring comments.
+read_field() {
+    sed -n "s/^$1[[:space:]]*=[[:space:]]*\([^[:space:]#]*\).*/\1/p" "$VERSION_FILE" | head -1
+}
+
+VERSION=$(read_field version)
+EXPECTED_SHA=$(read_field sha256)
+
+if [ -z "$VERSION" ] || [ -z "$EXPECTED_SHA" ]; then
+    echo "error: $VERSION_FILE must define both 'version' and 'sha256'" >&2
+    exit 1
+fi
+
+INSTALL_DIR="$REPO_ROOT/.tools/swiftlint/$VERSION"
+BIN="$INSTALL_DIR/swiftlint"
+
+if [ "${1:-}" = "--path-only" ]; then
+    if [ -x "$BIN" ]; then
+        echo "$BIN"
+        exit 0
+    fi
+    exit 1
+fi
+
+if [ -x "$BIN" ]; then
+    echo "SwiftLint $VERSION already installed." >&2
+    echo "$BIN"
+    exit 0
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Installing SwiftLint $VERSION." >&2
+curl --proto '=https' --tlsv1.2 -sSfL \
+    -o "$TMP_DIR/portable_swiftlint.zip" \
+    "https://github.com/realm/SwiftLint/releases/download/$VERSION/portable_swiftlint.zip" >&2
+
+ACTUAL_SHA=$(shasum -a 256 "$TMP_DIR/portable_swiftlint.zip" | cut -d ' ' -f 1)
+if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+    echo "error: checksum mismatch for SwiftLint $VERSION" >&2
+    echo "  expected: $EXPECTED_SHA" >&2
+    echo "  actual:   $ACTUAL_SHA" >&2
+    echo "Refusing to install. Update .swiftlint-version if the pin is stale." >&2
+    exit 1
+fi
+
+unzip -q "$TMP_DIR/portable_swiftlint.zip" -d "$TMP_DIR/unpacked"
+mkdir -p "$INSTALL_DIR"
+cp "$TMP_DIR/unpacked/LICENSE" "$INSTALL_DIR/LICENSE"
+
+# Move into place under a temporary name first so that concurrent installs
+# (for example a build phase racing the pre-push hook) can't observe a
+# partially written binary.
+chmod +x "$TMP_DIR/unpacked/swiftlint"
+mv "$TMP_DIR/unpacked/swiftlint" "$INSTALL_DIR/swiftlint.$$"
+mv "$INSTALL_DIR/swiftlint.$$" "$BIN"
+
+echo "$BIN"

--- a/setup_build_tools.sh
+++ b/setup_build_tools.sh
@@ -57,13 +57,8 @@ else
 fi
 
 #
-# Check if swiftlint is installed
+# Install the swiftlint version pinned in .swiftlint-version. Deliberately not
+# installed through Homebrew so that every engineer and CI run lint with the
+# same version.
 #
-which -s swiftlint
-if [[ $? != 0 ]] ; then
-    # Install swiftlint
-	echo "Installing swiftlint."
-    brew install swiftlint
-else
-	echo "Swiftlint already installed"
-fi
+"$(dirname "$0")/scripts/install-swiftlint.sh" > /dev/null


### PR DESCRIPTION
## :bulb: Description
Upgrade the Swiftlint workflows so that they are all pointed at the same version of Swiftlint

This PR pins Swiftlint in one place:
- `.swiftlint-version` holds the version (0.65.0) and the SHA-256 of the release asset.
- `scripts/install-swiftlint.sh` downloads and checksum-verifies that release into `.tools/swiftlint/<version>/` (gitignored).
- Both Xcode build phases (Client and Blockzilla), the pre-push hook, `bootstrap.sh`, `setup_build_tools.sh` and Bitrise now use that binary. On CI the `swiftlint-extended` step is replaced by a script step that runs it and exports the same `SWIFTLINT_REPORT`.

To upgrade, bump the two fields in `.swiftlint-version`.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

