### PR TITLE
Add FXIOS-16432 [WebCompat] Add the plain-language summary to Report Preview

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatPreviewBulletListCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatPreviewBulletListCell.swift
@@ -5,7 +5,6 @@
 import Common
 import UIKit
 
-/// Every bullet in one card as a single attributed string, so the dots scale and wrap with the text.
 final class WebCompatPreviewBulletListCell: UICollectionViewListCell, ThemeApplicable, ReusableCell, Notifiable {
     private var bullets: [String] = []
     private var theme: Theme?
@@ -44,14 +43,11 @@ final class WebCompatPreviewBulletListCell: UICollectionViewListCell, ThemeAppli
         self.bullets = bullets
         self.accessibilityIdentifier = accessibilityIdentifier
         isAccessibilityElement = true
-        // Otherwise VoiceOver reads the dot attachment before every line.
         accessibilityLabel = bullets.joined(separator: ". ")
         renderBullets()
     }
 
-    /// Attributed text ignores `adjustsFontForContentSizeCategory`, so font and indent are
-    /// re-resolved on every render. `configure` and `applyTheme` both land here; the guard keeps it
-    /// to one render instead of an unthemed pass followed by a coloured one.
+    /// Attributed text ignores `adjustsFontForContentSizeCategory`, so re-resolve font and indent.
     private func renderBullets() {
         guard let theme, !bullets.isEmpty else { return }
         let font = FXFontStyles.Regular.footnote.scaledFont()
@@ -96,8 +92,7 @@ final class WebCompatPreviewBulletListCell: UICollectionViewListCell, ThemeAppli
         }
         attachment.bounds = CGRect(x: 0, y: (font.xHeight - diameter) / 2, width: diameter, height: diameter)
 
-        // TextKit reads paragraph attributes off the paragraph's first character, so the attachment
-        // has to carry the style or the bullet loses its indent and gap.
+        // TextKit reads paragraph attributes off the first character, so the attachment carries them.
         let run = NSMutableAttributedString(attachment: attachment)
         run.addAttributes(attributes, range: NSRange(location: 0, length: run.length))
         return run

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatPreviewBulletListCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatPreviewBulletListCell.swift
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import UIKit
+
+/// Every bullet in one card as a single attributed string, so the dots scale and wrap with the text.
+final class WebCompatPreviewBulletListCell: UICollectionViewListCell, ThemeApplicable, ReusableCell, Notifiable {
+    private var bullets: [String] = []
+    private var theme: Theme?
+
+    private lazy var bulletsLabel: UILabel = .build { label in
+        label.numberOfLines = 0
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+        startObservingNotifications(
+            withNotificationCenter: NotificationCenter.default,
+            forObserver: self,
+            observing: [UIContentSizeCategory.didChangeNotification]
+        )
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+        let horizontalInset = WebCompatReporterUX.Card.contentInset
+        let verticalInset = WebCompatReporterUX.Card.verticalInset
+        contentView.addSubview(bulletsLabel)
+        NSLayoutConstraint.activate([
+            bulletsLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: horizontalInset),
+            bulletsLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -horizontalInset),
+            bulletsLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: verticalInset),
+            bulletsLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -verticalInset)
+        ])
+    }
+
+    func configure(bullets: [String], accessibilityIdentifier: String) {
+        self.bullets = bullets
+        self.accessibilityIdentifier = accessibilityIdentifier
+        isAccessibilityElement = true
+        // Otherwise VoiceOver reads the dot attachment before every line.
+        accessibilityLabel = bullets.joined(separator: ". ")
+        renderBullets()
+    }
+
+    /// Attributed text ignores `adjustsFontForContentSizeCategory`, so font and indent are
+    /// re-resolved on every render.
+    private func renderBullets() {
+        let font = FXFontStyles.Regular.footnote.scaledFont()
+        let indent = UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.Preview.bulletIndent)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.headIndent = indent
+        paragraphStyle.tabStops = [NSTextTab(textAlignment: .left, location: indent)]
+        paragraphStyle.paragraphSpacing = UIFontMetrics.default.scaledValue(
+            for: WebCompatReporterUX.Spacing.rowVertical
+        )
+
+        var textAttributes: [NSAttributedString.Key: Any] = [.font: font, .paragraphStyle: paragraphStyle]
+        textAttributes[.foregroundColor] = theme?.colors.textPrimary
+
+        let dot = dotRun(alignedTo: font, attributes: textAttributes)
+        let text = NSMutableAttributedString()
+        for bullet in bullets {
+            if text.length > 0 {
+                text.append(NSAttributedString(string: "\n", attributes: textAttributes))
+            }
+            text.append(dot)
+            text.append(NSAttributedString(string: "\t\(bullet)", attributes: textAttributes))
+        }
+        bulletsLabel.attributedText = text
+    }
+
+    private func dotRun(
+        alignedTo font: UIFont,
+        attributes: [NSAttributedString.Key: Any]
+    ) -> NSAttributedString {
+        guard let theme else { return NSAttributedString() }
+        let diameter = UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.Preview.bulletDiameter)
+        let size = CGSize(width: diameter, height: diameter)
+
+        let attachment = NSTextAttachment()
+        attachment.image = UIGraphicsImageRenderer(size: size).image { context in
+            theme.colors.iconSecondary.setFill()
+            context.cgContext.fillEllipse(in: CGRect(origin: .zero, size: size))
+        }
+        attachment.bounds = CGRect(x: 0, y: (font.xHeight - diameter) / 2, width: diameter, height: diameter)
+
+        // TextKit reads paragraph attributes off the paragraph's first character, so the attachment
+        // has to carry the style or the bullet loses its indent and gap.
+        let run = NSMutableAttributedString(attachment: attachment)
+        run.addAttributes(attributes, range: NSRange(location: 0, length: run.length))
+        return run
+    }
+
+    // MARK: - Notifiable
+
+    nonisolated func handleNotifications(_ notification: Notification) {
+        guard notification.name == UIContentSizeCategory.didChangeNotification else { return }
+        ensureMainThread { [weak self] in
+            self?.renderBullets()
+        }
+    }
+
+    // MARK: - ThemeApplicable
+
+    func applyTheme(theme: Theme) {
+        var background = UIBackgroundConfiguration.listGroupedCell()
+        background.backgroundColor = theme.colors.layer5
+        background.cornerRadius = WebCompatReporterUX.Card.largeCornerRadius
+        backgroundConfiguration = background
+        self.theme = theme
+        renderBullets()
+    }
+}

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatPreviewBulletListCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatPreviewBulletListCell.swift
@@ -50,21 +50,26 @@ final class WebCompatPreviewBulletListCell: UICollectionViewListCell, ThemeAppli
     }
 
     /// Attributed text ignores `adjustsFontForContentSizeCategory`, so font and indent are
-    /// re-resolved on every render.
+    /// re-resolved on every render. `configure` and `applyTheme` both land here; the guard keeps it
+    /// to one render instead of an unthemed pass followed by a coloured one.
     private func renderBullets() {
+        guard let theme, !bullets.isEmpty else { return }
         let font = FXFontStyles.Regular.footnote.scaledFont()
         let indent = UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.Preview.bulletIndent)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.headIndent = indent
         paragraphStyle.tabStops = [NSTextTab(textAlignment: .left, location: indent)]
         paragraphStyle.paragraphSpacing = UIFontMetrics.default.scaledValue(
-            for: WebCompatReporterUX.Spacing.rowVertical
+            for: WebCompatReporterUX.Preview.bulletSpacing
         )
 
-        var textAttributes: [NSAttributedString.Key: Any] = [.font: font, .paragraphStyle: paragraphStyle]
-        textAttributes[.foregroundColor] = theme?.colors.textPrimary
+        let textAttributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .paragraphStyle: paragraphStyle,
+            .foregroundColor: theme.colors.textPrimary
+        ]
 
-        let dot = dotRun(alignedTo: font, attributes: textAttributes)
+        let dot = dotRun(alignedTo: font, themedBy: theme, attributes: textAttributes)
         let text = NSMutableAttributedString()
         for bullet in bullets {
             if text.length > 0 {
@@ -78,9 +83,9 @@ final class WebCompatPreviewBulletListCell: UICollectionViewListCell, ThemeAppli
 
     private func dotRun(
         alignedTo font: UIFont,
+        themedBy theme: Theme,
         attributes: [NSAttributedString.Key: Any]
     ) -> NSAttributedString {
-        guard let theme else { return NSAttributedString() }
         let diameter = UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.Preview.bulletDiameter)
         let size = CGSize(width: diameter, height: diameter)
 

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatPreviewBulletListCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatPreviewBulletListCell.swift
@@ -5,12 +5,19 @@
 import Common
 import UIKit
 
-final class WebCompatPreviewBulletListCell: UICollectionViewListCell, ThemeApplicable, ReusableCell, Notifiable {
+/// The plain-language summary on Report Preview: a "●" label beside the text on every row.
+final class WebCompatPreviewBulletListCell: UICollectionViewListCell,
+                                            ThemeApplicable,
+                                            ReusableCell,
+                                            Notifiable {
+    private typealias BulletRow = (dotLabel: UILabel, textLabel: UILabel)
+
     private var bullets: [String] = []
+    private var bulletRows: [BulletRow] = []
     private var theme: Theme?
 
-    private lazy var bulletsLabel: UILabel = .build { label in
-        label.numberOfLines = 0
+    private lazy var bulletsStackView: UIStackView = .build { stackView in
+        stackView.axis = .vertical
     }
 
     override init(frame: CGRect) {
@@ -30,72 +37,81 @@ final class WebCompatPreviewBulletListCell: UICollectionViewListCell, ThemeAppli
     private func setupLayout() {
         let horizontalInset = WebCompatReporterUX.Card.contentInset
         let verticalInset = WebCompatReporterUX.Card.verticalInset
-        contentView.addSubview(bulletsLabel)
+        contentView.addSubview(bulletsStackView)
         NSLayoutConstraint.activate([
-            bulletsLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: horizontalInset),
-            bulletsLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -horizontalInset),
-            bulletsLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: verticalInset),
-            bulletsLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -verticalInset)
+            bulletsStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: horizontalInset),
+            bulletsStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -horizontalInset),
+            bulletsStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: verticalInset),
+            bulletsStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -verticalInset)
         ])
+        applyScaledSpacing()
     }
 
     func configure(bullets: [String], accessibilityIdentifier: String) {
-        self.bullets = bullets
         self.accessibilityIdentifier = accessibilityIdentifier
         isAccessibilityElement = true
         accessibilityLabel = bullets.joined(separator: ". ")
-        renderBullets()
+
+        // reconfigureItems re-runs this on a theme change, so only rebuild when the copy moved.
+        guard bullets != self.bullets else { return }
+        self.bullets = bullets
+        updateBullets()
     }
 
-    /// Attributed text ignores `adjustsFontForContentSizeCategory`, so re-resolve font and indent.
-    private func renderBullets() {
-        guard let theme, !bullets.isEmpty else { return }
-        let font = FXFontStyles.Regular.footnote.scaledFont()
-        let indent = UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.Preview.bulletIndent)
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.headIndent = indent
-        paragraphStyle.tabStops = [NSTextTab(textAlignment: .left, location: indent)]
-        paragraphStyle.paragraphSpacing = UIFontMetrics.default.scaledValue(
-            for: WebCompatReporterUX.Preview.bulletSpacing
+    private func updateBullets() {
+        bulletsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        bulletRows = bullets.map { addRow(for: $0) }
+        applyScaledSpacing()
+        applyColors()
+    }
+
+    private func addRow(for bullet: String) -> BulletRow {
+        let dotLabel: UILabel = .build { label in
+            label.text = "●"
+            label.font = UIFontMetrics(forTextStyle: .footnote).scaledFont(
+                for: FXFontStyles.Regular.footnote.systemFont()
+                    .withSize(WebCompatReporterUX.Preview.bulletDotFontSize)
+            )
+            label.adjustsFontForContentSizeCategory = true
+            label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+            // The text wraps, so the dot must never be the thing that gives way.
+            label.setContentCompressionResistancePriority(.required, for: .horizontal)
+            label.isAccessibilityElement = false
+        }
+        let textLabel: UILabel = .build { label in
+            label.text = bullet
+            label.numberOfLines = 0
+            label.font = FXFontStyles.Regular.footnote.scaledFont()
+            label.adjustsFontForContentSizeCategory = true
+            label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        }
+
+        let rowView: UIStackView = .build { stackView in
+            stackView.axis = .horizontal
+            stackView.alignment = .firstBaseline
+        }
+        rowView.addArrangedSubview(dotLabel)
+        rowView.addArrangedSubview(textLabel)
+        bulletsStackView.addArrangedSubview(rowView)
+        return (dotLabel, textLabel)
+    }
+
+    private func applyScaledSpacing() {
+        bulletsStackView.spacing = UIFontMetrics.default.scaledValue(
+            for: WebCompatReporterUX.Preview.bulletRowSpacing
         )
-
-        let textAttributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .paragraphStyle: paragraphStyle,
-            .foregroundColor: theme.colors.textPrimary
-        ]
-
-        let dot = dotRun(alignedTo: font, themedBy: theme, attributes: textAttributes)
-        let text = NSMutableAttributedString()
-        for bullet in bullets {
-            if text.length > 0 {
-                text.append(NSAttributedString(string: "\n", attributes: textAttributes))
-            }
-            text.append(dot)
-            text.append(NSAttributedString(string: "\t\(bullet)", attributes: textAttributes))
+        let dotSpacing = UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.Preview.bulletDotSpacing)
+        for case let rowView as UIStackView in bulletsStackView.arrangedSubviews {
+            rowView.spacing = dotSpacing
         }
-        bulletsLabel.attributedText = text
     }
 
-    private func dotRun(
-        alignedTo font: UIFont,
-        themedBy theme: Theme,
-        attributes: [NSAttributedString.Key: Any]
-    ) -> NSAttributedString {
-        let diameter = UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.Preview.bulletDiameter)
-        let size = CGSize(width: diameter, height: diameter)
-
-        let attachment = NSTextAttachment()
-        attachment.image = UIGraphicsImageRenderer(size: size).image { context in
-            theme.colors.iconSecondary.setFill()
-            context.cgContext.fillEllipse(in: CGRect(origin: .zero, size: size))
+    private func applyColors() {
+        guard let theme else { return }
+        for row in bulletRows {
+            row.dotLabel.textColor = theme.colors.iconSecondary
+            row.textLabel.textColor = theme.colors.textPrimary
         }
-        attachment.bounds = CGRect(x: 0, y: (font.xHeight - diameter) / 2, width: diameter, height: diameter)
-
-        // TextKit reads paragraph attributes off the first character, so the attachment carries them.
-        let run = NSMutableAttributedString(attachment: attachment)
-        run.addAttributes(attributes, range: NSRange(location: 0, length: run.length))
-        return run
     }
 
     // MARK: - Notifiable
@@ -103,7 +119,7 @@ final class WebCompatPreviewBulletListCell: UICollectionViewListCell, ThemeAppli
     nonisolated func handleNotifications(_ notification: Notification) {
         guard notification.name == UIContentSizeCategory.didChangeNotification else { return }
         ensureMainThread { [weak self] in
-            self?.renderBullets()
+            self?.applyScaledSpacing()
         }
     }
 
@@ -115,6 +131,6 @@ final class WebCompatPreviewBulletListCell: UICollectionViewListCell, ThemeAppli
         background.cornerRadius = WebCompatReporterUX.Card.largeCornerRadius
         backgroundConfiguration = background
         self.theme = theme
-        renderBullets()
+        applyColors()
     }
 }

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatPreviewBulletListCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatPreviewBulletListCell.swift
@@ -35,14 +35,13 @@ final class WebCompatPreviewBulletListCell: UICollectionViewListCell,
     }
 
     private func setupLayout() {
-        let horizontalInset = WebCompatReporterUX.Card.contentInset
-        let verticalInset = WebCompatReporterUX.Card.verticalInset
+        let insets = WebCompatReporterUX.Card.edgeInsets
         contentView.addSubview(bulletsStackView)
         NSLayoutConstraint.activate([
-            bulletsStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: horizontalInset),
-            bulletsStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -horizontalInset),
-            bulletsStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: verticalInset),
-            bulletsStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -verticalInset)
+            bulletsStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: insets.leading),
+            bulletsStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -insets.trailing),
+            bulletsStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: insets.top),
+            bulletsStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -insets.bottom)
         ])
         applyScaledSpacing()
     }

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatTechnicalDataSectionCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatTechnicalDataSectionCell.swift
@@ -31,8 +31,7 @@ final class WebCompatTechnicalDataSectionCell: UICollectionViewListCell, ThemeAp
     }
 
     private func setupLayout() {
-        let horizontalInset = WebCompatReporterUX.Card.contentInset
-        let verticalInset = WebCompatReporterUX.Card.verticalInset
+        let insets = WebCompatReporterUX.Card.edgeInsets
         contentView.addSubview(cardView)
         cardView.addSubview(keyValueLabel)
         NSLayoutConstraint.activate([
@@ -41,10 +40,10 @@ final class WebCompatTechnicalDataSectionCell: UICollectionViewListCell, ThemeAp
             cardView.topAnchor.constraint(equalTo: contentView.topAnchor),
             cardView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
 
-            keyValueLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: horizontalInset),
-            keyValueLabel.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -horizontalInset),
-            keyValueLabel.topAnchor.constraint(equalTo: cardView.topAnchor, constant: verticalInset),
-            keyValueLabel.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -verticalInset)
+            keyValueLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: insets.leading),
+            keyValueLabel.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -insets.trailing),
+            keyValueLabel.topAnchor.constraint(equalTo: cardView.topAnchor, constant: insets.top),
+            keyValueLabel.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -insets.bottom)
         ])
     }
 

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
@@ -16,6 +16,7 @@ public final class WebCompatReportPreviewViewController: UIViewController,
                                                         Themeable,
                                                         UICollectionViewDelegate {
     private enum SectionID: Hashable {
+        case bullets
         case technicalData
     }
 
@@ -28,6 +29,10 @@ public final class WebCompatReportPreviewViewController: UIViewController,
 
     private var viewModel: WebCompatReportPreviewViewModel
     private var theme: Theme
+
+    private var visibleSectionIDs: [SectionID] {
+        return viewModel.bullets.isEmpty ? [.technicalData] : [.bullets, .technicalData]
+    }
 
     private lazy var closeButton: UIBarButtonItem = {
         let image = UIImage(named: StandardImageIdentifiers.Large.cross)?.withRenderingMode(.alwaysTemplate)
@@ -115,6 +120,17 @@ public final class WebCompatReportPreviewViewController: UIViewController,
 
     // Registrations go here, not inside the provider: UIKit crashes on one built lazily per cell.
     private func makeDataSource() -> UICollectionViewDiffableDataSource<SectionID, SectionID> {
+        let bulletsRegistration = UICollectionView.CellRegistration<
+            WebCompatPreviewBulletListCell, SectionID
+        > { [weak self] cell, _, _ in
+            guard let self else { return }
+            cell.configure(
+                bullets: self.viewModel.bullets,
+                accessibilityIdentifier: self.viewModel.bulletsA11yIdentifier
+            )
+            cell.applyTheme(theme: self.theme)
+        }
+
         let technicalDataRegistration = UICollectionView.CellRegistration<
             UICollectionViewListCell, SectionID
         > { [weak self] cell, _, _ in
@@ -153,6 +169,10 @@ public final class WebCompatReportPreviewViewController: UIViewController,
             collectionView: collectionView
         ) { collectionView, indexPath, itemID in
             switch itemID {
+            case .bullets:
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: bulletsRegistration, for: indexPath, item: itemID
+                )
             case .technicalData:
                 return collectionView.dequeueConfiguredReusableCell(
                     using: technicalDataRegistration, for: indexPath, item: itemID
@@ -162,7 +182,7 @@ public final class WebCompatReportPreviewViewController: UIViewController,
     }
 
     private func updateSections(reconfiguringItems: Bool) {
-        let sectionIDs: [SectionID] = [.technicalData]
+        let sectionIDs = visibleSectionIDs
 
         // An unchanged apply would rebuild every cell, so only apply when the sections moved.
         if dataSource.snapshot().sectionIdentifiers != sectionIDs {

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewController.swift
@@ -149,12 +149,7 @@ public final class WebCompatReportPreviewViewController: UIViewController,
             content.text = self.viewModel.technicalDataTitle
             content.textProperties.font = FXFontStyles.Regular.body.scaledFont()
             content.textProperties.color = self.theme.colors.textPrimary
-            content.directionalLayoutMargins = NSDirectionalEdgeInsets(
-                top: WebCompatReporterUX.Card.verticalInset,
-                leading: WebCompatReporterUX.Card.contentInset,
-                bottom: WebCompatReporterUX.Card.verticalInset,
-                trailing: WebCompatReporterUX.Card.contentInset
-            )
+            content.directionalLayoutMargins = WebCompatReporterUX.Card.edgeInsets
             cell.contentConfiguration = content
 
             let options = UICellAccessory.DisclosureIndicatorOptions(

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewModel.swift
@@ -10,6 +10,8 @@ public struct WebCompatReportPreviewViewModel: Equatable, Sendable {
     public let title: String
     public let closeAccessibilityLabel: String
     public let closeA11yIdentifier: String
+    public let bullets: [String]
+    public let bulletsA11yIdentifier: String
     public let technicalDataTitle: String
     public let technicalDataA11yIdentifier: String
 
@@ -17,12 +19,16 @@ public struct WebCompatReportPreviewViewModel: Equatable, Sendable {
         title: String,
         closeAccessibilityLabel: String,
         closeA11yIdentifier: String,
+        bullets: [String] = [],
+        bulletsA11yIdentifier: String,
         technicalDataTitle: String,
         technicalDataA11yIdentifier: String
     ) {
         self.title = title
         self.closeAccessibilityLabel = closeAccessibilityLabel
         self.closeA11yIdentifier = closeA11yIdentifier
+        self.bullets = bullets
+        self.bulletsA11yIdentifier = bulletsA11yIdentifier
         self.technicalDataTitle = technicalDataTitle
         self.technicalDataA11yIdentifier = technicalDataA11yIdentifier
     }

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportPreviewViewModel.swift
@@ -19,7 +19,7 @@ public struct WebCompatReportPreviewViewModel: Equatable, Sendable {
         title: String,
         closeAccessibilityLabel: String,
         closeA11yIdentifier: String,
-        bullets: [String] = [],
+        bullets: [String],
         bulletsA11yIdentifier: String,
         technicalDataTitle: String,
         technicalDataA11yIdentifier: String

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -49,6 +49,9 @@ enum WebCompatReporterUX {
     /// The Report Preview screen.
     enum Preview {
         static let cardHorizontalInset: CGFloat = 24
+        /// Drawn rather than typed: the `•` glyph renders under half this at footnote size.
+        static let bulletDiameter: CGFloat = 6
+        static let bulletIndent: CGFloat = 24
     }
 
     /// The tilted page card on the Report Preview screen.

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -49,7 +49,6 @@ enum WebCompatReporterUX {
     /// The Report Preview screen.
     enum Preview {
         static let cardHorizontalInset: CGFloat = 24
-        /// Drawn rather than typed: the `•` glyph renders under half this at footnote size.
         static let bulletDiameter: CGFloat = 6
         static let bulletIndent: CGFloat = 24
         static let bulletSpacing: CGFloat = 12

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -49,9 +49,9 @@ enum WebCompatReporterUX {
     /// The Report Preview screen.
     enum Preview {
         static let cardHorizontalInset: CGFloat = 24
-        static let bulletDiameter: CGFloat = 6
-        static let bulletIndent: CGFloat = 24
-        static let bulletSpacing: CGFloat = 12
+        static let bulletRowSpacing: CGFloat = 18
+        static let bulletDotSpacing: CGFloat = 16
+        static let bulletDotFontSize: CGFloat = 7
     }
 
     /// The tilted page card on the Report Preview screen.

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -52,6 +52,7 @@ enum WebCompatReporterUX {
         /// Drawn rather than typed: the `•` glyph renders under half this at footnote size.
         static let bulletDiameter: CGFloat = 6
         static let bulletIndent: CGFloat = 24
+        static let bulletSpacing: CGFloat = 12
     }
 
     /// The tilted page card on the Report Preview screen.

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import CoreGraphics
+import UIKit
 
 /// Layout constants for the WebCompat "Report a Website Issue" bottom sheet.
 enum WebCompatReporterUX {
@@ -18,6 +18,12 @@ enum WebCompatReporterUX {
         static let contentInset: CGFloat = 16
         static let largeCornerRadius: CGFloat = 26
         static let verticalInset: CGFloat = 14.5
+        static let edgeInsets = NSDirectionalEdgeInsets(
+            top: verticalInset,
+            leading: contentInset,
+            bottom: verticalInset,
+            trailing: contentInset
+        )
     }
 
     enum Sheet {

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
@@ -13,7 +13,6 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
         static let presentationSize = CGSize(width: 390, height: 844)
     }
 
-    // Both cards are single-item sections, so a handler keyed on the wrong one still hits a cell.
     func testTappingTechnicalDataRow_notifiesDelegate_butTappingTheSummaryDoesNot() throws {
         let delegate = MockWebCompatReportPreviewDelegate()
         let subject = createSubject()

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportPreviewViewControllerTests.swift
@@ -13,7 +13,8 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
         static let presentationSize = CGSize(width: 390, height: 844)
     }
 
-    func testTappingTechnicalDataRow_notifiesDelegate() throws {
+    // Both cards are single-item sections, so a handler keyed on the wrong one still hits a cell.
+    func testTappingTechnicalDataRow_notifiesDelegate_butTappingTheSummaryDoesNot() throws {
         let delegate = MockWebCompatReportPreviewDelegate()
         let subject = createSubject()
         subject.delegate = delegate
@@ -21,7 +22,12 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
         let collectionView = try XCTUnwrap(collectionView(in: subject))
 
         subject.collectionView(collectionView, didSelectItemAt: IndexPath(item: 0, section: 0))
+        XCTAssertEqual(delegate.didTapTechnicalDataCallCount, 0)
 
+        subject.collectionView(
+            collectionView,
+            didSelectItemAt: IndexPath(item: 0, section: collectionView.numberOfSections - 1)
+        )
         XCTAssertEqual(delegate.didTapTechnicalDataCallCount, 1)
     }
 
@@ -38,15 +44,28 @@ final class WebCompatReportPreviewViewControllerTests: XCTestCase {
         XCTAssertEqual(delegate.didRequestDismissCallCount, 1)
     }
 
+    func testSummaryCard_appearsOnlyWithBullets() {
+        let withoutBullets = createSubject(bullets: [])
+        let withBullets = createSubject(bullets: ["Page URL"])
+        layout(withoutBullets)
+        layout(withBullets)
+
+        XCTAssertEqual(collectionView(in: withoutBullets)?.numberOfSections, 1)
+        XCTAssertEqual(collectionView(in: withBullets)?.numberOfSections, 2)
+    }
+
     // MARK: - Helpers
 
     private func createSubject(
+        bullets: [String] = ["Page URL"],
         themeManager: ThemeManager = MockThemeManager()
     ) -> WebCompatReportPreviewViewController {
         let viewModel = WebCompatReportPreviewViewModel(
             title: "Report Preview",
             closeAccessibilityLabel: "Close",
             closeA11yIdentifier: "close",
+            bullets: bullets,
+            bulletsA11yIdentifier: "bullets",
             technicalDataTitle: "Technical Data",
             technicalDataA11yIdentifier: "technicalData"
         )

--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -146,6 +146,7 @@ struct AccessibilityIdentifiers {
 
         struct Preview {
             static let closeButton = "WebCompatReporter.Preview.CloseButton"
+            static let summary = "WebCompatReporter.Preview.Summary"
             static let technicalDataRow = "WebCompatReporter.Preview.TechnicalDataRow"
             /// Suffixed with the payload group id, e.g. `…SectionHeader.basic`.
             static let sectionHeader = "WebCompatReporter.Preview.SectionHeader"

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -138,8 +138,6 @@ struct WebCompatReportPayload: Equatable {
         )
     }
 
-    /// In the design's order, and only for fields the report actually carries, so the summary
-    /// can't claim data we didn't collect.
     private var summaryBullets: [String] {
         let collectedKeys = Set(
             previewGroups
@@ -171,8 +169,7 @@ struct WebCompatReportPayload: Equatable {
             .map { $0.text }
     }
 
-    /// An empty list is still sent, so Technical Data prints it, but a bullet off it would promise
-    /// hostnames the report doesn't carry.
+    /// An empty list is still sent, so it prints in Technical Data but earns no bullet here.
     private func carriesData(_ value: WebCompatTechnicalDataViewModel.PreviewValue) -> Bool {
         switch value {
         case .null:
@@ -184,8 +181,7 @@ struct WebCompatReportPayload: Equatable {
         }
     }
 
-    /// The address sits under its own bullet. A line separator rather than a newline, so it stays
-    /// in the same paragraph and keeps the bullet's hanging indent instead of earning a dot.
+    /// A line separator, not a newline: same paragraph, so the address keeps the indent and no dot.
     private var pageURLBullet: String {
         let label: String = .WebCompatReporter.Preview.Data.PageURL
         guard let url else { return label }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Shared
 import WebCompatReporterKit
 
 /// One property per Glean metric in `broken_site_report.yaml`, so the field names
@@ -130,9 +131,52 @@ struct WebCompatReportPayload: Equatable {
             title: .WebCompatReporter.Preview.Title,
             closeAccessibilityLabel: .WebCompatReporter.Sheet.CloseButtonAccessibilityLabel,
             closeA11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.Preview.closeButton,
+            bullets: summaryBullets,
+            bulletsA11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.Preview.summary,
             technicalDataTitle: .WebCompatReporter.Preview.TechnicalData,
             technicalDataA11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.Preview.technicalDataRow
         )
+    }
+
+    /// In the design's order, and only for fields the report actually carries, so the summary
+    /// can't claim data we didn't collect.
+    private var summaryBullets: [String] {
+        let collectedKeys = Set(
+            previewGroups
+                .flatMap { $0.fields }
+                .filter { $0.value != .null }
+                .map { $0.key }
+        )
+        let userAgent = String(
+            format: .WebCompatReporter.Preview.Data.UserAgent,
+            AppName.shortName.rawValue
+        )
+        let bullets: [(text: String, keys: [PreviewField.Key])] = [
+            (pageURLBullet, [.url]),
+            (.WebCompatReporter.Preview.Data.IssueAndDescription, [.reason, .description]),
+            (.WebCompatReporter.Preview.Data.IsTablet, [.isTablet]),
+            (userAgent, [.useragentString, .defaultUseragentString]),
+            (.WebCompatReporter.Preview.Data.TrackingProtectionSetting, [.blockList, .etpCategory]),
+            (.WebCompatReporter.Preview.Data.BlockedTrackers, [.blockedOrigins]),
+            (.WebCompatReporter.Preview.Data.PrivateBrowsingStatus, [.isPrivateBrowsing]),
+            (.WebCompatReporter.Preview.Data.AvailableMemory, [.memory]),
+            (.WebCompatReporter.Preview.Data.PixelDensity, [.devicePixelRatio]),
+            (.WebCompatReporter.Preview.Data.HasTouchscreen, [.hasTouchScreen]),
+            (.WebCompatReporter.Preview.Data.PageLanguages, [.languages]),
+            (.WebCompatReporter.Preview.Data.DeviceLocale, [.defaultLocales]),
+            (.WebCompatReporter.Preview.Data.PageElements, [.fastclick, .marfeel, .mobify])
+        ]
+        return bullets
+            .filter { bullet in bullet.keys.contains(where: collectedKeys.contains) }
+            .map { $0.text }
+    }
+
+    /// The address sits under its own bullet. A line separator rather than a newline, so it stays
+    /// in the same paragraph and keeps the bullet's hanging indent instead of earning a dot.
+    private var pageURLBullet: String {
+        let label: String = .WebCompatReporter.Preview.Data.PageURL
+        guard let url else { return label }
+        return "\(label)\u{2028}[\(url)]"
     }
 
     func makeTechnicalDataViewModel() -> WebCompatTechnicalDataViewModel {

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -144,7 +144,7 @@ struct WebCompatReportPayload: Equatable {
         let collectedKeys = Set(
             previewGroups
                 .flatMap { $0.fields }
-                .filter { $0.value != .null }
+                .filter { carriesData($0.value) }
                 .map { $0.key }
         )
         let userAgent = String(
@@ -169,6 +169,19 @@ struct WebCompatReportPayload: Equatable {
         return bullets
             .filter { bullet in bullet.keys.contains(where: collectedKeys.contains) }
             .map { $0.text }
+    }
+
+    /// An empty list is still sent, so Technical Data prints it, but a bullet off it would promise
+    /// hostnames the report doesn't carry.
+    private func carriesData(_ value: WebCompatTechnicalDataViewModel.PreviewValue) -> Bool {
+        switch value {
+        case .null:
+            return false
+        case .list(let values):
+            return !values.isEmpty
+        case .string, .bool, .quantity:
+            return true
+        }
     }
 
     /// The address sits under its own bullet. A line separator rather than a newline, so it stays

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
@@ -148,7 +148,6 @@ final class WebCompatReportPayloadTests: XCTestCase {
         XCTAssertEqual(viewModel.technicalDataTitle, .WebCompatReporter.Preview.TechnicalData)
     }
 
-    // The summary can't claim data the report doesn't carry, and the order is the design's.
     func testMakeReportPreviewViewModel_bulletsCoverOnlyCollectedFields() {
         var payload = WebCompatReportPayload()
         payload.url = "https://example.com"
@@ -162,8 +161,6 @@ final class WebCompatReportPayloadTests: XCTestCase {
         ])
     }
 
-    // Paired with testPreviewGroups_optedInWithNothingBlocked_showsAnEmptyListNotNull: the field is
-    // still sent and still printed, but it earns no bullet.
     func testMakeReportPreviewViewModel_dropsTheBulletForAnEmptyList() {
         var payload = WebCompatReportPayload()
         payload.blockedOrigins = []

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
@@ -162,6 +162,17 @@ final class WebCompatReportPayloadTests: XCTestCase {
         ])
     }
 
+    // Paired with testPreviewGroups_optedInWithNothingBlocked_showsAnEmptyListNotNull: the field is
+    // still sent and still printed, but it earns no bullet.
+    func testMakeReportPreviewViewModel_dropsTheBulletForAnEmptyList() {
+        var payload = WebCompatReportPayload()
+        payload.blockedOrigins = []
+
+        let bullets = payload.makeReportPreviewViewModel().bullets
+
+        XCTAssertFalse(bullets.contains(.WebCompatReporter.Preview.Data.BlockedTrackers))
+    }
+
     // MARK: - Helpers
 
     private func renderedFields(of payload: WebCompatReportPayload) -> [String: String] {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
@@ -148,6 +148,20 @@ final class WebCompatReportPayloadTests: XCTestCase {
         XCTAssertEqual(viewModel.technicalDataTitle, .WebCompatReporter.Preview.TechnicalData)
     }
 
+    // The summary can't claim data the report doesn't carry, and the order is the design's.
+    func testMakeReportPreviewViewModel_bulletsCoverOnlyCollectedFields() {
+        var payload = WebCompatReportPayload()
+        payload.url = "https://example.com"
+        payload.breakageCategory = WebCompatSubOption.pageNotLoading.rawValue
+
+        let bullets = payload.makeReportPreviewViewModel().bullets
+
+        XCTAssertEqual(bullets, [
+            "\(String.WebCompatReporter.Preview.Data.PageURL)\u{2028}[https://example.com]",
+            .WebCompatReporter.Preview.Data.IssueAndDescription
+        ])
+    }
+
     // MARK: - Helpers
 
     private func renderedFields(of payload: WebCompatReportPayload) -> [String: String] {


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16432](https://mozilla-hub.atlassian.net/browse/FXIOS-16432)

## :bulb: Description
The plain-language card above the Technical Data row.

Bullets come off the payload the reporter submits, one per field it carries, so the summary can't claim data we didn't collect. Nothing collected, no card. Copy from [#35139](https://github.com/mozilla-mobile/firefox-ios/pull/35139).

Stacked on [#35095](https://github.com/mozilla-mobile/firefox-ios/pull/35095).

<img height="700" alt="Screenshot claude-fxios-16432-ios27 12-08-2026 at 16 09 11" src="https://github.com/user-attachments/assets/30d58354-0ee0-4547-a889-e11e91099b08" />


## :mag: Testing
Menu → **Report Broken Site** → category → **Preview**.

1. Card sits above **Technical Data**; wrapped lines hang off the text, not the dot.
2. Turn **include blocked list** off, preview again: that bullet is gone.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


[FXIOS-16432]: https://mozilla-hub.atlassian.net/browse/FXIOS-16432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
