### PR TITLE
Add FXIOS-16432 [WebCompat] Add the Report Preview screen with the Technical Data row

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
@@ -1,0 +1,225 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+
+@MainActor
+public protocol WebCompatReportPreviewDelegate: AnyObject {
+    func webCompatReportPreviewDidRequestDismiss()
+    func webCompatReportPreviewDidTapTechnicalData()
+}
+
+/// The Report Preview sheet, and the root of the stack Technical Data is pushed onto.
+public final class WebCompatReportPreviewViewController: UIViewController,
+                                                        Themeable,
+                                                        UICollectionViewDelegate {
+    private enum SectionID: Hashable {
+        case technicalData
+    }
+
+    public weak var delegate: WebCompatReportPreviewDelegate?
+
+    public let themeManager: ThemeManager
+    public var themeListenerCancellable: Any?
+    public var currentWindowUUID: WindowUUID?
+    private let notificationCenter: NotificationProtocol
+
+    private var viewModel: WebCompatReportPreviewViewModel
+    private var theme: Theme
+
+    private lazy var closeButton: UIBarButtonItem = {
+        let image = UIImage(named: StandardImageIdentifiers.Large.cross)?.withRenderingMode(.alwaysTemplate)
+        return UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(didTapClose))
+    }()
+
+    private lazy var collectionView: UICollectionView = .build({ collectionView in
+        collectionView.delegate = self
+    }) {
+        UICollectionView(frame: .zero, collectionViewLayout: self.makeLayout())
+    }
+
+    private lazy var dataSource = makeDataSource()
+
+    public init(
+        viewModel: WebCompatReportPreviewViewModel,
+        windowUUID: WindowUUID,
+        themeManager: ThemeManager,
+        notificationCenter: NotificationProtocol = NotificationCenter.default
+    ) {
+        self.viewModel = viewModel
+        self.currentWindowUUID = windowUUID
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        self.theme = themeManager.getCurrentTheme(for: windowUUID)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigationItem()
+        setupLayout()
+        listenForThemeChanges(withNotificationCenter: notificationCenter)
+        applyTheme()
+        configure(with: viewModel)
+    }
+
+    // MARK: - Configuration
+
+    public func configure(with viewModel: WebCompatReportPreviewViewModel) {
+        let viewModelDidChange = self.viewModel != viewModel
+        self.viewModel = viewModel
+        guard isViewLoaded else { return }
+        navigationItem.title = viewModel.title
+        closeButton.accessibilityLabel = viewModel.closeAccessibilityLabel
+        closeButton.accessibilityIdentifier = viewModel.closeA11yIdentifier
+        updateSections(reconfiguringItems: viewModelDidChange)
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigationItem() {
+        navigationItem.rightBarButtonItem = closeButton
+        navigationItem.largeTitleDisplayMode = .never
+    }
+
+    private func setupLayout() {
+        view.addSubview(collectionView)
+        collectionView.pinToSuperview()
+    }
+
+    private func makeLayout() -> UICollectionViewCompositionalLayout {
+        return UICollectionViewCompositionalLayout { _, environment in
+            var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+            configuration.backgroundColor = .clear
+            configuration.showsSeparators = false
+            let section = NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: environment)
+            section.contentInsets = NSDirectionalEdgeInsets(
+                top: WebCompatReporterUX.Spacing.sectionGap,
+                leading: WebCompatReporterUX.Preview.cardHorizontalInset,
+                bottom: 0,
+                trailing: WebCompatReporterUX.Preview.cardHorizontalInset
+            )
+            return section
+        }
+    }
+
+    // MARK: - Data source
+
+    // Registrations go here, not inside the provider: UIKit crashes on one built lazily per cell.
+    private func makeDataSource() -> UICollectionViewDiffableDataSource<SectionID, SectionID> {
+        let technicalDataRegistration = UICollectionView.CellRegistration<
+            UICollectionViewListCell, SectionID
+        > { [weak self] cell, _, _ in
+            guard let self else { return }
+            var background = UIBackgroundConfiguration.listGroupedCell()
+            background.backgroundColor = self.theme.colors.layer5
+            background.cornerRadius = WebCompatReporterUX.Card.largeCornerRadius
+            cell.backgroundConfiguration = background
+
+            var content = cell.defaultContentConfiguration()
+            content.text = self.viewModel.technicalDataTitle
+            content.textProperties.font = FXFontStyles.Regular.body.scaledFont()
+            content.textProperties.color = self.theme.colors.textPrimary
+            content.directionalLayoutMargins = NSDirectionalEdgeInsets(
+                top: WebCompatReporterUX.Card.verticalInset,
+                leading: WebCompatReporterUX.Card.contentInset,
+                bottom: WebCompatReporterUX.Card.verticalInset,
+                trailing: WebCompatReporterUX.Card.contentInset
+            )
+            cell.contentConfiguration = content
+
+            let options = UICellAccessory.DisclosureIndicatorOptions(
+                tintColor: self.theme.colors.iconSecondary
+            )
+            cell.accessories = [.disclosureIndicator(options: options)]
+            cell.accessibilityIdentifier = self.viewModel.technicalDataA11yIdentifier
+            cell.accessibilityTraits.insert(.button)
+        }
+
+        return UICollectionViewDiffableDataSource<SectionID, SectionID>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, itemID in
+            switch itemID {
+            case .technicalData:
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: technicalDataRegistration, for: indexPath, item: itemID
+                )
+            }
+        }
+    }
+
+    private func updateSections(reconfiguringItems: Bool) {
+        let sectionIDs: [SectionID] = [.technicalData]
+
+        // An unchanged apply would rebuild every cell, so only apply when the sections moved.
+        if dataSource.snapshot().sectionIdentifiers != sectionIDs {
+            var snapshot = NSDiffableDataSourceSnapshot<SectionID, SectionID>()
+            snapshot.appendSections(sectionIDs)
+            for sectionID in sectionIDs {
+                snapshot.appendItems([sectionID], toSection: sectionID)
+            }
+            dataSource.apply(snapshot, animatingDifferences: false)
+        }
+
+        if reconfiguringItems { reconfigureAllItems() }
+    }
+
+    private func reconfigureAllItems() {
+        var snapshot = dataSource.snapshot()
+        guard !snapshot.itemIdentifiers.isEmpty else { return }
+        snapshot.reconfigureItems(snapshot.itemIdentifiers)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+
+    // MARK: - Actions
+
+    @objc
+    private func didTapClose() {
+        delegate?.webCompatReportPreviewDidRequestDismiss()
+    }
+
+    // MARK: - Accessibility
+
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // No argument, so UIKit announces the screen rather than opening on "Close".
+        UIAccessibility.post(notification: .screenChanged, argument: nil)
+    }
+
+    override public func accessibilityPerformEscape() -> Bool {
+        guard let delegate else { return false }
+        delegate.webCompatReportPreviewDidRequestDismiss()
+        return true
+    }
+
+    // MARK: - UICollectionViewDelegate
+
+    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.deselectItem(at: indexPath, animated: false)
+        guard dataSource.itemIdentifier(for: indexPath) == .technicalData else { return }
+        delegate?.webCompatReportPreviewDidTapTechnicalData()
+    }
+
+    // MARK: - Themeable
+
+    public func applyTheme() {
+        theme = themeManager.getCurrentTheme(for: currentWindowUUID)
+        guard isViewLoaded else { return }
+        view.backgroundColor = theme.colors.layer1
+        navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
+        // Otherwise the title stays dark-on-dark in the dark theme.
+        navigationController?.navigationBar.titleTextAttributes = [
+            .foregroundColor: theme.colors.textPrimary
+        ]
+        collectionView.backgroundColor = theme.colors.layer1
+        reconfigureAllItems()
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
@@ -119,10 +119,15 @@ public final class WebCompatReportPreviewViewController: UIViewController,
             UICollectionViewListCell, SectionID
         > { [weak self] cell, _, _ in
             guard let self else { return }
-            var background = UIBackgroundConfiguration.listGroupedCell()
-            background.backgroundColor = self.theme.colors.layer5
-            background.cornerRadius = WebCompatReporterUX.Card.largeCornerRadius
-            cell.backgroundConfiguration = background
+            cell.configurationUpdateHandler = { [weak self] cell, state in
+                guard let self else { return }
+                var background = UIBackgroundConfiguration.listGroupedCell()
+                background.backgroundColor = state.isHighlighted
+                    ? self.theme.colors.layer5Hover
+                    : self.theme.colors.layer5
+                background.cornerRadius = WebCompatReporterUX.Card.largeCornerRadius
+                cell.backgroundConfiguration = background
+            }
 
             var content = cell.defaultContentConfiguration()
             content.text = self.viewModel.technicalDataTitle

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewModel.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// What the Report Preview screen renders. The Client supplies the copy, so the package stays
+/// free of Redux and Strings.
+public struct WebCompatReportPreviewViewModel: Equatable, Sendable {
+    public let title: String
+    public let closeAccessibilityLabel: String
+    public let closeA11yIdentifier: String
+    public let technicalDataTitle: String
+    public let technicalDataA11yIdentifier: String
+
+    public init(
+        title: String,
+        closeAccessibilityLabel: String,
+        closeA11yIdentifier: String,
+        technicalDataTitle: String,
+        technicalDataA11yIdentifier: String
+    ) {
+        self.title = title
+        self.closeAccessibilityLabel = closeAccessibilityLabel
+        self.closeA11yIdentifier = closeA11yIdentifier
+        self.technicalDataTitle = technicalDataTitle
+        self.technicalDataA11yIdentifier = technicalDataA11yIdentifier
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -42,6 +42,11 @@ enum WebCompatReporterUX {
         static let focusPadding: CGFloat = 16
     }
 
+    /// The Report Preview screen.
+    enum Preview {
+        static let cardHorizontalInset: CGFloat = 24
+    }
+
     /// The tilted page card on the Report Preview screen.
     enum Thumbnail {
         static let size = CGSize(width: 150, height: 180)

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatTechnicalDataViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatTechnicalDataViewController.swift
@@ -303,6 +303,10 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
         guard isViewLoaded else { return }
         view.backgroundColor = theme.colors.layer1
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
+        // Otherwise the title stays dark-on-dark in the dark theme.
+        navigationController?.navigationBar.titleTextAttributes = [
+            .foregroundColor: theme.colors.textPrimary
+        ]
         collectionView.backgroundColor = theme.colors.layer1
         reconfigureAllItems()
     }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+import XCTest
+@testable import WebCompatReporterKit
+
+@MainActor
+final class WebCompatReportPreviewViewControllerTests: XCTestCase {
+    private enum UX {
+        static let presentationSize = CGSize(width: 390, height: 844)
+    }
+
+    func testTappingTechnicalDataRow_notifiesDelegate() throws {
+        let delegate = MockWebCompatReportPreviewDelegate()
+        let subject = createSubject()
+        subject.delegate = delegate
+        layout(subject)
+        let collectionView = try XCTUnwrap(collectionView(in: subject))
+
+        subject.collectionView(collectionView, didSelectItemAt: IndexPath(item: 0, section: 0))
+
+        XCTAssertEqual(delegate.didTapTechnicalDataCallCount, 1)
+    }
+
+    func testCloseTap_notifiesDelegate() throws {
+        let delegate = MockWebCompatReportPreviewDelegate()
+        let subject = createSubject()
+        subject.delegate = delegate
+        subject.loadViewIfNeeded()
+
+        let closeButton = try XCTUnwrap(subject.navigationItem.rightBarButtonItem)
+        let target = try XCTUnwrap(closeButton.target as? NSObject)
+        target.perform(try XCTUnwrap(closeButton.action))
+
+        XCTAssertEqual(delegate.didRequestDismissCallCount, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func createSubject(
+        themeManager: ThemeManager = MockThemeManager()
+    ) -> WebCompatReportPreviewViewController {
+        let viewModel = WebCompatReportPreviewViewModel(
+            title: "Report Preview",
+            closeAccessibilityLabel: "Close",
+            closeA11yIdentifier: "close",
+            technicalDataTitle: "Technical Data",
+            technicalDataA11yIdentifier: "technicalData"
+        )
+        return WebCompatReportPreviewViewController(
+            viewModel: viewModel,
+            windowUUID: .XCTestDefaultUUID,
+            themeManager: themeManager,
+            notificationCenter: NotificationCenter.default
+        )
+    }
+
+    private func layout(_ subject: WebCompatReportPreviewViewController) {
+        subject.view.frame = CGRect(origin: .zero, size: UX.presentationSize)
+        subject.loadViewIfNeeded()
+        subject.view.layoutIfNeeded()
+    }
+
+    private func collectionView(in subject: WebCompatReportPreviewViewController) -> UICollectionView? {
+        return subject.view.subviews.compactMap { $0 as? UICollectionView }.first
+    }
+}
+
+private final class MockWebCompatReportPreviewDelegate: WebCompatReportPreviewDelegate {
+    var didRequestDismissCallCount = 0
+    var didTapTechnicalDataCallCount = 0
+
+    func webCompatReportPreviewDidRequestDismiss() {
+        didRequestDismissCallCount += 1
+    }
+
+    func webCompatReportPreviewDidTapTechnicalData() {
+        didTapTechnicalDataCallCount += 1
+    }
+}

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -146,6 +146,7 @@ struct AccessibilityIdentifiers {
 
         struct Preview {
             static let closeButton = "WebCompatReporter.Preview.CloseButton"
+            static let technicalDataRow = "WebCompatReporter.Preview.TechnicalDataRow"
             /// Suffixed with the payload group id, e.g. `…SectionHeader.basic`.
             static let sectionHeader = "WebCompatReporter.Preview.SectionHeader"
             static let sectionContent = "WebCompatReporter.Preview.SectionContent"

--- a/firefox-ios/Client/Coordinators/WebCompatReportCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/WebCompatReportCoordinator.swift
@@ -78,13 +78,14 @@ final class WebCompatReportCoordinator: BaseCoordinator,
         // The main router presents from the browser, which already shows the sheet, so the preview
         // goes up from the sheet itself.
         let previewCoordinator = WebCompatReportPreviewCoordinator(
+            payload: payload,
             router: DefaultRouter(navigationController: reportViewController),
             windowUUID: windowUUID,
             themeManager: themeManager,
             parentCoordinator: self
         )
         add(child: previewCoordinator)
-        previewCoordinator.start(payload: payload)
+        previewCoordinator.start()
     }
 
     // MARK: - ParentCoordinatorDelegate

--- a/firefox-ios/Client/Coordinators/WebCompatReportPreviewCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/WebCompatReportPreviewCoordinator.swift
@@ -7,38 +7,49 @@ import Foundation
 import UIKit
 import WebCompatReporterKit
 
-/// Owns the Report Preview sheet for as long as it is on screen. The report sheet is the
+/// Owns the Report Preview sheet and the Technical Data screen it pushes. The report sheet is the
 /// presenting context, so this is rooted at a router over it rather than the browser's.
-final class WebCompatReportPreviewCoordinator: BaseCoordinator, WebCompatTechnicalDataDelegate {
+final class WebCompatReportPreviewCoordinator: BaseCoordinator,
+                                               WebCompatReportPreviewDelegate,
+                                               WebCompatTechnicalDataDelegate {
+    private let payload: WebCompatReportPayload
     private let windowUUID: WindowUUID
     private let themeManager: ThemeManager
     private weak var parentCoordinator: ParentCoordinatorDelegate?
+    /// A second router, over the sheet's own stack: the injected one is rooted at the report form,
+    /// so pushing through it would put Technical Data behind the sheet instead of on top of it.
+    private var previewRouter: Router?
+    /// Tracked so a second tap can't stack a duplicate on top.
+    private weak var technicalDataViewController: WebCompatTechnicalDataViewController?
 
     init(
+        payload: WebCompatReportPayload,
         router: Router,
         windowUUID: WindowUUID,
         themeManager: ThemeManager,
         parentCoordinator: ParentCoordinatorDelegate?
     ) {
+        self.payload = payload
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.parentCoordinator = parentCoordinator
         super.init(router: router)
     }
 
-    func start(payload: WebCompatReportPayload) {
-        let previewViewController = WebCompatTechnicalDataViewController(
-            viewModel: payload.makePreviewViewModel(),
+    func start() {
+        let previewViewController = WebCompatReportPreviewViewController(
+            viewModel: payload.makeReportPreviewViewModel(),
             windowUUID: windowUUID,
             themeManager: themeManager
         )
         previewViewController.delegate = self
-        let previewNavigationController = UINavigationController(rootViewController: previewViewController)
-        if let sheet = previewNavigationController.sheetPresentationController {
+        let navigationController = UINavigationController(rootViewController: previewViewController)
+        previewRouter = DefaultRouter(navigationController: navigationController)
+        if let sheet = navigationController.sheetPresentationController {
             sheet.detents = [.medium(), .large()]
             sheet.prefersGrabberVisible = true
         }
-        router.present(previewNavigationController, animated: true) { [weak self] in
+        router.present(navigationController, animated: true) { [weak self] in
             // Runs when we dismiss through `UIAdaptivePresentationControllerDelegate`
             self?.didFinish()
         }
@@ -50,14 +61,31 @@ final class WebCompatReportPreviewCoordinator: BaseCoordinator, WebCompatTechnic
         didFinish()
     }
 
+    // MARK: - WebCompatReportPreviewDelegate
+
+    func webCompatReportPreviewDidRequestDismiss() {
+        dismissPreview(animated: true)
+    }
+
+    func webCompatReportPreviewDidTapTechnicalData() {
+        guard technicalDataViewController == nil else { return }
+        let viewController = WebCompatTechnicalDataViewController(
+            viewModel: payload.makeTechnicalDataViewModel(),
+            windowUUID: windowUUID,
+            themeManager: themeManager
+        )
+        viewController.delegate = self
+        technicalDataViewController = viewController
+        // The completion runs when it's popped, so the row can push a fresh screen again.
+        previewRouter?.push(viewController) { [weak self] in
+            self?.technicalDataViewController = nil
+        }
+    }
+
     // MARK: - WebCompatTechnicalDataDelegate
 
     func webCompatTechnicalDataDidRequestDismiss() {
         dismissPreview(animated: true)
-    }
-
-    func webCompatTechnicalDataDidTapScreenshot() {
-        // Unreachable while the thumbnail is off; FXIOS-16450 wires up the screenshot viewer.
     }
 
     // MARK: - Private

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -125,9 +125,19 @@ struct WebCompatReportPayload: Equatable {
         ]
     }
 
-    func makePreviewViewModel() -> WebCompatTechnicalDataViewModel {
-        return WebCompatTechnicalDataViewModel(
+    func makeReportPreviewViewModel() -> WebCompatReportPreviewViewModel {
+        return WebCompatReportPreviewViewModel(
             title: .WebCompatReporter.Preview.Title,
+            closeAccessibilityLabel: .WebCompatReporter.Sheet.CloseButtonAccessibilityLabel,
+            closeA11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.Preview.closeButton,
+            technicalDataTitle: .WebCompatReporter.Preview.TechnicalData,
+            technicalDataA11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.Preview.technicalDataRow
+        )
+    }
+
+    func makeTechnicalDataViewModel() -> WebCompatTechnicalDataViewModel {
+        return WebCompatTechnicalDataViewModel(
+            title: .WebCompatReporter.Preview.TechnicalData,
             closeAccessibilityLabel: .WebCompatReporter.Sheet.CloseButtonAccessibilityLabel,
             closeA11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.Preview.closeButton,
             sections: previewGroups.map { group in

--- a/firefox-ios/Client/Glean/probes/broken_site_report.interactions.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.interactions.yaml
@@ -78,8 +78,8 @@ broken_site_report.interactions:
   previewed:
     type: event
     description: |
-      Recorded when the user opens the report preview, which is currently
-      parked (FXIOS-16450).
+      Recorded when the user opens the Report Preview screen from the
+      reporter's Preview button.
     data_sensitivity:
       - interaction
     bugs:

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/WebCompatReportPreviewCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/WebCompatReportPreviewCoordinatorTests.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 import Common
+import WebCompatReporterKit
 
 @testable import Client
 
@@ -33,7 +34,7 @@ final class WebCompatReportPreviewCoordinatorTests: XCTestCase {
     // only place the parent hears about it.
     func test_swipeDismiss_finishesTheCoordinator() {
         let subject = createSubject()
-        subject.start(payload: WebCompatReportPayload())
+        subject.start()
 
         router.savedCompletion?()
 
@@ -42,12 +43,29 @@ final class WebCompatReportPreviewCoordinatorTests: XCTestCase {
 
     func test_technicalDataDidRequestDismiss_dismissesAndNotifiesParent() {
         let subject = createSubject()
-        subject.start(payload: WebCompatReportPayload())
+        subject.start()
 
         subject.webCompatTechnicalDataDidRequestDismiss()
 
         XCTAssertEqual(router.dismissCalled, 1)
         XCTAssertEqual(parentCoordinator.didFinishCalled, 1)
+    }
+
+    // The injected router is rooted at the report form, so pushing through it would leave Technical
+    // Data behind the sheet instead of on top of the preview.
+    func test_previewDidTapTechnicalData_pushesOntoTheSheetsOwnStack() throws {
+        let subject = createSubject()
+        subject.start()
+
+        subject.webCompatReportPreviewDidTapTechnicalData()
+
+        let navigationController = try XCTUnwrap(router.presentedViewController as? UINavigationController)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssertEqual(router.pushCalled, 0)
+        let pushed = try XCTUnwrap(navigationController.topViewController as? WebCompatTechnicalDataViewController)
+        XCTAssertIdentical(pushed.delegate, subject)
+        let root = try XCTUnwrap(navigationController.viewControllers.first as? WebCompatReportPreviewViewController)
+        XCTAssertIdentical(root.delegate, subject)
     }
 
     // MARK: - Helper Methods
@@ -56,6 +74,7 @@ final class WebCompatReportPreviewCoordinatorTests: XCTestCase {
         line: UInt = #line
     ) -> WebCompatReportPreviewCoordinator {
         let subject = WebCompatReportPreviewCoordinator(
+            payload: WebCompatReportPayload(),
             router: router,
             windowUUID: .XCTestDefaultUUID,
             themeManager: themeManager,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
@@ -88,9 +88,9 @@ final class WebCompatReportPayloadTests: XCTestCase {
         XCTAssertEqual(renderedFields(of: payload)["antiTracking.blockedOrigins"], "[]")
     }
 
-    // MARK: - makePreviewViewModel
+    // MARK: - makeTechnicalDataViewModel
 
-    func testMakePreviewViewModel_showsTheCollectedPayloadNotASecondCopyOfIt() throws {
+    func testMakeTechnicalDataViewModel_showsTheCollectedPayloadNotASecondCopyOfIt() throws {
         var payload = WebCompatReportPayload()
         payload.url = "https://example.com"
         payload.breakageCategory = WebCompatSubOption.pageNotLoading.rawValue
@@ -99,7 +99,7 @@ final class WebCompatReportPayloadTests: XCTestCase {
         payload.memory = 8192
         payload.defaultLocales = ["en-GB", "fr"]
 
-        let viewModel = payload.makePreviewViewModel()
+        let viewModel = payload.makeTechnicalDataViewModel()
 
         // Groups and labels come from the payload, so a new metric shows up without touching this file.
         XCTAssertEqual(viewModel.sections.map(\.id), payload.previewGroups.map(\.id.rawValue))
@@ -113,13 +113,13 @@ final class WebCompatReportPayloadTests: XCTestCase {
         XCTAssertTrue(rendered.contains("app.defaultLocales = [\"en-GB\", \"fr\"]"))
     }
 
-    func testMakePreviewViewModel_uncollectedMetricsReadAsNull() throws {
+    func testMakeTechnicalDataViewModel_uncollectedMetricsReadAsNull() throws {
         // What the form knows on its own; everything the collector fills in is still missing.
         let payload = WebCompatReportPayload.make(
             from: makeState(url: "https://example.com", selectedCategory: .other)
         )
 
-        let viewModel = payload.makePreviewViewModel()
+        let viewModel = payload.makeTechnicalDataViewModel()
 
         let frameworks = try XCTUnwrap(viewModel.sections.first { $0.id == "frameworks" })
         XCTAssertEqual(frameworks.rows.map { $0.value.displayText }, ["null", "null", "null"])
@@ -130,13 +130,22 @@ final class WebCompatReportPayloadTests: XCTestCase {
         XCTAssertEqual(description.value, .null)
     }
 
-    func testMakePreviewViewModel_givesEveryGroupItsOwnAccessibilityIdentifiers() {
-        let viewModel = WebCompatReportPayload().makePreviewViewModel()
+    func testMakeTechnicalDataViewModel_givesEveryGroupItsOwnAccessibilityIdentifiers() {
+        let viewModel = WebCompatReportPayload().makeTechnicalDataViewModel()
 
         // Header and card are addressed separately in UI tests, so they can't share an identifier.
         let identifiers = viewModel.sections.flatMap { [$0.a11yIdentifier, $0.contentA11yIdentifier] }
         XCTAssertEqual(Set(identifiers).count, identifiers.count)
         XCTAssertTrue(identifiers.allSatisfy { $0.hasPrefix("WebCompatReporter.Preview.") })
+    }
+
+    // MARK: - makeReportPreviewViewModel
+
+    func testMakeReportPreviewViewModel_titlesTheScreenAndTheRowFromDifferentStrings() {
+        let viewModel = WebCompatReportPayload().makeReportPreviewViewModel()
+
+        XCTAssertEqual(viewModel.title, .WebCompatReporter.Preview.Title)
+        XCTAssertEqual(viewModel.technicalDataTitle, .WebCompatReporter.Preview.TechnicalData)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16432](https://mozilla-hub.atlassian.net/browse/FXIOS-16432)

## :bulb: Description
The **Preview** button opens the Report Preview screen. Tapping **Technical Data** pushes the raw payload screen onto the same stack, so back returns to the preview.

Only that row ships here. The summary card is the next PR, the thumbnail comes with [FXIOS-16450](https://mozilla-hub.atlassian.net/browse/FXIOS-16450).

`makePreviewViewModel` splits into `makeReportPreviewViewModel` and `makeTechnicalDataViewModel`, and the pushed screen takes the `Preview.TechnicalData` string from the base PR. Technical Data also themes the shared nav bar title itself now, rather than relying on the screen below it. The `previewed` metric's description no longer claims the preview is parked: description only, no data review.

Two things I left alone. The screen's chassis duplicates `WebCompatTechnicalDataViewController`; that's worth one shared base after the card and thumbnail land, not before. And nothing records the drill-down, since `previewed` already covers reaching the preview and a new event needs its own data review.

Stacked on [#35139](https://github.com/mozilla-mobile/firefox-ios/pull/35139), itself stacked on [#35096](https://github.com/mozilla-mobile/firefox-ios/pull/35096).

<img height="700" alt="Screenshot 2026-08-12 at 11 29 39" src="https://github.com/user-attachments/assets/c028a337-49fd-4e52-8cdd-208224a82146" />



## :mag: Testing
Menu → **Report Broken Site** → category → **Preview**.

1. One **Technical Data** row. It highlights on press.
2. Tap it: Technical Data pushes in, back returns to the preview.
3. **X** closes the sheet, form still filled in behind it.
4. Fast double-tap on the row pushes one screen, not two.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


[FXIOS-16432]: https://mozilla-hub.atlassian.net/browse/FXIOS-16432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-16450]: https://mozilla-hub.atlassian.net/browse/FXIOS-16450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

