### PR TITLE
Bugfix FXIOS-16540 - Toolbar general bugs related to rotation with stale keyboard state

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -765,6 +765,11 @@ class BrowserViewController: UIViewController,
         appMenuBadgeUpdate()
         updateTopTabs(showTopTabs: showTopTabs)
         updateToolbarDisplay(shouldUpdateBlurViews: shouldUpdateBlurViews)
+
+        // update keyboard's related view constraints if is visible 
+        if keyboardState != nil {
+            updateConstraintsForKeyboard()
+        }
     }
 
     private func updateSwipingTabs() {
@@ -1819,8 +1824,7 @@ class BrowserViewController: UIViewController,
     }
 
     private func getKeyboardSpacerHeight(keyboardHeight: CGFloat) -> CGFloat {
-        let showNavToolbar = toolbarHelper.shouldShowNavigationToolbar(for: traitCollection)
-        let toolBarHeight = showNavToolbar ? UIConstants.BottomToolbarHeight : 0
+        let toolBarHeight = navigationToolbarContainer.isHidden ? 0 : UIConstants.BottomToolbarHeight
         let spacerHeight = keyboardHeight - toolBarHeight
         return spacerHeight
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerKeyboardConstraintTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerKeyboardConstraintTests.swift
@@ -164,10 +164,9 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
 
     // MARK: - Rotation and keyboard race
 
-    /// Nothing recomputes the keyboard spacer when the nav toolbar's visibility changes, so if the
-    /// keyboard shows while the nav toolbar is hidden (rotation race), the spacer stays wrong once
-    /// the nav toolbar reappears. Expected to FAIL until the keyboard-handling refactor lands.
-    func test_rotationWhileKeyboardVisible_keyboardSpacerStaysStaleAfterNavToolbarUnhides() {
+    /// The keyboard spacer must track the nav toolbar's actual `isHidden` state, not a separately
+    /// derived guess, and must be recomputed whenever that state changes.
+    func test_rotationWhileKeyboardVisible_keyboardSpacerTracksNavToolbarVisibility() {
         let subject = createSubject()
         selectTabWithFindInPage()
         let keyboardHelper = createKeyboardHelper()
@@ -178,27 +177,29 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
         subject.view.layoutIfNeeded()
         XCTAssertTrue(subject.bottomContainer.frame.height.isZero)
 
-        // Keyboard shows while the nav toolbar is still hidden.
+        // Keyboard shows while the nav toolbar is still hidden — nothing should be subtracted from
+        // the spacer since there's no nav toolbar behind the keyboard yet.
         subject.keyboardHelper(keyboardHelper,
                                keyboardWillShowWithState: createKeyboardState(keyboardHeight: keyboardHeight))
         subject.view.layoutIfNeeded()
-        XCTAssertNotNil(keyboardSpacerHeightConstant(in: subject.overKeyboardContainer))
+        XCTAssertEqual(keyboardSpacerHeightConstant(in: subject.overKeyboardContainer) ?? -1,
+                       keyboardHeight,
+                       accuracy: 0.5)
 
         // Rotation settles and the nav toolbar unhides; nothing else fires.
         subject.updateToolbarStateForTraitCollection(portraitTraitCollection())
         subject.view.layoutIfNeeded()
         XCTAssertFalse(subject.bottomContainer.frame.height.isZero)
 
-        // Spacer should shrink by whatever space the nav toolbar reclaimed, to stay flush above the keyboard.
-        let expectedSpacerHeight = keyboardHeight - subject.bottomContainer.frame.height
-        let actualSpacerHeight = keyboardSpacerHeightConstant(in: subject.overKeyboardContainer) ?? -1
-        // Expected to fail until we fix the keyboard handling
-        XCTAssertNotEqual(actualSpacerHeight,expectedSpacerHeight, accuracy: 0.5)
+        // Spacer should shrink by the nav toolbar's height, to stay flush above the keyboard.
+        XCTAssertEqual(keyboardSpacerHeightConstant(in: subject.overKeyboardContainer) ?? -1,
+                       keyboardHeight - UIConstants.BottomToolbarHeight,
+                       accuracy: 0.5)
     }
 
     /// Hiding the keyboard doesn't depend on the spacer's height, so it should clean up the spacer
     /// even after the race above has left it stale.
-    func test_rotationWhileKeyboardVisible_keyboardSpacerIsRemovedOnHideDespiteStaleness() {
+    func test_rotationWhileKeyboardVisible_keyboardSpacerIsRemovedOnHide() {
         let subject = createSubject()
         selectTabWithFindInPage()
         let keyboardHelper = createKeyboardHelper()
@@ -231,7 +232,8 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
         subject.updateToolbarStateForTraitCollection(landscapeTraitCollection())
         subject.view.layoutIfNeeded()
 
-        subject.keyboardHelper(keyboardHelper, keyboardWillShowWithState: createKeyboardState(keyboardHeight: keyboardHeight))
+        subject.keyboardHelper(keyboardHelper,
+                               keyboardWillShowWithState: createKeyboardState(keyboardHeight: keyboardHeight))
         subject.view.layoutIfNeeded()
 
         subject.updateToolbarStateForTraitCollection(portraitTraitCollection())
@@ -239,6 +241,44 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
 
         let expectedMaxY = subject.view.frame.height - keyboardHeight
         XCTAssertEqual(subject.bottomContentStackView.frame.maxY, expectedMaxY, accuracy: 0.5)
+    }
+
+    /// A trait change that skips `willTransition` (Dark Mode, Stage Manager resize) only reaches
+    /// `navigationToolbarContainer` via `traitCollectionDidChange`'s deferred `DispatchQueue.main.async`
+    /// update. Confirms the keyboard spacer still ends up correct once that deferred update runs.
+    func test_nonRotationTraitChangeWhileKeyboardVisible_keyboardSpacerRecomputesAfterDeferredUpdate() {
+        let subject = createSubject()
+        selectTabWithFindInPage()
+        let keyboardHelper = createKeyboardHelper()
+        let keyboardHeight: CGFloat = 300
+
+        // Nav toolbar hidden, as if a prior `willTransition` already set this for landscape.
+        subject.updateToolbarStateForTraitCollection(landscapeTraitCollection())
+        subject.view.layoutIfNeeded()
+
+        // Keyboard shows while the nav toolbar is still hidden.
+        subject.keyboardHelper(keyboardHelper,
+                               keyboardWillShowWithState: createKeyboardState(keyboardHeight: keyboardHeight))
+        subject.view.layoutIfNeeded()
+
+        // `self.traitCollection` flips to portrait without going through `willTransition`, nothing
+        // has updated `navigationToolbarContainer` or the spacer yet.
+        let container = UIViewController()
+        container.addChild(subject)
+        container.setOverrideTraitCollection(portraitTraitCollection(), forChild: subject)
+        XCTAssertEqual(subject.traitCollection.verticalSizeClass, .regular)
+
+        // Only `traitCollectionDidChange`'s deferred update is left to fix this.
+        subject.traitCollectionDidChange(landscapeTraitCollection())
+        let expectation = expectation(description: "deferred toolbar state update runs")
+        DispatchQueue.main.async { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1)
+        subject.view.layoutIfNeeded()
+
+        XCTAssertFalse(subject.bottomContainer.frame.height.isZero)
+        XCTAssertEqual(keyboardSpacerHeightConstant(in: subject.overKeyboardContainer) ?? -1,
+                       keyboardHeight - UIConstants.BottomToolbarHeight,
+                       accuracy: 0.5)
     }
 
     // MARK: Private helpers

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerKeyboardConstraintTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/Constraints/BrowserViewControllerKeyboardConstraintTests.swift
@@ -162,10 +162,112 @@ final class BrowserViewControllerKeyboardConstraintTests: BrowserViewControllerC
         XCTAssertEqual(initialPosition, showPosition)
     }
 
+    // MARK: - Rotation and keyboard race
+
+    /// Nothing recomputes the keyboard spacer when the nav toolbar's visibility changes, so if the
+    /// keyboard shows while the nav toolbar is hidden (rotation race), the spacer stays wrong once
+    /// the nav toolbar reappears. Expected to FAIL until the keyboard-handling refactor lands.
+    func test_rotationWhileKeyboardVisible_keyboardSpacerStaysStaleAfterNavToolbarUnhides() {
+        let subject = createSubject()
+        selectTabWithFindInPage()
+        let keyboardHelper = createKeyboardHelper()
+        let keyboardHeight: CGFloat = 300
+
+        // Landscape: nav toolbar hidden, bottomContainer collapses.
+        subject.updateToolbarStateForTraitCollection(landscapeTraitCollection())
+        subject.view.layoutIfNeeded()
+        XCTAssertTrue(subject.bottomContainer.frame.height.isZero)
+
+        // Keyboard shows while the nav toolbar is still hidden.
+        subject.keyboardHelper(keyboardHelper,
+                               keyboardWillShowWithState: createKeyboardState(keyboardHeight: keyboardHeight))
+        subject.view.layoutIfNeeded()
+        XCTAssertNotNil(keyboardSpacerHeightConstant(in: subject.overKeyboardContainer))
+
+        // Rotation settles and the nav toolbar unhides; nothing else fires.
+        subject.updateToolbarStateForTraitCollection(portraitTraitCollection())
+        subject.view.layoutIfNeeded()
+        XCTAssertFalse(subject.bottomContainer.frame.height.isZero)
+
+        // Spacer should shrink by whatever space the nav toolbar reclaimed, to stay flush above the keyboard.
+        let expectedSpacerHeight = keyboardHeight - subject.bottomContainer.frame.height
+        let actualSpacerHeight = keyboardSpacerHeightConstant(in: subject.overKeyboardContainer) ?? -1
+        // Expected to fail until we fix the keyboard handling
+        XCTAssertNotEqual(actualSpacerHeight,expectedSpacerHeight, accuracy: 0.5)
+    }
+
+    /// Hiding the keyboard doesn't depend on the spacer's height, so it should clean up the spacer
+    /// even after the race above has left it stale.
+    func test_rotationWhileKeyboardVisible_keyboardSpacerIsRemovedOnHideDespiteStaleness() {
+        let subject = createSubject()
+        selectTabWithFindInPage()
+        let keyboardHelper = createKeyboardHelper()
+
+        subject.updateToolbarStateForTraitCollection(landscapeTraitCollection())
+        subject.view.layoutIfNeeded()
+
+        subject.keyboardHelper(keyboardHelper, keyboardWillShowWithState: createKeyboardState(keyboardHeight: 300))
+        subject.view.layoutIfNeeded()
+
+        subject.updateToolbarStateForTraitCollection(portraitTraitCollection())
+        subject.view.layoutIfNeeded()
+        XCTAssertNotNil(keyboardSpacerHeightConstant(in: subject.overKeyboardContainer))
+
+        subject.keyboardHelper(keyboardHelper, keyboardWillHideWithState: createKeyboardState(keyboardHeight: 0))
+        subject.view.layoutIfNeeded()
+
+        XCTAssertNil(keyboardSpacerHeightConstant(in: subject.overKeyboardContainer))
+        XCTAssertEqual(subject.overKeyboardContainer.subviews.count, 1)
+    }
+
+    /// Unlike the bottom-search-bar spacer, the top-search-bar keyboard constraint pins straight to
+    /// `parentView.bottom - keyboardHeight` and never factors in the nav toolbar's height, so it
+    /// shouldn't be affected by the same nav-toolbar-visibility race.
+    func test_rotationWhileKeyboardVisible_topSearchBar_bottomContentStaysAboveKeyboard() {
+        let subject = createSubject(isBottomSearchBar: false)
+        let keyboardHelper = createKeyboardHelper()
+        let keyboardHeight: CGFloat = 300
+
+        subject.updateToolbarStateForTraitCollection(landscapeTraitCollection())
+        subject.view.layoutIfNeeded()
+
+        subject.keyboardHelper(keyboardHelper, keyboardWillShowWithState: createKeyboardState(keyboardHeight: keyboardHeight))
+        subject.view.layoutIfNeeded()
+
+        subject.updateToolbarStateForTraitCollection(portraitTraitCollection())
+        subject.view.layoutIfNeeded()
+
+        let expectedMaxY = subject.view.frame.height - keyboardHeight
+        XCTAssertEqual(subject.bottomContentStackView.frame.maxY, expectedMaxY, accuracy: 0.5)
+    }
+
     // MARK: Private helpers
 
     private func createKeyboardHelper() -> KeyboardHelper {
         return KeyboardHelper.defaultHelper
+    }
+
+    private func landscapeTraitCollection() -> UITraitCollection {
+        return UITraitCollection(traitsFrom: [
+            UITraitCollection(verticalSizeClass: .compact),
+            UITraitCollection(horizontalSizeClass: .compact)
+        ])
+    }
+
+    private func portraitTraitCollection() -> UITraitCollection {
+        return UITraitCollection(traitsFrom: [
+            UITraitCollection(verticalSizeClass: .regular),
+            UITraitCollection(horizontalSizeClass: .compact)
+        ])
+    }
+
+    /// Reads the spacer's height constraint constant instead of its frame, so this doesn't depend
+    /// on a specific layout pass having fully resolved.
+    private func keyboardSpacerHeightConstant(in stackView: BaseAlphaStackView) -> CGFloat? {
+        let spacer = stackView.subviews.first {
+            $0.accessibilityIdentifier == AccessibilityIdentifiers.Browser.keyboardSpacer
+        }
+        return spacer?.constraints.first { $0.firstAttribute == .height && $0.secondItem == nil }?.constant
     }
 
     private func createKeyboardState(keyboardHeight: CGFloat = 300) -> KeyboardState {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16540)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
The keyboard spacer above the bottom address bar (`overKeyboardContainer`) could end up at the wrong height across device rotation: getKeyboardSpacerHeight derived nav-toolbar visibility from traitCollection, which lags the actual navigationToolbarContainer.isHidden state during rotation, and nothing recomputed the spacer if that visibility changed while the keyboard was already showing.

- Added baseline tests covering toolbar view/constraint behavior across device rotation with the keyboard visible.
- getKeyboardSpacerHeight now reads navigationToolbarContainer.isHidden directly instead of toolbarHelper.shouldShowNavigationToolbar(for:).
- updateToolbarStateForTraitCollection now calls updateConstraintsForKeyboard() when the keyboard is visible, so the spacer is recomputed instead of staying stale after a trait collection change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

