### PR TITLE
[MTE-5697] - automate Set FF as default browser

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -364,6 +364,7 @@
         "ModernKitOnboardingTests\/testModernKitOnboardingLightThemeSelection()",
         "ModernKitOnboardingTests\/testModernKitOnboardingMultipleChoiceUI()",
         "ModernKitOnboardingTests\/testModernKitOnboardingSecondaryNavigation()",
+        "ModernKitOnboardingTests\/testModernKitOnboardingSetAsDefaultBrowser()",
         "ModernKitOnboardingTests\/testModernKitOnboardingSkipButton()",
         "ModernKitOnboardingTests\/testModernKitOnboardingSkipSync()",
         "ModernKitOnboardingTests\/testModernKitOnboardingSyncFlow()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ModernKitOnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ModernKitOnboardingTests.swift
@@ -15,6 +15,7 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
     var onboardingScreen: OnboardingScreen!
     var firefoxHomePageScreen: FirefoxHomePageScreen!
     var settingScreen: SettingScreen!
+    var iosSettingsScreen: IOSSettingsAppScreen!
 
     override func setUpExperimentVariables() {
         launchArguments = [
@@ -32,6 +33,7 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
         onboardingScreen = OnboardingScreen(app: app, flowType: flowType)
         firefoxHomePageScreen = FirefoxHomePageScreen(app: app)
         settingScreen = SettingScreen(app: app)
+        iosSettingsScreen = IOSSettingsAppScreen(firefoxApp: app)
     }
 
     override func tearDown() async throws {
@@ -482,6 +484,29 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
 
         firefoxHomePageScreen.dismissNewChangesPopupIfNeeded()
         firefoxHomePageScreen.assertTopSitesItemCellExist()
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/4038425
+    // Regression
+    func testModernKitOnboardingSetAsDefaultBrowser() {
+        launchApp()
+
+        onboardingScreen.handleTermsOfService()
+
+        // Step 1: The Set as Default Browser card (first onboarding card) is available
+        onboardingScreen.assertModernWelcomeScreen()
+
+        // Step 2: Tap "Set as Default Browser" - the Switch Your Default Browser bottom sheet opens
+        onboardingScreen.tapSetAsDefaultBrowser()
+        onboardingScreen.assertDefaultBrowserBottomSheet()
+
+        // Step 3: Tap "Go to Settings" - the iOS Settings app opens
+        onboardingScreen.tapGoToSettingsOnBottomSheet()
+        iosSettingsScreen.assertSettingsAppOpened()
+
+        // Step 4: Set Firefox as the default browser and return to Firefox - the selection is saved
+        iosSettingsScreen.setFirefoxAsDefaultBrowser()
+        iosSettingsScreen.returnToFirefox()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4038427

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/IOSSettingsAppScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/IOSSettingsAppScreen.swift
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+// ⚠️ Drives the iOS Settings app (com.apple.Preferences): expect system-app idle delays, English-only
+// labels, and device-wide default-browser state that persists beyond the test (callers reset it).
+@MainActor
+final class IOSSettingsAppScreen {
+    private let firefoxApp: XCUIApplication
+    private let settingsApp: XCUIApplication
+
+    init(firefoxApp: XCUIApplication,
+         settingsApp: XCUIApplication = XCUIApplication(bundleIdentifier: "com.apple.Preferences")) {
+        self.firefoxApp = firefoxApp
+        self.settingsApp = settingsApp
+    }
+
+    // MARK: - Elements
+
+    /// The Firefox option in the default-browser picker. Options are buttons whose label is the app's
+    /// display name; match either scheme (Fennec "Fennec (user)" or the Firefox release "Firefox").
+    private var firefoxBrowserOption: XCUIElement {
+        settingsApp.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] %@ OR label CONTAINS[c] %@", "Fennec", "Firefox")
+        ).firstMatch
+    }
+
+    // MARK: - Assertions
+
+    /// Waits for the iOS Settings app to reach the foreground after tapping Go to Settings.
+    func assertSettingsAppOpened() {
+        XCTAssertTrue(
+            settingsApp.wait(for: .runningForeground, timeout: TIMEOUT_LONG),
+            "iOS Settings app did not reach the foreground after tapping Go to Settings"
+        )
+    }
+
+    // MARK: - Actions
+
+    /// Selects Firefox in the "Default Browser App" picker, then re-opens the picker from the root to
+    /// confirm the choice was saved (still checked) — not merely registered on the initial tap.
+    func setFirefoxAsDefaultBrowser() {
+        openDefaultBrowserPicker()
+        let option = firefoxBrowserOption
+        BaseTestCase().mozWaitForElementToExist(option, timeout: TIMEOUT_LONG)
+        option.waitAndTap()
+        XCTAssertTrue(option.isSelected, "The Firefox option should be selected after tapping it")
+
+        openDefaultBrowserPicker()
+        let persisted = firefoxBrowserOption
+        BaseTestCase().mozWaitForElementToExist(persisted, timeout: TIMEOUT_LONG)
+        XCTAssertTrue(persisted.isSelected, "Firefox should still be the default browser after reopening the picker")
+    }
+
+    /// The Settings deep link lands on the root page on Simulator, and iOS 26 nests the default-browser
+    /// choice under Settings > Apps > Default Apps, so navigate there explicitly.
+    private func openDefaultBrowserPicker() {
+        // Settings resumes where a prior run left it, so pop any pushed screen back to root first (on iPad
+        // this pops the detail pane's own nav stack, since its back button survives sidebar re-selection).
+        popToSettingsRoot()
+
+        // Split-view Settings (iPad) shows "Apps" in a sidebar collection view, ambiguous with the same-named
+        // detail-pane title; single-column Settings (iPhone) shows a plain row. Prefer the sidebar when present.
+        let sidebarApps = settingsApp.collectionViews.staticTexts["Apps"]
+        tapSettingsRow(sidebarApps.exists ? sidebarApps : settingsApp.staticTexts["Apps"])
+
+        tapSettingsRow(settingsApp.staticTexts["Default Apps"])
+
+        // The browser entry is labelled "Browser App" / "Default Browser App" across iOS versions; match
+        // on the shared "Browser" fragment. Tapping it presents the browser picker.
+        let browserSetting = settingsApp.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS[c] %@", "Browser")
+        ).firstMatch
+        tapSettingsRow(browserSetting)
+    }
+
+    /// Taps the navigation back button until the root of Settings is reached (no back button left).
+    private func popToSettingsRoot() {
+        let backButton = settingsApp.navigationBars.buttons["BackButton"]
+        var attempts = 0
+        while backButton.exists && attempts < 8 {
+            backButton.tap()
+            attempts += 1
+        }
+    }
+
+    /// Taps a Settings row, first waiting for it to render (so a fast scroll can't race a transition and
+    /// overshoot a top row), then searching up (recovers overshoot) and finally down for below-fold rows.
+    private func tapSettingsRow(_ element: XCUIElement) {
+        _ = element.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false)
+
+        var swipes = 0
+        while !element.isHittable && swipes < 6 {
+            settingsApp.partialSwipeDown()
+            swipes += 1
+        }
+        swipes = 0
+        while !element.isHittable && swipes < 8 {
+            settingsApp.partialSwipeUp()
+            swipes += 1
+        }
+
+        element.waitAndTap()
+    }
+
+    /// Brings Firefox back to the foreground after leaving for the Settings app.
+    func returnToFirefox() {
+        firefoxApp.activate()
+        XCTAssertTrue(
+            firefoxApp.wait(for: .runningForeground, timeout: TIMEOUT_LONG),
+            "Firefox did not return to the foreground after setting the default browser"
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/OnboardingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/OnboardingScreen.swift
@@ -572,6 +572,29 @@ final class OnboardingScreen {
         XCTAssertTrue(secondaryButton.exists, "Secondary button should exist")
     }
 
+    /// Taps the first card's "Set as Default Browser" primary button, opening the "Switch Your Default
+    /// Browser" bottom sheet. Does not advance the carousel, so `currentScreen` is left unchanged.
+    func tapSetAsDefaultBrowser() {
+        BaseTestCase().mozWaitForElementToExist(primaryButton)
+        primaryButton.waitAndTap()
+    }
+
+    /// Asserts the "Switch Your Default Browser" instructions bottom sheet is displayed, verifying both
+    /// its title and the "Go to Settings" primary button.
+    func assertDefaultBrowserBottomSheet() {
+        let title = sel.DEFAULT_BROWSER_SHEET_TITLE.element(in: app)
+        let goToSettings = sel.DEFAULT_BROWSER_SHEET_GO_TO_SETTINGS_BUTTON.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(goToSettings)
+        XCTAssertTrue(title.exists, "Default browser bottom sheet title should exist")
+        XCTAssertTrue(goToSettings.exists, "Default browser bottom sheet Go to Settings button should exist")
+    }
+
+    /// Taps the "Go to Settings" button on the bottom sheet. This backgrounds the app and opens the iOS
+    /// Settings app on the Firefox page.
+    func tapGoToSettingsOnBottomSheet() {
+        sel.DEFAULT_BROWSER_SHEET_GO_TO_SETTINGS_BUTTON.element(in: app).waitAndTap()
+    }
+
     func assertToolbarCustomizationScreen() {
         let title = sel.titleLabel(rootId: rootA11yId).element(in: app)
         let primary = sel.primaryButton(rootId: rootA11yId).element(in: app)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/OnboardingSelectorSet.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/OnboardingSelectorSet.swift
@@ -39,6 +39,9 @@ protocol OnboardingSelectorsSet {
     var NAVBAR_SYNC_AND_SAVE: Selector { get }
     var CLOSE_TOUR_BUTTON: Selector { get }
     var PAGE_CONTROL: Selector { get }
+    var DEFAULT_BROWSER_SHEET_TITLE: Selector { get }
+    var DEFAULT_BROWSER_SHEET_GO_TO_SETTINGS_BUTTON: Selector { get }
+    var DEFAULT_BROWSER_SHEET_CLOSE_BUTTON: Selector { get }
     var all: [Selector] { get }
 }
 
@@ -68,6 +71,11 @@ struct OnboardingSelectors: OnboardingSelectorsSet {
         static let syncAndSaveData = "Sync and Save Data"
         static let closeTourButton = AccessibilityIdentifiers.Onboarding.closeButton
         static let pageControl = AccessibilityIdentifiers.Onboarding.pageControl
+        // The default-browser instructions popup builds its a11y ids as "\(a11yIdRoot).DefaultBrowserSettings.*".
+        // The popup's a11yIdRoot is empty, so we match by identifier suffix to stay robust to that prefix.
+        static let defaultBrowserSheet_TitleSuffix = ".DefaultBrowserSettings.TitleLabel"
+        static let defaultBrowserSheet_PrimaryButtonSuffix = ".DefaultBrowserSettings.PrimaryButton"
+        static let defaultBrowserSheet_CloseButton = AccessibilityIdentifiers.Onboarding.bottomSheetCloseButton
     }
 
     let AGREE_AND_CONTINUE_BUTTON = Selector.buttonId(
@@ -286,12 +294,46 @@ struct OnboardingSelectors: OnboardingSelectorsSet {
         groups: ["onboarding"]
     )
 
+    let DEFAULT_BROWSER_SHEET_TITLE = Selector(
+        strategy: .predicate(
+            NSPredicate(
+                format: "elementType == %d AND identifier ENDSWITH %@",
+                XCUIElement.ElementType.staticText.rawValue,
+                IDs.defaultBrowserSheet_TitleSuffix
+            )
+        ),
+        value: IDs.defaultBrowserSheet_TitleSuffix,
+        description: "Title of the Switch Your Default Browser instructions bottom sheet",
+        groups: ["onboarding"]
+    )
+
+    let DEFAULT_BROWSER_SHEET_GO_TO_SETTINGS_BUTTON = Selector(
+        strategy: .predicate(
+            NSPredicate(
+                format: "elementType == %d AND identifier ENDSWITH %@",
+                XCUIElement.ElementType.button.rawValue,
+                IDs.defaultBrowserSheet_PrimaryButtonSuffix
+            )
+        ),
+        value: IDs.defaultBrowserSheet_PrimaryButtonSuffix,
+        description: "Go to Settings button on the Switch Your Default Browser bottom sheet",
+        groups: ["onboarding"]
+    )
+
+    let DEFAULT_BROWSER_SHEET_CLOSE_BUTTON = Selector.buttonId(
+        IDs.defaultBrowserSheet_CloseButton,
+        description: "Close button dismissing the Switch Your Default Browser bottom sheet",
+        groups: ["onboarding"]
+    )
+
     var all: [Selector] {
         [AGREE_AND_CONTINUE_BUTTON, CONTINUE_BUTTON, MANAGE_TEXT_BUTTON, QR_SIGN_IN_BUTTON, EMAIL_SIGN_IN_BUTTON,
          DONE_BUTTON, CLOSE_BUTTON, NAVBAR_SYNC_AND_SAVE, CLOSE_TOUR_BUTTON, PAGE_CONTROL,
          TERMS_OF_USE_LINK, PRIVACY_NOTICE_LINK, MANAGE_LINK, TOS_PAGE_DONE_BUTTON, MANAGE_SHEET_DONE_BUTTON,
          MANAGE_SHEET_TITLE, MANAGE_SHEET_TECHNICAL_DATA_TITLE, MANAGE_SHEET_TECHNICAL_DATA_SWITCH,
          MANAGE_SHEET_TECHNICAL_DATA_DESCRIPTION, MANAGE_SHEET_CRASH_REPORTS_TITLE,
-         MANAGE_SHEET_CRASH_REPORTS_SWITCH, MANAGE_SHEET_CRASH_REPORTS_DESCRIPTION]
+         MANAGE_SHEET_CRASH_REPORTS_SWITCH, MANAGE_SHEET_CRASH_REPORTS_DESCRIPTION,
+         DEFAULT_BROWSER_SHEET_TITLE, DEFAULT_BROWSER_SHEET_GO_TO_SETTINGS_BUTTON,
+         DEFAULT_BROWSER_SHEET_CLOSE_BUTTON]
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5697

## :bulb: Description
Automate Set FF as default browser test case
https://mozilla.testrail.io/index.php?/cases/view/4038425
This test passed locally for both iPhone and iPad, but it will require monitoring to see the behaviour on CI
New IOSSettingsAppScreen class added that contains different functions to manipulate and change the default app browser from the general settings.

