### PR TITLE
Remove testXssAccountTakeover from smoke plan

### DIFF
--- a/focus-ios/focus-ios-tests/SmokeTest.xctestplan
+++ b/focus-ios/focus-ios-tests/SmokeTest.xctestplan
@@ -15,6 +15,7 @@
     {
       "skippedTests" : [
         "AsianLocaleTest",
+        "BrowsingTest\/testXssAccountTakeover()",
         "CollapsedURLTest",
         "CopyPasteTest\/testCopyMenuItem()",
         "CopyTest",


### PR DESCRIPTION
## :scroll: Tickets


## :bulb: Description
Removed testXssAccountTakeover from smoke plan
