### PR TITLE
Bugfix FXIOS-16345 testSettingsRoute_whenModalIsPresented_dismissesModalBeforeShowingSettings flaky test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1151,6 +1151,9 @@ final class BrowserCoordinatorTests: XCTestCase,
 
         subject.handle(route: .settings(section: .appIcon))
 
+        // Wait for a pending main-thread transition settle before asserting
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+
         XCTAssertEqual(presentedViewController.dismissCalled, 1)
         let presentedNavigationController = try XCTUnwrap(
             mockRouter.presentedViewController as? ThemedNavigationController


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16345)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35030)

## :bulb: Description
- Fix flaky test by waiting for transition to finish

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

