### PR TITLE
Add MTE-5587 Complete Firefox Suggests Test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_integration.py
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTests/test_integration.py
@@ -41,3 +41,7 @@ def test_sync_disconnect_connect_fxa(tps, xcodebuild):
 
 def test_sync_china_fxa_server(xcodebuild):
     xcodebuild.test('XCUITests/IntegrationTests/testFxASyncPageUsingChinaFxA')
+
+def test_sync_tabs_firefox_suggest(tps, xcodebuild):
+    tps.run('test_tabs_desktop.js')
+    xcodebuild.test('XCUITests/IntegrationTests/testFxATabsFirefoxSuggest')

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -14,7 +14,9 @@ private let loginEntry = "https://accounts.google.com"
 private let tabOpenInDesktop = "https://example.com/"
 
 class IntegrationTests: BaseTestCase {
-    let testWithDB = ["testFxASyncHistory"]
+    var browserScreen: BrowserScreen!
+
+    let testWithDB = ["testFxASyncHistory", "testFxAFirefoxSuggest"]
     let testFxAChinaServer = ["testFxASyncPageUsingChinaFxA"]
 
     // This DB contains 1 entry example.com
@@ -43,6 +45,7 @@ class IntegrationTests: BaseTestCase {
         }
         launchArguments.append(LaunchArguments.DisableAnimations)
         try await super.setUp()
+        browserScreen = BrowserScreen(app: app)
     }
 
     func allowNotifications() {
@@ -252,6 +255,27 @@ class IntegrationTests: BaseTestCase {
         app.swipeDown()
         mozWaitForElementToExist(app.tables.otherElements["profile1"])
         XCTAssertTrue(app.tables.staticTexts[tabOpenInDesktop].exists, "The tab is not synced")
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/2576803
+    // [Config] orientation:portrait, orientation:landscape 
+    // Smoketest
+    func testFxATabsFirefoxSuggest() {
+        // Precondition: Sign into Mozilla Account
+        signInFxAccounts()
+        waitForInitialSyncComplete()
+        navigator.nowAt(SettingsScreen)
+        navigator.goto(HomePanelsScreen)
+
+        // Firefox Suggest and Google Search
+        // Synced tab: example.com/
+        browserScreen.tapOnAddressBar()
+        browserScreen.tapClearButtonIfExists()
+        browserScreen.typeOnSearchBar(text: "exam")
+        mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
+        mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Google Search"])
+        mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Firefox Suggest"])
+        mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["Example Domain"])
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306822

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -278,8 +278,8 @@ class IntegrationTests: BaseTestCase {
             mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
             mozWaitForElementToExist(siteTable.otherElements["Google Search"])
             // Firefox Suggest is displayed
-            if !siteTable.otherElements["Firefox Suggest"].exists {
-                siteTable.swipeUp()
+            if XCUIDevice.shared.orientation == UIDeviceOrientation.landscapeLeft {
+                siteTable.cells.firstMatch.swipeUp()
             }
             mozWaitForElementToExist(siteTable.otherElements["Firefox Suggest"])
             mozWaitForElementToExist(siteTable.staticTexts["Example Domain"])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -269,13 +269,21 @@ class IntegrationTests: BaseTestCase {
 
         // Firefox Suggest and Google Search
         // Synced tab: example.com/
-        browserScreen.tapOnAddressBar()
-        browserScreen.tapClearButtonIfExists()
-        browserScreen.typeOnSearchBar(text: "exam")
-        mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
-        mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Google Search"])
-        mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Firefox Suggest"])
-        mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["Example Domain"])
+        let siteTable = app.tables["SiteTable"]
+        for orientation in [UIDeviceOrientation.portrait, UIDeviceOrientation.landscapeLeft] {
+            XCUIDevice.shared.orientation = orientation
+            browserScreen.tapOnAddressBar()
+            browserScreen.tapClearButtonIfExists()
+            browserScreen.typeOnSearchBar(text: "exam")
+            mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
+            mozWaitForElementToExist(siteTable.otherElements["Google Search"])
+            // Firefox Suggest is displayed
+            if !siteTable.otherElements["Firefox Suggest"].exists {
+                siteTable.swipeUp()
+            }
+            mozWaitForElementToExist(siteTable.otherElements["Firefox Suggest"])
+            mozWaitForElementToExist(siteTable.staticTexts["Example Domain"])
+        }
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306822

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -464,6 +464,7 @@ class SearchTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2576803
     // [Config] orientation:portrait, orientation:landscape
+    // Smoketest
     func testFirefoxSuggest() {
         app.launch()
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -458,38 +458,73 @@ class SearchTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2576803
+    // [Config] orientation:portrait, orientation:landscape
     func testFirefoxSuggest() {
-        // In history: mozilla.org
         app.launch()
-        navigator.openURL("https://www.mozilla.org/en-US/")
+
+        // Create an open Tab
+        navigator.openURL("localhost:\(serverPort)/test-fixture/\(TestPages.mozillaOrg)")
         waitUntilPageLoad()
 
-        // Bookmark The Book of Mozilla (on localhost)
-        navigator.createNewTab()
-        navigator.openURL("localhost:\(serverPort)/test-fixture/\(TestPages.mozillaBook)")
+        // Create some history
+        navigator.openNewURL(urlString: "https://www.example.com")
         waitUntilPageLoad()
-        navigator.nowAt(BrowserTab)
-        navigator.goto(BrowserTabMenu)
-        // navigator.goto(SaveBrowserTabMenu)
+        navigator.performAction(Action.CloseTab)
+
+        // Create a bookmark
+        navigator.openNewURL(urlString: "localhost:\(serverPort)/test-fixture/\(TestPages.mozillaBook)")
+        waitUntilPageLoad()
         navigator.performAction(Action.Bookmark)
+        navigator.performAction(Action.CloseTab)
 
-        // Close all tabs so that the search result does not include
-        // current tabs.
-        navigator.performAction(Action.AcceptRemovingAllTabs)
+        // Firefox Suggest should show up for sponsored suggestion, open tab, history
+        // and bookmark.
+        let firefoxSuggestTerms = [
+            "wiki": "Wikipedia - Wiki", // Sponsored suggestion
+            "internet": "Internet for people, not profit — Mozilla", // Open tab
+            "exam": "www.example.com/", // History
+            "book of": "The Book of Mozilla" // Bookmark
+        ]
+        for (term, expectedTitle) in firefoxSuggestTerms {
+            browserScreen.tapOnAddressBar()
+            browserScreen.tapClearButtonIfExists()
+            browserScreen.typeOnSearchBar(text: term)
+            mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
+            mozWaitForElementToExist(app.tables["SiteTable"].staticTexts[expectedTitle])
+            let searchEngines = [
+                "Bing search", "DuckDuckGo search", "Perplexity search", "Wikipedia (en) search", "eBay search"
+            ]
+            for searchEngine in searchEngines {
+                mozWaitForElementToExist(app.scrollViews.buttons[searchEngine])
+            }
+            // Search engine suggestions
+            mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Google Search"])
+            mozWaitForElementToExist(app.tables["SiteTable"].staticTexts[term])
+            mozWaitForElementToExist(
+                app.tables["SiteTable"].buttons[StandardImageIdentifiers.Large.appendDownLeft].firstMatch
+            )
 
-        // Type partial match ("mo") of the history and the bookmark
-        waitForTabsButton()
-        navigator.goto(TabTray)
-        navigator.goto(HomePanelsScreen)
-        typeOnSearchBar(text: "mo")
+            // Firefox Suggest is displayed
+            mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Firefox Suggest"])
+            mozWaitForElementToExist(app.tables["SiteTable"].staticTexts[expectedTitle])
+        }
 
-        // Google Search appears
+        // Non Firefox Suggest result: A random term
+        let term = "heeeeeeellllllllllloooooooo"
+        browserScreen.tapOnAddressBar()
+        browserScreen.tapClearButtonIfExists()
+        browserScreen.typeOnSearchBar(text: term)
+        mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
+        let searchEngines = [
+            "Bing search", "DuckDuckGo search", "Perplexity search", "Wikipedia (en) search", "eBay search"
+        ]
+        for searchEngine in searchEngines {
+            mozWaitForElementToExist(app.scrollViews.buttons[searchEngine])
+        }
+        // Search engine suggestions
         mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Google Search"])
-
-        // Firefox Suggest appears
-        mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Firefox Suggest"])
-        mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["The Book of Mozilla"]) // Bookmark
-        mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["www.mozilla.org/"]) // History
+        mozWaitForElementToExist(app.tables["SiteTable"].staticTexts[term])
+        mozWaitForElementToNotExist(app.tables["SiteTable"].otherElements["Firefox Suggest"])
     }
 
     private func turnOnOffSearchSuggestions(turnOnSwitch: Bool) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -481,6 +481,7 @@ class SearchTests: FeatureFlaggedTestBase {
         waitUntilPageLoad()
         navigator.performAction(Action.Bookmark)
         navigator.performAction(Action.CloseTab)
+        navigator.performAction(Action.OpenNewTabFromTabTray)
 
         let siteTable = app.tables["SiteTable"]
 
@@ -512,8 +513,8 @@ class SearchTests: FeatureFlaggedTestBase {
                 mozWaitForElementToExist(siteTable.staticTexts[term])
 
                 // Firefox Suggest is displayed
-                if !siteTable.otherElements["Firefox Suggest"].exists {
-                    siteTable.swipeUp()
+                if XCUIDevice.shared.orientation == UIDeviceOrientation.landscapeLeft {
+                    siteTable.cells.firstMatch.swipeUp()
                 }
                 mozWaitForElementToExist(siteTable.otherElements["Firefox Suggest"])
                 mozWaitForElementToExist(siteTable.staticTexts[expectedTitle])

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -29,7 +29,7 @@ class SearchTests: FeatureFlaggedTestBase {
         searchSettingsScreen = SearchSettingsScreen(app: app)
         searchScreen = SearchScreen(app: app)
     }
-    
+
     override func tearDown() async throws {
         XCUIDevice.shared.orientation = .portrait
         try await super.tearDown()
@@ -483,7 +483,7 @@ class SearchTests: FeatureFlaggedTestBase {
         navigator.performAction(Action.CloseTab)
 
         let siteTable = app.tables["SiteTable"]
-        
+
         for orientation in [UIDeviceOrientation.portrait, UIDeviceOrientation.landscapeLeft] {
             XCUIDevice.shared.orientation = orientation
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -29,6 +29,11 @@ class SearchTests: FeatureFlaggedTestBase {
         searchSettingsScreen = SearchSettingsScreen(app: app)
         searchScreen = SearchScreen(app: app)
     }
+    
+    override func tearDown() async throws {
+        XCUIDevice.shared.orientation = .portrait
+        try await super.tearDown()
+    }
 
     private func typeOnSearchBar(text: String) {
         browserScreen.tapOnAddressBar()
@@ -477,20 +482,49 @@ class SearchTests: FeatureFlaggedTestBase {
         navigator.performAction(Action.Bookmark)
         navigator.performAction(Action.CloseTab)
 
-        // Firefox Suggest should show up for sponsored suggestion, open tab, history
-        // and bookmark.
-        let firefoxSuggestTerms = [
-            "wiki": "Wikipedia - Wiki", // Sponsored suggestion
-            "internet": "Internet for people, not profit — Mozilla", // Open tab
-            "exam": "www.example.com/", // History
-            "book of": "The Book of Mozilla" // Bookmark
-        ]
-        for (term, expectedTitle) in firefoxSuggestTerms {
+        let siteTable = app.tables["SiteTable"]
+        
+        for orientation in [UIDeviceOrientation.portrait, UIDeviceOrientation.landscapeLeft] {
+            XCUIDevice.shared.orientation = orientation
+
+            // Firefox Suggest should show up for sponsored suggestion, open tab, history
+            // and bookmark.
+            let firefoxSuggestTerms = [
+                "wiki": "Wikipedia - Wiki", // Sponsored suggestion
+                "internet": "Internet for people, not profit — Mozilla", // Open tab
+                "exam": "www.example.com/", // History
+                "book of": "The Book of Mozilla" // Bookmark
+            ]
+            for (term, expectedTitle) in firefoxSuggestTerms {
+                browserScreen.tapOnAddressBar()
+                browserScreen.tapClearButtonIfExists()
+                browserScreen.typeOnSearchBar(text: term)
+                mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
+                mozWaitForElementToExist(siteTable.staticTexts[expectedTitle])
+                let searchEngines = [
+                    "Bing search", "DuckDuckGo search", "Perplexity search", "Wikipedia (en) search", "eBay search"
+                ]
+                for searchEngine in searchEngines {
+                    mozWaitForElementToExist(app.scrollViews.buttons[searchEngine])
+                }
+                // Search engine suggestions
+                mozWaitForElementToExist(siteTable.otherElements["Google Search"])
+                mozWaitForElementToExist(siteTable.staticTexts[term])
+
+                // Firefox Suggest is displayed
+                if !siteTable.otherElements["Firefox Suggest"].exists {
+                    siteTable.swipeUp()
+                }
+                mozWaitForElementToExist(siteTable.otherElements["Firefox Suggest"])
+                mozWaitForElementToExist(siteTable.staticTexts[expectedTitle])
+            }
+
+            // Non Firefox Suggest result: A random term
+            let term = "heeeeeeellllllllllloooooooo"
             browserScreen.tapOnAddressBar()
             browserScreen.tapClearButtonIfExists()
             browserScreen.typeOnSearchBar(text: term)
             mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
-            mozWaitForElementToExist(app.tables["SiteTable"].staticTexts[expectedTitle])
             let searchEngines = [
                 "Bing search", "DuckDuckGo search", "Perplexity search", "Wikipedia (en) search", "eBay search"
             ]
@@ -498,33 +532,10 @@ class SearchTests: FeatureFlaggedTestBase {
                 mozWaitForElementToExist(app.scrollViews.buttons[searchEngine])
             }
             // Search engine suggestions
-            mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Google Search"])
-            mozWaitForElementToExist(app.tables["SiteTable"].staticTexts[term])
-            mozWaitForElementToExist(
-                app.tables["SiteTable"].buttons[StandardImageIdentifiers.Large.appendDownLeft].firstMatch
-            )
-
-            // Firefox Suggest is displayed
-            mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Firefox Suggest"])
-            mozWaitForElementToExist(app.tables["SiteTable"].staticTexts[expectedTitle])
+            mozWaitForElementToExist(siteTable.otherElements["Google Search"])
+            mozWaitForElementToExist(siteTable.staticTexts[term])
+            mozWaitForElementToNotExist(siteTable.otherElements["Firefox Suggest"])
         }
-
-        // Non Firefox Suggest result: A random term
-        let term = "heeeeeeellllllllllloooooooo"
-        browserScreen.tapOnAddressBar()
-        browserScreen.tapClearButtonIfExists()
-        browserScreen.typeOnSearchBar(text: term)
-        mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
-        let searchEngines = [
-            "Bing search", "DuckDuckGo search", "Perplexity search", "Wikipedia (en) search", "eBay search"
-        ]
-        for searchEngine in searchEngines {
-            mozWaitForElementToExist(app.scrollViews.buttons[searchEngine])
-        }
-        // Search engine suggestions
-        mozWaitForElementToExist(app.tables["SiteTable"].otherElements["Google Search"])
-        mozWaitForElementToExist(app.tables["SiteTable"].staticTexts[term])
-        mozWaitForElementToNotExist(app.tables["SiteTable"].otherElements["Firefox Suggest"])
     }
 
     private func turnOnOffSearchSuggestions(turnOnSwitch: Bool) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5586)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Let me enumerate all scenarios that Firefox Suggest searches would appear:
* History
* Open tabs
* Synced tabs (via sync integration test)
* Bookmark
* History
* Sponsored suggestions

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

`testFirefoxSuggest()`
https://github.com/user-attachments/assets/cb64fcc3-3b12-4712-a849-b22a2c5309c5

`testFxATabsFirefoxSuggest()`
https://github.com/user-attachments/assets/72bb4ac8-e1ee-48ee-87c0-414c5ab49a62



| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

