### PR TITLE
Bugfix FXIOS-16472 [WebCompat] Keep the report draft across Learn More

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -331,6 +331,8 @@ public final class WebCompatReportSheetViewController: UIViewController,
                   let sectionID = self.dataSource.sectionIdentifier(for: indexPath.section),
                   let footer = self.sectionsByID[sectionID]?.footer else { return }
             footerView.configure(footer: footer) { [weak self] url in
+                // Text fields report on end-editing, so commit the active one before leaving the form.
+                self?.view.endEditing(true)
                 self?.delegate?.webCompatReportSheetDidTapLearnMore(url: url)
             }
             footerView.applyTheme(theme: self.theme)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -48,6 +48,7 @@ final class BrowserCoordinator: BaseCoordinator,
     var homepageViewController: HomepageViewController?
     private weak var nativeErrorPageViewController: NativeErrorPageViewController?
     private weak var privateHomepageViewController: PrivateHomepageViewController?
+    private weak var reportBrokenSiteViewController: WebCompatReportViewController?
 
     private var profile: Profile
     private let tabManager: TabManager
@@ -629,6 +630,7 @@ final class BrowserCoordinator: BaseCoordinator,
     func presentReportBrokenSite(url: URL?) {
         let reportViewController = WebCompatReportViewController(windowUUID: windowUUID, reportedURL: url)
         reportViewController.reportCoordinator = self
+        reportBrokenSiteViewController = reportViewController
         router.present(reportViewController, animated: true, completion: nil)
     }
 
@@ -649,10 +651,16 @@ final class BrowserCoordinator: BaseCoordinator,
     }
 
     func webCompatReportViewControllerDidTapLearnMore(url: URL) {
-        // Dismiss first, otherwise the explainer loads in a tab hidden behind the sheet.
-        router.dismiss(animated: true, completion: { [weak self] in
-            self?.browserViewController.openURLInNewTab(url)
-        })
+        // Dismissing the sheet or opening a tab tears its Redux state down and loses the report.
+        // `TermsOfUseLinkViewController` is a generic in-app web view, reused here despite the name.
+        let linkViewController = TermsOfUseLinkViewController(
+            url: url,
+            windowUUID: windowUUID,
+            themeManager: themeManager
+        )
+        let navigationController = UINavigationController(rootViewController: linkViewController)
+        navigationController.modalPresentationStyle = .pageSheet
+        reportBrokenSiteViewController?.present(navigationController, animated: true)
     }
 
     func presentSavePDFController() {

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -14,7 +14,7 @@ protocol WebCompatReportCoordinatorDelegate: AnyObject {
     func webCompatReportViewControllerDidFinish()
     /// Report was sent; the coordinator dismisses and confirms it.
     func webCompatReportViewControllerDidSubmit()
-    /// User tapped the "Learn More…" link; the coordinator dismisses the sheet and opens the explainer page.
+    /// User tapped the "Learn More…" link; the coordinator shows the explainer page without dismissing the sheet.
     func webCompatReportViewControllerDidTapLearnMore(url: URL)
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1238,6 +1238,21 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertTrue(subject.childCoordinators.isEmpty)
     }
 
+    // MARK: - Report broken site
+
+    func testWebCompatReportLearnMore_keepsTheSheetUpAndDoesNotOpenATab() throws {
+        let subject = createSubject()
+        subject.browserViewController = browserViewController
+        subject.presentReportBrokenSite(url: URL(string: "https://example.com"))
+        let learnMoreURL = try XCTUnwrap(URL(string: "https://support.mozilla.org/1/mobile/report-broken-site"))
+
+        subject.webCompatReportViewControllerDidTapLearnMore(url: learnMoreURL)
+
+        // Either would tear the sheet's Redux state down and lose the in-progress report.
+        XCTAssertEqual(mockRouter.dismissCalled, 0)
+        XCTAssertFalse(browserViewController.openURLInNewTabCalled)
+    }
+
     // MARK: - Sign in route
 
     func testHandleFxaSignIn_returnsTrue() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16472)

## :bulb: Description
Learn More dismissed the report sheet and opened the article in a new tab. Dismissing tears down the sheet's Redux state, so the draft (category, sub-option, URL, toggles, description) was lost.

The article now opens on top of the sheet. Close returns to the form as it was left, so nothing needs persisting. It reuses `TermsOfUseLinkViewController`, already a generic in-app web view with a Close button. Renaming it would touch the Terms of Use flow for no behaviour change, so it keeps the name.

Leaving the form also commits the active text field, like Send and Preview do. Text fields report on end-editing, so a description still being typed never reached the report state.

## :movie_camera: Demos

<img height="700" alt="IMG_5176" src="https://github.com/user-attachments/assets/1f2e2909-3dd8-429d-8878-5493a0e14673" />

## :test_tube: Testing
1. Open a site, ⋯ menu → **Report Broken Site**.
2. Fill in the form, keyboard up.
3. Tap **Learn More…**. The article opens over the form. No dismissal, no new tab.
4. Tap **Close**. The form is back as it was, description included.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
