### PR TITLE
Add FXIOS-16501 [Nova] Change active segmented controller tab background in Library

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -464,9 +464,6 @@ final class TabTrayViewController: UIViewController,
         }
         syncTabButton.tintColor = theme.colors.iconPrimary
         panelContainer.backgroundColor = theme.colors.layer3
-        if theme.isNova {
-            segmentedControl.selectedSegmentTintColor = theme.colors.layer2
-        }
 
         if shouldUsePrivateOverride {
             activeExperimentSegmentControl.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -464,6 +464,9 @@ final class TabTrayViewController: UIViewController,
         }
         syncTabButton.tintColor = theme.colors.iconPrimary
         panelContainer.backgroundColor = theme.colors.layer3
+        if theme.isNova {
+            segmentedControl.selectedSegmentTintColor = theme.colors.layer2
+        }
 
         if shouldUsePrivateOverride {
             activeExperimentSegmentControl.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -411,6 +411,9 @@ class LibraryViewController: UIViewController, Themeable {
         navigationController?.toolbar.barTintColor = theme.colors.layer1
         navigationController?.toolbar.tintColor = theme.colors.actionPrimary
         librarySegmentControl.tintColor = theme.colors.textPrimary
+        if theme.isNova {
+            librarySegmentControl.selectedSegmentTintColor = theme.colors.layer2
+        }
 
         setNeedsStatusBarAppearanceUpdate()
         setupToolBarAppearance()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16501)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35036)

## :bulb: Description
This PR adds Nova color to the active tab of segmented controller from Library Panel.

<img width="1230" height="211" alt="Screenshot 2026-08-07 at 12 55 22" src="https://github.com/user-attachments/assets/746d64df-7822-43fc-bd63-837ae93c5360" />



## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

