### PR TITLE
Bugfix FXIOS-15160 Fix basic auth PDF loading

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -970,12 +970,17 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         tab.getSessionCookies { [weak tab, weak self] cookies in
+            let credential: URLCredential? = {
+                // Avoid passing a stale credential from a previously-authenticated host
+                guard let stored = tab?.httpAuthCredential, stored.host == request.url?.host else { return nil }
+                return stored.credential
+            }()
             let tempPDF = DefaultTemporaryDocument(
                 filename: filename,
                 request: request,
                 mimeType: MIMEType.PDF,
                 cookies: cookies,
-                credential: tab?.httpAuthCredential
+                credential: credential
             )
             tempPDF.onDownloadProgressUpdate = { progress in
                 self?.handleDownloadProgressUpdate(progress: progress, tab: tab)
@@ -1211,7 +1216,7 @@ extension BrowserViewController: WKNavigationDelegate {
                     loginsHelper: loginsHelper,
                 )
 
-                tab.httpAuthCredential = loginEntry.credentials
+                tab.httpAuthCredential = (challenge.protectionSpace.host, loginEntry.credentials)
                 return (.useCredential, loginEntry.credentials)
             } catch {
                 // For example, an error is thrown when the user taps "Cancel" on the authentication prompt

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -974,7 +974,8 @@ extension BrowserViewController: WKNavigationDelegate {
                 filename: filename,
                 request: request,
                 mimeType: MIMEType.PDF,
-                cookies: cookies
+                cookies: cookies,
+                credential: tab?.httpAuthCredential
             )
             tempPDF.onDownloadProgressUpdate = { progress in
                 self?.handleDownloadProgressUpdate(progress: progress, tab: tab)
@@ -1210,6 +1211,7 @@ extension BrowserViewController: WKNavigationDelegate {
                     loginsHelper: loginsHelper,
                 )
 
+                tab.httpAuthCredential = loginEntry.credentials
                 return (.useCredential, loginEntry.credentials)
             } catch {
                 // For example, an error is thrown when the user taps "Cancel" on the authentication prompt

--- a/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
+++ b/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
@@ -45,6 +45,24 @@ final class WeakURLSessionDelegate: NSObject, URLSessionDownloadDelegate, @unche
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard let delegate else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        delegate.urlSession?(
+            session,
+            task: task,
+            didReceive: challenge,
+            completionHandler: completionHandler
+        )
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
         willPerformHTTPRedirection response: HTTPURLResponse,
         newRequest request: URLRequest,
         completionHandler: @escaping @Sendable (URLRequest?) -> Void
@@ -87,6 +105,7 @@ final class DefaultTemporaryDocument: NSObject,
     private let session: URLSession
     private let request: URLRequest
     private let cookies: [HTTPCookie]
+    private let credential: URLCredential?
     private var currentDownloadTask: URLSessionDownloadTask?
 
     private var onDownload: ((URL?) -> Void)?
@@ -111,11 +130,13 @@ final class DefaultTemporaryDocument: NSObject,
         request: URLRequest,
         mimeType: String? = nil,
         cookies: [HTTPCookie] = [],
+        credential: URLCredential? = nil,
         session: URLSession = .shared,
         logger: Logger = DefaultLogger.shared
     ) {
         self.request = Self.applyCookiesToRequest(request, cookies: cookies)
         self.cookies = cookies
+        self.credential = credential
         self.filename = filename ?? "unknown"
         self.mimeType = mimeType
         self.session = session
@@ -133,6 +154,7 @@ final class DefaultTemporaryDocument: NSObject,
     ) {
         self.request = request
         self.cookies = []
+        self.credential = nil
         self.filename = preflightResponse.suggestedFilename ?? "unknown"
         self.mimeType = mimeType
         self.session = session
@@ -281,6 +303,23 @@ final class DefaultTemporaryDocument: NSObject,
     }
 
     // MARK: - URLSessionDownloadDelegate
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        let method = challenge.protectionSpace.authenticationMethod
+        let isHTTPAuthChallenge = method == NSURLAuthenticationMethodHTTPBasic
+            || method == NSURLAuthenticationMethodHTTPDigest
+            || method == NSURLAuthenticationMethodNTLM
+        if let credential, isHTTPAuthChallenge, challenge.protectionSpace.host == request.url?.host {
+            completionHandler(.useCredential, credential)
+        } else {
+            completionHandler(.performDefaultHandling, nil)
+        }
+    }
 
     func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         currentDownloadTask = nil

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -357,6 +357,7 @@ class Tab: NSObject,
 
     var mimeType: String?
     var isEditing = false
+    // TODO: [FXIOS-15182] We can remove this HTTP auth credential once the refactors to TemporaryDocument are implemented
     var httpAuthCredential: URLCredential?
     // When viewing a non-HTML content type in the webview (like a PDF document), this URL will
     // point to a tempfile containing the content so it can be shared to external applications.

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -358,7 +358,7 @@ class Tab: NSObject,
     var mimeType: String?
     var isEditing = false
     // TODO: [FXIOS-15182] We can remove this HTTP auth credential once the refactors to TemporaryDocument are implemented
-    var httpAuthCredential: URLCredential?
+    var httpAuthCredential: (host: String, credential: URLCredential)?
     // When viewing a non-HTML content type in the webview (like a PDF document), this URL will
     // point to a tempfile containing the content so it can be shared to external applications.
     var temporaryDocument: TemporaryDocument?

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -357,6 +357,7 @@ class Tab: NSObject,
 
     var mimeType: String?
     var isEditing = false
+    var httpAuthCredential: URLCredential?
     // When viewing a non-HTML content type in the webview (like a PDF document), this URL will
     // point to a tempfile containing the content so it can be shared to external applications.
     var temporaryDocument: TemporaryDocument?


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15160)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32637)

## :bulb: Description

This fixes basic auth loading for PDFs. I am investigating a broader fix for this in conjunction with the refactors described in [32685](https://github.com/mozilla-mobile/firefox-ios/issues/32685), however that refactor is significant and there are still several open questions being explored. The change here is lower-risk and more targeted and will fix basic auth in the meantime while we're exploring the new direction for TemporaryDocument in [32685](https://github.com/mozilla-mobile/firefox-ios/issues/32685).

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

