### PR TITLE
Refactor FXIOS-16186 [WebCompat] Extract WebCompatReportCoordinator from BrowserCoordinator

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1358,6 +1358,7 @@
 		8C5E7E932F6B3C3F00A3DD27 /* TranslationSettingsDiffableDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5E7E922F6B3C3F00A3DD27 /* TranslationSettingsDiffableDataSourceTests.swift */; };
 		8C61A2812F3371330021C88D /* BrowserViewControllerKVOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C61A2802F3371330021C88D /* BrowserViewControllerKVOTests.swift */; };
 		8C6AF26A2D38FB1500254698 /* GleanLifecycleObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6AF2692D38FB1500254698 /* GleanLifecycleObserverTests.swift */; };
+		8C76F013302344B700D4BC87 /* WebCompatReportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C76F012302344B700D4BC87 /* WebCompatReportCoordinator.swift */; };
 		8C77849F2DF33707001FB8B0 /* OnboardingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C77849E2DF33707001FB8B0 /* OnboardingService.swift */; };
 		8CA4E80D2D22C066007207C1 /* GleanUsageReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */; };
 		8CA4E80F2D22D2C7007207C1 /* GleanUsageReportingLifecycleObserverTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA4E80E2D22D2C7007207C1 /* GleanUsageReportingLifecycleObserverTest.swift */; };
@@ -10121,6 +10122,7 @@
 		8C5E7E922F6B3C3F00A3DD27 /* TranslationSettingsDiffableDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationSettingsDiffableDataSourceTests.swift; sourceTree = "<group>"; };
 		8C61A2802F3371330021C88D /* BrowserViewControllerKVOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerKVOTests.swift; sourceTree = "<group>"; };
 		8C6AF2692D38FB1500254698 /* GleanLifecycleObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanLifecycleObserverTests.swift; sourceTree = "<group>"; };
+		8C76F012302344B700D4BC87 /* WebCompatReportCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportCoordinator.swift; sourceTree = "<group>"; };
 		8C77849E2DF33707001FB8B0 /* OnboardingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingService.swift; sourceTree = "<group>"; };
 		8C7A4A32A98AD1B79E3D69BE /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = "ru.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanUsageReporting.swift; sourceTree = "<group>"; };
@@ -14744,6 +14746,7 @@
 				C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */,
 				FB16062100000000000000A1 /* PhotoPickerCoordinator.swift */,
 				FB16062200000000000000A1 /* CameraCoordinator.swift */,
+				8C76F012302344B700D4BC87 /* WebCompatReportCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -19972,6 +19975,7 @@
 				0AFF7F6C2C7C7BBA00265214 /* CertificatesCell.swift in Sources */,
 				391C28173007C3C500833828 /* TrackerBlockStatsModels.swift in Sources */,
 				8AAEBA062BF51141000C02B5 /* MicrosurveyMiddleware.swift in Sources */,
+				8C76F013302344B700D4BC87 /* WebCompatReportCoordinator.swift in Sources */,
 				431C0CA925C890E500395CE4 /* DefaultBrowserOnboardingViewModel.swift in Sources */,
 				2140E4632E71FC250054173A /* RecordVisitObservationManager.swift in Sources */,
 				8A454D432CB9B8F5009436D9 /* TopSitesManager.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1591,6 +1591,7 @@
 		C0FFE71000000000000000A3 /* worldCupConfetti.json in Resources */ = {isa = PBXBuildFile; fileRef = C0FFE71000000000000000A2 /* worldCupConfetti.json */; };
 		C209316E2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */; };
 		C20931722F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */; };
+		8C76F015302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C76F014302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift */; };
 		C2126EF82F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2126EF72F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift */; };
 		C2126EFA2F447A46001C01FE /* SummarizerNimbusUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */; };
 		C21326992F5713F000746393 /* SummarizerLanguageProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21326982F5713F000746393 /* SummarizerLanguageProviderTests.swift */; };
@@ -10741,6 +10742,7 @@
 		C1F24EFFB6E9B114849A4DB3 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersCoordinator.swift; sourceTree = "<group>"; };
 		C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersCoordinatorTests.swift; sourceTree = "<group>"; };
+		8C76F014302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportCoordinatorTests.swift; sourceTree = "<group>"; };
 		C2126EF72F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerLanguageExpansionConfiguration.swift; sourceTree = "<group>"; };
 		C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerNimbusUtilsTests.swift; sourceTree = "<group>"; };
 		C21326982F5713F000746393 /* SummarizerLanguageProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerLanguageProviderTests.swift; sourceTree = "<group>"; };
@@ -14777,6 +14779,7 @@
 				61F7A4322D136C3A00F7317B /* RouteBuilderTests.swift */,
 				0B6153E12E24ECCA000D2FBD /* SummarizeCoordinatorTests.swift */,
 				C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */,
+				8C76F014302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift */,
 				FB16062100000000000000B1 /* PhotoPickerCoordinatorTests.swift */,
 				FB16062200000000000000B1 /* CameraCoordinatorTests.swift */,
 			);
@@ -21400,6 +21403,7 @@
 				ABEF80D92A2F283E003F52C4 /* CreditCardBottomSheetViewModelTests.swift in Sources */,
 				8AABBD052A0041380089941E /* MockCoordinator.swift in Sources */,
 				C20931722F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift in Sources */,
+				8C76F015302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift in Sources */,
 				FB16062100000000000000B2 /* PhotoPickerCoordinatorTests.swift in Sources */,
 				FB16062200000000000000B2 /* CameraCoordinatorTests.swift in Sources */,
 				FB16062100000000000000D2 /* GoogleLensImageProcessorTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -37,7 +37,7 @@ final class BrowserCoordinator: BaseCoordinator,
                           SearchEngineSelectionCoordinatorDelegate,
                           TermsOfUseDelegate,
                           ShareSheetCoordinatorDelegate,
-                          WebCompatReportCoordinatorDelegate,
+                          WebCompatReportCoordinatorNavigationDelegate,
                           FeatureFlaggable {
     private struct UX {
         static let searchEnginePopoverSize = CGSize(width: 250, height: 536)
@@ -48,7 +48,6 @@ final class BrowserCoordinator: BaseCoordinator,
     var homepageViewController: HomepageViewController?
     private weak var nativeErrorPageViewController: NativeErrorPageViewController?
     private weak var privateHomepageViewController: PrivateHomepageViewController?
-    private weak var reportBrokenSiteViewController: WebCompatReportViewController?
 
     private var profile: Profile
     private let tabManager: TabManager
@@ -628,39 +627,24 @@ final class BrowserCoordinator: BaseCoordinator,
     }
 
     func presentReportBrokenSite(url: URL?) {
-        let reportViewController = WebCompatReportViewController(windowUUID: windowUUID, reportedURL: url)
-        reportViewController.reportCoordinator = self
-        reportBrokenSiteViewController = reportViewController
-        router.present(reportViewController, animated: true, completion: nil)
-    }
-
-    // MARK: - WebCompatReportCoordinatorDelegate
-
-    func webCompatReportViewControllerDidFinish() {
-        router.dismiss(animated: true, completion: nil)
-    }
-
-    func webCompatReportViewControllerDidSubmit() {
-        // Dismiss first, otherwise the toast is covered by the sheet.
-        router.dismiss(animated: true, completion: { [weak self] in
-            // TODO: FXIOS-16468 swap in the dedicated "Report sent" string once l10n exports it.
-            self?.browserViewController.showPlainToast(
-                message: String.Microsurvey.Survey.ConfirmationPage.ConfirmationLabel
-            )
-        })
-    }
-
-    func webCompatReportViewControllerDidTapLearnMore(url: URL) {
-        // Dismissing the sheet or opening a tab tears its Redux state down and loses the report.
-        // `TermsOfUseLinkViewController` is a generic in-app web view, reused here despite the name.
-        let linkViewController = TermsOfUseLinkViewController(
-            url: url,
+        let webCompatReportCoordinator = WebCompatReportCoordinator(
+            router: router,
             windowUUID: windowUUID,
-            themeManager: themeManager
+            themeManager: themeManager,
+            parentCoordinatorDelegate: self,
+            navigationDelegate: self
         )
-        let navigationController = UINavigationController(rootViewController: linkViewController)
-        navigationController.modalPresentationStyle = .pageSheet
-        reportBrokenSiteViewController?.present(navigationController, animated: true)
+        add(child: webCompatReportCoordinator)
+        webCompatReportCoordinator.start(reportedURL: url)
+    }
+
+    // MARK: - WebCompatReportCoordinatorNavigationDelegate
+
+    func webCompatReportDidSubmit() {
+        // TODO: FXIOS-16468 swap in the dedicated "Report sent" string once l10n exports it.
+        browserViewController.showPlainToast(
+            message: String.Microsurvey.Survey.ConfirmationPage.ConfirmationLabel
+        )
     }
 
     func presentSavePDFController() {

--- a/firefox-ios/Client/Coordinators/WebCompatReportCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/WebCompatReportCoordinator.swift
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import UIKit
+
+/// What the report flow needs from the browser, which the flow itself can't reach.
+@MainActor
+protocol WebCompatReportCoordinatorNavigationDelegate: AnyObject {
+    func webCompatReportDidSubmit()
+}
+
+final class WebCompatReportCoordinator: BaseCoordinator, WebCompatReportCoordinatorDelegate {
+    private let windowUUID: WindowUUID
+    private let themeManager: ThemeManager
+    private weak var parentCoordinatorDelegate: ParentCoordinatorDelegate?
+    private weak var navigationDelegate: WebCompatReportCoordinatorNavigationDelegate?
+    private weak var reportViewController: WebCompatReportViewController?
+
+    init(
+        router: Router,
+        windowUUID: WindowUUID,
+        themeManager: ThemeManager,
+        parentCoordinatorDelegate: ParentCoordinatorDelegate?,
+        navigationDelegate: WebCompatReportCoordinatorNavigationDelegate?
+    ) {
+        self.windowUUID = windowUUID
+        self.themeManager = themeManager
+        self.parentCoordinatorDelegate = parentCoordinatorDelegate
+        self.navigationDelegate = navigationDelegate
+        super.init(router: router)
+    }
+
+    func start(reportedURL: URL?) {
+        let reportViewController = WebCompatReportViewController(windowUUID: windowUUID, reportedURL: reportedURL)
+        reportViewController.reportCoordinator = self
+        self.reportViewController = reportViewController
+        router.present(reportViewController, animated: true, completion: nil)
+    }
+
+    // MARK: - WebCompatReportCoordinatorDelegate
+
+    func webCompatReportViewControllerDidFinish() {
+        dismissReport()
+    }
+
+    func webCompatReportViewControllerDidSubmit() {
+        // Dismiss first, otherwise the toast is covered by the sheet.
+        dismissReport { [weak self] in
+            self?.navigationDelegate?.webCompatReportDidSubmit()
+        }
+    }
+
+    func webCompatReportViewControllerDidTapLearnMore(url: URL) {
+        // Dismissing the sheet or opening a tab tears its Redux state down and loses the report.
+        // `TermsOfUseLinkViewController` is a generic in-app web view, reused here despite the name.
+        let linkViewController = TermsOfUseLinkViewController(
+            url: url,
+            windowUUID: windowUUID,
+            themeManager: themeManager
+        )
+        let navigationController = UINavigationController(rootViewController: linkViewController)
+        navigationController.modalPresentationStyle = .pageSheet
+        reportViewController?.present(navigationController, animated: true)
+    }
+
+    private func dismissReport(completion: (() -> Void)? = nil) {
+        router.dismiss(animated: true) { [weak self] in
+            completion?()
+            guard let self else { return }
+            self.parentCoordinatorDelegate?.didFinish(from: self)
+        }
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1248,17 +1248,15 @@ final class BrowserCoordinatorTests: XCTestCase,
 
     // MARK: - Report broken site
 
-    func testWebCompatReportLearnMore_keepsTheSheetUpAndDoesNotOpenATab() throws {
+    func testPresentReportBrokenSite_startsTheReportCoordinator() {
         let subject = createSubject()
         subject.browserViewController = browserViewController
+
         subject.presentReportBrokenSite(url: URL(string: "https://example.com"))
-        let learnMoreURL = try XCTUnwrap(URL(string: "https://support.mozilla.org/1/mobile/report-broken-site"))
 
-        subject.webCompatReportViewControllerDidTapLearnMore(url: learnMoreURL)
-
-        // Either would tear the sheet's Redux state down and lose the in-progress report.
-        XCTAssertEqual(mockRouter.dismissCalled, 0)
-        XCTAssertFalse(browserViewController.openURLInNewTabCalled)
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+        XCTAssertTrue(subject.childCoordinators.first is WebCompatReportCoordinator)
+        XCTAssertEqual(mockRouter.presentCalled, 1)
     }
 
     // MARK: - Sign in route

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/WebCompatReportCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/WebCompatReportCoordinatorTests.swift
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+
+@testable import Client
+
+@MainActor
+final class WebCompatReportCoordinatorTests: XCTestCase {
+    private var router: MockRouter!
+    private var parentCoordinator: MockParentCoordinator!
+    private var navigationDelegate: MockWebCompatReportCoordinatorNavigationDelegate!
+    private var themeManager: MockThemeManager!
+    private let reportedURL = URL(string: "https://example.com")!
+    private let learnMoreURL = URL(string: "https://example.com/learn-more")!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        router = MockRouter(navigationController: MockNavigationController())
+        parentCoordinator = MockParentCoordinator()
+        navigationDelegate = MockWebCompatReportCoordinatorNavigationDelegate()
+        themeManager = MockThemeManager()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() async throws {
+        router = nil
+        parentCoordinator = nil
+        navigationDelegate = nil
+        themeManager = nil
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    func test_start_presentsViewController() throws {
+        let subject = createSubject()
+
+        subject.start(reportedURL: reportedURL)
+
+        let presentedViewController = try XCTUnwrap(router.presentedViewController as? WebCompatReportViewController)
+
+        XCTAssertEqual(router.presentCalled, 1)
+        XCTAssertTrue(presentedViewController.reportCoordinator === subject)
+    }
+
+    func test_viewControllerDidFinish_dismissesAndNotifiesParent() {
+        let subject = createSubject()
+
+        subject.webCompatReportViewControllerDidFinish()
+        router.savedCompletion?()
+
+        XCTAssertEqual(router.dismissCalled, 1)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    // The toast would be covered by the sheet if it went up first.
+    func test_viewControllerDidSubmit_confirmsAfterDismissCompletes() {
+        let subject = createSubject()
+
+        subject.webCompatReportViewControllerDidSubmit()
+
+        XCTAssertEqual(router.dismissCalled, 1)
+        XCTAssertEqual(navigationDelegate.didSubmitCalled, 0)
+
+        router.savedCompletion?()
+
+        XCTAssertEqual(navigationDelegate.didSubmitCalled, 1)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    func test_viewControllerDidTapLearnMore_keepsTheSheetUp() {
+        let subject = createSubject()
+        subject.start(reportedURL: reportedURL)
+
+        subject.webCompatReportViewControllerDidTapLearnMore(url: learnMoreURL)
+
+        // Dismissing would tear the sheet's Redux state down and lose the in-progress report.
+        XCTAssertEqual(router.dismissCalled, 0)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 0)
+    }
+
+    // MARK: - Helper Methods
+    private func createSubject(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> WebCompatReportCoordinator {
+        let subject = WebCompatReportCoordinator(
+            router: router,
+            windowUUID: .XCTestDefaultUUID,
+            themeManager: themeManager,
+            parentCoordinatorDelegate: parentCoordinator,
+            navigationDelegate: navigationDelegate
+        )
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+}
+
+private final class MockWebCompatReportCoordinatorNavigationDelegate: WebCompatReportCoordinatorNavigationDelegate {
+    var didSubmitCalled = 0
+
+    func webCompatReportDidSubmit() {
+        didSubmitCalled += 1
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16186](https://mozilla-hub.atlassian.net/browse/FXIOS-16186)

## :bulb: Description
`BrowserCoordinator` owned the Report Broken Site sheet directly, which leaves nowhere sensible to hang the Report Preview that gets presented over it.

`WebCompatReportCoordinator` owns the flow now, and presentation and dismissal both go through its router. `BrowserCoordinator` keeps only what needs the browser: opening Learn More in a tab, and the confirmation toast.

One behaviour change: the flow is a child coordinator now, so `didFinish(from:)` fires on close, submit and Learn More, and the child gets removed. There was no child to remove before.

[#35053](https://github.com/mozilla-mobile/firefox-ios/pull/35053) stacks on this.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## :test_tube: Testing
Nothing should look different from `main`.

1. **Menu → Report Broken Site**, then close the sheet. Report is discarded.
2. Reopen, pick a category, **Send**. Sheet dismisses and the toast is visible, not stuck behind it.
3. Reopen, tap **Learn More…**. Sheet dismisses first, then the explainer opens in a new tab.
4. Run through it a few times. The sheet should present cleanly every time.


[FXIOS-16186]: https://mozilla-hub.atlassian.net/browse/FXIOS-16186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ