### PR TITLE
Add FXIOS-16494 [Nova] Replace Form and List background token

### DIFF
--- a/BrowserKit/Sources/Common/Theming/NovaDarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaDarkTheme.swift
@@ -151,7 +151,7 @@ private struct NovaDarkColourPalette: ThemeColourPalette {
     var iconAccentYellow: UIColor = DarkTheme().colors.iconAccentYellow
 
     // MARK: - Deprecated
-    var layer5: UIColor = DarkTheme().colors.layer5
+    var layer5: UIColor { layerSurfaceMedium }
     var layerGradientOverlay: Gradient = DarkTheme().colors.layerGradientOverlay
     var layerHomepage: Gradient = DarkTheme().colors.layerHomepage
     var layerAccentNonOpaque: UIColor = DarkTheme().colors.layerAccentNonOpaque

--- a/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
@@ -138,7 +138,7 @@ private struct NovaLightColourPalette: ThemeColourPalette {
     var iconAccentYellow: UIColor = LightTheme().colors.iconAccentYellow
 
     // MARK: - Deprecated
-    var layer5: UIColor = LightTheme().colors.layer5
+    var layer5: UIColor { layerSurfaceMedium }
     var layerGradientOverlay: Gradient = LightTheme().colors.layerGradientOverlay
     var layerHomepage: Gradient = LightTheme().colors.layerHomepage
     var layerAccentNonOpaque: UIColor = LightTheme().colors.layerAccentNonOpaque

--- a/BrowserKit/Sources/Common/Theming/NovaPrivateTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaPrivateTheme.swift
@@ -138,7 +138,7 @@ private struct NovaPrivateColourPalette: ThemeColourPalette {
     var iconAccentYellow: UIColor = PrivateModeTheme().colors.iconAccentYellow
 
     // MARK: - Deprecated
-    var layer5: UIColor = PrivateModeTheme().colors.layer5
+    var layer5: UIColor { layerSurfaceMedium }
     var layerGradientOverlay: Gradient = PrivateModeTheme().colors.layerGradientOverlay
     var layerHomepage: Gradient = PrivateModeTheme().colors.layerHomepage
     var layerAccentNonOpaque: UIColor = PrivateModeTheme().colors.layerAccentNonOpaque


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16494)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35026)

## :bulb: Description
For Nova design system, layer5 token is deprecated. This PR replaces it with layerSurfaceMedium token, only for Nova. Old themes still use layer5. This token is used for forms and lists background.

<img width="523" height="514" alt="Screenshot 2026-08-04 at 17 35 01" src="https://github.com/user-attachments/assets/512d3c6e-ae56-4ec2-b86b-241600be7833" />
<img width="496" height="160" alt="Screenshot 2026-08-04 at 17 36 01" src="https://github.com/user-attachments/assets/254eef68-c3fd-4930-a8ed-d6ea732c9fe1" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

