### PR TITLE
Enable FXIOS-16506 Enable interactive gesture by default in nightly

### DIFF
--- a/firefox-ios/nimbus-features/addressBarGestureToOpenTabTrayFeature.yaml
+++ b/firefox-ios/nimbus-features/addressBarGestureToOpenTabTrayFeature.yaml
@@ -27,6 +27,6 @@ features:
           enabled_closetab: true
       - channel: developer
         value:
-          enabled_swipe: true
-          enabled_interactive: false
-          enabled_closetab: false
+          enabled_swipe: false
+          enabled_interactive: true
+          enabled_closetab: true

--- a/firefox-ios/nimbus-features/addressBarGestureToOpenTabTrayFeature.yaml
+++ b/firefox-ios/nimbus-features/addressBarGestureToOpenTabTrayFeature.yaml
@@ -23,8 +23,8 @@ features:
       - channel: beta
         value:
           enabled_swipe: false
-          enabled_interactive: false
-          enabled_closetab: false
+          enabled_interactive: true
+          enabled_closetab: true
       - channel: developer
         value:
           enabled_swipe: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16506)
<!-- [Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO) -->

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Enabled the interactive gesture feature flags by default in beta/nightly builds

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

