### PR TITLE
Add FXIOS-16186 [WebCompat] Wire the Report Preview screen into the reporter flow

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportPreviewPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportPreviewPreview.swift
@@ -14,8 +14,8 @@ private struct WebCompatReportPreviewHost: UIViewControllerRepresentable {
     typealias PreviewSection = WebCompatReportPreviewViewModel.PreviewSection
     typealias PreviewValue = WebCompatReportPreviewViewModel.PreviewValue
 
-    let theme: Theme
     let screenshot: UIImage?
+    var themeType: ThemeType = .light
 
     func makeUIViewController(context: Context) -> UINavigationController {
         let viewModel = WebCompatReportPreviewViewModel(
@@ -26,7 +26,16 @@ private struct WebCompatReportPreviewHost: UIViewControllerRepresentable {
             screenshotA11yIdentifier: "WebCompatReporter.Preview.Screenshot",
             sections: Self.sampleSections
         )
-        let controller = WebCompatReportPreviewViewController(viewModel: viewModel, theme: theme)
+        // The screen reads its colors from the manager, so the canvas appearance alone can't
+        // darken it; the manager has to be told.
+        let themeManager = DefaultThemeManager(sharedContainerIdentifier: "")
+        themeManager.setSystemTheme(isOn: false)
+        themeManager.setManualTheme(to: themeType)
+        let controller = WebCompatReportPreviewViewController(
+            viewModel: viewModel,
+            windowUUID: .DefaultUITestingUUID,
+            themeManager: themeManager
+        )
         controller.updateScreenshot(screenshot)
         return UINavigationController(rootViewController: controller)
     }
@@ -111,19 +120,19 @@ private func previewSampleScreenshot() -> UIImage {
 
 @available(iOS 17.0, *)
 #Preview("With screenshot") {
-    WebCompatReportPreviewHost(theme: LightTheme(), screenshot: previewSampleScreenshot())
+    WebCompatReportPreviewHost(screenshot: previewSampleScreenshot())
         .ignoresSafeArea()
 }
 
 @available(iOS 17.0, *)
 #Preview("Screenshot off") {
-    WebCompatReportPreviewHost(theme: LightTheme(), screenshot: nil)
+    WebCompatReportPreviewHost(screenshot: nil)
         .ignoresSafeArea()
 }
 
 @available(iOS 17.0, *)
 #Preview("With screenshot (dark)") {
-    WebCompatReportPreviewHost(theme: DarkTheme(), screenshot: previewSampleScreenshot())
+    WebCompatReportPreviewHost(screenshot: previewSampleScreenshot(), themeType: .dark)
         .ignoresSafeArea()
 }
 #endif

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
@@ -18,7 +18,7 @@ public protocol WebCompatReportPreviewDelegate: AnyObject {
 /// TODO: FXIOS-16432 - Split this into the plain-language Report Preview screen and the pushed
 /// Technical Data screen, renaming the `ReportPreview` types accordingly.
 public final class WebCompatReportPreviewViewController: UIViewController,
-                                                         ThemeApplicable,
+                                                         Themeable,
                                                          UICollectionViewDelegate {
     private enum UX {
         static let headerHorizontalInset: CGFloat = 20
@@ -47,6 +47,11 @@ public final class WebCompatReportPreviewViewController: UIViewController,
 
     public weak var delegate: WebCompatReportPreviewDelegate?
 
+    public let themeManager: ThemeManager
+    public var themeListenerCancellable: Any?
+    public var currentWindowUUID: WindowUUID?
+    private let notificationCenter: NotificationProtocol
+
     private var viewModel: WebCompatReportPreviewViewModel
     private var screenshot: UIImage?
     private var theme: Theme
@@ -73,9 +78,17 @@ public final class WebCompatReportPreviewViewController: UIViewController,
 
     private lazy var dataSource = makeDataSource()
 
-    public init(viewModel: WebCompatReportPreviewViewModel, theme: Theme) {
+    public init(
+        viewModel: WebCompatReportPreviewViewModel,
+        windowUUID: WindowUUID,
+        themeManager: ThemeManager,
+        notificationCenter: NotificationProtocol = NotificationCenter.default
+    ) {
         self.viewModel = viewModel
-        self.theme = theme
+        self.currentWindowUUID = windowUUID
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        self.theme = themeManager.getCurrentTheme(for: windowUUID)
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -90,7 +103,8 @@ public final class WebCompatReportPreviewViewController: UIViewController,
         setupNavigationItem()
         setupLayout()
         configure(with: viewModel)
-        applyTheme(theme: theme)
+        listenForThemeChanges(withNotificationCenter: notificationCenter)
+        applyTheme()
     }
 
     // MARK: - Configuration
@@ -341,10 +355,10 @@ public final class WebCompatReportPreviewViewController: UIViewController,
         collectionView.deselectItem(at: indexPath, animated: false)
     }
 
-    // MARK: - ThemeApplicable
+    // MARK: - Themeable
 
-    public func applyTheme(theme: Theme) {
-        self.theme = theme
+    public func applyTheme() {
+        theme = themeManager.getCurrentTheme(for: currentWindowUUID)
         guard isViewLoaded else { return }
         view.backgroundColor = theme.colors.layer1
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary

--- a/BrowserKit/Tests/WebCompatReporterKitTests/MockThemeManager.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/MockThemeManager.swift
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+
+/// A theme manager whose theme can be swapped mid-test, so a `Themeable` screen can be asked to
+/// restyle. The Client's `MockThemeManager` isn't reachable from here.
+@MainActor
+final class MockThemeManager: ThemeManager {
+    var currentTheme: Theme = LightTheme()
+
+    var systemThemeIsOn = false
+    var automaticBrightnessIsOn = false
+    var automaticBrightnessValue: Float = 0
+
+    func getCurrentTheme(for window: WindowUUID?) -> Theme {
+        return currentTheme
+    }
+
+    func resolvedTheme(with shouldShowPrivateTheme: Bool) -> Theme {
+        return currentTheme
+    }
+
+    func windowNonspecificTheme() -> Theme {
+        return currentTheme
+    }
+
+    func setManualTheme(to newTheme: ThemeType) {
+        currentTheme = newTheme == .dark ? DarkTheme() : LightTheme()
+    }
+
+    func getUserManualTheme() -> ThemeType {
+        return currentTheme.type
+    }
+
+    func setSystemTheme(isOn: Bool) {}
+    func setAutomaticBrightness(isOn: Bool) {}
+    func setAutomaticBrightnessValue(_ value: Float) {}
+    func applyThemeUpdatesToWindows() {}
+    func setPrivateTheme(isOn: Bool, for window: WindowUUID) {}
+    func getPrivateThemeIsOn(for window: WindowUUID) -> Bool { return false }
+    func setWindow(_ window: UIWindow, for uuid: WindowUUID) {}
+    func windowDidClose(uuid: WindowUUID) {}
+}

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
@@ -51,25 +51,31 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
     }
 
     func testApplyTheme_afterExpanding_keepsTheSectionExpanded() throws {
-        let subject = createSubject(sections: sampleSections)
+        let themeManager = MockThemeManager()
+        let subject = createSubject(sections: sampleSections, themeManager: themeManager)
         layout(subject)
         try expandFirstSection(in: subject)
 
-        subject.applyTheme(theme: DarkTheme())
+        themeManager.currentTheme = DarkTheme()
+        subject.applyTheme()
         subject.view.layoutIfNeeded()
 
+        XCTAssertEqual(collectionView(in: subject)?.backgroundColor, DarkTheme().colors.layer1)
         XCTAssertEqual(collectionView(in: subject)?.numberOfItems(inSection: 0), 2)
     }
 
     // If a round-tripped snapshot omitted collapsed children, applying it would delete them.
     func testApplyTheme_whileCollapsed_thenExpanding_stillRevealsRows() throws {
-        let subject = createSubject(sections: sampleSections)
+        let themeManager = MockThemeManager()
+        let subject = createSubject(sections: sampleSections, themeManager: themeManager)
         layout(subject)
 
-        subject.applyTheme(theme: DarkTheme())
+        themeManager.currentTheme = DarkTheme()
+        subject.applyTheme()
         subject.view.layoutIfNeeded()
         try expandFirstSection(in: subject)
 
+        XCTAssertEqual(collectionView(in: subject)?.backgroundColor, DarkTheme().colors.layer1)
         XCTAssertEqual(collectionView(in: subject)?.numberOfItems(inSection: 0), 2)
     }
 
@@ -160,11 +166,14 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
     }
 
     private func createSubject(
-        sections: [WebCompatReportPreviewViewModel.PreviewSection] = []
+        sections: [WebCompatReportPreviewViewModel.PreviewSection] = [],
+        themeManager: ThemeManager = MockThemeManager()
     ) -> WebCompatReportPreviewViewController {
         return WebCompatReportPreviewViewController(
             viewModel: makeViewModel(sections: sections),
-            theme: LightTheme()
+            windowUUID: .XCTestDefaultUUID,
+            themeManager: themeManager,
+            notificationCenter: NotificationCenter.default
         )
     }
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1359,6 +1359,7 @@
 		8C61A2812F3371330021C88D /* BrowserViewControllerKVOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C61A2802F3371330021C88D /* BrowserViewControllerKVOTests.swift */; };
 		8C6AF26A2D38FB1500254698 /* GleanLifecycleObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6AF2692D38FB1500254698 /* GleanLifecycleObserverTests.swift */; };
 		8C76F013302344B700D4BC87 /* WebCompatReportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C76F012302344B700D4BC87 /* WebCompatReportCoordinator.swift */; };
+		8CE71B433025C458006C7828 /* WebCompatReportPreviewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE71B423025C458006C7828 /* WebCompatReportPreviewCoordinator.swift */; };
 		8C77849F2DF33707001FB8B0 /* OnboardingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C77849E2DF33707001FB8B0 /* OnboardingService.swift */; };
 		8CA4E80D2D22C066007207C1 /* GleanUsageReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */; };
 		8CA4E80F2D22D2C7007207C1 /* GleanUsageReportingLifecycleObserverTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA4E80E2D22D2C7007207C1 /* GleanUsageReportingLifecycleObserverTest.swift */; };
@@ -10124,6 +10125,7 @@
 		8C61A2802F3371330021C88D /* BrowserViewControllerKVOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerKVOTests.swift; sourceTree = "<group>"; };
 		8C6AF2692D38FB1500254698 /* GleanLifecycleObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanLifecycleObserverTests.swift; sourceTree = "<group>"; };
 		8C76F012302344B700D4BC87 /* WebCompatReportCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportCoordinator.swift; sourceTree = "<group>"; };
+		8CE71B423025C458006C7828 /* WebCompatReportPreviewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportPreviewCoordinator.swift; sourceTree = "<group>"; };
 		8C77849E2DF33707001FB8B0 /* OnboardingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingService.swift; sourceTree = "<group>"; };
 		8C7A4A32A98AD1B79E3D69BE /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = "ru.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanUsageReporting.swift; sourceTree = "<group>"; };
@@ -14749,6 +14751,7 @@
 				FB16062100000000000000A1 /* PhotoPickerCoordinator.swift */,
 				FB16062200000000000000A1 /* CameraCoordinator.swift */,
 				8C76F012302344B700D4BC87 /* WebCompatReportCoordinator.swift */,
+				8CE71B423025C458006C7828 /* WebCompatReportPreviewCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -19979,6 +19982,7 @@
 				391C28173007C3C500833828 /* TrackerBlockStatsModels.swift in Sources */,
 				8AAEBA062BF51141000C02B5 /* MicrosurveyMiddleware.swift in Sources */,
 				8C76F013302344B700D4BC87 /* WebCompatReportCoordinator.swift in Sources */,
+				8CE71B433025C458006C7828 /* WebCompatReportPreviewCoordinator.swift in Sources */,
 				431C0CA925C890E500395CE4 /* DefaultBrowserOnboardingViewModel.swift in Sources */,
 				2140E4632E71FC250054173A /* RecordVisitObservationManager.swift in Sources */,
 				8A454D432CB9B8F5009436D9 /* TopSitesManager.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1593,6 +1593,7 @@
 		C209316E2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */; };
 		C20931722F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */; };
 		8C76F015302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C76F014302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift */; };
+		8CE71B453025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE71B443025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift */; };
 		C2126EF82F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2126EF72F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift */; };
 		C2126EFA2F447A46001C01FE /* SummarizerNimbusUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */; };
 		C21326992F5713F000746393 /* SummarizerLanguageProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21326982F5713F000746393 /* SummarizerLanguageProviderTests.swift */; };
@@ -10745,6 +10746,7 @@
 		C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersCoordinator.swift; sourceTree = "<group>"; };
 		C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersCoordinatorTests.swift; sourceTree = "<group>"; };
 		8C76F014302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportCoordinatorTests.swift; sourceTree = "<group>"; };
+		8CE71B443025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportPreviewCoordinatorTests.swift; sourceTree = "<group>"; };
 		C2126EF72F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerLanguageExpansionConfiguration.swift; sourceTree = "<group>"; };
 		C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerNimbusUtilsTests.swift; sourceTree = "<group>"; };
 		C21326982F5713F000746393 /* SummarizerLanguageProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerLanguageProviderTests.swift; sourceTree = "<group>"; };
@@ -14783,6 +14785,7 @@
 				0B6153E12E24ECCA000D2FBD /* SummarizeCoordinatorTests.swift */,
 				C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */,
 				8C76F014302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift */,
+				8CE71B443025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift */,
 				FB16062100000000000000B1 /* PhotoPickerCoordinatorTests.swift */,
 				FB16062200000000000000B1 /* CameraCoordinatorTests.swift */,
 			);
@@ -21408,6 +21411,7 @@
 				8AABBD052A0041380089941E /* MockCoordinator.swift in Sources */,
 				C20931722F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift in Sources */,
 				8C76F015302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift in Sources */,
+				8CE71B453025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift in Sources */,
 				FB16062100000000000000B2 /* PhotoPickerCoordinatorTests.swift in Sources */,
 				FB16062200000000000000B2 /* CameraCoordinatorTests.swift in Sources */,
 				FB16062100000000000000D2 /* GoogleLensImageProcessorTests.swift in Sources */,

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -143,6 +143,13 @@ struct AccessibilityIdentifiers {
         static let includeScreenshot = "WebCompatReporter.IncludeScreenshot"
         static let includeBlockedList = "WebCompatReporter.IncludeBlockedList"
         static let learnMore = "WebCompatReporter.LearnMore"
+
+        struct Preview {
+            static let closeButton = "WebCompatReporter.Preview.CloseButton"
+            /// Suffixed with the payload group id, e.g. `…SectionHeader.basic`.
+            static let sectionHeader = "WebCompatReporter.Preview.SectionHeader"
+            static let sectionContent = "WebCompatReporter.Preview.SectionContent"
+        }
     }
 
     struct UnifiedSearch {

--- a/firefox-ios/Client/Coordinators/WebCompatReportCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/WebCompatReportCoordinator.swift
@@ -12,12 +12,19 @@ protocol WebCompatReportCoordinatorNavigationDelegate: AnyObject {
     func webCompatReportDidSubmit()
 }
 
-final class WebCompatReportCoordinator: BaseCoordinator, WebCompatReportCoordinatorDelegate {
+final class WebCompatReportCoordinator: BaseCoordinator,
+                                        WebCompatReportCoordinatorDelegate,
+                                        ParentCoordinatorDelegate {
     private let windowUUID: WindowUUID
     private let themeManager: ThemeManager
     private weak var parentCoordinatorDelegate: ParentCoordinatorDelegate?
     private weak var navigationDelegate: WebCompatReportCoordinatorNavigationDelegate?
     private weak var reportViewController: WebCompatReportViewController?
+
+    private var previewCoordinator: WebCompatReportPreviewCoordinator? {
+        return childCoordinators.first { $0 is WebCompatReportPreviewCoordinator }
+            as? WebCompatReportPreviewCoordinator
+    }
 
     init(
         router: Router,
@@ -66,7 +73,29 @@ final class WebCompatReportCoordinator: BaseCoordinator, WebCompatReportCoordina
         reportViewController?.present(navigationController, animated: true)
     }
 
+    func webCompatReportViewControllerDidTapPreview(payload: WebCompatReportPayload) {
+        guard let reportViewController, previewCoordinator == nil else { return }
+        // The main router presents from the browser, which already shows the sheet, so the preview
+        // goes up from the sheet itself.
+        let previewCoordinator = WebCompatReportPreviewCoordinator(
+            router: DefaultRouter(navigationController: reportViewController),
+            windowUUID: windowUUID,
+            themeManager: themeManager,
+            parentCoordinator: self
+        )
+        add(child: previewCoordinator)
+        previewCoordinator.start(payload: payload)
+    }
+
+    // MARK: - ParentCoordinatorDelegate
+
+    func didFinish(from childCoordinator: Coordinator) {
+        remove(child: childCoordinator)
+    }
+
+    /// Dismisses the preview first, so the sheet isn't pulled out from under it.
     private func dismissReport(completion: (() -> Void)? = nil) {
+        previewCoordinator?.dismissPreview(animated: false)
         router.dismiss(animated: true) { [weak self] in
             completion?()
             guard let self else { return }

--- a/firefox-ios/Client/Coordinators/WebCompatReportPreviewCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/WebCompatReportPreviewCoordinator.swift
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import UIKit
+import WebCompatReporterKit
+
+/// Owns the Report Preview sheet for as long as it is on screen. The report sheet is the
+/// presenting context, so this is rooted at a router over it rather than the browser's.
+final class WebCompatReportPreviewCoordinator: BaseCoordinator, WebCompatReportPreviewDelegate {
+    private let windowUUID: WindowUUID
+    private let themeManager: ThemeManager
+    private weak var parentCoordinator: ParentCoordinatorDelegate?
+
+    init(
+        router: Router,
+        windowUUID: WindowUUID,
+        themeManager: ThemeManager,
+        parentCoordinator: ParentCoordinatorDelegate?
+    ) {
+        self.windowUUID = windowUUID
+        self.themeManager = themeManager
+        self.parentCoordinator = parentCoordinator
+        super.init(router: router)
+    }
+
+    func start(payload: WebCompatReportPayload) {
+        let previewViewController = WebCompatReportPreviewViewController(
+            viewModel: payload.makePreviewViewModel(),
+            windowUUID: windowUUID,
+            themeManager: themeManager
+        )
+        previewViewController.delegate = self
+        let previewNavigationController = UINavigationController(rootViewController: previewViewController)
+        if let sheet = previewNavigationController.sheetPresentationController {
+            sheet.detents = [.medium(), .large()]
+            sheet.prefersGrabberVisible = true
+        }
+        router.present(previewNavigationController, animated: true) { [weak self] in
+            // Runs when we dismiss through `UIAdaptivePresentationControllerDelegate`
+            self?.didFinish()
+        }
+    }
+
+    /// Takes the preview down without abandoning the report; only the form's own close does that.
+    func dismissPreview(animated: Bool) {
+        router.dismiss(animated: animated, completion: nil)
+        didFinish()
+    }
+
+    // MARK: - WebCompatReportPreviewDelegate
+
+    func webCompatReportPreviewDidRequestDismiss() {
+        dismissPreview(animated: true)
+    }
+
+    func webCompatReportPreviewDidTapScreenshot() {
+        // Unreachable while the thumbnail is off; FXIOS-16450 wires up the screenshot viewer.
+    }
+
+    // MARK: - Private
+
+    private func didFinish() {
+        parentCoordinator?.didFinish(from: self)
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import WebCompatReporterKit
 
 /// One property per Glean metric in `broken_site_report.yaml`, so the field names
 /// live in one place. The struct is flat; each comment below is the Glean category
@@ -43,5 +44,132 @@ struct WebCompatReportPayload: Equatable {
         let details = state.additionalDetails.trimmingCharacters(in: .whitespacesAndNewlines)
         payload.description = details.isEmpty ? nil : details
         return payload
+    }
+
+    struct PreviewField {
+        enum Key: String {
+            case description
+            case reason
+            case url
+            case languages
+            case useragentString
+            case blockList
+            case blockedOrigins
+            case etpCategory
+            case isPrivateBrowsing
+            case fastclick
+            case marfeel
+            case mobify
+            case defaultLocales
+            case defaultUseragentString
+            case isTablet
+            case memory
+            case devicePixelRatio
+            case hasTouchScreen
+        }
+
+        let key: Key
+        let value: WebCompatReportPreviewViewModel.PreviewValue
+    }
+
+    struct PreviewGroup {
+        enum Identifier: String {
+            case basic
+            case tabInfo
+            case antiTracking
+            case frameworks
+            case app
+            case system
+            case graphics
+        }
+
+        let id: Identifier
+        let fields: [PreviewField]
+    }
+
+    /// Projected from this struct, not from Redux state, so the preview can only show what gets sent.
+    var previewGroups: [PreviewGroup] {
+        return [
+            PreviewGroup(id: .basic, fields: [
+                PreviewField(key: .description, value: previewValue(description)),
+                PreviewField(key: .reason, value: previewValue(breakageCategory)),
+                PreviewField(key: .url, value: previewValue(url))
+            ]),
+            PreviewGroup(id: .tabInfo, fields: [
+                PreviewField(key: .languages, value: previewValue(languages)),
+                PreviewField(key: .useragentString, value: previewValue(userAgentString))
+            ]),
+            PreviewGroup(id: .antiTracking, fields: [
+                PreviewField(key: .blockList, value: previewValue(blockList)),
+                PreviewField(key: .blockedOrigins, value: previewValue(blockedOrigins)),
+                PreviewField(key: .etpCategory, value: previewValue(etpCategory)),
+                PreviewField(key: .isPrivateBrowsing, value: previewValue(isPrivateBrowsing))
+            ]),
+            PreviewGroup(id: .frameworks, fields: [
+                PreviewField(key: .fastclick, value: previewValue(fastclick)),
+                PreviewField(key: .marfeel, value: previewValue(marfeel)),
+                PreviewField(key: .mobify, value: previewValue(mobify))
+            ]),
+            PreviewGroup(id: .app, fields: [
+                PreviewField(key: .defaultLocales, value: previewValue(defaultLocales)),
+                PreviewField(key: .defaultUseragentString, value: previewValue(defaultUserAgentString))
+            ]),
+            PreviewGroup(id: .system, fields: [
+                PreviewField(key: .isTablet, value: previewValue(isTablet)),
+                PreviewField(key: .memory, value: previewValue(memory))
+            ]),
+            PreviewGroup(id: .graphics, fields: [
+                PreviewField(key: .devicePixelRatio, value: previewValue(devicePixelRatio)),
+                PreviewField(key: .hasTouchScreen, value: previewValue(hasTouchScreen))
+            ])
+        ]
+    }
+
+    func makePreviewViewModel() -> WebCompatReportPreviewViewModel {
+        return WebCompatReportPreviewViewModel(
+            title: .WebCompatReporter.Preview.Title,
+            closeAccessibilityLabel: .WebCompatReporter.Sheet.CloseButtonAccessibilityLabel,
+            closeA11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.Preview.closeButton,
+            // Unread while the thumbnail is off; they come back with the screenshot in FXIOS-16450.
+            screenshotAccessibilityLabel: "",
+            screenshotA11yIdentifier: "",
+            sections: previewGroups.map { group in
+                let groupID = group.id.rawValue
+                return WebCompatReportPreviewViewModel.PreviewSection(
+                    id: groupID,
+                    title: groupID,
+                    a11yIdentifier: "\(AccessibilityIdentifiers.WebCompatReporter.Preview.sectionHeader).\(groupID)",
+                    contentA11yIdentifier:
+                        "\(AccessibilityIdentifiers.WebCompatReporter.Preview.sectionContent).\(groupID)",
+                    rows: group.fields.map { field in
+                        WebCompatReportPreviewViewModel.PreviewRow(
+                            id: "\(groupID).\(field.key.rawValue)",
+                            label: field.key.rawValue,
+                            value: field.value
+                        )
+                    }
+                )
+            }
+        )
+    }
+
+    private func previewValue(_ text: String?) -> WebCompatReportPreviewViewModel.PreviewValue {
+        guard let text, !text.isEmpty else { return .null }
+        return .string(text)
+    }
+
+    private func previewValue(_ values: [String]?) -> WebCompatReportPreviewViewModel.PreviewValue {
+        guard let values else { return .null }
+        return .list(values)
+    }
+
+    private func previewValue(_ flag: Bool?) -> WebCompatReportPreviewViewModel.PreviewValue {
+        guard let flag else { return .null }
+        return .bool(flag)
+    }
+
+    private func previewValue(_ number: Int?) -> WebCompatReportPreviewViewModel.PreviewValue {
+        guard let number else { return .null }
+        return .quantity(number)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -16,6 +16,8 @@ protocol WebCompatReportCoordinatorDelegate: AnyObject {
     func webCompatReportViewControllerDidSubmit()
     /// User tapped the "Learn More…" link; the coordinator shows the explainer page without dismissing the sheet.
     func webCompatReportViewControllerDidTapLearnMore(url: URL)
+    /// The middleware assembled the report; the coordinator presents it.
+    func webCompatReportViewControllerDidTapPreview(payload: WebCompatReportPayload)
 }
 
 /// Store-connected container that hosts the `WebCompatReporterKit` sheet, maps
@@ -111,6 +113,9 @@ final class WebCompatReportViewController: UINavigationController,
             reportCoordinator?.webCompatReportViewControllerDidSubmit()
             return
         }
+        if let payload = state.previewPayload {
+            reportCoordinator?.webCompatReportViewControllerDidTapPreview(payload: payload)
+        }
         sheetViewController.configure(with: WebCompatReportViewController.makeViewModel(from: state))
     }
 
@@ -120,6 +125,8 @@ final class WebCompatReportViewController: UINavigationController,
         return WebCompatReportViewModel(
             navigationTitle: .MainMenu.ToolsSection.ReportBrokenSite,
             closeButtonAccessibilityLabel: .WebCompatReporter.Sheet.CloseButtonAccessibilityLabel,
+            previewButtonTitle: .WebCompatReporter.Sheet.PreviewButton,
+            isPreviewEnabled: state.canPreview,
             sections: makeSections(from: state)
         )
     }
@@ -315,9 +322,8 @@ final class WebCompatReportViewController: UINavigationController,
         ))
     }
 
-    // MARK: - WebCompatReportSheetDelegate
-
-    func webCompatReportSheetDidTapClose() {
+    /// Kept here so the cancel action is dispatched from the one place that talks to the store.
+    func finishReport() {
         store.dispatch(WebCompatReporterViewAction(
             windowUUID: windowUUID,
             actionType: WebCompatReporterViewActionType.cancel
@@ -325,7 +331,14 @@ final class WebCompatReportViewController: UINavigationController,
         reportCoordinator?.webCompatReportViewControllerDidFinish()
     }
 
+    // MARK: - WebCompatReportSheetDelegate
+
+    func webCompatReportSheetDidTapClose() {
+        finishReport()
+    }
+
     func webCompatReportSheetDidTapPreview() {
+        // The report comes back through newState, not from here.
         store.dispatch(WebCompatReporterViewAction(
             windowUUID: windowUUID,
             actionType: WebCompatReporterViewActionType.preview

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterAction.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterAction.swift
@@ -38,11 +38,14 @@ struct WebCompatReporterMiddlewareAction: Action {
     let windowUUID: WindowUUID
     let actionType: ActionType
     let url: String?
+    let previewPayload: WebCompatReportPayload?
 
     init(url: String? = nil,
+         previewPayload: WebCompatReportPayload? = nil,
          windowUUID: WindowUUID,
          actionType: ActionType) {
         self.url = url
+        self.previewPayload = previewPayload
         self.windowUUID = windowUUID
         self.actionType = actionType
     }
@@ -64,5 +67,6 @@ enum WebCompatReporterViewActionType: ActionType {
 
 enum WebCompatReporterMiddlewareActionType: ActionType {
     case didLoadInitialDraft
+    case didBuildPreview
     case didSubmit
 }

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
@@ -46,6 +46,11 @@ final class WebCompatReporterMiddleware {
 
         case WebCompatReporterViewActionType.preview:
             telemetry.previewed()
+            store.dispatch(WebCompatReporterMiddlewareAction(
+                previewPayload: makeReport(windowUUID: action.windowUUID, state: state),
+                windowUUID: action.windowUUID,
+                actionType: WebCompatReporterMiddlewareActionType.didBuildPreview
+            ))
 
         case WebCompatReporterViewActionType.cancel:
             telemetry.cancelled()
@@ -63,16 +68,7 @@ final class WebCompatReporterMiddleware {
 
     private func submitReport(windowUUID: WindowUUID, state: AppState) {
         let reporterState = WebCompatReporterState(appState: state, uuid: windowUUID)
-        var payload = WebCompatReportPayload.make(from: reporterState)
-        if let tab = selectedTab(for: windowUUID) {
-            payload = WebCompatReportDataCollector.enrich(
-                payload,
-                tab: tab,
-                includeBlockedList: reporterState.includeBlockedList,
-                includeTabSpecificInfo: isReporting(reporterState.url, on: tab)
-            )
-        }
-        recorder.submit(payload)
+        recorder.submit(makeReport(windowUUID: windowUUID, state: state))
         // The screenshot option is parked (FXIOS-16450) and no image is transported yet.
         telemetry.created(withBlockedTrackers: reporterState.includeBlockedList, withScreenshot: false)
 
@@ -80,6 +76,19 @@ final class WebCompatReporterMiddleware {
             windowUUID: windowUUID,
             actionType: WebCompatReporterMiddlewareActionType.didSubmit
         ))
+    }
+
+    /// The only place a report is assembled, so the preview can't differ from what's sent.
+    private func makeReport(windowUUID: WindowUUID, state: AppState) -> WebCompatReportPayload {
+        let reporterState = WebCompatReporterState(appState: state, uuid: windowUUID)
+        let payload = WebCompatReportPayload.make(from: reporterState)
+        guard let tab = selectedTab(for: windowUUID) else { return payload }
+        return WebCompatReportDataCollector.enrich(
+            payload,
+            tab: tab,
+            includeBlockedList: reporterState.includeBlockedList,
+            includeTabSpecificInfo: isReporting(reporterState.url, on: tab)
+        )
     }
 
     private func selectedTab(for windowUUID: WindowUUID) -> Tab? {

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
@@ -17,6 +17,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
     var includeScreenshot: Bool
     var includeBlockedList: Bool
     var shouldDismiss: Bool
+    /// The report as the middleware would send it.
+    var previewPayload: WebCompatReportPayload?
 
     /// Preview stays disabled, and the details field stays hidden, until the user picks a category.
     var canPreview: Bool { selectedCategory != nil }
@@ -45,7 +47,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
             additionalDetails: state.additionalDetails,
             includeScreenshot: state.includeScreenshot,
             includeBlockedList: state.includeBlockedList,
-            shouldDismiss: state.shouldDismiss
+            shouldDismiss: state.shouldDismiss,
+            previewPayload: state.previewPayload
         )
     }
 
@@ -58,7 +61,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
             additionalDetails: "",
             includeScreenshot: true,
             includeBlockedList: false,
-            shouldDismiss: false
+            shouldDismiss: false,
+            previewPayload: nil
         )
     }
 
@@ -69,7 +73,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
          additionalDetails: String = "",
          includeScreenshot: Bool = true,
          includeBlockedList: Bool = false,
-         shouldDismiss: Bool = false) {
+         shouldDismiss: Bool = false,
+         previewPayload: WebCompatReportPayload? = nil) {
         self.windowUUID = windowUUID
         self.url = url
         self.selectedCategory = selectedCategory
@@ -78,6 +83,7 @@ struct WebCompatReporterState: ScreenState, Equatable {
         self.includeScreenshot = includeScreenshot
         self.includeBlockedList = includeBlockedList
         self.shouldDismiss = shouldDismiss
+        self.previewPayload = previewPayload
     }
 
     static let reducer: Reducer<Self> = (legacyReducer, modernReducer)
@@ -92,8 +98,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
             return defaultState(from: state)
         }
 
-        // shouldDismiss is a one-shot signal, so it never survives into the next state.
-        let state = state.copy(shouldDismiss: false)
+        // shouldDismiss and previewPayload are one-shot, so neither survives into the next state.
+        let state = state.copy(shouldDismiss: false).copy(previewPayload: nil)
 
         switch action {
         case let action as WebCompatReporterMiddlewareAction:
@@ -114,6 +120,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
         switch action.actionType {
         case WebCompatReporterMiddlewareActionType.didLoadInitialDraft:
             return state.copy(url: action.url ?? state.url)
+        case WebCompatReporterMiddlewareActionType.didBuildPreview:
+            return state.copy(previewPayload: action.previewPayload)
         case WebCompatReporterMiddlewareActionType.didSubmit:
             return state.copy(shouldDismiss: true)
         default:
@@ -164,7 +172,8 @@ struct WebCompatReporterState: ScreenState, Equatable {
             additionalDetails: state.additionalDetails,
             includeScreenshot: state.includeScreenshot,
             includeBlockedList: state.includeBlockedList,
-            shouldDismiss: false
+            shouldDismiss: false,
+            previewPayload: nil
         )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/WebCompatReportCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/WebCompatReportCoordinatorTests.swift
@@ -81,6 +81,40 @@ final class WebCompatReportCoordinatorTests: XCTestCase {
         XCTAssertEqual(parentCoordinator.didFinishCalled, 0)
     }
 
+    func test_didTapPreview_addsThePreviewAsAChild() {
+        let subject = createSubject()
+        subject.start(reportedURL: reportedURL)
+
+        subject.webCompatReportViewControllerDidTapPreview(payload: WebCompatReportPayload())
+
+        XCTAssertTrue(subject.childCoordinators.first is WebCompatReportPreviewCoordinator)
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+    }
+
+    func test_didTapPreview_whileOneIsOpen_doesNotStartASecond() {
+        let subject = createSubject()
+        subject.start(reportedURL: reportedURL)
+
+        subject.webCompatReportViewControllerDidTapPreview(payload: WebCompatReportPayload())
+        subject.webCompatReportViewControllerDidTapPreview(payload: WebCompatReportPayload())
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+    }
+
+    // A child left behind blocks the guard above, which kept Preview dead for the rest of the form.
+    func test_previewDidFinish_removesItSoPreviewOpensAgain() throws {
+        let subject = createSubject()
+        subject.start(reportedURL: reportedURL)
+        subject.webCompatReportViewControllerDidTapPreview(payload: WebCompatReportPayload())
+        let previewCoordinator = try XCTUnwrap(subject.childCoordinators.first)
+
+        subject.didFinish(from: previewCoordinator)
+        XCTAssertTrue(subject.childCoordinators.isEmpty)
+
+        subject.webCompatReportViewControllerDidTapPreview(payload: WebCompatReportPayload())
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+    }
+
     // MARK: - Helper Methods
     private func createSubject(
         file: StaticString = #filePath,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/WebCompatReportPreviewCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/WebCompatReportPreviewCoordinatorTests.swift
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+
+@testable import Client
+
+@MainActor
+final class WebCompatReportPreviewCoordinatorTests: XCTestCase {
+    private var router: MockRouter!
+    private var parentCoordinator: MockParentCoordinator!
+    private var themeManager: MockThemeManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        router = MockRouter(navigationController: MockNavigationController())
+        parentCoordinator = MockParentCoordinator()
+        themeManager = MockThemeManager()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() async throws {
+        router = nil
+        parentCoordinator = nil
+        themeManager = nil
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    // Swiping the sheet down never goes through the coordinator, so the present completion is the
+    // only place the parent hears about it.
+    func test_swipeDismiss_finishesTheCoordinator() {
+        let subject = createSubject()
+        subject.start(payload: WebCompatReportPayload())
+
+        router.savedCompletion?()
+
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    func test_previewDidRequestDismiss_dismissesAndNotifiesParent() {
+        let subject = createSubject()
+        subject.start(payload: WebCompatReportPayload())
+
+        subject.webCompatReportPreviewDidRequestDismiss()
+
+        XCTAssertEqual(router.dismissCalled, 1)
+        XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    // MARK: - Helper Methods
+    private func createSubject(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> WebCompatReportPreviewCoordinator {
+        let subject = WebCompatReportPreviewCoordinator(
+            router: router,
+            windowUUID: .XCTestDefaultUUID,
+            themeManager: themeManager,
+            parentCoordinator: parentCoordinator
+        )
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -141,6 +141,52 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(dispatchedViewActions().isEmpty)
     }
 
+    func testDidTapPreview_onlyDispatches() {
+        let coordinator = MockWebCompatReportCoordinatorDelegate()
+        let subject = createSubject(reportedURL: nil)
+        subject.reportCoordinator = coordinator
+        subject.loadViewIfNeeded()
+
+        subject.webCompatReportSheetDidTapPreview()
+
+        // Building a payload here is what let preview and submit drift.
+        XCTAssertEqual(lastViewAction()?.actionType as? WebCompatReporterViewActionType, .preview)
+        XCTAssertTrue(coordinator.didTapPreviewPayloads.isEmpty)
+    }
+
+    func testNewState_withPreviewPayload_handsItToTheCoordinator() throws {
+        let coordinator = MockWebCompatReportCoordinatorDelegate()
+        let subject = createSubject(reportedURL: nil)
+        subject.reportCoordinator = coordinator
+        subject.loadViewIfNeeded()
+        var payload = WebCompatReportPayload()
+        payload.url = "https://example.com"
+
+        subject.newState(state: WebCompatReporterState(
+            windowUUID: windowUUID,
+            url: "https://example.com",
+            selectedCategory: .videoOrAudio,
+            previewPayload: payload
+        ))
+
+        XCTAssertEqual(coordinator.didTapPreviewPayloads, [payload])
+    }
+
+    func testNewState_withoutPreviewPayload_leavesTheCoordinatorAlone() {
+        let coordinator = MockWebCompatReportCoordinatorDelegate()
+        let subject = createSubject(reportedURL: nil)
+        subject.reportCoordinator = coordinator
+        subject.loadViewIfNeeded()
+
+        subject.newState(state: WebCompatReporterState(
+            windowUUID: windowUUID,
+            url: "https://example.com",
+            selectedCategory: .videoOrAudio
+        ))
+
+        XCTAssertTrue(coordinator.didTapPreviewPayloads.isEmpty)
+    }
+
     func testSimpleCreation_hasNoLeaks() {
         let subject = createSubject(reportedURL: nil)
         subject.loadViewIfNeeded()
@@ -302,6 +348,7 @@ private final class MockWebCompatReportCoordinatorDelegate: WebCompatReportCoord
     var didFinishCallCount = 0
     var didSubmitCallCount = 0
     var didTapLearnMoreURLs: [URL] = []
+    var didTapPreviewPayloads: [WebCompatReportPayload] = []
 
     func webCompatReportViewControllerDidFinish() {
         didFinishCallCount += 1
@@ -313,5 +360,9 @@ private final class MockWebCompatReportCoordinatorDelegate: WebCompatReportCoord
 
     func webCompatReportViewControllerDidTapLearnMore(url: URL) {
         didTapLearnMoreURLs.append(url)
+    }
+
+    func webCompatReportViewControllerDidTapPreview(payload: WebCompatReportPayload) {
+        didTapPreviewPayloads.append(payload)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
@@ -37,7 +37,117 @@ final class WebCompatReportPayloadTests: XCTestCase {
         XCTAssertNil(payload.breakageCategory)
     }
 
+    // MARK: - previewGroups
+
+    func testPreviewGroups_coverEveryMetricExactlyOnce() {
+        let groups = WebCompatReportPayload().previewGroups
+
+        // A metric missing here leaves the device without ever being shown. Counted off the struct,
+        // so a new one fails this until it's given a line.
+        let metricCount = Mirror(reflecting: WebCompatReportPayload()).children.count
+        let keys = groups.flatMap { group in group.fields.map { "\(group.id.rawValue).\($0.key.rawValue)" } }
+        XCTAssertEqual(Set(keys).count, keys.count)
+        XCTAssertEqual(keys.count, metricCount)
+    }
+
+    func testPreviewGroups_areNamedAndOrderedLikeTheReportSchema() {
+        // Labelled with the raw schema keys, so a renamed or reordered group misdescribes the ping.
+        XCTAssertEqual(
+            WebCompatReportPayload().previewGroups.map(\.id.rawValue),
+            ["basic", "tabInfo", "antiTracking", "frameworks", "app", "system", "graphics"]
+        )
+    }
+
+    func testPreviewGroups_uncollectedMetricsReadAsNull() {
+        let groups = WebCompatReportPayload().previewGroups
+
+        let values = groups.flatMap { $0.fields.map { $0.value.displayText } }
+        XCTAssertTrue(values.allSatisfy { $0 == "null" })
+    }
+
+    func testPreviewGroups_renderEachTypeTheWayTheReportSpellsIt() {
+        var payload = WebCompatReportPayload()
+        payload.url = "https://example.com"
+        payload.isPrivateBrowsing = false
+        payload.memory = 4096
+        payload.defaultLocales = ["en-GB", "fr"]
+
+        let rendered = renderedFields(of: payload)
+
+        XCTAssertEqual(rendered["basic.url"], "\"https://example.com\"")
+        XCTAssertEqual(rendered["antiTracking.isPrivateBrowsing"], "false")
+        XCTAssertEqual(rendered["system.memory"], "4096")
+        XCTAssertEqual(rendered["app.defaultLocales"], "[\"en-GB\", \"fr\"]")
+    }
+
+    func testPreviewGroups_optedInWithNothingBlocked_showsAnEmptyListNotNull() {
+        var payload = WebCompatReportPayload()
+        payload.blockedOrigins = []
+
+        // "We looked and found none" is a different answer from "we didn't look".
+        XCTAssertEqual(renderedFields(of: payload)["antiTracking.blockedOrigins"], "[]")
+    }
+
+    // MARK: - makePreviewViewModel
+
+    func testMakePreviewViewModel_showsTheCollectedPayloadNotASecondCopyOfIt() throws {
+        var payload = WebCompatReportPayload()
+        payload.url = "https://example.com"
+        payload.breakageCategory = WebCompatSubOption.pageNotLoading.rawValue
+        payload.description = "video never starts"
+        payload.isPrivateBrowsing = true
+        payload.memory = 8192
+        payload.defaultLocales = ["en-GB", "fr"]
+
+        let viewModel = payload.makePreviewViewModel()
+
+        // Groups and labels come from the payload, so a new metric shows up without touching this file.
+        XCTAssertEqual(viewModel.sections.map(\.id), payload.previewGroups.map(\.id.rawValue))
+        let rendered = viewModel.sections.flatMap { section in
+            section.rows.map { "\(section.id).\($0.label) = \($0.value.displayText)" }
+        }
+        XCTAssertTrue(rendered.contains("basic.url = \"https://example.com\""))
+        XCTAssertTrue(rendered.contains("basic.reason = \"\(WebCompatSubOption.pageNotLoading.rawValue)\""))
+        XCTAssertTrue(rendered.contains("antiTracking.isPrivateBrowsing = true"))
+        XCTAssertTrue(rendered.contains("system.memory = 8192"))
+        XCTAssertTrue(rendered.contains("app.defaultLocales = [\"en-GB\", \"fr\"]"))
+    }
+
+    func testMakePreviewViewModel_uncollectedMetricsReadAsNull() throws {
+        // What the form knows on its own; everything the collector fills in is still missing.
+        let payload = WebCompatReportPayload.make(
+            from: makeState(url: "https://example.com", selectedCategory: .other)
+        )
+
+        let viewModel = payload.makePreviewViewModel()
+
+        let frameworks = try XCTUnwrap(viewModel.sections.first { $0.id == "frameworks" })
+        XCTAssertEqual(frameworks.rows.map { $0.value.displayText }, ["null", "null", "null"])
+        // An empty details field is absent from the report, so it reads `null` rather than `""`.
+        let description = try XCTUnwrap(
+            viewModel.sections.first { $0.id == "basic" }?.rows.first { $0.label == "description" }
+        )
+        XCTAssertEqual(description.value, .null)
+    }
+
+    func testMakePreviewViewModel_givesEveryGroupItsOwnAccessibilityIdentifiers() {
+        let viewModel = WebCompatReportPayload().makePreviewViewModel()
+
+        // Header and card are addressed separately in UI tests, so they can't share an identifier.
+        let identifiers = viewModel.sections.flatMap { [$0.a11yIdentifier, $0.contentA11yIdentifier] }
+        XCTAssertEqual(Set(identifiers).count, identifiers.count)
+        XCTAssertTrue(identifiers.allSatisfy { $0.hasPrefix("WebCompatReporter.Preview.") })
+    }
+
     // MARK: - Helpers
+
+    private func renderedFields(of payload: WebCompatReportPayload) -> [String: String] {
+        return Dictionary(
+            uniqueKeysWithValues: payload.previewGroups.flatMap { group in
+                group.fields.map { ("\(group.id.rawValue).\($0.key.rawValue)", $0.value.displayText) }
+            }
+        )
+    }
 
     private func makeState(
         url: String = "",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -91,6 +91,40 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         releaseMiddlewareProvidersFromMemory(subject)
     }
 
+    // MARK: - preview
+
+    func test_preview_dispatchesDidBuildPreviewWithTheReport() throws {
+        let subject = createSubject(selectedTab: makeTab(url: "https://example.com/page"))
+        setReportedURL("https://example.com/page")
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.preview))
+
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WebCompatReporterMiddlewareAction)
+        let dispatchedType = try XCTUnwrap(dispatched.actionType as? WebCompatReporterMiddlewareActionType)
+        XCTAssertEqual(dispatchedType, WebCompatReporterMiddlewareActionType.didBuildPreview)
+        let payload = try XCTUnwrap(dispatched.previewPayload)
+        XCTAssertEqual(payload.url, "https://example.com/page")
+        XCTAssertEqual(payload.isPrivateBrowsing, false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func test_preview_whenURLNoLongerMatchesTheTab_dropsTabFieldsLikeSubmit() throws {
+        // The preview has to drop exactly what the ping drops.
+        let subject = createSubject(selectedTab: makeTab(url: "https://example.com/page"))
+        setReportedURL("https://different.example/other")
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.preview))
+
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? WebCompatReporterMiddlewareAction)
+        let payload = try XCTUnwrap(dispatched.previewPayload)
+        XCTAssertNil(payload.isPrivateBrowsing)
+        XCTAssertNil(payload.blockList)
+        XCTAssertNil(payload.userAgentString)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
     // MARK: - Pure view actions are not handled by the middleware
 
     func test_selectCategory_doesNotDispatchViaMiddleware() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
@@ -300,6 +300,48 @@ final class WebCompatReporterStateTests: XCTestCase {
         XCTAssertEqual(newState, initialState)
     }
 
+    // MARK: - previewPayload
+
+    func test_didBuildPreview_carriesThePayloadIntoState() {
+        var payload = WebCompatReportPayload()
+        payload.url = "https://example.com"
+        let reducer = WebCompatReporterState.reducer
+
+        let newState = reducer.legacyReducer(
+            WebCompatReporterState(windowUUID: .XCTestDefaultUUID),
+            WebCompatReporterMiddlewareAction(
+                previewPayload: payload,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: WebCompatReporterMiddlewareActionType.didBuildPreview
+            )
+        )
+
+        XCTAssertEqual(newState.previewPayload, payload)
+    }
+
+    func test_previewPayload_doesNotSurviveTheNextAction() {
+        // Without the clear, previewing twice without editing leaves state unchanged and never reopens.
+        var payload = WebCompatReportPayload()
+        payload.url = "https://example.com"
+        let initialState = WebCompatReporterState(
+            windowUUID: .XCTestDefaultUUID,
+            url: "https://example.com",
+            previewPayload: payload
+        )
+        let reducer = WebCompatReporterState.reducer
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            WebCompatReporterViewAction(
+                url: "https://changed.com",
+                windowUUID: .XCTestDefaultUUID,
+                actionType: WebCompatReporterViewActionType.editURL
+            )
+        )
+
+        XCTAssertNil(newState.previewPayload)
+    }
+
     // MARK: - Equality
 
     func test_equality_sameValues_returnsTrue() {


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16186](https://mozilla-hub.atlassian.net/browse/FXIOS-16186)

## :bulb: Description
> [!NOTE]
> Stacked on [#35052](https://github.com/mozilla-mobile/firefox-ios/pull/35052). Review that first.

The Report Preview screen landed in [#34868](https://github.com/mozilla-mobile/firefox-ios/pull/34868), but nothing in the Client reached it. This wires it up.

- Preview button is back. [FXIOS-16450](https://mozilla-hub.atlassian.net/browse/FXIOS-16450) hid it by leaving `previewButtonTitle` nil, so supplying the title is the whole fix.
- `WebCompatReportPayload.previewGroups` builds the sections from the struct that actually gets sent, so the preview can't drift from the report.
- The coordinator presents the preview through a second router rooted at the sheet, since the main one presents from the browser and the sheet is already up.
- The preview screen is `Themeable` now instead of having a theme pushed into it. That's the first commit, reviewable on its own.
- Thumbnail stays off. The screenshot toggle is still parked, so no image is handed over and no screenshot code comes with this.

## :movie_camera: Demos

<img height="700" alt="IMG_5177" src="https://github.com/user-attachments/assets/4b97b295-8f85-45e4-96b5-84577af1487c" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## :test_tube: Testing
1. **Menu → Report Broken Site**. **Preview** shows top-right, disabled.
2. Pick a category. Preview becomes tappable.
3. Tap it. Payload appears as `key: value` under collapsible headers (`basic`, `tabInfo`, `antiTracking`, …), with no page thumbnail.
4. Expand a group and check `url`, `reason` and `description` match what you entered.
5. Close the preview. You land back on the form with the draft still filled in.
6. Close the form itself. Report is discarded.
7. Switch to dark mode with the preview open. It restyles without reopening.
8. VoiceOver: two-finger scrub dismisses the preview, and group headers announce expanded/collapsed.


[FXIOS-16186]: https://mozilla-hub.atlassian.net/browse/FXIOS-16186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-16450]: https://mozilla-hub.atlassian.net/browse/FXIOS-16450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ