### PR TITLE
Add FXIOS-16496 [Nova] Update background for context menu

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -274,14 +274,14 @@ class PhotonActionSheet: UIViewController,
 
         // In a popover the popover provides the blur background
         if viewModel.presentationStyle == .popover {
-            view.backgroundColor = theme.colors.layer1
+            view.backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer1
         } else if UIAccessibility.isReduceTransparencyEnabled {
             backgroundBlurView?.alpha = 0.0
 
             // Remove the visual effect and the background alpha
             (tableView.backgroundView as? UIVisualEffectView)?.effect = nil
-            tableView.backgroundView?.backgroundColor = theme.colors.layer1
-            tableView.backgroundColor = theme.colors.layer1
+            tableView.backgroundView?.backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer1
+            tableView.backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer1
         } else {
             backgroundBlurView?.alpha = 1.0
 
@@ -294,10 +294,12 @@ class PhotonActionSheet: UIViewController,
                 let blurEffectView = UIVisualEffectView(effect: blurEffect)
                 tableView.backgroundView = blurEffectView
             }
-            tableView.backgroundView?.backgroundColor = theme.colors.layer1.withAlphaComponent(0.9)
+            tableView.backgroundView?.backgroundColor = theme.isNova
+                ? theme.colors.layerSurfaceMedium.withAlphaComponent(0.9)
+                : theme.colors.layer1.withAlphaComponent(0.9)
         }
 
-        closeButton.backgroundColor = theme.colors.layer1
+        closeButton.backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer1
         closeButton.setTitleColor(theme.colors.actionPrimary, for: .normal)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16496)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35027)

## :bulb: Description

This PR updates the background for context menu using `layerSurfaceMedium` token for Nova design.


<img width="777" height="610" alt="Screenshot 2026-08-04 at 17 12 47" src="https://github.com/user-attachments/assets/32818556-9e3c-454f-a656-3caf68fb1975" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

