### PR TITLE
Add FXIOS-16493 [Nova] Update alert colors

### DIFF
--- a/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
@@ -155,4 +155,12 @@ extension UIAlertController {
         alert.addAction(UIAlertAction(title: .OKString, style: .default, handler: okayCallback))
         return alert
     }
+
+    func applyNovaActionTint(_ theme: Theme) {
+        // The violet action tint only applies below iOS 26
+        if #available(iOS 26.0, *) { return }
+        let featureFlagsProvider: FeatureFlagProviding = AppContainer.shared.resolve()
+        guard featureFlagsProvider.isEnabled(.novaDesign) else { return }
+        view.tintColor = theme.colors.actionPrimary
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3048,6 +3048,7 @@ class BrowserViewController: UIViewController,
             updateDisplayedPopoverProperties = setupPopover
         }
 
+        alert.applyNovaActionTint(themeManager.getCurrentTheme(for: windowUUID))
         present(alert, animated: true)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -899,6 +899,7 @@ final class TabTrayViewController: UIViewController,
             accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCancelButton
         )
         alert.popoverPresentationController?.barButtonItem = deleteButton
+        alert.applyNovaActionTint(retrieveTheme())
         present(alert, animated: true, completion: nil)
     }
 
@@ -945,6 +946,7 @@ final class TabTrayViewController: UIViewController,
         )
 
         alert.popoverPresentationController?.barButtonItem = deleteButton
+        alert.applyNovaActionTint(retrieveTheme())
         present(alert, animated: true, completion: nil)
     }
 

--- a/firefox-ios/Client/Frontend/Library/ClearHistorySheetProvider.swift
+++ b/firefox-ios/Client/Frontend/Library/ClearHistorySheetProvider.swift
@@ -22,10 +22,12 @@ class ClearHistorySheetProvider {
     ///   - didComplete: Did complete a recent history clear up action
     func showClearRecentHistory(
         onViewController viewController: UIViewController,
+        theme: Theme,
         didComplete: @MainActor @escaping (HistoryDeletionUtilityDateOptions) -> Void
     ) {
         let alert = createAlertAndConfigureWithArrowIfNeeded(from: viewController)
         setupActions(for: alert, didComplete: didComplete)
+        alert.applyNovaActionTint(theme)
 
         viewController.present(alert, animated: true)
     }

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -297,7 +297,10 @@ class HistoryPanel: UIViewController,
     }
 
     func showClearRecentHistory() {
-        clearHistoryHelper.showClearRecentHistory(onViewController: self) { [weak self] dateOption in
+        clearHistoryHelper.showClearRecentHistory(
+            onViewController: self,
+            theme: themeManager.getCurrentTheme(for: windowUUID)
+        ) { [weak self] dateOption in
             // Delete groupings that belong to THAT section.
             switch dateOption {
             case .lastHour, .lastTwentyFourHours, .lastSevenDays, .lastFourWeeks:

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -923,6 +923,9 @@ class PickerSetting<Value: Equatable>: Setting {
         }
         alertController.addAction(UIAlertAction(title: .CancelString, style: .cancel))
 
+        if let theme {
+            alertController.applyNovaActionTint(theme)
+        }
         navigationController?.present(alertController, animated: true)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16493)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35025)

## :bulb: Description
This PR updates alert colors to mach Nova design - the violet tint is used only under iOS 26.

<img width="666" height="585" alt="Screenshot 2026-08-07 at 11 05 14" src="https://github.com/user-attachments/assets/2a277460-a665-481b-b935-32cb1e0c1ef3" />


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

