### PR TITLE
Add FXIOS-16300 [Google Lens] Tooltip

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -524,6 +524,10 @@ public class BrowserAddressToolbar: UIView,
         toolbarDelegate?.addressToolbarNeedsSearchReset()
     }
 
+    func locationViewDidDisplayEditingAccessoryButton(_ button: UIButton, contextualHintType: String) {
+        toolbarDelegate?.configureContextualHint(self, for: button, with: contextualHintType)
+    }
+
     // MARK: - ThemeApplicable
     public func applyTheme(theme: Theme) {
         let colors = theme.colors

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -15,9 +15,7 @@ protocol LocationTextFieldDelegate: AnyObject {
     func locationTextFieldDidBeginEditing(_ textField: UITextField)
     func locationTextFieldDidEndEditing()
     func locationTextFieldNeedsSearchReset()
-    func locationTextField(_ textField: LocationTextField,
-                           didDisplayEditingAccessoryButton button: UIButton,
-                           contextualHintType: String)
+    func locationTextFieldDidDisplayEditingAccessoryButton(_ button: UIButton, contextualHintType: String)
 }
 
 final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable, Notifiable {
@@ -260,9 +258,8 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
 
             if !wasShowingEditingAccessory,
                let contextualHintType = editingAccessoryAction?.contextualHintType {
-                autocompleteDelegate?.locationTextField(
-                    self,
-                    didDisplayEditingAccessoryButton: editingAccessoryRightView,
+                autocompleteDelegate?.locationTextFieldDidDisplayEditingAccessoryButton(
+                    editingAccessoryRightView,
                     contextualHintType: contextualHintType
                 )
             }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -15,6 +15,9 @@ protocol LocationTextFieldDelegate: AnyObject {
     func locationTextFieldDidBeginEditing(_ textField: UITextField)
     func locationTextFieldDidEndEditing()
     func locationTextFieldNeedsSearchReset()
+    func locationTextField(_ textField: LocationTextField,
+                           didDisplayEditingAccessoryButton button: UIButton,
+                           contextualHintType: String)
 }
 
 final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable, Notifiable {
@@ -247,10 +250,22 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
 
     private func updateRightView() {
         let textIsEmpty = textWithoutSuggestion()?.isEmpty ?? true
-        if editingAccessoryAction?.iconName != nil, isEditing, textIsEmpty {
+        let shouldShowEditingAccessory = editingAccessoryAction?.iconName != nil && isEditing && textIsEmpty
+        let wasShowingEditingAccessory = rightView != nil && rightView === editingAccessoryRightView
+
+        if shouldShowEditingAccessory {
             rightView = editingAccessoryRightView
             rightViewMode = .whileEditing
             clearButtonMode = .never
+
+            if !wasShowingEditingAccessory,
+               let contextualHintType = editingAccessoryAction?.contextualHintType {
+                autocompleteDelegate?.locationTextField(
+                    self,
+                    didDisplayEditingAccessoryButton: editingAccessoryRightView,
+                    contextualHintType: contextualHintType
+                )
+            }
         } else {
             rightView = nil
             rightViewMode = .never

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -736,6 +736,12 @@ final class LocationView: UIView,
         delegate?.locationTextFieldNeedsSearchReset()
     }
 
+    func locationTextField(_ textField: LocationTextField,
+                           didDisplayEditingAccessoryButton button: UIButton,
+                           contextualHintType: String) {
+        delegate?.locationViewDidDisplayEditingAccessoryButton(button, contextualHintType: contextualHintType)
+    }
+
     // MARK: - Accessibility
     private func configureA11y(_ config: LocationViewConfiguration) {
         lockIconButton.accessibilityIdentifier = config.lockIconButtonA11yId

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -736,9 +736,7 @@ final class LocationView: UIView,
         delegate?.locationTextFieldNeedsSearchReset()
     }
 
-    func locationTextField(_ textField: LocationTextField,
-                           didDisplayEditingAccessoryButton button: UIButton,
-                           contextualHintType: String) {
+    func locationTextFieldDidDisplayEditingAccessoryButton(_ button: UIButton, contextualHintType: String) {
         delegate?.locationViewDidDisplayEditingAccessoryButton(button, contextualHintType: contextualHintType)
     }
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewDelegate.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationViewDelegate.swift
@@ -44,4 +44,7 @@ protocol LocationViewDelegate: AnyObject {
     /// Called when the user types over the old highlighted text immediately after
     /// focusing the text field.
     func locationTextFieldNeedsSearchReset()
+
+    /// Called when the editing accessory button becomes visible in the location view.
+    func locationViewDidDisplayEditingAccessoryButton(_ button: UIButton, contextualHintType: String)
 }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2421,6 +2421,7 @@
 		FB16062100000000000000E2 /* GoogleLensImageProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062100000000000000E1 /* GoogleLensImageProcessor.swift */; };
 		FB16062100000000000000E4 /* GoogleLensRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062100000000000000E3 /* GoogleLensRequestBuilder.swift */; };
 		FB16062100000000000000E6 /* GoogleLensService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062100000000000000E5 /* GoogleLensService.swift */; };
+		FB16062100000000000000E8 /* GoogleLensTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062100000000000000E7 /* GoogleLensTip.swift */; };
 		FB16062200000000000000A2 /* CameraCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062200000000000000A1 /* CameraCoordinator.swift */; };
 		FB16062200000000000000B2 /* CameraCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062200000000000000B1 /* CameraCoordinatorTests.swift */; };
 		FBADD1700000000000000002 /* LaunchPairingFromURLSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBADD1700000000000000001 /* LaunchPairingFromURLSettingTests.swift */; };
@@ -12151,6 +12152,7 @@
 		FB16062100000000000000E1 /* GoogleLensImageProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLensImageProcessor.swift; sourceTree = "<group>"; };
 		FB16062100000000000000E3 /* GoogleLensRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLensRequestBuilder.swift; sourceTree = "<group>"; };
 		FB16062100000000000000E5 /* GoogleLensService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLensService.swift; sourceTree = "<group>"; };
+		FB16062100000000000000E7 /* GoogleLensTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLensTip.swift; sourceTree = "<group>"; };
 		FB16062200000000000000A1 /* CameraCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCoordinator.swift; sourceTree = "<group>"; };
 		FB16062200000000000000B1 /* CameraCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCoordinatorTests.swift; sourceTree = "<group>"; };
 		FB254B83B0B5E0487089B861 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Today.strings; sourceTree = "<group>"; };
@@ -17806,6 +17808,7 @@
 				FB16062100000000000000E1 /* GoogleLensImageProcessor.swift */,
 				FB16062100000000000000E3 /* GoogleLensRequestBuilder.swift */,
 				FB16062100000000000000E5 /* GoogleLensService.swift */,
+				FB16062100000000000000E7 /* GoogleLensTip.swift */,
 			);
 			path = GoogleLens;
 			sourceTree = "<group>";
@@ -19969,6 +19972,7 @@
 				ECD8E56C2FF7EB69002092C6 /* WaybackService.swift in Sources */,
 				FB16062100000000000000E4 /* GoogleLensRequestBuilder.swift in Sources */,
 				FB16062100000000000000E6 /* GoogleLensService.swift in Sources */,
+				FB16062100000000000000E8 /* GoogleLensTip.swift in Sources */,
 				8A93080927BFE88F0052167D /* PhotonActionSheetContainerCell.swift in Sources */,
 				F85C7F0E2711C556004BDBA4 /* SettingsViewController.swift in Sources */,
 				0BDDB3442CA6E43100D501DF /* FolderHierarchyFetcher.swift in Sources */,

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -8,6 +8,7 @@ import UIKit
 import Common
 import Glean
 import TabDataStore
+import TipKit
 
 import class MozillaAppServices.Viaduct
 import struct MozillaAppServices.RustAdsClient
@@ -151,6 +152,16 @@ class AppDelegate: UIResponder,
         if featureFlagsProvider.isEnabled(.translation) {
             Task(priority: .utility) {
                 await ASTranslationModelsFetcher().prewarmResourcesForStartup()
+            }
+        }
+
+        if #available(iOS 17.0, *) {
+            do {
+                try Tips.configure()
+            } catch {
+                logger.log("Failed to configure TipKit: \(error.localizedDescription)",
+                           level: .warning,
+                           category: .lifecycle)
             }
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
@@ -122,8 +122,7 @@ extension BrowserViewController: PhotonActionSheetProtocol {
 
     @MainActor
     func configureGoogleLensTip(for button: UIButton) {
-        guard #available(iOS 17.0, *) else { return }
-        guard googleLensTipViewController == nil else { return }
+        guard #available(iOS 17.0, *), googleLensTipViewController == nil else { return }
 
         googleLensTipObservationTask?.cancel()
         let tip = GoogleLensTip()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
@@ -4,6 +4,7 @@
 
 import Common
 import Shared
+import TipKit
 import UIKit
 
 extension BrowserViewController: PhotonActionSheetProtocol {
@@ -117,6 +118,48 @@ extension BrowserViewController: PhotonActionSheetProtocol {
     private func presentTranslationContextualHint() {
         present(translationContextHintVC, animated: true)
         UIAccessibility.post(notification: .layoutChanged, argument: translationContextHintVC)
+    }
+
+    @MainActor
+    func configureGoogleLensTip(for button: UIButton) {
+        guard #available(iOS 17.0, *) else { return }
+        guard googleLensTipViewController == nil else { return }
+
+        googleLensTipObservationTask?.cancel()
+        let tip = GoogleLensTip()
+        googleLensTipObservationTask = Task { @MainActor [weak self, weak button] in
+            for await status in tip.statusUpdates {
+                guard !Task.isCancelled else { return }
+
+                switch status {
+                // Wait for TipKit to finish evaluating the tip's display eligibility.
+                case .pending:
+                    continue
+                // Present the tip once TipKit determines it is eligible for display.
+                case .available:
+                    await Task.yield()
+                    guard let self,
+                          let button,
+                          button.window != nil,
+                          self.presentedViewController == nil
+                    else { return }
+
+                    let tipViewController = TipUIPopoverViewController(tip, sourceItem: button)
+                    self.googleLensTipViewController = tipViewController
+                    self.present(tipViewController, animated: true)
+                // Dismiss the presented tip when TipKit marks it as closed or otherwise invalid.
+                case .invalidated:
+                    guard let self else { return }
+                    if self.presentedViewController === self.googleLensTipViewController {
+                        self.dismiss(animated: true)
+                    }
+                    self.googleLensTipViewController = nil
+                    return
+                @unknown default:
+                    break
+                }
+            }
+        }
     }
 
     private func presentContextualHint(for hintType: ContextualHintType) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
@@ -122,38 +122,46 @@ extension BrowserViewController: PhotonActionSheetProtocol {
 
     @MainActor
     func configureGoogleLensTip(for button: UIButton) {
-        guard #available(iOS 17.0, *), googleLensTipViewController == nil else { return }
+        guard #available(iOS 17.0, *),
+              googleLensTipViewController == nil else { return }
 
         googleLensTipObservationTask?.cancel()
-        let tip = GoogleLensTip()
         googleLensTipObservationTask = Task { @MainActor [weak self, weak button] in
+            let tip = GoogleLensTip()
+
             for await status in tip.statusUpdates {
-                guard !Task.isCancelled else { return }
+                guard let self, !Task.isCancelled else { return }
 
                 switch status {
                 // Wait for TipKit to finish evaluating the tip's display eligibility.
                 case .pending:
                     continue
+
                 // Present the tip once TipKit determines it is eligible for display.
                 case .available:
-                    await Task.yield()
-                    guard let self,
-                          let button,
+                    guard let button,
                           button.window != nil,
-                          self.presentedViewController == nil
+                          self.presentedViewController == nil,
+                          let toolbarState = store.state.componentState(ToolbarState.self,
+                                                                        for: .toolbar,
+                                                                        window: self.windowUUID)
                     else { return }
 
                     let tipViewController = TipUIPopoverViewController(tip, sourceItem: button)
+                    tipViewController.popoverPresentationController?.permittedArrowDirections =
+                        toolbarState.toolbarPosition == .bottom ? .down : .up
                     self.googleLensTipViewController = tipViewController
                     self.present(tipViewController, animated: true)
+
                 // Dismiss the presented tip when TipKit marks it as closed or otherwise invalid.
                 case .invalidated:
-                    guard let self else { return }
-                    if self.presentedViewController === self.googleLensTipViewController {
+                    guard let tipViewController = self.googleLensTipViewController else { return }
+                    if self.presentedViewController === tipViewController {
                         self.dismiss(animated: true)
                     }
                     self.googleLensTipViewController = nil
                     return
+
                 @unknown default:
                     break
                 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -264,6 +264,8 @@ class BrowserViewController: UIViewController,
     // MARK: Contextual Hints
 
     var navigationHintDoubleTapTimer: Timer?
+    var googleLensTipObservationTask: Task<Void, Never>?
+    weak var googleLensTipViewController: UIViewController?
     private(set) lazy var navigationContextHintVC: ContextualHintViewController = {
         let navigationViewProvider = ContextualHintViewProvider(forHintType: .navigation, with: profile)
         return ContextualHintViewController(with: navigationViewProvider, windowUUID: windowUUID)
@@ -505,6 +507,7 @@ class BrowserViewController: UIViewController,
             logger.log("BVC deallocating (window: \(windowUUID))", level: .info, category: .lifecycle)
             unsubscribeFromRedux()
             stopObservingAllWebViews()
+            googleLensTipObservationTask?.cancel()
         }
     }
 
@@ -4066,6 +4069,8 @@ class BrowserViewController: UIViewController,
             configureSummarizeToolbarEntryContextualHint(for: button)
         case ContextualHintType.translation.rawValue:
             configureTranslationContextualHint(for: button)
+        case TipKitHintType.googleLens.rawValue:
+            configureGoogleLensTip(for: button)
         default:
             return
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -62,6 +62,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         actionType: .googleLens,
         iconName: StandardImageIdentifiers.Medium.logoGoogleLens,
         isEnabled: true,
+        contextualHintType: TipKitHintType.googleLens.rawValue,
         a11yLabel: .AddressToolbar.GoogleLens.A11yLabel,
         a11yId: AccessibilityIdentifiers.Browser.AddressToolbar.googleLensButton,
         menuElements: [

--- a/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewProvider.swift
+++ b/firefox-ios/Client/Frontend/ContextualHint/ContextualHintViewProvider.swift
@@ -23,6 +23,10 @@ enum ContextualHintType: String {
     case summarizeToolbarEntry = "SummarizeToolbarEntry"
 }
 
+enum TipKitHintType: String {
+    case googleLens = "GoogleLens"
+}
+
 @MainActor
 class ContextualHintViewProvider: ContextualHintPrefsKeysProvider,
                                   SearchBarLocationProvider,

--- a/firefox-ios/Client/Frontend/GoogleLens/GoogleLensTip.swift
+++ b/firefox-ios/Client/Frontend/GoogleLens/GoogleLensTip.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import SwiftUI
+import TipKit
+
+@available(iOS 17.0, *)
+struct GoogleLensTip: Tip {
+    var title: Text {
+        Text(verbatim: String.ContextualHints.Toolbar.GoogleLens.Title)
+    }
+
+    var message: Text? {
+        Text(verbatim: String.ContextualHints.Toolbar.GoogleLens.Description)
+    }
+
+    var options: [any TipOption] {
+        MaxDisplayCount(1)
+        IgnoresDisplayFrequency(true)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -147,6 +147,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(newState.editingAccessoryAction?.actionType, .googleLens)
         XCTAssertEqual(newState.editingAccessoryAction?.iconName, StandardImageIdentifiers.Medium.logoGoogleLens)
+        XCTAssertEqual(newState.editingAccessoryAction?.contextualHintType, TipKitHintType.googleLens.rawValue)
         XCTAssertEqual(newState.editingAccessoryAction?.a11yLabel, .AddressToolbar.GoogleLens.A11yLabel)
         XCTAssertEqual(newState.editingAccessoryAction?.menuElements, expectedMenuElements)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -202,6 +202,7 @@ final class AddressToolbarContainerModelTests: XCTestCase {
         XCTAssertEqual(state.addressToolbar.editingAccessoryAction?.actionType, .googleLens)
         let accessoryAction = model.addressToolbarConfig.locationViewConfiguration.editingAccessoryAction
         XCTAssertEqual(accessoryAction?.iconName, StandardImageIdentifiers.Medium.logoGoogleLens)
+        XCTAssertEqual(accessoryAction?.contextualHintType, TipKitHintType.googleLens.rawValue)
         XCTAssertEqual(accessoryAction?.a11yLabel, .AddressToolbar.GoogleLens.A11yLabel)
         XCTAssertEqual(accessoryAction?.menuElements, expectedMenuElements)
     }
@@ -335,6 +336,7 @@ final class AddressToolbarContainerModelTests: XCTestCase {
             actionType: .googleLens,
             iconName: StandardImageIdentifiers.Medium.logoGoogleLens,
             isEnabled: true,
+            contextualHintType: TipKitHintType.googleLens.rawValue,
             a11yLabel: .AddressToolbar.GoogleLens.A11yLabel,
             a11yId: AccessibilityIdentifiers.Browser.AddressToolbar.googleLensButton,
             menuElements: [


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16300)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35059)

## :bulb: Description
- Add a tooltip highlighting the Google Lens entry point in the address toolbar

### 📝 Technical Notes
- The Google Lens tooltip uses [TipKit](https://developer.apple.com/documentation/tipkit/), which requires iOS 17+. There is currently no fallback for older iOS versions
- Tooltip only appears one time

## :movie_camera: Demos
<img width="302" height="656" alt="Screenshot iPhone 17 08-05-2026 at 3 58 47 PM" src="https://github.com/user-attachments/assets/6fcab8fd-b2b2-4a26-9e0e-e1ff23ea03d1" />

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

