### PR TITLE
Add FXIOS-16539 [Nova] Update TabTray design

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
@@ -62,6 +62,26 @@ struct TabTrayPanelSwipePalette: ThemeColourPalette {
         return partialOverrides.iconDisabled
     }
 
+    var layer2: UIColor {
+        return partialOverrides.layer2
+    }
+
+    var layerSurfaceLow: UIColor {
+        return partialOverrides.layerSurfaceLow
+    }
+
+    var layerGlassTintNova: UIColor {
+        return partialOverrides.layerGlassTintNova
+    }
+
+    var iconInverted: UIColor {
+        return partialOverrides.iconInverted
+    }
+
+    var actionPrimary: UIColor {
+        return partialOverrides.actionPrimary
+    }
+
     struct PartialOverrides {
         var layer1: UIColor
         var iconPrimary: UIColor
@@ -76,9 +96,13 @@ struct TabTrayPanelSwipePalette: ThemeColourPalette {
         var borderAccentPrivate: UIColor
         var shadowDefault: UIColor
         var iconDisabled: UIColor
+        var layer2: UIColor
+        var layerSurfaceLow: UIColor
+        var layerGlassTintNova: UIColor
+        var iconInverted: UIColor
+        var actionPrimary: UIColor
     }
 
-    var layer2: UIColor { base.layer2 }
     var layer4: UIColor { base.layer4 }
     var layer5: UIColor { base.layer5 }
     var layer5Hover: UIColor { base.layer5Hover }
@@ -97,13 +121,11 @@ struct TabTrayPanelSwipePalette: ThemeColourPalette {
     var layerSelectedText: UIColor { base.layerSelectedText }
     var layerAutofillText: UIColor { base.layerAutofillText }
     var layerGradientURL: Gradient { base.layerGradientURL }
-    var layerSurfaceLow: UIColor { base.layerSurfaceLow }
     var layerSurfaceMedium: UIColor { base.layerSurfaceMedium }
     var layerSurfaceMediumAlpha: UIColor { base.layerSurfaceMediumAlpha }
     var layerSurfaceMediumAlt: UIColor { base.layerSurfaceMediumAlt }
     var layerGradientSummary: Gradient { base.layerGradientSummary }
 
-    var actionPrimary: UIColor { base.actionPrimary }
     var actionPrimaryHover: UIColor { base.actionPrimaryHover }
     var actionPrimaryDisabled: UIColor { base.actionPrimaryDisabled }
     var actionSecondaryDisabled: UIColor { base.actionSecondaryDisabled }
@@ -160,9 +182,7 @@ struct TabTrayPanelSwipePalette: ThemeColourPalette {
     // MARK: - Nova only tokens
     var layerAccentSubtle: UIColor { base.layerAccentSubtle }
     var layerInverse: UIColor { base.layerInverse }
-    var layerGlassTintNova: UIColor { base.layerGlassTintNova }
     var textToast: UIColor { base.textToast }
-    var iconInverted: UIColor { base.iconInverted }
     var iconOnColorDisabled: UIColor { base.iconOnColorDisabled }
     var iconPrivate: UIColor { base.iconPrivate }
     var borderStrong: UIColor { base.borderStrong }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipeTheme.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipeTheme.swift
@@ -26,7 +26,12 @@ struct TabTrayPanelSwipeTheme: Theme {
             borderAccent: mixColor(\.borderAccent),
             borderAccentPrivate: mixColor(\.borderAccentPrivate),
             shadowDefault: mixColor(\.shadowDefault),
-            iconDisabled: mixColor(\.iconDisabled)
+            iconDisabled: mixColor(\.iconDisabled),
+            layer2: mixColor(\.layer2),
+            layerSurfaceLow: mixColor(\.layerSurfaceLow),
+            layerGlassTintNova: from.isNova ? mixColor(\.layerGlassTintNova) : .clear,
+            iconInverted: from.isNova ? mixColor(\.iconInverted) : .clear,
+            actionPrimary: mixColor(\.actionPrimary)
         )
 
         self.type = from.type

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -380,11 +380,15 @@ class TabTraySelectorView: UIView, ThemeApplicable {
         self.theme = theme
 
         if #unavailable(iOS 26) {
-            let backgroundAlpha: CGFloat = tabTrayUtils.backgroundAlpha()
-            backgroundColor = theme.colors.layer1.withAlphaComponent(backgroundAlpha)
+            let trackColor = theme.isNova ? theme.colors.layerSurfaceLow : theme.colors.layer1
+            backgroundColor = trackColor.withAlphaComponent(tabTrayUtils.backgroundAlpha())
+        } else if theme.isNova, !DeviceInfo.isRunningLiquidGlassEarlyBeta, !(theme is TabTrayPanelSwipeTheme) {
+            let glass = UIGlassEffect(style: .regular)
+            glass.tintColor = theme.colors.layerGlassTintNova
+            visualEffectView.effect = glass
         }
 
-        selectionBackgroundView.backgroundColor = theme.colors.layerEmphasis
+        selectionBackgroundView.backgroundColor = theme.isNova ? theme.colors.layer2 : theme.colors.layerEmphasis
 
         for button in buttons {
             button.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentEmptyPrivateTabsView.swift
@@ -133,7 +133,7 @@ class ExperimentEmptyPrivateTabsView: UIView,
     }
 
     func applyTheme(theme: Theme) {
-        backgroundColor = theme.colors.layer3
+        backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
         titleLabel.textColor = theme.colors.textPrimary
         descriptionLabel.textColor = theme.colors.textPrimary
         learnMoreButton.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
@@ -154,7 +154,7 @@ class ExperimentRemoteTabsEmptyView: UIView,
         titleLabel.textColor = theme.colors.textPrimary
         descriptionLabel.textColor = theme.colors.textPrimary
         signInButton.applyTheme(theme: theme)
-        backgroundColor = theme.colors.layer3
+        backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -199,7 +199,7 @@ final class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCe
 
     func applyTheme(theme: Theme) {
         backgroundHolder.backgroundColor = theme.colors.layer1
-        closeButtonImageOverlay.tintColor = theme.colors.textOnDark
+        closeButtonImageOverlay.tintColor = theme.isNova ? theme.colors.textOnLight : theme.colors.textOnDark
         screenshotView.backgroundColor = theme.colors.layer1
         smallFaviconView.tintColor = theme.colors.textPrimary
         setupShadow(theme: theme)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -256,15 +256,16 @@ final class TabDisplayPanelViewController: UIViewController,
             if statusBarView.superview == nil {
                 view.addSubview(statusBarView)
             }
-            statusBarView.backgroundColor = theme.colors.layer3
+            statusBarView.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
             adjustStatusBarFrameIfNeeded()
         } else {
             gradientLayer.isHidden = false
             statusBarView.removeFromSuperview()
             gradientLayer.locations = [0.0, 0.12]
+            let fadeColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
             gradientLayer.colors = [
-                theme.colors.layer3.cgColor,
-                theme.colors.layer3.withAlphaComponent(0.0).cgColor
+                fadeColor.cgColor,
+                fadeColor.withAlphaComponent(0.0).cgColor
             ]
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -248,7 +248,7 @@ final class TabDisplayView: UIView,
 
     func applyTheme(theme: Theme) {
         self.theme = theme
-        collectionView.backgroundColor = theme.colors.layer3
+        collectionView.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
         collectionView.visibleCells.forEach { ($0 as? ThemeApplicable)?.applyTheme(theme: theme) }
         collectionView.visibleSupplementaryViews(ofKind: TabTitleSupplementaryView.cellIdentifier)
             .compactMap { $0 as? TabTitleSupplementaryView }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -193,6 +193,11 @@ final class TabTrayViewController: UIViewController,
         (AppContainer.shared.resolve() as FeatureFlagProviding).isEnabled(.novaDesign)
     }
 
+    private var usesNovaGlassToolbarButtons: Bool {
+        guard #available(iOS 26.0, *) else { return false }
+        return isNovaDesignEnabled
+    }
+
     @available(iOS 26.0, *)
     private func applyToolbarGlassButtonTints(theme: Theme) {
         guard isNovaDesignEnabled else { return }
@@ -239,7 +244,7 @@ final class TabTrayViewController: UIViewController,
     }()
 
     private lazy var doneButton: UIBarButtonItem = {
-        if #available(iOS 26.0, *), isNovaDesignEnabled {
+        if usesNovaGlassToolbarButtons {
             let button = UIBarButtonItem(image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.checkmark),
                                          style: .plain,
                                          target: self,
@@ -502,7 +507,7 @@ final class TabTrayViewController: UIViewController,
         }
         syncTabButton.tintColor = theme.colors.iconPrimary
         panelContainer.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
-        if #available(iOS 26.0, *), isNovaDesignEnabled {
+        if #available(iOS 26.0, *) {
             applyToolbarGlassButtonTints(theme: theme)
         }
         if theme.isNova {
@@ -532,12 +537,14 @@ final class TabTrayViewController: UIViewController,
 
         view.backgroundColor = swipeTheme.colors.layer1
         navigationToolbar.barTintColor = swipeTheme.colors.layer1
-        deleteButton.tintColor = swipeTheme.colors.iconPrimary
-        newTabButton.tintColor = swipeTheme.colors.iconPrimary
-        if #available(iOS 26, *) {
-            doneButton.tintColor = swipeTheme.isNova ? swipeTheme.colors.iconInverted : swipeTheme.colors.iconPrimary
-        } else {
-            doneButton.tintColor = swipeTheme.colors.iconPrimary
+        if !usesNovaGlassToolbarButtons {
+            deleteButton.tintColor = swipeTheme.colors.iconPrimary
+            newTabButton.tintColor = swipeTheme.colors.iconPrimary
+            if #available(iOS 26, *) {
+                doneButton.tintColor = swipeTheme.isNova ? swipeTheme.colors.iconInverted : swipeTheme.colors.iconPrimary
+            } else {
+                doneButton.tintColor = swipeTheme.colors.iconPrimary
+            }
         }
         syncTabButton.tintColor = swipeTheme.colors.iconPrimary
         panelContainer.backgroundColor = swipeTheme.isNova ? swipeTheme.colors.layer1 : swipeTheme.colors.layer3
@@ -545,7 +552,7 @@ final class TabTrayViewController: UIViewController,
         activeExperimentSegmentControl.applyTheme(theme: swipeTheme)
         if progress >= 1.0, let toTheme = childPanelThemes?[safe: toIndex] {
             activeExperimentSegmentControl.applyTheme(theme: toTheme)
-            if #available(iOS 26.0, *), isNovaDesignEnabled {
+            if #available(iOS 26.0, *) {
                 applyToolbarGlassButtonTints(theme: toTheme)
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -197,9 +197,18 @@ final class TabTrayViewController: UIViewController,
     private func applyToolbarGlassButtonTints(theme: Theme) {
         guard isNovaDesignEnabled else { return }
         let glassTint = theme.colors.layerGlassTintNova
-        setProminentGlass(deleteButton, StandardImageIdentifiers.Large.delete, background: glassTint, glyph: theme.colors.iconPrimary)
-        setProminentGlass(newTabButton, StandardImageIdentifiers.Large.plus, background: glassTint, glyph: theme.colors.iconPrimary)
-        setProminentGlass(doneButton, StandardImageIdentifiers.Large.checkmark, background: theme.colors.actionPrimary, glyph: theme.colors.iconInverted)
+        setProminentGlass(deleteButton,
+                          StandardImageIdentifiers.Large.delete,
+                          background: glassTint,
+                          glyph: theme.colors.iconPrimary)
+        setProminentGlass(newTabButton,
+                          StandardImageIdentifiers.Large.plus,
+                          background: glassTint,
+                          glyph: theme.colors.iconPrimary)
+        setProminentGlass(doneButton,
+                          StandardImageIdentifiers.Large.checkmark,
+                          background: theme.colors.actionPrimary,
+                          glyph: theme.colors.iconInverted)
     }
 
     @available(iOS 26.0, *)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -197,16 +197,16 @@ final class TabTrayViewController: UIViewController,
     private func applyToolbarGlassButtonTints(theme: Theme) {
         guard isNovaDesignEnabled else { return }
         let glassTint = theme.colors.layerGlassTintNova
-        let buttons: [(item: UIBarButtonItem, imageName: String, background: UIColor, glyph: UIColor)] = [
-            (deleteButton, StandardImageIdentifiers.Large.delete, glassTint, theme.colors.iconPrimary),
-            (newTabButton, StandardImageIdentifiers.Large.plus, glassTint, theme.colors.iconPrimary),
-            (doneButton, StandardImageIdentifiers.Large.checkmark, theme.colors.actionPrimary, theme.colors.iconInverted)
-        ]
-        for button in buttons {
-            button.item.style = .prominent
-            button.item.tintColor = button.background
-            button.item.image = UIImage(named: button.imageName)?.withTintColor(button.glyph, renderingMode: .alwaysOriginal)
-        }
+        setProminentGlass(deleteButton, StandardImageIdentifiers.Large.delete, background: glassTint, glyph: theme.colors.iconPrimary)
+        setProminentGlass(newTabButton, StandardImageIdentifiers.Large.plus, background: glassTint, glyph: theme.colors.iconPrimary)
+        setProminentGlass(doneButton, StandardImageIdentifiers.Large.checkmark, background: theme.colors.actionPrimary, glyph: theme.colors.iconInverted)
+    }
+
+    @available(iOS 26.0, *)
+    private func setProminentGlass(_ button: UIBarButtonItem, _ imageName: String, background: UIColor, glyph: UIColor) {
+        button.style = .prominent
+        button.tintColor = background
+        button.image = UIImage(named: imageName)?.withTintColor(glyph, renderingMode: .alwaysOriginal)
     }
 
     private lazy var deleteButton: UIBarButtonItem = {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -189,6 +189,26 @@ final class TabTrayViewController: UIViewController,
         return isRegularLayout ? regularLayoutItems : iPhoneItems
     }
 
+    private var isNovaDesignEnabled: Bool {
+        (AppContainer.shared.resolve() as FeatureFlagProviding).isEnabled(.novaDesign)
+    }
+
+    @available(iOS 26.0, *)
+    private func applyToolbarGlassButtonTints(theme: Theme) {
+        guard isNovaDesignEnabled else { return }
+        let glassTint = theme.colors.layerGlassTintNova
+        let buttons: [(item: UIBarButtonItem, imageName: String, background: UIColor, glyph: UIColor)] = [
+            (deleteButton, StandardImageIdentifiers.Large.delete, glassTint, theme.colors.iconPrimary),
+            (newTabButton, StandardImageIdentifiers.Large.plus, glassTint, theme.colors.iconPrimary),
+            (doneButton, StandardImageIdentifiers.Large.checkmark, theme.colors.actionPrimary, theme.colors.iconInverted)
+        ]
+        for button in buttons {
+            button.item.style = .prominent
+            button.item.tintColor = button.background
+            button.item.image = UIImage(named: button.imageName)?.withTintColor(button.glyph, renderingMode: .alwaysOriginal)
+        }
+    }
+
     private lazy var deleteButton: UIBarButtonItem = {
         return createButtonItem(imageName: StandardImageIdentifiers.Large.delete,
                                 action: #selector(deleteTabsButtonTapped),
@@ -210,6 +230,15 @@ final class TabTrayViewController: UIViewController,
     }()
 
     private lazy var doneButton: UIBarButtonItem = {
+        if #available(iOS 26.0, *), isNovaDesignEnabled {
+            let button = UIBarButtonItem(image: UIImage.templateImageNamed(StandardImageIdentifiers.Large.checkmark),
+                                         style: .plain,
+                                         target: self,
+                                         action: #selector(doneButtonTapped))
+            button.accessibilityIdentifier = AccessibilityIdentifiers.TabTray.doneButton
+            button.accessibilityLabel = .SettingsSearchDoneButton
+            return button
+        }
         let button = UIBarButtonItem(barButtonSystemItem: .done,
                                      target: self,
                                      action: #selector(doneButtonTapped))
@@ -463,7 +492,16 @@ final class TabTrayViewController: UIViewController,
             doneButton.tintColor = theme.colors.iconPrimary
         }
         syncTabButton.tintColor = theme.colors.iconPrimary
-        panelContainer.backgroundColor = theme.colors.layer3
+        panelContainer.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
+        if #available(iOS 26.0, *), isNovaDesignEnabled {
+            applyToolbarGlassButtonTints(theme: theme)
+        }
+        if theme.isNova {
+            segmentedControl.selectedSegmentTintColor = theme.colors.layer2
+            if #unavailable(iOS 26) {
+                segmentedControl.backgroundColor = theme.colors.layerSurfaceLow
+            }
+        }
 
         if shouldUsePrivateOverride {
             activeExperimentSegmentControl.applyTheme(theme: theme)
@@ -493,9 +531,15 @@ final class TabTrayViewController: UIViewController,
             doneButton.tintColor = swipeTheme.colors.iconPrimary
         }
         syncTabButton.tintColor = swipeTheme.colors.iconPrimary
-        panelContainer.backgroundColor = swipeTheme.colors.layer3
+        panelContainer.backgroundColor = swipeTheme.isNova ? swipeTheme.colors.layer1 : swipeTheme.colors.layer3
 
         activeExperimentSegmentControl.applyTheme(theme: swipeTheme)
+        if progress >= 1.0, let toTheme = childPanelThemes?[safe: toIndex] {
+            activeExperimentSegmentControl.applyTheme(theme: toTheme)
+            if #available(iOS 26.0, *), isNovaDesignEnabled {
+                applyToolbarGlassButtonTints(theme: toTheme)
+            }
+        }
         setupToolBarAppearance(theme: swipeTheme)
         setupNavigationBarAppearance(theme: swipeTheme)
     }
@@ -508,7 +552,8 @@ final class TabTrayViewController: UIViewController,
         if #available(iOS 26, *), !isReduceTransparencyEnabled { return }
 
         let backgroundAlpha = tabTrayUtils.backgroundAlpha()
-        let color = theme.colors.layer1.withAlphaComponent(backgroundAlpha)
+        let color = (theme.isNova ? theme.colors.layerSurfaceLow : theme.colors.layer1)
+            .withAlphaComponent(backgroundAlpha)
 
         let standardAppearance = UIToolbarAppearance()
         standardAppearance.configureWithDefaultBackground()
@@ -526,7 +571,8 @@ final class TabTrayViewController: UIViewController,
         guard tabTrayUtils.shouldDisplayExperimentUI() else { return }
 
         let backgroundAlpha = tabTrayUtils.backgroundAlpha()
-        let color = theme.colors.layer1.withAlphaComponent(backgroundAlpha)
+        let color = (theme.isNova ? theme.colors.layerSurfaceLow : theme.colors.layer1)
+            .withAlphaComponent(backgroundAlpha)
 
         let standardAppearance = UINavigationBarAppearance()
         standardAppearance.configureWithDefaultBackground()
@@ -644,7 +690,7 @@ final class TabTrayViewController: UIViewController,
         applyTheme()
 
         if #available(iOS 26, *) { return }
-        blurView.isHidden = !tabTrayUtils.shouldBlur()
+        blurView.isHidden = isNovaDesignEnabled || !tabTrayUtils.shouldBlur()
     }
 
     private func updateTitle() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16539)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates UI elements from Tab Tray to follow Nova design from [Figma]
(https://www.figma.com/design/XrQf2Lqhpi2s5N03lTtJ5h/2026-03-31-nova?node-id=12537-92422&m=dev)
background, close button on each tab, segmented controller design and the 3 bar buttons.
The changes are Nova only and do not impact old themes/old design.

<img width="268" height="554" alt="Screenshot 2026-08-07 at 17 20 23" src="https://github.com/user-attachments/assets/2aecbe32-ab80-4a79-9a1c-4b9bce37706f" />

<img width="254" height="545" alt="Screenshot 2026-08-07 at 17 22 37" src="https://github.com/user-attachments/assets/dea387ee-dc34-467d-8928-8cbd72116bc9" />

<img width="246" height="547" alt="Screenshot 2026-08-07 at 17 23 00" src="https://github.com/user-attachments/assets/5d8754ce-533e-4279-85f4-8425b67f71ff" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

