### PR TITLE
Refactor FXIOS-16505 Merge swipe-up gestures and UI/UX changes

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
@@ -11,6 +11,7 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
     private struct UX {
         static let closeTabAnimationsDuration: CGFloat = 0.3
         static let dismissPreviewDelay: CGFloat = 0.4
+        static let swipeUpVelocityThreshold: CGFloat = -1100
     }
 
     private let tabPreview: SwipeUpTabWebViewPreview
@@ -196,7 +197,7 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
                 topPadding: topBlurView.bounds.height,
                 bottomPadding: bottomBlurView.bounds.height
             )
-            if gesture.velocity(in: nil).y <= -1100 {
+            if gesture.velocity(in: nil).y <= UX.swipeUpVelocityThreshold {
                 handleGestureEnded(gesture: gesture)
                 return
             }
@@ -217,7 +218,7 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
     private func handleGestureEnded(gesture: UIPanGestureRecognizer) {
         let fingerLocation = gesture.location(in: tabPreview)
         var outcome = tabPreview.releaseOutcome(fingerLocation: fingerLocation)
-        if gesture.velocity(in: nil).y <= -1100 {
+        if gesture.velocity(in: nil).y <= -UX.swipeUpVelocityThreshold {
             outcome = SwipeUpTabWebViewPreview.ReleaseOutcome.openTabTray
         }
         switch outcome {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
@@ -201,7 +201,6 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
                 handleGestureEnded(gesture: gesture)
                 return
             }
-            addHaptics()
         case .changed:
             tabPreview.addTabScreenshot(image: tab.screenshot)
             let translation = gesture.translation(in: gesture.view)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
@@ -267,7 +267,6 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
     @objc
     private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
         if !swipeGestureFeatureFlagProvider.isInteractiveGestureEnabled { return }
-        print("Velocity: ", gesture.velocity(in: nil))
         handleGestureState(gesture)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
@@ -196,6 +196,10 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
                 topPadding: topBlurView.bounds.height,
                 bottomPadding: bottomBlurView.bounds.height
             )
+            if gesture.velocity(in: nil).y <= -1100 {
+                handleGestureEnded(gesture: gesture)
+                return
+            }
             addHaptics()
         case .changed:
             tabPreview.addTabScreenshot(image: tab.screenshot)
@@ -210,9 +214,13 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
     }
 
     @objc
-    private func handleGestureEnded(gesture: UIGestureRecognizer) {
+    private func handleGestureEnded(gesture: UIPanGestureRecognizer) {
         let fingerLocation = gesture.location(in: tabPreview)
-        switch tabPreview.releaseOutcome(fingerLocation: fingerLocation) {
+        var outcome = tabPreview.releaseOutcome(fingerLocation: fingerLocation)
+        if gesture.velocity(in: nil).y <= -1100 {
+            outcome = SwipeUpTabWebViewPreview.ReleaseOutcome.openTabTray
+        }
+        switch outcome {
         case .closeTab:
             // Lock the pan gesture until the close animation finishes so a new gesture can't
             // start mid-animation.
@@ -259,6 +267,7 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
     @objc
     private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
         if !swipeGestureFeatureFlagProvider.isInteractiveGestureEnabled { return }
+        print("Velocity: ", gesture.velocity(in: nil))
         handleGestureState(gesture)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
@@ -218,7 +218,7 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
     private func handleGestureEnded(gesture: UIPanGestureRecognizer) {
         let fingerLocation = gesture.location(in: tabPreview)
         var outcome = tabPreview.releaseOutcome(fingerLocation: fingerLocation)
-        if gesture.velocity(in: nil).y <= -UX.swipeUpVelocityThreshold {
+        if gesture.velocity(in: nil).y <= UX.swipeUpVelocityThreshold {
             outcome = SwipeUpTabWebViewPreview.ReleaseOutcome.openTabTray
         }
         switch outcome {

--- a/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
@@ -56,8 +56,6 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
 
     private var screenshotViewContainerTopConstraint: NSLayoutConstraint?
     private var screenshotViewContainerBottomConstraint: NSLayoutConstraint?
-    private var tabBackgroundHoverTopConstraint: NSLayoutConstraint?
-    private var tabBackgroundHoverBottomConstraint: NSLayoutConstraint?
 
     var previewCardFrame: CGRect {
         return screenshotViewContainer.frame
@@ -92,11 +90,6 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
         addSubviews(tabBackgroundHover, backgroundView, screenshotViewContainer, closeButton)
         screenshotViewContainer.addSubview(screenshotView)
 
-        tabBackgroundHoverTopConstraint = tabBackgroundHover.topAnchor.constraint(equalTo: topAnchor)
-        tabBackgroundHoverBottomConstraint = tabBackgroundHover.bottomAnchor.constraint(equalTo: bottomAnchor)
-        tabBackgroundHoverTopConstraint?.isActive = true
-        tabBackgroundHoverBottomConstraint?.isActive = true
-
         screenshotViewContainerTopConstraint = screenshotViewContainer.topAnchor.constraint(equalTo: topAnchor)
         screenshotViewContainerBottomConstraint = screenshotViewContainer.bottomAnchor.constraint(equalTo: bottomAnchor)
         screenshotViewContainerTopConstraint?.isActive = true
@@ -105,6 +98,8 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
             closeButton.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
             closeButton.centerXAnchor.constraint(equalTo: centerXAnchor),
 
+            tabBackgroundHover.topAnchor.constraint(equalTo: topAnchor),
+            tabBackgroundHover.bottomAnchor.constraint(equalTo: bottomAnchor),
             tabBackgroundHover.leadingAnchor.constraint(equalTo: leadingAnchor),
             tabBackgroundHover.trailingAnchor.constraint(equalTo: trailingAnchor),
 
@@ -122,8 +117,6 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
 
     func setInitialTransform(topPadding: CGFloat, bottomPadding: CGFloat) {
         screenshotView.layer.cornerRadius = 0
-        tabBackgroundHoverTopConstraint?.constant = topPadding
-        tabBackgroundHoverBottomConstraint?.constant = -bottomPadding
 
         if swipeGestureFeatureFlagProvider.isCloseTabEnabled {
             closeButton.transform = .identity.translatedBy(x: 0.0, y: -closeButton.bounds.height * 2.0)
@@ -241,7 +234,7 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
     func applyTheme(theme: Theme) {
         tabBackgroundHover.backgroundColor = theme.colors.layer3
         closeButton.configuration?.baseBackgroundColor = theme.colors.layerCriticalSubdued
-        closeButton.configuration?.baseForegroundColor = .systemRed
+        closeButton.configuration?.baseForegroundColor = theme.colors.layerCritical
         screenshotViewContainer.layer.shadowColor = theme.colors.shadowStrong.cgColor
     }
 

--- a/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
@@ -235,14 +235,10 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
 
     func applyTheme(theme: Theme) {
         tabBackgroundHover.backgroundColor = theme.colors.layer3
-        if theme.type == .dark {
-            closeButton.configuration?.baseBackgroundColor = theme.colors.layerCriticalSubdued
-        } else {
-            if #unavailable(iOS 26) {
+        if #unavailable(iOS 26) {
                 closeButton.configuration?.baseBackgroundColor = theme.colors.layer2
-            } else {
-                closeButton.configuration?.baseBackgroundColor = nil
-            }
+        } else {
+            closeButton.configuration?.baseBackgroundColor = nil
         }
         closeButton.configuration?.baseForegroundColor = theme.colors.actionCritical
         screenshotViewContainer.layer.shadowColor = theme.colors.shadowStrong.cgColor

--- a/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
@@ -164,7 +164,8 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
         let scale = max((1 - abs(UX.scaleSpeed * translation.y) / bounds.height), UX.minimumTabPreviewScale)
 
         // Gradually dim the preview when it's in the close tab region
-        let previewAlpha = min(1, (1 - UX.closePreviewDimSpeed * (UX.closeReleaseThreshold - (fingerLocation.y / bounds.height))))
+        let previewAlpha = min(1,
+                               1 - UX.closePreviewDimSpeed * (UX.closeReleaseThreshold - (fingerLocation.y / bounds.height)))
         screenshotViewContainer.alpha = previewAlpha
 
         // Transform that places the finger horizontally centered and <fingerCardPositionRatio> down the card.

--- a/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
@@ -169,6 +169,10 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
         // Shrink continuously during the gesture
         let scale = max((1 - abs(UX.scaleSpeed * translation.y) / bounds.height), UX.minimumTabPreviewScale)
 
+        // Gradually dim the preview when it's in the close tab region
+        let previewAlpha = min(1, (1 - 5 * (UX.closeReleaseThreshold - (fingerLocation.y / bounds.height))))
+        screenshotViewContainer.alpha = previewAlpha
+
         // Transform that places the finger horizontally centered and <fingerCardPositionRatio> down the card.
         let naturalCenter = screenshotViewContainer.center
         let scaledHeight = scale * screenshotViewContainer.bounds.height
@@ -236,10 +240,8 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
 
     func applyTheme(theme: Theme) {
         tabBackgroundHover.backgroundColor = theme.colors.layer3
-        if #unavailable(iOS 26) {
-            closeButton.configuration?.baseBackgroundColor = theme.colors.layer2
-        }
-        closeButton.configuration?.baseForegroundColor = theme.colors.iconPrimary
+        closeButton.configuration?.baseBackgroundColor = theme.colors.layerCriticalSubdued
+        closeButton.configuration?.baseForegroundColor = .systemRed
         screenshotViewContainer.layer.shadowColor = theme.colors.shadowStrong.cgColor
     }
 

--- a/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
@@ -23,6 +23,7 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
         // A number used in calculating the size of the tab preview during the animation,
         // larger values shrink the preview faster
         static let scaleSpeed: CGFloat = 1.237
+        static let closePreviewDimSpeed: CGFloat = 5
     }
 
     private let swipeGestureFeatureFlagProvider: SwipeGestureFeatureFlagProvider
@@ -163,7 +164,7 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
         let scale = max((1 - abs(UX.scaleSpeed * translation.y) / bounds.height), UX.minimumTabPreviewScale)
 
         // Gradually dim the preview when it's in the close tab region
-        let previewAlpha = min(1, (1 - 5 * (UX.closeReleaseThreshold - (fingerLocation.y / bounds.height))))
+        let previewAlpha = min(1, (1 - UX.closePreviewDimSpeed * (UX.closeReleaseThreshold - (fingerLocation.y / bounds.height))))
         screenshotViewContainer.alpha = previewAlpha
 
         // Transform that places the finger horizontally centered and <fingerCardPositionRatio> down the card.
@@ -233,8 +234,16 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
 
     func applyTheme(theme: Theme) {
         tabBackgroundHover.backgroundColor = theme.colors.layer3
-        closeButton.configuration?.baseBackgroundColor = theme.colors.layerCriticalSubdued
-        closeButton.configuration?.baseForegroundColor = theme.colors.layerCritical
+        if theme.type == .dark {
+            closeButton.configuration?.baseBackgroundColor = theme.colors.layerCriticalSubdued
+        } else {
+            if #unavailable(iOS 26) {
+                closeButton.configuration?.baseBackgroundColor = theme.colors.layer2
+            } else {
+                closeButton.configuration?.baseBackgroundColor = nil
+            }
+        }
+        closeButton.configuration?.baseForegroundColor = theme.colors.actionCritical
         screenshotViewContainer.layer.shadowColor = theme.colors.shadowStrong.cgColor
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16505)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35039)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

Interactive drag gesture first checks the vertical velocity when the gesture begins. If the value is above a given threshold (in our case, 1100 upwards), the gesture behaves like the existing swipe gesture and immediately opens the tab tray. If the velocity is less than 1100 upwards, the gesture behaves as normal with the tab preview popping out of the screen.

There are also a couple UI/UX changes included in this ticket:
1. The close icon has been styled with various shades of red, depending on the iOS version and the applied theme (light or dark or private)
2. The tab preview now slowly fades as it’s dragged into the closeTab region
3. The toolbar preview that was previously blurred at the bottom of the screen during the pan gesture is now hidden.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/b56c2a91-1244-429d-982b-91a9b83b2bbb

</details>
<details>
<summary>After</summary>

https://github.com/user-attachments/assets/dc287961-3981-4c9e-9f5d-c3e98cbfdbc2

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

