### PR TITLE
Refactor FXIOS-16534 Move Wayback UA to UserAgent

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -38,6 +38,10 @@ open class UserAgent {
         return clientUserAgent(prefix: "Firefox-iOS-FxA")
     }
 
+    public static var waybackUserAgent: String {
+        return "firefox-ios-neterr/\(AppInfo.appVersion) (+https://mzl.la/3RNfZFB)"
+    }
+
     public static var defaultClientUserAgent: String {
         return clientUserAgent(prefix: "Firefox-iOS")
     }

--- a/firefox-ios/Client/Frontend/Wayback/WaybackService.swift
+++ b/firefox-ios/Client/Frontend/Wayback/WaybackService.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Common
+import Shared
 
 class WaybackService {
     struct Snapshot: Decodable {
@@ -22,12 +22,8 @@ class WaybackService {
     }
 
     private static let session: URLSession = {
-        let version = AppInfo.appVersion
         let config = URLSessionConfiguration.default
-        // TODO: FXIOS-16534 Move to shared UserAgent configuration
-        config.httpAdditionalHeaders = [
-            "User-Agent": "firefox-ios-neterr/\(version) (+https://mzl.la/3RNfZFB)"
-        ]
+        config.httpAdditionalHeaders = ["User-Agent": UserAgent.waybackUserAgent]
         return URLSession(configuration: config)
     }()
 

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
+import Common
 @testable import Shared
 
 final class UserAgentTests: XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
@@ -6,6 +6,13 @@ import XCTest
 @testable import Shared
 
 final class UserAgentTests: XCTestCase {
+    func testWaybackUserAgent_returnsExpectedUserAgent() {
+        XCTAssertEqual(
+            UserAgent.waybackUserAgent,
+            "firefox-ios-neterr/\(AppInfo.appVersion) (+https://mzl.la/3RNfZFB)"
+        )
+    }
+
     func testGetUserAgentDesktop_withListedDomain_returnProperUserAgent() {
         let domains = CustomUserAgentConstant.customDesktopUAForDomain
         domains.forEach { domain, agent in


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16534)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35082)

## :bulb: Description
Moves the Wayback API user-agent construction into the shared `UserAgent` class and updates `WaybackService` to consume it. This keeps user-agent definitions centralized and removes the temporary FXIOS-16534 TODO from the service.

Adds unit coverage for the Wayback user-agent format.

Closes #35082.

Validation:
- Swift syntax parsing passed for all changed files.
- SwiftLint reported zero violations for all changed files.
- `git diff --check` passed.
- The targeted Xcode unit test was attempted, but Xcode stalled in `Resolve Package Graph` before reaching the build phase.

## :movie_camera: Demos
Not applicable. This refactor has no UI changes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
