### PR TITLE
Refactor FXIOS-15545 Workaround for settings page

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -294,10 +294,15 @@ class IntegrationTests: BaseTestCase {
         app.cells["SignOut"].waitAndTap()
 
         app.buttons["Disconnect"].waitAndTap()
-        sleep(3)
+        mozWaitForElementToNotExist(app.buttons["Disconnect"])
 
-        // Connect same account again
+        // Workaround (FXIOS-15545): Navigate away from the settings screen and back 
+        // so that the settings screen will refresh with "Sign in to Sync".
         navigator.nowAt(SettingsScreen)
+        navigator.goto(TabTray)
+        navigator.goto(SettingsScreen)
+
+        // Connect the same account again
         app.tables.cells["SignInToSync"].waitAndTap()
         app.buttons["EmailSignIn.button"].waitAndTap()
 
@@ -308,7 +313,6 @@ class IntegrationTests: BaseTestCase {
         mozWaitForElementToNotExist(app.staticTexts["Enter your password"], timeout: TIMEOUT_LONG)
 
         navigator.nowAt(SettingsScreen)
-        app.swipeDown()
         mozWaitForElementToExist(app.staticTexts["GENERAL"])
         mozWaitForElementToExist(app.staticTexts["ACCOUNT"])
         mozWaitForElementToExist(app.tables.staticTexts["Sync Now"], timeout: TIMEOUT_LONG)


### PR DESCRIPTION
…xA account

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15545)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Temporary workaround for https://github.com/mozilla-mobile/firefox-ios/issues/33303: The Settings page shows that we're still signed in although we've just signed out.

If the PR https://github.com/mozilla-mobile/firefox-ios/pull/34840 is merged, we do not need this workaround. (cc @PARAIPAN9)

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

