### PR TITLE
Bugfix FXIOS-16480 [WebCompat] Order Report Broken Site after Website Dark Mode

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -276,8 +276,11 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
             if isSummarizerLanguageExpansionEnabled {
                 options.append(configureReaderViewItem(with: uuid, tabInfo: tabInfo))
             }
+            options.append(configureWebsiteDarkModeItem(with: uuid, and: tabInfo))
+            if let reportBrokenSiteItem = configureReportBrokenSiteItem(with: uuid, tabInfo: tabInfo) {
+                options.append(reportBrokenSiteItem)
+            }
             options.append(contentsOf: [
-                configureWebsiteDarkModeItem(with: uuid, and: tabInfo),
                 configureShortcutsItem(with: uuid, and: tabInfo),
                 MenuElement(
                     title: .MainMenu.Submenus.Save.SaveAsPDF,
@@ -349,9 +352,6 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                     }
                 ),
             ])
-            if let reportBrokenSiteItem = configureReportBrokenSiteItem(with: uuid, tabInfo: tabInfo) {
-                options.append(reportBrokenSiteItem)
-            }
         }
         return MenuSection(isExpanded: isExpanded, options: options)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
@@ -216,21 +216,52 @@ final class MainMenuConfigurationUtilityTests: XCTestCase {
         XCTAssertFalse(hasReportBrokenSiteItem(isTelemetryEnabled: false))
     }
 
-    private func hasReportBrokenSiteItem(isTelemetryEnabled: Bool) -> Bool {
-        let featureFlagProvider = MockNimbusFeatureFlags()
-        featureFlagProvider.enabledFlags = [.reportBrokenSite]
-        DependencyHelperMock().bootstrapDependencies(injectedFeatureFlagProvider: featureFlagProvider)
+    func test_reportBrokenSiteItem_isHidden_whenFlagIsDisabled() {
+        XCTAssertFalse(hasReportBrokenSiteItem(isReportBrokenSiteEnabled: false))
+    }
 
-        let profile = MockProfile()
-        profile.prefs.setBool(isTelemetryEnabled, forKey: AppConstants.prefSendUsageData)
-        let configurationUtility = MainMenuConfigurationUtility(profile: profile)
+    func test_reportBrokenSiteItem_isPlacedBetweenWebsiteDarkModeAndShortcuts() throws {
+        let sections = makeConfigurationUtility().generateMenuElements(
+            with: getTabInfo(url: URL(string: "https://www.mozilla.org")),
+            and: windowUUID,
+            isExpanded: true
+        )
+        let titles = try XCTUnwrap(sections.first).options.map { $0.title }
 
-        let sections = configurationUtility.generateMenuElements(
+        let websiteDarkModeIndex = try XCTUnwrap(titles.firstIndex(of: .MainMenu.Submenus.Tools.WebsiteDarkMode))
+        let reportBrokenSiteIndex = try XCTUnwrap(titles.firstIndex(of: .MainMenu.ToolsSection.ReportBrokenSite))
+        let shortcutsIndex = try XCTUnwrap(titles.firstIndex(of: .MainMenu.Submenus.Save.AddToShortcuts))
+
+        XCTAssertEqual(reportBrokenSiteIndex, websiteDarkModeIndex + 1)
+        XCTAssertEqual(shortcutsIndex, reportBrokenSiteIndex + 1)
+    }
+
+    private func hasReportBrokenSiteItem(
+        isReportBrokenSiteEnabled: Bool = true,
+        isTelemetryEnabled: Bool = true
+    ) -> Bool {
+        let sections = makeConfigurationUtility(
+            isReportBrokenSiteEnabled: isReportBrokenSiteEnabled,
+            isTelemetryEnabled: isTelemetryEnabled
+        ).generateMenuElements(
             with: getTabInfo(url: URL(string: "https://www.mozilla.org")),
             and: windowUUID,
             isExpanded: true
         )
         return sections.flatMap { $0.options }.contains { $0.title == .MainMenu.ToolsSection.ReportBrokenSite }
+    }
+
+    private func makeConfigurationUtility(
+        isReportBrokenSiteEnabled: Bool = true,
+        isTelemetryEnabled: Bool = true
+    ) -> MainMenuConfigurationUtility {
+        let featureFlagProvider = MockNimbusFeatureFlags()
+        featureFlagProvider.enabledFlags = isReportBrokenSiteEnabled ? [.reportBrokenSite] : []
+        DependencyHelperMock().bootstrapDependencies(injectedFeatureFlagProvider: featureFlagProvider)
+
+        let profile = MockProfile()
+        profile.prefs.setBool(isTelemetryEnabled, forKey: AppConstants.prefSendUsageData)
+        return MainMenuConfigurationUtility(profile: profile)
     }
 
     private func setIsSummarizerLanguageExpansionEnabled(_ enabled: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16480](https://mozilla-hub.atlassian.net/browse/FXIOS-16480)

## :bulb: Description
Report Broken Site was appended after the whole Tools list, so it rendered last, below Share. Moved between Website Dark Mode and Add to Shortcuts to match Figma. Position only, same gating.

Also collapses the two ways this test file toggled the flag onto the injected `MockNimbusFeatureFlags` from [FXIOS-16477](https://mozilla-hub.atlassian.net/browse/FXIOS-16477).

## :movie_camera: Demos
<img height="700" alt="Screenshot 2026-08-05 at 11 33 39" src="https://github.com/user-attachments/assets/2ee1378b-0ca2-4356-bf3d-30ec7e1e8360" />


## Testing
On a web page with the flag and technical data on, expand Tools in the main menu: Report Broken Site should sit between Website Dark Mode and Add to Shortcuts. Turning technical data off should remove it.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


[FXIOS-16480]: https://mozilla-hub.atlassian.net/browse/FXIOS-16480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-16477]: https://mozilla-hub.atlassian.net/browse/FXIOS-16477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

