### PR TITLE
Refactor FXIOS-16139 [Redux] Move availableContentHeight and availableWallpaperHeight into WallpaperState

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3247,8 +3247,8 @@ class BrowserViewController: UIViewController,
         let availableContentHeight = getAvailableHomepageContentHeight()
         let availableWallpaperHeight = getAvailableHomepageWallpaperHeight(availableContentHeight: availableContentHeight)
 
-        guard homepageState.availableContentHeight != availableContentHeight
-              || homepageState.availableWallpaperHeight != availableWallpaperHeight
+        guard homepageState.wallpaperState.availableContentHeight != availableContentHeight
+              || homepageState.wallpaperState.availableWallpaperHeight != availableWallpaperHeight
         else { return }
 
         store.dispatch(

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -436,7 +436,8 @@ final class HomepageViewController: UIViewController,
         // TODO: - FXIOS-13346 / FXIOS-13343 - fix collection view being reloaded all the time also when data don't change
         // this is a quick workaround to avoid blocking the main thread by calling apply snapshot many times.
         if homepageState != state {
-            let animatingDifferences = state.availableContentHeight == homepageState.availableContentHeight
+            let animatingDifferences = state.wallpaperState.availableContentHeight
+                                        == homepageState.wallpaperState.availableContentHeight
             self.homepageState = state
 
             refreshHomepageDataSourceSnapshot(
@@ -445,7 +446,7 @@ final class HomepageViewController: UIViewController,
                 self?.collectionView?.layoutIfNeeded()
                 self?.updateNewsTransitionHeaderProgress()
             }
-            updateWallpaperConstraints(availableWallpaperHeight: state.availableWallpaperHeight)
+            updateWallpaperConstraints(availableWallpaperHeight: state.wallpaperState.availableWallpaperHeight)
         }
 
         // FXIOS-11523 - Trigger impression when user opens homepage view new tab + scroll to top
@@ -476,7 +477,7 @@ final class HomepageViewController: UIViewController,
         view.addSubview(wallpaperView)
 
         let heightConstraint = wallpaperView.heightAnchor.constraint(
-            equalToConstant: homepageState.availableWallpaperHeight
+            equalToConstant: homepageState.wallpaperState.availableWallpaperHeight
         )
         let topConstraint = wallpaperView.topAnchor.constraint(equalTo: view.topAnchor)
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -869,7 +869,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         let homepageState = store.state.componentState(HomepageState.self, for: .homepage, window: windowUUID)
         let collectionViewHeight = environment.container.contentSize.height
 
-        let availableContentHeight = homepageState?.availableContentHeight ?? 0
+        let availableContentHeight = homepageState?.wallpaperState.availableContentHeight ?? 0
         let height = availableContentHeight > 0 ? availableContentHeight : collectionViewHeight
 
         let headerLogoHeight = getHeaderLogoHeight(environment: environment)

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -261,9 +261,7 @@ struct HomepageState: ScreenState, Equatable {
             wallpaperState: WallpaperState.defaultState(from: state.wallpaperState),
             isZeroSearch: state.isZeroSearch,
             shouldTriggerImpression: false,
-            shouldShowPrivacyNotice: state.shouldShowPrivacyNotice,
-            availableContentHeight: state.availableContentHeight,
-            availableWallpaperHeight: state.availableWallpaperHeight
+            shouldShowPrivacyNotice: state.shouldShowPrivacyNotice
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -37,16 +37,6 @@ struct HomepageState: ScreenState, Equatable {
     /// new privacy notice is available after a user has already accepted the ToS/ToU
     let shouldShowPrivacyNotice: Bool
 
-    /// `availableContentHeight` represents the height available for the homepage content to occupy when the address is not
-    /// being edited. This is used to keep the homepage layout constant, such that it doesn't shift when the homepage's
-    /// view size changes eg when the address bar is tapped and the keyboard is presented. This value is kept in state
-    /// because it is determined by BVC
-    let availableContentHeight: CGFloat
-
-    /// `availableWallpaperHeight` is the height to apply to the homepage wallpaper background so it can remain pinned to
-    /// the top of the window while still extending to the same visual bottom as the homepage content.
-    let availableWallpaperHeight: CGFloat
-
     init(appState: AppState, uuid: WindowUUID) {
         guard let homepageState = appState.componentState(
             HomepageState.self,
@@ -70,9 +60,7 @@ struct HomepageState: ScreenState, Equatable {
             wallpaperState: homepageState.wallpaperState,
             isZeroSearch: homepageState.isZeroSearch,
             shouldTriggerImpression: homepageState.shouldTriggerImpression,
-            shouldShowPrivacyNotice: homepageState.shouldShowPrivacyNotice,
-            availableContentHeight: homepageState.availableContentHeight,
-            availableWallpaperHeight: homepageState.availableWallpaperHeight
+            shouldShowPrivacyNotice: homepageState.shouldShowPrivacyNotice
         )
     }
 
@@ -90,9 +78,7 @@ struct HomepageState: ScreenState, Equatable {
             wallpaperState: WallpaperState(windowUUID: windowUUID),
             isZeroSearch: false,
             shouldTriggerImpression: false,
-            shouldShowPrivacyNotice: false,
-            availableContentHeight: 0,
-            availableWallpaperHeight: 0
+            shouldShowPrivacyNotice: false
         )
     }
 
@@ -109,9 +95,7 @@ struct HomepageState: ScreenState, Equatable {
         wallpaperState: WallpaperState,
         isZeroSearch: Bool,
         shouldTriggerImpression: Bool,
-        shouldShowPrivacyNotice: Bool,
-        availableContentHeight: CGFloat,
-        availableWallpaperHeight: CGFloat
+        shouldShowPrivacyNotice: Bool
     ) {
         self.windowUUID = windowUUID
         self.headerState = headerState
@@ -126,8 +110,6 @@ struct HomepageState: ScreenState, Equatable {
         self.isZeroSearch = isZeroSearch
         self.shouldTriggerImpression = shouldTriggerImpression
         self.shouldShowPrivacyNotice = shouldShowPrivacyNotice
-        self.availableContentHeight = availableContentHeight
-        self.availableWallpaperHeight = availableWallpaperHeight
     }
 
     static let reducer: Reducer<Self> = (legacyReducer, modernReducer)
@@ -152,8 +134,6 @@ struct HomepageState: ScreenState, Equatable {
             }
 
             return handleEmbeddedHomepageAction(state: state, action: action, isZeroSearch: isZeroSearch)
-        case HomepageActionType.availableContentHeightDidChange:
-            return handleAvailableContentHeightChangeAction(state: state, action: action)
         case HomepageActionType.privacyNoticeCloseButtonTapped:
             return handlePrivacyNoticeCloseButtonTappedAction(state: state, action: action)
         case GeneralBrowserActionType.didSelectedTabChangeToHomepage:
@@ -198,32 +178,6 @@ struct HomepageState: ScreenState, Equatable {
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
             .copy(isZeroSearch: isZeroSearch)
-    }
-
-    @MainActor
-    private static func handleAvailableContentHeightChangeAction(state: HomepageState, action: Action) -> HomepageState {
-        guard let homepageAction = action as? HomepageAction else {
-            return defaultState(from: state)
-        }
-
-        // Height updates can arrive with only one field populated; keep the other value stable.
-        let availableContentHeight = homepageAction.availableContentHeight ?? state.availableContentHeight
-        let availableWallpaperHeight = homepageAction.availableWallpaperHeight ?? state.availableWallpaperHeight
-
-        return state
-            .resetTransientState()
-            .copy(headerState: HeaderState.reducer.legacyReducer(state.headerState, action))
-            .copy(messageState: MessageCardState.reducer.legacyReducer(state.messageState, action))
-            .copy(topSitesState: TopSitesSectionState.reducer.legacyReducer(state.topSitesState, action))
-            .copy(searchState: SearchBarState.reducer.legacyReducer(state.searchState, action))
-            .copy(jumpBackInState: JumpBackInSectionState.reducer.legacyReducer(state.jumpBackInState, action))
-            .copy(trackerBlockerModuleState: TrackerBlockerModuleState.reducer
-                                             .legacyReducer(state.trackerBlockerModuleState, action))
-            .copy(bookmarkState: BookmarksSectionState.reducer.legacyReducer(state.bookmarkState, action))
-            .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
-            .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
-            .copy(availableContentHeight: availableContentHeight)
-            .copy(availableWallpaperHeight: availableWallpaperHeight)
     }
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/Redux/WallpaperState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/Redux/WallpaperState.swift
@@ -10,13 +10,35 @@ struct WallpaperState: ScreenState, Equatable {
     var windowUUID: WindowUUID
     let wallpaperConfiguration: WallpaperConfiguration
 
+    /// `availableContentHeight` represents the height available for the homepage content to occupy when the address is not
+    /// being edited. This is used to keep the homepage layout constant, such that it doesn't shift when the homepage's
+    /// view size changes eg when the address bar is tapped and the keyboard is presented. This value is kept in state
+    /// because it is determined by BVC
+    let availableContentHeight: CGFloat
+
+    /// `availableWallpaperHeight` is the height to apply to the homepage wallpaper background so it can remain pinned to
+    /// the top of the window while still extending to the same visual bottom as the homepage content.
+    let availableWallpaperHeight: CGFloat
+
     init(windowUUID: WindowUUID) {
-        self.init(windowUUID: windowUUID, wallpaperConfiguration: WallpaperConfiguration())
+        self.init(
+            windowUUID: windowUUID,
+            wallpaperConfiguration: WallpaperConfiguration(),
+            availableContentHeight: 0,
+            availableWallpaperHeight: 0
+        )
     }
 
-    private init(windowUUID: WindowUUID, wallpaperConfiguration: WallpaperConfiguration) {
+    private init(
+        windowUUID: WindowUUID,
+        wallpaperConfiguration: WallpaperConfiguration,
+        availableContentHeight: CGFloat,
+        availableWallpaperHeight: CGFloat
+    ) {
         self.windowUUID = windowUUID
         self.wallpaperConfiguration = wallpaperConfiguration
+        self.availableContentHeight = availableContentHeight
+        self.availableWallpaperHeight = availableWallpaperHeight
     }
 
     static let reducer: Reducer<Self> = (legacyReducer, modernReducer)
@@ -35,6 +57,8 @@ struct WallpaperState: ScreenState, Equatable {
         case WallpaperMiddlewareActionType.wallpaperDidInitialize,
                 WallpaperMiddlewareActionType.wallpaperDidChange:
             return handleWallpaperAction(action: action, state: state)
+        case HomepageActionType.availableContentHeightDidChange:
+            return handleAvailableContentHeightChangeAction(action: action, state: state)
         default:
             return defaultState(from: state)
         }
@@ -47,10 +71,22 @@ struct WallpaperState: ScreenState, Equatable {
         )
     }
 
+    private static func handleAvailableContentHeightChangeAction(action: Action,
+                                                                 state: WallpaperState) -> WallpaperState {
+        guard let homepageAction = action as? HomepageAction else { return defaultState(from: state) }
+
+        // Height updates can arrive with only one field populated; keep the other value stable.
+        return state
+            .copy(availableContentHeight: homepageAction.availableContentHeight ?? state.availableContentHeight)
+            .copy(availableWallpaperHeight: homepageAction.availableWallpaperHeight ?? state.availableWallpaperHeight)
+    }
+
    static func defaultState(from state: WallpaperState) -> WallpaperState {
         return WallpaperState(
             windowUUID: state.windowUUID,
-            wallpaperConfiguration: state.wallpaperConfiguration
+            wallpaperConfiguration: state.wallpaperConfiguration,
+            availableContentHeight: state.availableContentHeight,
+            availableWallpaperHeight: state.availableWallpaperHeight
         )
    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
@@ -41,8 +41,8 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertFalse(initialState.trackerBlockerModuleState.shouldShowSection)
         XCTAssertFalse(initialState.isZeroSearch)
         XCTAssertFalse(initialState.shouldTriggerImpression)
-        XCTAssertEqual(initialState.availableContentHeight, 0)
-        XCTAssertEqual(initialState.availableWallpaperHeight, 0)
+        XCTAssertEqual(initialState.wallpaperState.availableContentHeight, 0)
+        XCTAssertEqual(initialState.wallpaperState.availableWallpaperHeight, 0)
     }
 
     @MainActor
@@ -62,8 +62,9 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertFalse(newState.headerState.isPrivate)
         XCTAssertFalse(newState.isZeroSearch)
         XCTAssertFalse(initialState.shouldTriggerImpression)
-        XCTAssertEqual(newState.availableContentHeight, initialState.availableContentHeight)
-        XCTAssertEqual(newState.availableWallpaperHeight, initialState.availableWallpaperHeight)
+        XCTAssertEqual(newState.wallpaperState.availableContentHeight, initialState.wallpaperState.availableContentHeight)
+        XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight,
+                       initialState.wallpaperState.availableWallpaperHeight)
     }
 
     @MainActor
@@ -83,8 +84,9 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertTrue(newState.isZeroSearch)
         XCTAssertFalse(initialState.shouldTriggerImpression)
-        XCTAssertEqual(newState.availableContentHeight, initialState.availableContentHeight)
-        XCTAssertEqual(newState.availableWallpaperHeight, initialState.availableWallpaperHeight)
+        XCTAssertEqual(newState.wallpaperState.availableContentHeight, initialState.wallpaperState.availableContentHeight)
+        XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight,
+                       initialState.wallpaperState.availableWallpaperHeight)
     }
 
     @MainActor
@@ -104,8 +106,9 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(newState.isZeroSearch)
         XCTAssertFalse(initialState.shouldTriggerImpression)
-        XCTAssertEqual(newState.availableContentHeight, initialState.availableContentHeight)
-        XCTAssertEqual(newState.availableWallpaperHeight, initialState.availableWallpaperHeight)
+        XCTAssertEqual(newState.wallpaperState.availableContentHeight, initialState.wallpaperState.availableContentHeight)
+        XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight,
+                       initialState.wallpaperState.availableWallpaperHeight)
     }
 
     @MainActor
@@ -124,8 +127,9 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(newState.isZeroSearch)
         XCTAssertTrue(newState.shouldTriggerImpression)
-        XCTAssertEqual(newState.availableContentHeight, initialState.availableContentHeight)
-        XCTAssertEqual(newState.availableWallpaperHeight, initialState.availableWallpaperHeight)
+        XCTAssertEqual(newState.wallpaperState.availableContentHeight, initialState.wallpaperState.availableContentHeight)
+        XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight,
+                       initialState.wallpaperState.availableWallpaperHeight)
     }
 
     @MainActor
@@ -143,8 +147,8 @@ final class HomepageStateTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(newState.availableContentHeight, 500)
-        XCTAssertEqual(newState.availableWallpaperHeight, 525)
+        XCTAssertEqual(newState.wallpaperState.availableContentHeight, 500)
+        XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight, 525)
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(newState.shouldTriggerImpression)
         XCTAssertEqual(newState.isZeroSearch, initialState.isZeroSearch)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Wallpaper/WallpaperStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Wallpaper/WallpaperStateTests.swift
@@ -19,6 +19,8 @@ final class WallpaperStateTests: XCTestCase {
         XCTAssertNil(initialState.wallpaperConfiguration.textColor)
         XCTAssertNil(initialState.wallpaperConfiguration.cardColor)
         XCTAssertNil(initialState.wallpaperConfiguration.logoTextColor)
+        XCTAssertEqual(initialState.availableContentHeight, 0)
+        XCTAssertEqual(initialState.availableWallpaperHeight, 0)
     }
 
     @MainActor
@@ -79,6 +81,81 @@ final class WallpaperStateTests: XCTestCase {
         XCTAssertEqual(newState.wallpaperConfiguration.textColor, .black)
         XCTAssertEqual(newState.wallpaperConfiguration.cardColor, .black)
         XCTAssertEqual(newState.wallpaperConfiguration.logoTextColor, .black)
+    }
+
+    @MainActor
+    func test_availableContentHeightDidChange_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = headerReducer()
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            HomepageAction(
+                availableContentHeight: 500,
+                availableWallpaperHeight: 525,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.availableContentHeightDidChange
+            )
+        )
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertEqual(newState.availableContentHeight, 500)
+        XCTAssertEqual(newState.availableWallpaperHeight, 525)
+    }
+
+    @MainActor
+    func test_availableContentHeightDidChange_withPartialHeights_keepsPreviousValues() {
+        let reducer = headerReducer()
+
+        let initialState = reducer.legacyReducer(
+            createSubject(),
+            HomepageAction(
+                availableContentHeight: 500,
+                availableWallpaperHeight: 525,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.availableContentHeightDidChange
+            )
+        )
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            HomepageAction(
+                availableWallpaperHeight: 600,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.availableContentHeightDidChange
+            )
+        )
+
+        XCTAssertEqual(newState.availableContentHeight, 500)
+        XCTAssertEqual(newState.availableWallpaperHeight, 600)
+    }
+
+    @MainActor
+    func test_wallpaperDidChange_keepsAvailableHeights() {
+        let reducer = headerReducer()
+
+        let initialState = reducer.legacyReducer(
+            createSubject(),
+            HomepageAction(
+                availableContentHeight: 500,
+                availableWallpaperHeight: 525,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.availableContentHeightDidChange
+            )
+        )
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            WallpaperAction(
+                wallpaperConfiguration: WallpaperConfiguration(portraitImage: image),
+                windowUUID: .XCTestDefaultUUID,
+                actionType: WallpaperMiddlewareActionType.wallpaperDidChange
+            )
+        )
+
+        XCTAssertEqual(newState.wallpaperConfiguration.portraitImage, image)
+        XCTAssertEqual(newState.availableContentHeight, 500)
+        XCTAssertEqual(newState.availableWallpaperHeight, 525)
     }
 
     // MARK: - Private


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16139)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Move availableContentHeight and availableWallpaperHeight into WallpaperState and update tests. This is part of changes for the Redux Passthrough Reducers Refactor and ADR

Tested code paths re-routed properly through wallpaperState when rotating the screen and updating the wallpapers and changing the url bar position.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

