### PR TITLE
Add FXIOS-16165 Add new feature flaggable EditBookmark UI

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -461,6 +461,8 @@
 		367C100A7ABD4B4585D029D5 /* AutoTranslatePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137DDFADC6034016BE36E02B /* AutoTranslatePromptView.swift */; };
 		3846234C30231473003B1711 /* WaybackTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3846234B3023146F003B1711 /* WaybackTelemetry.swift */; };
 		3846234E30231F50003B1711 /* WaybackTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3846234D30231F4B003B1711 /* WaybackTelemetryTests.swift */; };
+		384626063023A0F5003B1711 /* GroupedEditBookmarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384626053023A0EE003B1711 /* GroupedEditBookmarkViewController.swift */; };
+		384626083023A206003B1711 /* GroupedEditBookmarkDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384626073023A1F7003B1711 /* GroupedEditBookmarkDiffableDataSource.swift */; };
 		39012F281F8ED262002E3D31 /* ScreenGraphTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39012F271F8ED262002E3D31 /* ScreenGraphTest.swift */; };
 		391B4FFF1F9767F50094F841 /* FxScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */; };
 		391C28173007C3C500833828 /* TrackerBlockStatsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391C28163007C3C500833828 /* TrackerBlockStatsModels.swift */; };
@@ -3544,6 +3546,8 @@
 		3840498CB36D14A6131110A0 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		3846234B3023146F003B1711 /* WaybackTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaybackTelemetry.swift; sourceTree = "<group>"; };
 		3846234D30231F4B003B1711 /* WaybackTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaybackTelemetryTests.swift; sourceTree = "<group>"; };
+		384626053023A0EE003B1711 /* GroupedEditBookmarkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditBookmarkViewController.swift; sourceTree = "<group>"; };
+		384626073023A1F7003B1711 /* GroupedEditBookmarkDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditBookmarkDiffableDataSource.swift; sourceTree = "<group>"; };
 		388646D292305C259ACDC38B /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Storage.strings; sourceTree = "<group>"; };
 		389B44EEA4AAA49F0D86656C /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		38D94387A7F935DB357BF25F /* ur */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
@@ -12646,6 +12650,8 @@
 		0B8BF3732CA2EB3300E9812D /* Edit Bookmark */ = {
 			isa = PBXGroup;
 			children = (
+				384626073023A1F7003B1711 /* GroupedEditBookmarkDiffableDataSource.swift */,
+				384626053023A0EE003B1711 /* GroupedEditBookmarkViewController.swift */,
 				EC7BFBF130190EAA00254E9A /* BookmarkItemData+Copy.swift */,
 				EC71F4E030190C8000A84FB9 /* GroupedEditBookmarkViewModel.swift */,
 				0B8BF3712CA2DA4600E9812D /* EditBookmarkViewController.swift */,
@@ -20296,6 +20302,7 @@
 				C4F3B29A1CFCF93A00966259 /* ButtonToast.swift in Sources */,
 				1D7B78972ADF32590011E9F2 /* EventQueue.swift in Sources */,
 				0AD3EEAC2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift in Sources */,
+				384626063023A0F5003B1711 /* GroupedEditBookmarkViewController.swift in Sources */,
 				C81B78A4280752A20000C15F /* NimbusFeatureFlagLayer.swift in Sources */,
 				2165B2CC28748CD7004C0786 /* LibraryPanelDescriptor.swift in Sources */,
 				D31A0FC71A65D6D000DC8C7E /* SearchSuggestClient.swift in Sources */,
@@ -20827,6 +20834,7 @@
 				8A9E041B2D4D08350022ED90 /* BookmarkConfiguration.swift in Sources */,
 				8A04136928258DF600D20B10 /* SponsoredTileTelemetry.swift in Sources */,
 				AAD861A82E9E748700F6E0E0 /* TranslationSetting.swift in Sources */,
+				384626083023A206003B1711 /* GroupedEditBookmarkDiffableDataSource.swift in Sources */,
 				D04CD718215EBD85004FF5B0 /* SettingsLoadingView.swift in Sources */,
 				0B8BF3702CA2D60B00E9812D /* BookmarksViewController.swift in Sources */,
 				21420EF72ABA338D00B28550 /* TabTrayCoordinator.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -463,6 +463,8 @@
 		3846234E30231F50003B1711 /* WaybackTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3846234D30231F4B003B1711 /* WaybackTelemetryTests.swift */; };
 		384626063023A0F5003B1711 /* GroupedEditBookmarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384626053023A0EE003B1711 /* GroupedEditBookmarkViewController.swift */; };
 		384626083023A206003B1711 /* GroupedEditBookmarkDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384626073023A1F7003B1711 /* GroupedEditBookmarkDiffableDataSource.swift */; };
+		38BF9252302A306F008582D5 /* GroupedEditBookmarkDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BF9251302A3064008582D5 /* GroupedEditBookmarkDataSourceTests.swift */; };
+		38BF9254302A308E008582D5 /* GroupedEditBookmarkViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BF9253302A3087008582D5 /* GroupedEditBookmarkViewControllerTests.swift */; };
 		39012F281F8ED262002E3D31 /* ScreenGraphTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39012F271F8ED262002E3D31 /* ScreenGraphTest.swift */; };
 		391B4FFF1F9767F50094F841 /* FxScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EB46981E26DDB4006346E8 /* FxScreenGraph.swift */; };
 		391C28173007C3C500833828 /* TrackerBlockStatsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391C28163007C3C500833828 /* TrackerBlockStatsModels.swift */; };
@@ -3550,6 +3552,8 @@
 		384626073023A1F7003B1711 /* GroupedEditBookmarkDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditBookmarkDiffableDataSource.swift; sourceTree = "<group>"; };
 		388646D292305C259ACDC38B /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Storage.strings; sourceTree = "<group>"; };
 		389B44EEA4AAA49F0D86656C /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
+		38BF9251302A3064008582D5 /* GroupedEditBookmarkDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditBookmarkDataSourceTests.swift; sourceTree = "<group>"; };
+		38BF9253302A3087008582D5 /* GroupedEditBookmarkViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedEditBookmarkViewControllerTests.swift; sourceTree = "<group>"; };
 		38D94387A7F935DB357BF25F /* ur */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		38E342918C832D414886C892 /* ne-NP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ne-NP"; path = "ne-NP.lproj/Shared.strings"; sourceTree = "<group>"; };
 		38FB48A49755FD25FEA9E8DF /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/Shared.strings; sourceTree = "<group>"; };
@@ -12628,6 +12632,8 @@
 		0B7CF8852CAC1BFB00DC02F8 /* Bookmarks */ = {
 			isa = PBXGroup;
 			children = (
+				38BF9253302A3087008582D5 /* GroupedEditBookmarkViewControllerTests.swift */,
+				38BF9251302A3064008582D5 /* GroupedEditBookmarkDataSourceTests.swift */,
 				ECF75D3D30193E8A008183CA /* GroupedEditBookmarkViewModelTests.swift */,
 				EC82F42C3017AEB200194A83 /* GroupedEditFolderViewControllerTests.swift */,
 				EC407901300AA88F0003DE07 /* GroupedEditFolderViewModelTests.swift */,
@@ -20923,6 +20929,7 @@
 				FF0005AD2F000004000BBBBB /* MockQuickAnswersStore.swift in Sources */,
 				EDC3D3552CB70A3F00C62DE3 /* OpenSearchEngineTests.swift in Sources */,
 				E571EE7E28756A130051D9AA /* StoryProviderTests.swift in Sources */,
+				38BF9252302A306F008582D5 /* GroupedEditBookmarkDataSourceTests.swift in Sources */,
 				21219854300962F000E45CE9 /* ThemeableTests.swift in Sources */,
 				21420EF92ABC75A400B28550 /* TabTrayCoordinatorTests.swift in Sources */,
 				1DDE3DB52AC360EC0039363B /* TabCellTests.swift in Sources */,
@@ -21287,6 +21294,7 @@
 				45D5EDC0292D619000311934 /* MockablePinnedSites.swift in Sources */,
 				5AE371852A4DD6FE0092A760 /* PasswordManagerCoordinatorDelegateMock.swift in Sources */,
 				8A6E8DEB2B275BA9000C4301 /* PrivateHomepageViewControllerTests.swift in Sources */,
+				38BF9254302A308E008582D5 /* GroupedEditBookmarkViewControllerTests.swift in Sources */,
 				8A93F86529D37331004159D9 /* DefaultRouterTests.swift in Sources */,
 				5AD3B6802CF6674F00AFA1FE /* MockUIApplication.swift in Sources */,
 				8AF10D8A29D713F50086351D /* LaunchScreenViewModelTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Library/BookmarksCoordinator.swift
@@ -90,13 +90,23 @@ class BookmarksCoordinator: BaseCoordinator,
     }
 
     func start(parentFolder: FxBookmarkNode, bookmark: FxBookmarkNode) {
-        let viewModel = EditBookmarkViewModel(parentFolder: parentFolder,
-                                              node: bookmark,
-                                              profile: profile)
-        viewModel.bookmarkCoordinatorDelegate = self
-        let controller = EditBookmarkViewController(viewModel: viewModel,
-                                                    windowUUID: windowUUID)
-        router.setRootViewController(controller)
+        if featureFlagsProvider.isEnabled(.newBookmarkFolderTree) {
+            let viewModel = GroupedEditBookmarkViewModel(parentFolder: parentFolder,
+                                                         node: bookmark,
+                                                         profile: profile)
+            viewModel.bookmarkCoordinatorDelegate = self
+            let controller = GroupedEditBookmarkViewController(viewModel: viewModel,
+                                                               windowUUID: windowUUID)
+            router.setRootViewController(controller)
+        } else {
+            let viewModel = EditBookmarkViewModel(parentFolder: parentFolder,
+                                                  node: bookmark,
+                                                  profile: profile)
+            viewModel.bookmarkCoordinatorDelegate = self
+            let controller = EditBookmarkViewController(viewModel: viewModel,
+                                                        windowUUID: windowUUID)
+            router.setRootViewController(controller)
+        }
     }
 
     func showBookmarkDetail(for node: FxBookmarkNode, folder: FxBookmarkNode) {
@@ -167,6 +177,9 @@ class BookmarksCoordinator: BaseCoordinator,
                                       parentFolderSelector: ParentFolderSelector?,
                                       groupedParentFolderSelector: GroupedParentFolderSelector?) -> UIViewController {
         if type == .bookmark {
+            if featureFlagsProvider.isEnabled(.newBookmarkFolderTree) {
+                return makeGroupedEditBookmarkController(for: nil, folder: parentFolder)
+            }
             return makeEditBookmarkController(for: nil, folder: parentFolder)
         }
         if type == .folder {
@@ -182,6 +195,9 @@ class BookmarksCoordinator: BaseCoordinator,
 
     private func makeDetailController(for node: FxBookmarkNode, folder: FxBookmarkNode) -> UIViewController {
         if node.type == .bookmark {
+            if featureFlagsProvider.isEnabled(.newBookmarkFolderTree) {
+                return makeGroupedEditBookmarkController(for: node, folder: folder)
+            }
             return makeEditBookmarkController(for: node, folder: folder)
         }
         if node.type == .folder {
@@ -202,6 +218,25 @@ class BookmarksCoordinator: BaseCoordinator,
         setBackBarButtonItemTitle(viewModel.getBackNavigationButtonTitle)
         let controller = EditBookmarkViewController(viewModel: viewModel,
                                                     windowUUID: windowUUID)
+        controller.onViewWillAppear = { [weak self] in
+            self?.libraryNavigationHandler?.setNavigationBarHidden(true)
+        }
+        controller.onViewWillDisappear = { [weak self, weak controller] in
+            guard !(controller?.transitionCoordinator?.isInteractive ?? false) else { return }
+            self?.libraryNavigationHandler?.setNavigationBarHidden(false)
+        }
+        return controller
+    }
+
+    private func makeGroupedEditBookmarkController(for node: FxBookmarkNode?, folder: FxBookmarkNode) -> UIViewController {
+        let viewModel = GroupedEditBookmarkViewModel(parentFolder: folder, node: node, profile: profile)
+        viewModel.onBookmarkSaved = { [weak self] in
+            self?.reloadLastBookmarksController()
+        }
+        viewModel.bookmarkCoordinatorDelegate = self
+        setBackBarButtonItemTitle(viewModel.getBackNavigationButtonTitle)
+        let controller = GroupedEditBookmarkViewController(viewModel: viewModel,
+                                                           windowUUID: windowUUID)
         controller.onViewWillAppear = { [weak self] in
             self?.libraryNavigationHandler?.setNavigationBarHidden(true)
         }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkDiffableDataSource.swift
@@ -7,8 +7,8 @@ import Foundation
 typealias GroupedEditBookmarkTableSection = GroupedEditBookmarkDiffableDataSource.TableSection
 typealias GroupedEditBookmarkTableCell = GroupedEditBookmarkDiffableDataSource.TableCell
 
-class GroupedEditBookmarkDiffableDataSource: UITableViewDiffableDataSource<GroupedEditBookmarkTableSection,
-                                                                           GroupedEditBookmarkTableCell> {
+final class GroupedEditBookmarkDiffableDataSource: UITableViewDiffableDataSource<GroupedEditBookmarkTableSection,
+                                                                                 GroupedEditBookmarkTableCell> {
     enum TableSection: Int, CaseIterable {
         case main
         case selectFolder

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkDiffableDataSource.swift
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+typealias GroupedEditBookmarkTableSection = GroupedEditBookmarkDiffableDataSource.TableSection
+typealias GroupedEditBookmarkTableCell = GroupedEditBookmarkDiffableDataSource.TableCell
+
+class GroupedEditBookmarkDiffableDataSource: UITableViewDiffableDataSource<GroupedEditBookmarkTableSection,
+                                                                           GroupedEditBookmarkTableCell> {
+    enum TableSection: Int, CaseIterable {
+        case main
+        case selectFolder
+    }
+
+    enum TableCell: Hashable {
+        case bookmark
+        case folder(GroupedFolder, Bool)
+        case newFolder
+    }
+
+    var onSnapshotUpdate: (@MainActor () -> Void)?
+
+    func updateSnapshot(isFolderCollapsed: Bool, folders: [GroupedFolder]) {
+        var snapshot = NSDiffableDataSourceSnapshot<GroupedEditBookmarkTableSection, GroupedEditBookmarkTableCell>()
+        snapshot.appendSections([.main, .selectFolder])
+
+        snapshot.appendItems([.bookmark], toSection: .main)
+
+        let folderItems = folders.map { TableCell.folder($0, isFolderCollapsed) }
+        snapshot.appendItems(folderItems, toSection: .selectFolder)
+
+        // Add the New Folder section if not collapsed
+        if !isFolderCollapsed {
+            snapshot.appendItems([.newFolder], toSection: .selectFolder)
+        }
+
+        apply(snapshot, animatingDifferences: true) { [weak self] in
+            self?.onSnapshotUpdate?()
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewController.swift
@@ -24,7 +24,7 @@ class GroupedEditBookmarkViewController: UIViewController,
         return themeManager.getCurrentTheme(for: currentWindowUUID)
     }
 
-    private lazy var tableView: UITableView = .build({ view in
+    lazy var tableView: UITableView = .build({ view in
         view.delegate = self
         view.register(cellType: EditBookmarkCell.self)
         view.register(cellType: OneLineTableViewCell.self)
@@ -59,7 +59,7 @@ class GroupedEditBookmarkViewController: UIViewController,
     var onViewWillAppear: (@MainActor () -> Void)?
 
     private let viewModel: GroupedEditBookmarkViewModel
-    private lazy var dataSource: GroupedEditBookmarkDiffableDataSource = {
+    lazy var dataSource: GroupedEditBookmarkDiffableDataSource = {
         return GroupedEditBookmarkDiffableDataSource(tableView: tableView,
                                                      cellProvider: { [weak self] _, indexPath, item in
             return self?.configureCells(at: indexPath, item: item) ?? UITableViewCell()

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewController.swift
@@ -6,9 +6,9 @@ import Foundation
 import Common
 import MozillaAppServices
 
-class GroupedEditBookmarkViewController: UIViewController,
-                                         UITableViewDelegate,
-                                         Themeable {
+final class GroupedEditBookmarkViewController: UIViewController,
+                                               UITableViewDelegate,
+                                               Themeable {
     private struct UX {
         static let bookmarkCellTopPadding: CGFloat = 25.0
         static let folderHeaderIdentifier = "folderHeaderIdentifier"

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewController.swift
@@ -1,0 +1,348 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+import MozillaAppServices
+
+class GroupedEditBookmarkViewController: UIViewController,
+                                         UITableViewDelegate,
+                                         Themeable {
+    private struct UX {
+        static let bookmarkCellTopPadding: CGFloat = 25.0
+        static let folderHeaderIdentifier = "folderHeaderIdentifier"
+        static let folderHeaderHorizontalPadding: CGFloat = 16.0
+        static let folderHeaderBottomPadding: CGFloat = 8.0
+    }
+
+    var currentWindowUUID: WindowUUID?
+    var themeManager: any ThemeManager
+    var themeListenerCancellable: Any?
+    var notificationCenter: any NotificationProtocol
+    private var theme: any Theme {
+        return themeManager.getCurrentTheme(for: currentWindowUUID)
+    }
+
+    private lazy var tableView: UITableView = .build({ view in
+        view.delegate = self
+        view.register(cellType: EditBookmarkCell.self)
+        view.register(cellType: OneLineTableViewCell.self)
+        view.register(cellType: FolderTreeCell.self)
+        view.register(UITableViewHeaderFooterView.self,
+                      forHeaderFooterViewReuseIdentifier: UX.folderHeaderIdentifier)
+        view.separatorStyle = .none
+        let headerSpacerView = UIView(frame: CGRect(origin: .zero,
+                                                    size: CGSize(width: 0, height: UX.bookmarkCellTopPadding)))
+        view.tableHeaderView = headerSpacerView
+        view.keyboardDismissMode = .onDrag
+    }, {
+        if #available(iOS 26.0, *) {
+            UITableView(frame: .zero, style: .insetGrouped)
+        } else {
+            UITableView()
+        }
+    })
+
+    private lazy var saveBarButton: UIBarButtonItem =  {
+        let button = UIBarButtonItem(
+            title: String.Bookmarks.Menu.EditBookmarkSave,
+            style: .plain,
+            target: self,
+            action: #selector(saveButtonAction)
+        )
+        button.accessibilityIdentifier = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.saveButton
+        return button
+    }()
+
+    var onViewWillDisappear: (@MainActor () -> Void)?
+    var onViewWillAppear: (@MainActor () -> Void)?
+
+    private let viewModel: GroupedEditBookmarkViewModel
+    private lazy var dataSource: GroupedEditBookmarkDiffableDataSource = {
+        return GroupedEditBookmarkDiffableDataSource(tableView: tableView,
+                                                     cellProvider: { [weak self] _, indexPath, item in
+            return self?.configureCells(at: indexPath, item: item) ?? UITableViewCell()
+        })
+    }()
+
+    init(viewModel: GroupedEditBookmarkViewModel,
+         windowUUID: WindowUUID,
+         notificationCenter: NotificationProtocol = NotificationCenter.default,
+         themeManager: ThemeManager = AppContainer.shared.resolve()) {
+        self.viewModel = viewModel
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        self.currentWindowUUID = windowUUID
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Life Cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = .Bookmarks.Menu.EditBookmarkTitle
+        viewModel.onFolderStatusUpdate = { [weak self] in
+            self?.reloadTableViewData()
+        }
+
+        navigationItem.rightBarButtonItem = saveBarButton
+        // The back button title sometimes doesn't align with the chevron, force navigation bar layout
+        navigationController?.navigationBar.layoutIfNeeded()
+        setupSubviews()
+
+        dataSource.defaultRowAnimation = .fade
+        reloadTableViewData()
+
+        listenForThemeChanges(withNotificationCenter: notificationCenter)
+        applyTheme()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setTheme(theme)
+        _ = viewModel.getBackNavigationButtonTitle
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+        onViewWillAppear?()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        let editBookmarkCell = tableView.visibleCells.first {
+            return $0 is EditBookmarkCell
+        } as? EditBookmarkCell
+        editBookmarkCell?.focusTitleTextField()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if let isDragging = transitionCoordinator?.isInteractive, !isDragging {
+            navigationController?.setNavigationBarHidden(true, animated: false)
+        }
+        // Save when popping the view off the navigation stack (when in library)
+        if isMovingFromParent {
+            viewModel.saveBookmark()
+        }
+        onViewWillDisappear?()
+    }
+
+    // MARK: - Setup
+    private func setupSubviews() {
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    // MARK: - Actions
+
+    private func reloadTableViewData() {
+        dataSource.updateSnapshot(isFolderCollapsed: viewModel.isFolderCollapsed,
+                                  folders: viewModel.folderStructures)
+    }
+
+    @objc
+    func saveButtonAction() {
+        // If we are in the standalone version of edit bookmark, we should save before dismissing
+        if navigationController?.viewControllers.first == self {
+            viewModel.saveBookmark()
+            viewModel.didFinish()
+        } else {
+            // If we are in the library, save will happen in viewWillDisappear
+            navigationController?.popViewController(animated: true)
+        }
+    }
+
+    // MARK: - Themeable
+
+    func applyTheme() {
+        setTheme(theme)
+        reloadTableViewData()
+    }
+
+    private func setTheme(_ theme: any Theme) {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = theme.colors.layer1
+        // remove divider from navigation bar
+        appearance.shadowColor = .clear
+        appearance.titleTextAttributes = [
+            .foregroundColor: theme.colors.textPrimary
+        ]
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
+        view.backgroundColor = theme.colors.layer1
+        tableView.backgroundColor = theme.colors.layer1
+        if #available(iOS 26.0, *) {
+            saveBarButton.tintColor = theme.colors.textAccent
+        }
+    }
+
+    // MARK: - Configure Table View Cells
+
+    private func configureCells(at indexPath: IndexPath, item: GroupedEditBookmarkTableCell) -> UITableViewCell {
+        switch item {
+        case .bookmark:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: EditBookmarkCell.cellIdentifier,
+                                                           for: indexPath) as? EditBookmarkCell
+            else {
+                return UITableViewCell()
+            }
+            configureEditBookmarkCell(cell)
+            return cell
+
+        case .folder(let folder, _):
+            if let placeholderTitle = placeholderHeaderTitle(for: folder) {
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: OneLineTableViewCell.cellIdentifier,
+                                                               for: indexPath) as? OneLineTableViewCell
+                else { return UITableViewCell() }
+                configurePlaceholderHeaderCell(cell, title: placeholderTitle, folder: folder)
+                return cell
+            }
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: FolderTreeCell.cellIdentifier,
+                                                           for: indexPath) as? FolderTreeCell
+            else { return UITableViewCell() }
+            configureParentFolderCell(cell, folder: folder)
+            cell.accessibilityIdentifier =
+                "\(AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.bookmarkParentFolderCell)_\(indexPath.row)"
+            return cell
+
+        case .newFolder:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: OneLineTableViewCell.cellIdentifier,
+                                                           for: indexPath) as? OneLineTableViewCell,
+                  !viewModel.isFolderCollapsed
+            else {
+                return UITableViewCell()
+            }
+            configureNewFolderCell(cell)
+            return cell
+        }
+    }
+
+    private func configureEditBookmarkCell(_ cell: EditBookmarkCell) {
+        cell.setData(siteURL: viewModel.bookmarkURL, title: viewModel.bookmarkTitle)
+        cell.onURLFieldUpdate = { [weak self] in
+            self?.viewModel.setUpdatedURL($0)
+        }
+        cell.onTitleFieldUpdate = { [weak self] in
+            self?.viewModel.setUpdatedTitle($0)
+        }
+        cell.selectionStyle = .none
+        cell.applyTheme(theme: theme)
+    }
+
+    private func configureParentFolderCell(_ cell: FolderTreeCell, folder: GroupedFolder) {
+        let breadcrumb: String?
+        if !viewModel.isFolderCollapsed,
+           folder.indentation > 0,
+           let parentTitle = folder.parentTitle, !parentTitle.isEmpty {
+            breadcrumb = String(format: String.Bookmarks.Menu.EditBookmarkParentFolderBreadcrumbFormat, parentTitle)
+        } else {
+            breadcrumb = nil
+        }
+
+        let folderImage = UIImage(named: StandardImageIdentifiers.Large.folder)
+        cell.indentationLevel = viewModel.indentationForFolder(folder)
+        cell.configure(title: folder.title,
+                       breadcrumb: breadcrumb,
+                       image: folderImage,
+                       isSelected: viewModel.shouldShowDisclosureIndicatorForFolder(folder))
+        cell.applyTheme(theme: theme)
+    }
+
+    private func placeholderHeaderTitle(for folder: GroupedFolder) -> String? {
+        switch folder.guid {
+        case GroupedEditBookmarkViewModel.mobileHeaderPlaceholderGuid:
+            return .Bookmarks.Menu.EditBookmarkMobileBookmarksLabel
+        case GroupedEditBookmarkViewModel.desktopHeaderPlaceholderGuid:
+            return String.Bookmarks.Menu.EditBookmarkDesktopBookmarksLabel
+        default:
+            return nil
+        }
+    }
+
+    private func configurePlaceholderHeaderCell(_ cell: OneLineTableViewCell, title: String, folder: GroupedFolder) {
+        cell.titleLabel.text = title
+        cell.customization = .desktopBookmarksLabel
+        cell.indentationLevel = folder.indentation
+        cell.accessoryType = .none
+        cell.selectionStyle = .none
+        cell.applyTheme(theme: theme)
+    }
+
+    private func configureNewFolderCell(_ cell: OneLineTableViewCell) {
+        cell.titleLabel.text = .BookmarksNewFolder
+        let folderImage = UIImage(named: StandardImageIdentifiers.Large.newFolder)?.withRenderingMode(.alwaysTemplate)
+        cell.leftImageView.image = folderImage
+        cell.indentationLevel = 0
+        cell.accessoryType = .none
+        cell.selectionStyle = .default
+        cell.accessibilityIdentifier = AccessibilityIdentifiers.LibraryPanels.BookmarksPanel.newFolderCell
+        cell.accessibilityTraits = .button
+        cell.customization = .newFolder
+        cell.applyTheme(theme: theme)
+    }
+
+    // MARK: - UITableViewDelegate
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: UX.folderHeaderIdentifier),
+              let sectionEnum = EditBookmarkTableSection(rawValue: section),
+              sectionEnum == .selectFolder
+        else { return nil }
+        var configuration = UIListContentConfiguration.plainHeader()
+        configuration.text = .Bookmarks.Menu.EditBookmarkSaveIn.uppercased()
+        configuration.textProperties.font = FXFontStyles.Regular.callout.scaledFont()
+        configuration.textProperties.color = theme.colors.textSecondary
+        let layoutMargins = NSDirectionalEdgeInsets(top: 0,
+                                                    leading: UX.folderHeaderHorizontalPadding,
+                                                    bottom: UX.folderHeaderBottomPadding,
+                                                    trailing: UX.folderHeaderHorizontalPadding)
+        configuration.directionalLayoutMargins = layoutMargins
+        header.contentConfiguration = configuration
+        header.directionalLayoutMargins = .zero
+        header.preservesSuperviewLayoutMargins = false
+        return header
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        guard let section = EditBookmarkTableSection(rawValue: section),
+              section == .selectFolder else { return 0 }
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        if let folder = viewModel.folderStructures[safe: indexPath.row],
+           placeholderHeaderTitle(for: folder) != nil {
+            return nil
+        }
+        return indexPath
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
+
+        switch item {
+        case .folder(let folder, _):
+            viewModel.selectFolder(folder)
+        case .newFolder:
+            viewModel.createNewFolder()
+        default:
+            break
+        }
+
+        tableView.deselectRow(at: indexPath, animated: false)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditBookmarkDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditBookmarkDataSourceTests.swift
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+@MainActor
+final class GroupedEditBookmarkDataSourceTests: XCTestCase {
+    private let folders = [
+        GroupedFolder(title: "Parent", guid: "ParentFolder", indentation: 0),
+        GroupedFolder(title: "Child", guid: "ChildFolder", indentation: 1)
+    ]
+    private var tableView: UITableView!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tableView = UITableView()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = UIViewController()
+        window.rootViewController?.view.addSubview(tableView)
+        window.makeKeyAndVisible()
+    }
+
+    override func tearDown() async throws {
+        tableView = nil
+        try await super.tearDown()
+    }
+
+    func testOnSnapshotUpdate() {
+        let expectation = XCTestExpectation(description: "onShapshotUpate should be called")
+        let subject = createSubject(tableView: tableView)
+
+        subject.onSnapshotUpdate = {
+            expectation.fulfill()
+        }
+
+        subject.updateSnapshot(isFolderCollapsed: true, folders: folders)
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+
+    func testDataSourceSnapshot_whenFolderIsCollapsed() {
+        let subject = createSubject(tableView: tableView)
+        let sections: [GroupedEditBookmarkTableSection] = [.main, .selectFolder]
+        var tableCells: [GroupedEditBookmarkTableCell] = [.bookmark]
+        folders.forEach {
+            tableCells.append(GroupedEditBookmarkTableCell.folder($0, true))
+        }
+
+        subject.updateSnapshot(isFolderCollapsed: true, folders: folders)
+
+        XCTAssertEqual(subject.snapshot().sectionIdentifiers, sections)
+        XCTAssertEqual(subject.snapshot().itemIdentifiers, tableCells)
+    }
+
+    func testDataSourceSnapshot_whenFolderIsNotCollapsed() {
+        let subject = createSubject(tableView: tableView)
+        let sections: [GroupedEditBookmarkTableSection] = [.main, .selectFolder]
+        var tableCells: [GroupedEditBookmarkTableCell] = [.bookmark]
+        folders.forEach {
+            tableCells.append(GroupedEditBookmarkTableCell.folder($0, false))
+        }
+        tableCells.append(.newFolder)
+
+        subject.updateSnapshot(isFolderCollapsed: false, folders: folders)
+
+        XCTAssertEqual(subject.snapshot().sectionIdentifiers, sections)
+        XCTAssertEqual(subject.snapshot().itemIdentifiers, tableCells)
+    }
+
+    func testDataSourceSnapshot_whenNoFolders_selectFolderSectionHasOnlyBookmarkSiblings() {
+        let subject = createSubject(tableView: tableView)
+
+        subject.updateSnapshot(isFolderCollapsed: true, folders: [])
+
+        XCTAssertEqual(subject.snapshot().itemIdentifiers, [.bookmark])
+    }
+
+    private func createSubject(tableView: UITableView) -> GroupedEditBookmarkDiffableDataSource {
+        let dataSource = GroupedEditBookmarkDiffableDataSource(tableView: tableView) { _, _, _ in
+            return UITableViewCell()
+        }
+        trackForMemoryLeaks(dataSource)
+        return dataSource
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditBookmarkViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditBookmarkViewControllerTests.swift
@@ -1,0 +1,232 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import MozillaAppServices
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class GroupedEditBookmarkViewControllerTests: XCTestCase {
+    private var profile: MockProfile!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile()
+    }
+
+    override func tearDown() async throws {
+        DependencyHelperMock().reset()
+        profile = nil
+        try await super.tearDown()
+    }
+
+    func test_numberOfSections_returnsMainAndSelectFolderSections() {
+        let subject = createSubject()
+
+        XCTAssertEqual(subject.tableView.numberOfSections, 2)
+    }
+
+    func test_numberOfRows_mainSection_isAlwaysOne() {
+        let subject = createSubject()
+
+        XCTAssertEqual(subject.tableView.numberOfRows(inSection: 0), 1)
+    }
+
+    func test_numberOfRows_selectFolderSection_whenCollapsed_matchesFolderCount() {
+        let subject = createSubject()
+
+        XCTAssertEqual(subject.tableView.numberOfRows(inSection: 1), 1)
+    }
+
+    func test_cellForRow_mainSection_returnsEditBookmarkCell() {
+        let subject = createSubject()
+
+        let cell = subject.tableView.dataSource?.tableView(subject.tableView,
+                                                           cellForRowAt: IndexPath(row: 0, section: 0))
+
+        XCTAssertTrue(cell is EditBookmarkCell)
+    }
+
+    func test_cellForRow_selectFolderSection_returnsFolderTreeCell() {
+        let subject = createSubject()
+
+        let cell = subject.tableView.dataSource?.tableView(subject.tableView,
+                                                           cellForRowAt: IndexPath(row: 0, section: 1))
+
+        XCTAssertTrue(cell is FolderTreeCell)
+    }
+
+    func test_didSelectRow_folderCell_expandsAndFetchesFolders() {
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        selectFolderAndWait(viewModel, subject: subject, indexPath: IndexPath(row: 0, section: 1))
+
+        XCTAssertFalse(viewModel.isFolderCollapsed)
+        XCTAssertEqual(fetcher.fetchFoldersCalled, 1)
+    }
+
+    func test_numberOfRows_selectFolderSection_whenExpanded_includesNewFolderCell() {
+        let folders = [GroupedFolder(title: "Top", guid: "top", indentation: 0)]
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        fetcher.mockFolderStructures = folders
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        selectFolderAndWait(viewModel, subject: subject, indexPath: IndexPath(row: 0, section: 1))
+
+        // folders returned by the fetcher, plus the "New Folder" row appended while expanded
+        XCTAssertEqual(subject.tableView.numberOfRows(inSection: 1), folders.count + 1)
+    }
+
+    func test_cellForRow_newFolderRow_returnsOneLineTableViewCell() {
+        let folders = [GroupedFolder(title: "Top", guid: "top", indentation: 0)]
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        fetcher.mockFolderStructures = folders
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        selectFolderAndWait(viewModel, subject: subject, indexPath: IndexPath(row: 0, section: 1))
+        let newFolderRow = folders.count
+        let cell = subject.tableView.dataSource?.tableView(
+            subject.tableView,
+            cellForRowAt: IndexPath(row: newFolderRow, section: 1)
+        )
+
+        XCTAssertTrue(cell is OneLineTableViewCell)
+    }
+
+    func test_didSelectRow_selectingFolder_collapsesAndUpdatesSelectedFolder() {
+        let folder = GroupedFolder(title: "Top", guid: "top", indentation: 0)
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        fetcher.mockFolderStructures = [folder]
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        // Expand the list first
+        selectFolderAndWait(viewModel, subject: subject, indexPath: IndexPath(row: 0, section: 1))
+        // Selecting the folder again collapses the list synchronously
+        subject.tableView(subject.tableView, didSelectRowAt: IndexPath(row: 0, section: 1))
+
+        XCTAssertTrue(viewModel.isFolderCollapsed)
+        XCTAssertEqual(viewModel.selectedFolder?.guid, folder.guid)
+    }
+
+    func test_willSelectRow_placeholderHeaderCell_returnsNil() {
+        let placeholder = GroupedFolder(
+            title: "",
+            guid: GroupedEditBookmarkViewModel.mobileHeaderPlaceholderGuid,
+            indentation: 0
+        )
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        fetcher.mockFolderStructures = [placeholder]
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        selectFolderAndWait(viewModel, subject: subject, indexPath: IndexPath(row: 0, section: 1))
+        let result = subject.tableView(subject.tableView, willSelectRowAt: IndexPath(row: 0, section: 1))
+
+        XCTAssertNil(result)
+    }
+
+    func test_saveButtonAction_whenStandalone_savesBookmark() {
+        let viewModel = createViewModel()
+        let subject = createSubject(viewModel: viewModel)
+        let navController = UINavigationController(rootViewController: subject)
+        _ = navController
+
+        let expectation = XCTestExpectation(description: "bookmark saved")
+        viewModel.onBookmarkSaved = { expectation.fulfill() }
+
+        subject.saveButtonAction()
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_saveButtonAction_whenInLibrary_popsViewController() {
+        let subject = createSubject()
+        let navController = UINavigationController()
+        navController.pushViewController(UIViewController(), animated: false)
+        navController.pushViewController(subject, animated: false)
+
+        subject.saveButtonAction()
+
+        XCTAssertFalse(navController.viewControllers.contains(subject))
+    }
+
+    // MARK: - Private
+
+    private func createSubject(
+        viewModel: GroupedEditBookmarkViewModel? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> GroupedEditBookmarkViewController {
+        let subject = GroupedEditBookmarkViewController(
+            viewModel: viewModel ?? createViewModel(),
+            windowUUID: .XCTestDefaultUUID
+        )
+        subject.loadViewIfNeeded()
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
+    private func createViewModel(
+        folderFetcher: GroupedFolderHierarchyFetcher? = nil
+    ) -> GroupedEditBookmarkViewModel {
+        let parentFolder = BookmarkFolderData(
+            guid: "parent_guid",
+            dateAdded: 0,
+            lastModified: 0,
+            parentGUID: nil,
+            position: 0,
+            title: "Parent",
+            childGUIDs: [],
+            children: nil
+        )
+        let node = BookmarkItemData(
+            guid: "bookmark_guid",
+            dateAdded: 0,
+            lastModified: 0,
+            parentGUID: "parent_guid",
+            position: 0,
+            url: "https://example.com",
+            title: "Example"
+        )
+        return GroupedEditBookmarkViewModel(
+            parentFolder: parentFolder,
+            node: node,
+            profile: profile,
+            bookmarksSaver: MockBookmarksSaver(),
+            folderFetcher: folderFetcher ?? MockGroupedFolderHierarchyFetcher()
+        )
+    }
+
+    private func selectFolderAndWait(
+        _ viewModel: GroupedEditBookmarkViewModel,
+        subject: GroupedEditBookmarkViewController,
+        indexPath: IndexPath
+    ) {
+        let statusExpectation = XCTestExpectation(description: "folder status updated")
+        let snapshotExpectation = XCTestExpectation(description: "snapshot applied")
+
+        let existingHandler = viewModel.onFolderStatusUpdate
+        viewModel.onFolderStatusUpdate = {
+            existingHandler?()
+            statusExpectation.fulfill()
+        }
+
+        let existingSnapshotHandler = subject.dataSource.onSnapshotUpdate
+        subject.dataSource.onSnapshotUpdate = {
+            existingSnapshotHandler?()
+            snapshotExpectation.fulfill()
+        }
+
+        subject.tableView(subject.tableView, didSelectRowAt: indexPath)
+        wait(for: [statusExpectation, snapshotExpectation], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16165)

## :bulb: Description
This PR adds the new GroupedEditBookmarkViewController which mimics the old EditBookmarkViewController but supports grouping. The PR also adds the necessary changes to the coordinator to use the new grouped controller instead of the old one when the New Bookmarks Folder Tree feature flag is on. To test this feature, enable the feature flag, then edit a bookmark.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

