### PR TITLE
Bugfix FXIOS-16529 Add UA to Wayback API call

### DIFF
--- a/firefox-ios/Client/Frontend/Wayback/WaybackService.swift
+++ b/firefox-ios/Client/Frontend/Wayback/WaybackService.swift
@@ -24,7 +24,7 @@ class WaybackService {
     private static let session: URLSession = {
         let version = AppInfo.appVersion
         let config = URLSessionConfiguration.default
-        // TODO: FXIOS-16529 Move to shared UserAgent configuration
+        // TODO: FXIOS-16534 Move to shared UserAgent configuration
         config.httpAdditionalHeaders = [
             "User-Agent": "firefox-ios-neterr/\(version) (+https://mzl.la/3RNfZFB)"
         ]

--- a/firefox-ios/Client/Frontend/Wayback/WaybackService.swift
+++ b/firefox-ios/Client/Frontend/Wayback/WaybackService.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 
 class WaybackService {
     struct Snapshot: Decodable {
@@ -21,7 +22,7 @@ class WaybackService {
     }
 
     private static let session: URLSession = {
-        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+        let version = AppInfo.appVersion
         let config = URLSessionConfiguration.default
         config.httpAdditionalHeaders = [
             "User-Agent": "firefox-ios-neterr/\(version) (+https://mzl.la/3RNfZFB)"

--- a/firefox-ios/Client/Frontend/Wayback/WaybackService.swift
+++ b/firefox-ios/Client/Frontend/Wayback/WaybackService.swift
@@ -24,6 +24,7 @@ class WaybackService {
     private static let session: URLSession = {
         let version = AppInfo.appVersion
         let config = URLSessionConfiguration.default
+        // TODO: FXIOS-16529 Move to shared UserAgent configuration
         config.httpAdditionalHeaders = [
             "User-Agent": "firefox-ios-neterr/\(version) (+https://mzl.la/3RNfZFB)"
         ]

--- a/firefox-ios/Client/Frontend/Wayback/WaybackService.swift
+++ b/firefox-ios/Client/Frontend/Wayback/WaybackService.swift
@@ -20,10 +20,19 @@ class WaybackService {
         }
     }
 
+    private static let session: URLSession = {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+        let config = URLSessionConfiguration.default
+        config.httpAdditionalHeaders = [
+            "User-Agent": "firefox-ios-neterr/\(version) (+https://mzl.la/3RNfZFB)"
+        ]
+        return URLSession(configuration: config)
+    }()
+
     /// Returns the archived snapshot for a URL, or nil if none exists.
     static func fetchSnapshot(
         for urlString: String,
-        session: URLSession = .shared
+        session: URLSession = WaybackService.session
     ) async throws -> Snapshot? {
         var components = URLComponents(string: "https://archive.org/wayback/available")!
         components.queryItems = [URLQueryItem(name: "url", value: urlString)]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16529)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35071)

## :bulb: Description
Very simple PR that adds a UA when calling the Wayback API. This was done since the API was rate limiting us before and failing, adding this distinguishes us from other general callers making the API call work again (this is a theory as to why it works now)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

