### PR TITLE
Refactor FXIOS-16432 [WebCompat] Strip the screenshot out of Technical Data

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatTechnicalDataSectionCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatTechnicalDataSectionCell.swift
@@ -8,16 +8,10 @@ import UIKit
 /// One expanded section's body: every `key: value` line in a single rounded card. Long values
 /// wrap rather than truncate.
 final class WebCompatTechnicalDataSectionCell: UICollectionViewListCell, ThemeApplicable, ReusableCell {
-    private enum UX {
-        static let horizontalInset: CGFloat = 16
-        static let verticalInset: CGFloat = 14.5
-        static let cardCornerRadius: CGFloat = 26
-    }
-
     /// A view rather than a `backgroundConfiguration`. A list cell masks its background's
     /// corners by group position, which here would only ever round the bottom two.
     private lazy var cardView: UIView = .build { view in
-        view.layer.cornerRadius = UX.cardCornerRadius
+        view.layer.cornerRadius = WebCompatReporterUX.Card.largeCornerRadius
         view.layer.cornerCurve = .continuous
     }
 
@@ -37,6 +31,8 @@ final class WebCompatTechnicalDataSectionCell: UICollectionViewListCell, ThemeAp
     }
 
     private func setupLayout() {
+        let horizontalInset = WebCompatReporterUX.Card.contentInset
+        let verticalInset = WebCompatReporterUX.Card.verticalInset
         contentView.addSubview(cardView)
         cardView.addSubview(keyValueLabel)
         NSLayoutConstraint.activate([
@@ -45,10 +41,10 @@ final class WebCompatTechnicalDataSectionCell: UICollectionViewListCell, ThemeAp
             cardView.topAnchor.constraint(equalTo: contentView.topAnchor),
             cardView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
 
-            keyValueLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: UX.horizontalInset),
-            keyValueLabel.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -UX.horizontalInset),
-            keyValueLabel.topAnchor.constraint(equalTo: cardView.topAnchor, constant: UX.verticalInset),
-            keyValueLabel.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -UX.verticalInset)
+            keyValueLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: horizontalInset),
+            keyValueLabel.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -horizontalInset),
+            keyValueLabel.topAnchor.constraint(equalTo: cardView.topAnchor, constant: verticalInset),
+            keyValueLabel.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -verticalInset)
         ])
     }
 
@@ -64,7 +60,7 @@ final class WebCompatTechnicalDataSectionCell: UICollectionViewListCell, ThemeAp
         // Half-height stops a one-line card rounding into a capsule. Zero means constraints
         // haven't resolved, and clamping to it would flatten the corners.
         guard cardView.bounds.height > 0 else { return }
-        let radius = min(UX.cardCornerRadius, cardView.bounds.height / 2)
+        let radius = min(WebCompatReporterUX.Card.largeCornerRadius, cardView.bounds.height / 2)
         guard cardView.layer.cornerRadius != radius else { return }
         cardView.layer.cornerRadius = radius
     }

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatFullPageScreenshotPreview.swift
@@ -8,10 +8,7 @@ import ComponentLibrary
 import SwiftUI
 import UIKit
 
-/// Hosts the viewer over a stand-in page: heading, image block, filler lines.
-///
-/// The page is drawn the way a website would render, so its colours are the page's own and
-/// deliberately not the app theme — a real capture doesn't follow the theme either.
+/// Hosts the viewer over `WebCompatPreviewSamplePage`.
 private struct FullPageScreenshotPreview: UIViewControllerRepresentable {
     enum PageLength: CGFloat {
         case short = 400
@@ -20,36 +17,11 @@ private struct FullPageScreenshotPreview: UIViewControllerRepresentable {
         case long = 8000
     }
 
-    private enum UX {
-        static let pageWidth: CGFloat = 320
-        static let horizontalInset: CGFloat = 16
-
-        enum Title {
-            static let top: CGFloat = 24
-            static let fontSize: CGFloat = 28
-        }
-
-        enum ImageBlock {
-            static let top: CGFloat = 72
-            static let height: CGFloat = 180
-            static let cornerRadius: CGFloat = 8
-            static let color = UIColor.systemBrown
-        }
-
-        enum TextLine {
-            static let top: CGFloat = 280
-            static let height: CGFloat = 10
-            static let spacing: CGFloat = 26
-            static let cornerRadius: CGFloat = 3
-            static let opacity: CGFloat = 0.12
-        }
-    }
-
     let pageLength: PageLength
 
     func makeUIViewController(context: Context) -> WebCompatFullPageScreenshotViewController {
         return WebCompatFullPageScreenshotViewController(
-            image: samplePage(),
+            image: WebCompatPreviewSamplePage.image(height: pageLength.rawValue),
             viewModel: WebCompatFullPageScreenshotViewModel(
                 captureAccessibilityLabel: "Screenshot of the page",
                 captureAccessibilityIdentifier: "WebCompatReporter.Preview.ScreenshotCapture"
@@ -64,50 +36,6 @@ private struct FullPageScreenshotPreview: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ viewController: WebCompatFullPageScreenshotViewController, context: Context) {}
-
-    private func samplePage() -> UIImage {
-        let size = CGSize(width: UX.pageWidth, height: pageLength.rawValue)
-        let contentWidth = size.width - UX.horizontalInset * 2
-        let renderer = UIGraphicsImageRenderer(size: size)
-        return renderer.image { context in
-            UIColor.white.setFill()
-            context.fill(CGRect(origin: .zero, size: size))
-
-            "Croque Monsieur".draw(
-                at: CGPoint(x: UX.horizontalInset, y: UX.Title.top),
-                withAttributes: [
-                    .font: UIFont.boldSystemFont(ofSize: UX.Title.fontSize),
-                    .foregroundColor: UIColor.black
-                ]
-            )
-
-            UX.ImageBlock.color.setFill()
-            UIBezierPath(
-                roundedRect: CGRect(
-                    x: UX.horizontalInset,
-                    y: UX.ImageBlock.top,
-                    width: contentWidth,
-                    height: UX.ImageBlock.height
-                ),
-                cornerRadius: UX.ImageBlock.cornerRadius
-            ).fill()
-
-            UIColor.black.withAlphaComponent(UX.TextLine.opacity).setFill()
-            var lineY = UX.TextLine.top
-            while lineY + UX.TextLine.height < size.height {
-                UIBezierPath(
-                    roundedRect: CGRect(
-                        x: UX.horizontalInset,
-                        y: lineY,
-                        width: contentWidth,
-                        height: UX.TextLine.height
-                    ),
-                    cornerRadius: UX.TextLine.cornerRadius
-                ).fill()
-                lineY += UX.TextLine.spacing
-            }
-        }
-    }
 }
 
 @available(iOS 17.0, *)

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatPreviewSamplePage.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatPreviewSamplePage.swift
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+#if DEBUG
+import UIKit
+
+/// A stand-in captured page for the previews. Its colours are the page's own and deliberately not
+/// the app theme, because a real capture doesn't follow the theme either.
+enum WebCompatPreviewSamplePage {
+    private enum UX {
+        static let width: CGFloat = 320
+        static let horizontalInset: CGFloat = 16
+
+        enum Title {
+            static let top: CGFloat = 24
+            static let fontSize: CGFloat = 28
+        }
+
+        enum ImageBlock {
+            static let top: CGFloat = 72
+            static let height: CGFloat = 180
+            static let cornerRadius: CGFloat = 8
+            static let color = UIColor.systemBrown
+        }
+
+        enum TextLine {
+            static let top: CGFloat = 280
+            static let height: CGFloat = 10
+            static let spacing: CGFloat = 26
+            static let cornerRadius: CGFloat = 3
+            static let opacity: CGFloat = 0.12
+        }
+    }
+
+    static func image(height: CGFloat) -> UIImage {
+        let size = CGSize(width: UX.width, height: height)
+        let contentWidth = size.width - UX.horizontalInset * 2
+        return UIGraphicsImageRenderer(size: size).image { context in
+            UIColor.white.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+
+            "Croque Monsieur".draw(
+                at: CGPoint(x: UX.horizontalInset, y: UX.Title.top),
+                withAttributes: [
+                    .font: UIFont.boldSystemFont(ofSize: UX.Title.fontSize),
+                    .foregroundColor: UIColor.black
+                ]
+            )
+
+            UX.ImageBlock.color.setFill()
+            UIBezierPath(
+                roundedRect: CGRect(
+                    x: UX.horizontalInset,
+                    y: UX.ImageBlock.top,
+                    width: contentWidth,
+                    height: UX.ImageBlock.height
+                ),
+                cornerRadius: UX.ImageBlock.cornerRadius
+            ).fill()
+
+            UIColor.black.withAlphaComponent(UX.TextLine.opacity).setFill()
+            var lineY = UX.TextLine.top
+            while lineY + UX.TextLine.height < size.height {
+                UIBezierPath(
+                    roundedRect: CGRect(
+                        x: UX.horizontalInset,
+                        y: lineY,
+                        width: contentWidth,
+                        height: UX.TextLine.height
+                    ),
+                    cornerRadius: UX.TextLine.cornerRadius
+                ).fill()
+                lineY += UX.TextLine.spacing
+            }
+        }
+    }
+}
+#endif

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatTechnicalDataPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatTechnicalDataPreview.swift
@@ -14,7 +14,6 @@ private struct WebCompatTechnicalDataHost: UIViewControllerRepresentable {
     typealias PreviewSection = WebCompatTechnicalDataViewModel.PreviewSection
     typealias PreviewValue = WebCompatTechnicalDataViewModel.PreviewValue
 
-    let screenshot: UIImage?
     var themeType: ThemeType = .light
 
     func makeUIViewController(context: Context) -> UINavigationController {
@@ -22,8 +21,6 @@ private struct WebCompatTechnicalDataHost: UIViewControllerRepresentable {
             title: "Technical Data",
             closeAccessibilityLabel: "Close",
             closeA11yIdentifier: "WebCompatReporter.Preview.Close",
-            screenshotAccessibilityLabel: "Screenshot of the page you are reporting",
-            screenshotA11yIdentifier: "WebCompatReporter.Preview.Screenshot",
             sections: Self.sampleSections
         )
         // The screen reads its colors from the manager, so the canvas appearance alone can't
@@ -36,7 +33,6 @@ private struct WebCompatTechnicalDataHost: UIViewControllerRepresentable {
             windowUUID: .DefaultUITestingUUID,
             themeManager: themeManager
         )
-        controller.updateScreenshot(screenshot)
         return UINavigationController(rootViewController: controller)
     }
 
@@ -88,51 +84,15 @@ private struct WebCompatTechnicalDataHost: UIViewControllerRepresentable {
     ]
 }
 
-private func previewSampleScreenshot() -> UIImage {
-    let size = CGSize(width: 320, height: 1400)
-    let renderer = UIGraphicsImageRenderer(size: size)
-    return renderer.image { context in
-        UIColor.white.setFill()
-        context.fill(CGRect(origin: .zero, size: size))
-
-        "Croque Monsieur".draw(
-            at: CGPoint(x: 16, y: 24),
-            withAttributes: [.font: UIFont.boldSystemFont(ofSize: 28), .foregroundColor: UIColor.black]
-        )
-
-        UIColor(red: 0.72, green: 0.55, blue: 0.36, alpha: 1).setFill()
-        UIBezierPath(
-            roundedRect: CGRect(x: 16, y: 72, width: size.width - 32, height: 180),
-            cornerRadius: 8
-        ).fill()
-
-        UIColor.black.withAlphaComponent(0.12).setFill()
-        var lineY: CGFloat = 280
-        while lineY < size.height - 20 {
-            UIBezierPath(
-                roundedRect: CGRect(x: 16, y: lineY, width: size.width - 32, height: 10),
-                cornerRadius: 3
-            ).fill()
-            lineY += 26
-        }
-    }
-}
-
 @available(iOS 17.0, *)
-#Preview("With screenshot") {
-    WebCompatTechnicalDataHost(screenshot: previewSampleScreenshot())
+#Preview("Technical Data") {
+    WebCompatTechnicalDataHost()
         .ignoresSafeArea()
 }
 
 @available(iOS 17.0, *)
-#Preview("Screenshot off") {
-    WebCompatTechnicalDataHost(screenshot: nil)
-        .ignoresSafeArea()
-}
-
-@available(iOS 17.0, *)
-#Preview("With screenshot (dark)") {
-    WebCompatTechnicalDataHost(screenshot: previewSampleScreenshot(), themeType: .dark)
+#Preview("Technical Data (dark)") {
+    WebCompatTechnicalDataHost(themeType: .dark)
         .ignoresSafeArea()
 }
 #endif

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -16,6 +16,8 @@ enum WebCompatReporterUX {
     enum Card {
         static let cornerRadius: CGFloat = 16
         static let contentInset: CGFloat = 16
+        static let largeCornerRadius: CGFloat = 26
+        static let verticalInset: CGFloat = 14.5
     }
 
     enum Sheet {

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatTechnicalDataViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatTechnicalDataViewController.swift
@@ -9,14 +9,10 @@ import UIKit
 @MainActor
 public protocol WebCompatTechnicalDataDelegate: AnyObject {
     func webCompatTechnicalDataDidRequestDismiss()
-    func webCompatTechnicalDataDidTapScreenshot()
 }
 
-/// The Technical Data screen: a tappable page thumbnail above collapsible sections listing the
-/// raw payload as key/value pairs. Store-agnostic, so configure it with a view model.
-///
-/// TODO: FXIOS-16432 - Add the plain-language Report Preview screen that pushes this one, and
-/// move the thumbnail onto it.
+/// The Technical Data screen, pushed from Report Preview: collapsible sections listing the raw
+/// payload as key/value pairs. Store-agnostic, so configure it with a view model.
 public final class WebCompatTechnicalDataViewController: UIViewController,
                                                          Themeable,
                                                          UICollectionViewDelegate {
@@ -28,13 +24,9 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
     /// `header` omits `rows` deliberately. Carrying them would mark the header changed on any
     /// value edit, when it only renders the title.
     private enum ItemKind: Equatable {
-        case screenshot(UIImage)
         case header(title: String, a11yIdentifier: String)
         case content(WebCompatTechnicalDataViewModel.PreviewSection)
     }
-
-    private static let screenshotDataSourceSectionID = "webcompat.preview.screenshot.section"
-    private static let screenshotDataSourceItemID = "webcompat.preview.screenshot.item"
 
     /// Suffixed so an item id can't collide with a section id in `itemsByID`.
     private static func headerDataSourceItemID(for sectionID: String) -> String {
@@ -53,17 +45,12 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
     private let notificationCenter: NotificationProtocol
 
     private var viewModel: WebCompatTechnicalDataViewModel
-    private var screenshot: UIImage?
     private var theme: Theme
 
     /// The data source keys on item ids, so the values themselves live here.
     private var itemsByID: [String: ItemKind] = [:]
-    /// Display order, so the layout closure can spot the screenshot section.
+    /// Display order, so an unchanged section set can skip the top-level apply.
     private var orderedSectionIDs: [String] = []
-
-    /// The first applyTheme runs inside `viewDidLoad`, where reconfiguring collapses the nav
-    /// bar's large title. Later changes do reconfigure.
-    private var hasAppliedThemeOnce = false
 
     private lazy var closeButton: UIBarButtonItem = {
         let image = UIImage(named: StandardImageIdentifiers.Large.cross)?.withRenderingMode(.alwaysTemplate)
@@ -102,9 +89,10 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
         super.viewDidLoad()
         setupNavigationItem()
         setupLayout()
-        configure(with: viewModel)
         listenForThemeChanges(withNotificationCenter: notificationCenter)
+        // Before the first configure, so the reconfigure hits an empty snapshot and no-ops.
         applyTheme()
+        configure(with: viewModel)
     }
 
     // MARK: - Configuration
@@ -116,14 +104,6 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
         navigationItem.title = viewModel.title
         closeButton.accessibilityLabel = viewModel.closeAccessibilityLabel
         closeButton.accessibilityIdentifier = viewModel.closeA11yIdentifier
-        updateSections()
-    }
-
-    /// The capture arrives after the screen is on screen, so it comes in on its own rather than
-    /// through the view model. Nil drops the thumbnail.
-    public func updateScreenshot(_ image: UIImage?) {
-        screenshot = image
-        guard isViewLoaded else { return }
         updateSections()
     }
 
@@ -140,17 +120,7 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
     }
 
     private func makeLayout() -> UICollectionViewCompositionalLayout {
-        return UICollectionViewCompositionalLayout { [weak self] index, environment in
-            let sectionIDs = self?.orderedSectionIDs ?? []
-            let sectionID = index < sectionIDs.count ? sectionIDs[index] : nil
-            if sectionID == Self.screenshotDataSourceSectionID {
-                var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
-                configuration.backgroundColor = .clear
-                configuration.showsSeparators = false
-                let section = NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: environment)
-                section.contentInsets.top = WebCompatReporterUX.Thumbnail.topInset
-                return section
-            }
+        return UICollectionViewCompositionalLayout { _, environment in
             var configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
             // Clear so the collection view's own themed background shows through. A theme change
             // then repaints instead of having to rebuild the layout for its colour.
@@ -164,20 +134,6 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
 
     // Registrations go here, not inside the provider: UIKit crashes on one built lazily per cell.
     private func makeDataSource() -> UICollectionViewDiffableDataSource<String, String> {
-        let screenshotRegistration = UICollectionView.CellRegistration<
-            WebCompatPreviewScreenshotCell, UIImage
-        > { [weak self] cell, _, image in
-            guard let self else { return }
-            cell.configure(
-                image: image,
-                imageAccessibilityLabel: self.viewModel.screenshotAccessibilityLabel,
-                a11yIdentifier: self.viewModel.screenshotA11yIdentifier
-            ) { [weak self] in
-                self?.delegate?.webCompatTechnicalDataDidTapScreenshot()
-            }
-            cell.applyTheme(theme: self.theme)
-        }
-
         let headerRegistration = UICollectionView.CellRegistration<
             UICollectionViewListCell, ItemKind
         > { [weak self] cell, _, item in
@@ -222,10 +178,6 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
                 )
             }
             switch self.itemsByID[itemID] {
-            case let .screenshot(image):
-                return collectionView.dequeueConfiguredReusableCell(
-                    using: screenshotRegistration, for: indexPath, item: image
-                )
             case let .header(title, a11yIdentifier):
                 return collectionView.dequeueConfiguredReusableCell(
                     using: headerRegistration,
@@ -252,10 +204,6 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
         itemsByID = [:]
         orderedSectionIDs = []
 
-        if let screenshot {
-            itemsByID[Self.screenshotDataSourceItemID] = .screenshot(screenshot)
-            orderedSectionIDs.append(Self.screenshotDataSourceSectionID)
-        }
         for section in viewModel.sections {
             itemsByID[Self.headerDataSourceItemID(for: section.id)] = .header(
                 title: section.title,
@@ -271,13 +219,6 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
             var sectionsSnapshot = NSDiffableDataSourceSnapshot<String, String>()
             sectionsSnapshot.appendSections(orderedSectionIDs)
             dataSource.apply(sectionsSnapshot, animatingDifferences: false)
-        }
-
-        if screenshot != nil,
-           dataSource.snapshot(for: Self.screenshotDataSourceSectionID).items.isEmpty {
-            var snapshot = NSDiffableDataSourceSectionSnapshot<String>()
-            snapshot.append([Self.screenshotDataSourceItemID])
-            dataSource.apply(snapshot, to: Self.screenshotDataSourceSectionID, animatingDifferences: false)
         }
 
         for section in viewModel.sections where dataSource.snapshot(for: section.id).items.isEmpty {
@@ -363,7 +304,6 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
         view.backgroundColor = theme.colors.layer1
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
         collectionView.backgroundColor = theme.colors.layer1
-        if hasAppliedThemeOnce { reconfigureAllItems() }
-        hasAppliedThemeOnce = true
+        reconfigureAllItems()
     }
 }

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatTechnicalDataViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatTechnicalDataViewModel.swift
@@ -75,23 +75,17 @@ public struct WebCompatTechnicalDataViewModel: Equatable, Sendable {
     public let title: String
     public let closeAccessibilityLabel: String
     public let closeA11yIdentifier: String
-    public let screenshotAccessibilityLabel: String
-    public let screenshotA11yIdentifier: String
     public let sections: [PreviewSection]
 
     public init(
         title: String,
         closeAccessibilityLabel: String,
         closeA11yIdentifier: String,
-        screenshotAccessibilityLabel: String,
-        screenshotA11yIdentifier: String,
         sections: [PreviewSection] = []
     ) {
         self.title = title
         self.closeAccessibilityLabel = closeAccessibilityLabel
         self.closeA11yIdentifier = closeA11yIdentifier
-        self.screenshotAccessibilityLabel = screenshotAccessibilityLabel
-        self.screenshotA11yIdentifier = screenshotA11yIdentifier
         self.sections = sections
     }
 }

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatTechnicalDataViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatTechnicalDataViewControllerTests.swift
@@ -159,8 +159,6 @@ final class WebCompatTechnicalDataViewControllerTests: XCTestCase {
             title: "Technical Data",
             closeAccessibilityLabel: "Close",
             closeA11yIdentifier: "close",
-            screenshotAccessibilityLabel: "Screenshot",
-            screenshotA11yIdentifier: "screenshot",
             sections: sections
         )
     }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -130,9 +130,6 @@ struct WebCompatReportPayload: Equatable {
             title: .WebCompatReporter.Preview.Title,
             closeAccessibilityLabel: .WebCompatReporter.Sheet.CloseButtonAccessibilityLabel,
             closeA11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.Preview.closeButton,
-            // Unread while the thumbnail is off; they come back with the screenshot in FXIOS-16450.
-            screenshotAccessibilityLabel: "",
-            screenshotA11yIdentifier: "",
             sections: previewGroups.map { group in
                 let groupID = group.id.rawValue
                 return WebCompatTechnicalDataViewModel.PreviewSection(


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16432](https://mozilla-hub.atlassian.net/browse/FXIOS-16432)

## :bulb: Description
The thumbnail belongs on Report Preview, so Technical Data drops its screenshot section, view model fields and layout branch. Nothing changes on screen, because the thumbnail stays off until [FXIOS-16450](https://mozilla-hub.atlassian.net/browse/FXIOS-16450) wires up the viewer.

Also folds the section cell's private card constants into the shared ones, and merges two copies of the preview sample page renderer.


## :mag: Testing
Menu → **Report Broken Site** → pick a category → **Preview**. Expect the same collapsible `key: value` sections as before, with no thumbnail above them. Expand a few and flip to the dark theme: corners and colours unchanged.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


[FXIOS-16432]: https://mozilla-hub.atlassian.net/browse/FXIOS-16432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXIOS-16450]: https://mozilla-hub.atlassian.net/browse/FXIOS-16450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
