### PR TITLE
Add FXIOS-16523 [Technical Debt] [Redux] Add ADR for Redux State Best Practices: Initialization and Transient State

### DIFF
--- a/adr/0013-redux-state-reducers-best-practices-initialization-and-transient-state.md
+++ b/adr/0013-redux-state-reducers-best-practices-initialization-and-transient-state.md
@@ -49,7 +49,7 @@ Redux States should have **precisely three** initializers:
 
 All Redux State types conform to `StateType`, which requires a `defaultState(from:)` implementation. 
 
-A correct `defaultState(from:)` implementaiton should:
+A correct `defaultState(from:)` implementation should:
 
 - Return a new instance of the State using the memberwise `init()`, NOT the `.copy()` methods
 - Copy over persistent properties directly from the `from` argument
@@ -121,7 +121,7 @@ You should then carefully audit each reducer `return` statement as you apply the
 
 ### Neutral Consequences
 
-- N/A
+- Refactoring the Redux State memberwise `init()` to remove default arguments may involve refactoring call sites in unit test files
 
 ### Negative Consequences
 

--- a/adr/0013-redux-state-reducers-best-practices-initialization-and-transient-state.md
+++ b/adr/0013-redux-state-reducers-best-practices-initialization-and-transient-state.md
@@ -1,0 +1,128 @@
+# 13. Redux State Best Practices: Initialization and Transient State
+
+Date: 2026-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+Following the introduction of the `@Copyable` macro in [ADR-0011](0011-redux-state-reducer-initializer-cleanup-with-copy-macro.md), we want to create a more detailed standard for how we write our Redux State reducers.
+
+This will further ensure consistency across the broader project.
+
+### Motivation
+
+In a number of our State types, we have **transient state** (i.e. properties that act as one-shot UI signals, like `didNavigate`). These one-shot transient state properties *must* be cleared before a new state is reduced for the next action.
+
+> [!Note]
+> **Transient State**: One-shot UI signals that must be cleared after use (e.g. after triggering an animation or navigation).
+
+In many cases, this clearing was happening in the memberwise `init` on the State. Default values were assigned to transient properties to clear them implicitly. As a result, it is not obvious what properties are truly transient and which are just conveniently provided a default value.
+
+Furthermore, there has been inconsistent implementation of the `defaultState()` method. We should prefer to use the memberwise state `init` inside `defaultState()` and explicitly set transient values to their defaults. The added benefit to this is that the compiler will alert us to update this function when a new property is added to the State in the future. If we just use the `.copy()` methods, we will not get this feedback.
+
+## Decision
+
+In order to leverage compiler feedback and explicitly define which State properties are transient, we want to enforce standards around the following:
+
+### 1. Usage of the `@Copyable` Macro
+
+All our Redux States should leverage the `@Copyable` macro to make reducer return statements more readable.
+
+You can read more about the macro in [ADR-0011](0011-redux-state-reducer-initializer-cleanup-with-copy-macro.md).
+
+### 2. Our State `init` Pattern
+
+Redux States should have **precisely three** initializers:
+1. `init(appState: AppState, uuid: WindowUUID)`: Used in state subscription
+2. `init(windowUUID: WindowUUID)`: Used when adding a new presented component to the Redux state hierarchy
+3. Memberwise `init(prop1: Type, prop2: Type, ...)` which individually initializes all stored properties
+
+> [!CAUTION]
+> Do not add default values to any of these initializers.
+
+### 3. Correct `StateType` `defaultState(from:)` Implementation
+
+All Redux State types conform to `StateType`, which requires a `defaultState(from:)` implementation. 
+
+A correct `defaultState(from:)` implementaiton should:
+
+- Return a new instance of the State using the memberwise `init()`, NOT the `.copy()` methods
+- Copy over persistent properties directly from the `state` argument
+- Reset all transient properties back to their defaults
+
+> [!CAUTION]
+> Never `return state`. You must always construct a *new* state.
+
+Example usage:
+```
+static func defaultState(from state: TabsPanelState) -> TabsPanelState {
+        return TabsPanelState(
+            // Copy over persistent properties
+            windowUUID: state.windowUUID,
+            isPrivateMode: state.isPrivateMode,
+            tabs: state.tabs,
+
+            // Reset transient properties
+            scrollState: nil,
+            didTapAddTab: false,
+            urlRequest: nil
+        )
+    }
+```
+
+### 4. Correct `StateType` `resetTransientState()` Usage
+
+If your Redux State contains transient properties, you must use the `resetTransientState()` method to clear those properties before leveraging the `@Copyable` macro.
+
+The default implementation for `resetTransientState()` simply calls `defaultState(from:)` on `self`.
+
+Using `resetTransientState()` ensures all transient state is cleared from your copy of the previous state before applying your updates to the state in response to the latest action.
+
+Example usage:
+```
+func handleSomeAction(...) -> SomeState {
+    ...
+    return state
+        .resetTransientState() // Clears all transient state back to defaults
+        .copy(someProperty1: newValue1)
+        .copy(someProperty2: newValue2)
+        ...
+}
+```
+
+> [!Note]
+> You only need to call `resetTransientState()` if your State contains transient properties.
+
+
+## Migration Tip
+
+When migrating a State type to use `@Copyable`, first check that State's memberwise `init()` method. 
+
+Does it contain default arguments? If it does, you may be dealing with a State which contains transient state.
+
+You should remove the default values from the memberwise `init()` but be considerate of what those values previously cleared.
+
+You should then carefully audit each reducer return statement as you apply the `.copy()` methods. You want to ensure the *before* and *after* behaviour does not change.
+
+## Consequences
+
+### Positive Consequences
+
+- Consistency across Redux States for intializers, `StateType` `defaultState()` implementation, and `resetTransientState()` usage
+- Ensures developers are conscious about defining and clearing transient state (code becomes self-documenting)
+- Improved compiler feedback
+
+### Neutral Consequences
+
+- N/A
+
+### Negative Consequences
+
+- N/A
+
+## References
+
+- [ADR-0011: Redux State Reducer Initializer Cleanup with Copy Macro](0011-redux-state-reducer-initializer-cleanup-with-copy-macro.md)

--- a/adr/0013-redux-state-reducers-best-practices-initialization-and-transient-state.md
+++ b/adr/0013-redux-state-reducers-best-practices-initialization-and-transient-state.md
@@ -19,13 +19,15 @@ In a number of our State types, we have **transient state** (i.e. properties tha
 > [!Note]
 > **Transient State**: One-shot UI signals that must be cleared after use (e.g. after triggering an animation or navigation).
 
-In many cases, this clearing was happening in the memberwise `init` on the State. Default values were assigned to transient properties to clear them implicitly. As a result, it is not obvious what properties are truly transient and which are just conveniently provided a default value.
+Throughout the project, we have inconsistent treatment of transient state. In many places, we cleared transient state using default arguments supplied to the State's memberwise `init`. This clears properties implicitly. As a result, it is not obvious what properties are truly transient and which are just conveniently provided a default value.
 
-Furthermore, there has been inconsistent implementation of the `defaultState()` method. We should prefer to use the memberwise state `init` inside `defaultState()` and explicitly set transient values to their defaults. The added benefit to this is that the compiler will alert us to update this function when a new property is added to the State in the future. If we just use the `.copy()` methods, we will not get this feedback.
+Furthermore, there has been inconsistent implementation of the `defaultState()` method. We should prefer to use the memberwise state `init` inside `defaultState()` and explicitly set transient values to their defaults. The added benefit to this is that the compiler will alert us when a new property is added to the State in the future. That lets us be conscientious about identifying transient state and assigning defaults. If we just use the `.copy()` methods, we will not get this feedback. 
+
+We want `defautState()` to be the single source of truth for transient properties—not default argument values in the `init` or a strange mix between the two.
 
 ## Decision
 
-In order to leverage compiler feedback and explicitly define which State properties are transient, we want to enforce standards around the following:
+In order to leverage compiler feedback and explicitly define a source of truth for transient State properties, we want to enforce standards around the following:
 
 ### 1. Usage of the `@Copyable` Macro
 
@@ -36,12 +38,12 @@ You can read more about the macro in [ADR-0011](0011-redux-state-reducer-initial
 ### 2. Our State `init` Pattern
 
 Redux States should have **precisely three** initializers:
-1. `init(appState: AppState, uuid: WindowUUID)`: Used in state subscription
+1. `init(appState: AppState, uuid: WindowUUID)`: Used for state subscription in the presentation layer
 2. `init(windowUUID: WindowUUID)`: Used when adding a new presented component to the Redux state hierarchy
-3. Memberwise `init(prop1: Type, prop2: Type, ...)` which individually initializes all stored properties
+3. Memberwise `init(prop1: Type, prop2: Type, ...)` used to individually initialize all stored properties
 
 > [!CAUTION]
-> Do not add default values to any of these initializers.
+> Do NOT add default values to any initializer arguments.
 
 ### 3. Correct `StateType` `defaultState(from:)` Implementation
 
@@ -50,11 +52,11 @@ All Redux State types conform to `StateType`, which requires a `defaultState(fro
 A correct `defaultState(from:)` implementaiton should:
 
 - Return a new instance of the State using the memberwise `init()`, NOT the `.copy()` methods
-- Copy over persistent properties directly from the `state` argument
+- Copy over persistent properties directly from the `from` argument
 - Reset all transient properties back to their defaults
 
 > [!CAUTION]
-> Never `return state`. You must always construct a *new* state.
+> Never return the previous state instance with `return state`. You must always construct a *new* state instance for Redux to work correctly.
 
 Example usage:
 ```
@@ -75,11 +77,11 @@ static func defaultState(from state: TabsPanelState) -> TabsPanelState {
 
 ### 4. Correct `StateType` `resetTransientState()` Usage
 
-If your Redux State contains transient properties, you must use the `resetTransientState()` method to clear those properties before leveraging the `@Copyable` macro.
+If your Redux State contains transient properties, you must use the `resetTransientState()` method to clear those properties before leveraging the `@Copyable` macro's `.copy()` methods.
+
+Using `resetTransientState()` ensures all transient state is cleared from your copy of the previous state *before* applying your updates to the state in response to the latest action.
 
 The default implementation for `resetTransientState()` simply calls `defaultState(from:)` on `self`.
-
-Using `resetTransientState()` ensures all transient state is cleared from your copy of the previous state before applying your updates to the state in response to the latest action.
 
 Example usage:
 ```
@@ -99,21 +101,23 @@ func handleSomeAction(...) -> SomeState {
 
 ## Migration Tip
 
-When migrating a State type to use `@Copyable`, first check that State's memberwise `init()` method. 
+When migrating a State type to use `@Copyable`, first review that State's memberwise `init()` method. 
 
-Does it contain default arguments? If it does, you may be dealing with a State which contains transient state.
+Does the `init()` contain default arguments? If yes, you may be dealing with a State which contains transient state.
 
-You should remove the default values from the memberwise `init()` but be considerate of what those values previously cleared.
+You should remove the default values from the memberwise `init()` as part of the migration work. However, you must be thoughtful about which values must be reset. 
 
-You should then carefully audit each reducer return statement as you apply the `.copy()` methods. You want to ensure the *before* and *after* behaviour does not change.
+Update the `defaultState()` method to correctly set these default values for any transient state instead (remembering that transient state is state which should always be cleared by the next action, after having been consumed once).
+
+You should then carefully audit each reducer `return` statement as you apply the `.copy()` methods. You want to ensure the *before* behaviour (`init` with default arguments) and *after* behaviour (`.resetTransientState()` and `.copy()` usage) remains the same.
 
 ## Consequences
 
 ### Positive Consequences
 
 - Consistency across Redux States for intializers, `StateType` `defaultState()` implementation, and `resetTransientState()` usage
-- Ensures developers are conscious about defining and clearing transient state (code becomes self-documenting)
-- Improved compiler feedback
+- Ensures developers are conscientious about defining and clearing transient state (and the code becomes self-documenting)
+- Improved compiler feedback when adding new transient properties
 
 ### Neutral Consequences
 

--- a/adr/README.md
+++ b/adr/README.md
@@ -19,7 +19,7 @@ This log lists the architectural decisions for MADR.
 - [ADR-0010](0010-offload-background-webviews-on-memory-warning.md) - Offload Background WebViews on Memory Warning
 - [ADR-0011](0011-redux-state-reducer-initializer-cleanup-with-copy-macro.md) - Redux State Reducer Initializer Cleanup with Copy Macro
 - [ADR-0012](0012-redux-action-guidelines.md) - Redux Action Guidelines
-
+- [ADR-0013](0013-redux-state-reducers-best-practices-initialization-and-transient-state) - Redux State Best Practices: Initialization and Transient State
 <!-- adrlogstop -->
 
 For new ADRs, please use [template.md](template.md) as basis.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16523)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35064)

## :bulb: Description
Add a reducer to provide best practices on Redux State initialization, `@Copyable` usage, and resetting transient state properties.

### Example
@Kiyo99 applied these principles in example PR: https://github.com/mozilla-mobile/firefox-ios/pull/34922

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

