### PR TITLE
Add MTE-5790 Supported search engines

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -177,6 +177,7 @@
         "ScreenGraphTest",
         "SearchSettingsUITests",
         "SearchTests\/testBottomVIewURLBar_TAE()",
+        "SearchTests\/testDefaultSearchEngines()",
         "SearchTests\/testOpenTabsInSearchSuggestions_TAE()",
         "SearchTests\/testRecentSearchesSettingsToggleOff_recentSearchesExperimentOn()",
         "SearchTests\/testRecentSearchesSettingsToggleOn_recentSearchesExperimentOn()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -534,6 +534,7 @@
         "SearchTests\/testBottomVIewURLBar_TAE()",
         "SearchTests\/testCopyPasteComplete()",
         "SearchTests\/testDefaultSearchEngine()",
+        "SearchTests\/testDefaultSearchEngines()",
         "SearchTests\/testDismissPromptPresence()",
         "SearchTests\/testDoNotShowSuggestionsWhenEnteringURL()",
         "SearchTests\/testFirefoxSuggest()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SearchSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SearchSettingsScreen.swift
@@ -12,6 +12,10 @@ final class SearchSettingsScreen {
     private var navBar: XCUIElement { sel.NAVBAR.element(in: app) }
     private var trendingSearchesToggle: XCUIElement { sel.TRENDING_SEARCH_SWITCH.element(in: app) }
     private var recentSearchesToggle: XCUIElement { sel.RECENT_SEARCH_SWITCH.element(in: app) }
+    private var defaultSearchEngineSectionTitle: XCUIElement { sel.DEFAULT_SEARCH_ENGINE_SECTION_TITLE.element(in: app) }
+    private var alternativeSearchEnginesSectionTitle: XCUIElement {
+        sel.ALTERNATIVE_SEARCH_ENGINES_SECTION_TITLE.element(in: app)
+    }
 
     init(app: XCUIApplication, selectors: SearchSettingsSelectorsSet = SearchSettingsSelectors()) {
         self.app = app
@@ -77,5 +81,17 @@ final class SearchSettingsScreen {
     func waitForSearchEngineSelectionComplete(timeout: TimeInterval = TIMEOUT) {
         let defaultSearchEngineNavBar = sel.DEFAULT_SEARCH_ENGINE_NAVBAR.element(in: app)
         BaseTestCase().mozWaitForElementToNotExist(defaultSearchEngineNavBar, timeout: timeout)
+    }
+
+    func assertDefaultSearchEngineSectionExists() {
+        BaseTestCase().mozWaitForElementToExist(defaultSearchEngineSectionTitle)
+    }
+
+    func assertAlternativeSearchEnginesSectionExists() {
+        BaseTestCase().mozWaitForElementToExist(alternativeSearchEnginesSectionTitle)
+    }
+
+    func assertSearchEngineExists(named engineName: String) {
+        BaseTestCase().mozWaitForElementToExist(sel.searchEngineRow(named: engineName).element(in: app))
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -492,6 +492,17 @@ class SearchTests: FeatureFlaggedTestBase {
         mozWaitForElementToExist(app.tables["SiteTable"].staticTexts["www.mozilla.org/"]) // History
     }
 
+    // https://mozilla.testrail.io/index.php?/cases/view/3209706
+    func testDefaultSearchEngines() {
+        app.launch()
+        navigator.goto(SearchSettings)
+        mozWaitForElementToExist(app.staticTexts["Default Search Engine"])
+        mozWaitForElementToExist(app.staticTexts["Alternative Search Engines"])
+        for searchEngine in ["Google", "Bing", "DuckDuckGo", "Perplexity", "Wikipedia (en)", "eBay"] {
+            mozWaitForElementToExist(app.tables.staticTexts[searchEngine])
+        }
+    }
+
     private func turnOnOffSearchSuggestions(turnOnSwitch: Bool) {
         let showSearchSuggestions = app.switches[AccessibilityIdentifiers.Settings.Search.showSearchSuggestions]
         mozWaitForElementToExist(showSearchSuggestions)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -496,10 +496,10 @@ class SearchTests: FeatureFlaggedTestBase {
     func testDefaultSearchEngines() {
         app.launch()
         navigator.goto(SearchSettings)
-        mozWaitForElementToExist(app.staticTexts["Default Search Engine"])
-        mozWaitForElementToExist(app.staticTexts["Alternative Search Engines"])
+        searchSettingsScreen.assertDefaultSearchEngineSectionExists()
+        searchSettingsScreen.assertAlternativeSearchEnginesSectionExists()
         for searchEngine in ["Google", "Bing", "DuckDuckGo", "Perplexity", "Wikipedia (en)", "eBay"] {
-            mozWaitForElementToExist(app.tables.staticTexts[searchEngine])
+            searchSettingsScreen.assertSearchEngineExists(named: searchEngine)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SearchSettingsSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SearchSettingsSelectors.swift
@@ -11,6 +11,9 @@ protocol SearchSettingsSelectorsSet {
     var TRENDING_SEARCH_SWITCH: Selector { get }
     var RECENT_SEARCH_SWITCH: Selector { get }
     var DEFAULT_SEARCH_ENGINE_NAVBAR: Selector { get }
+    var DEFAULT_SEARCH_ENGINE_SECTION_TITLE: Selector { get }
+    var ALTERNATIVE_SEARCH_ENGINES_SECTION_TITLE: Selector { get }
+    func searchEngineRow(named engineName: String) -> Selector
     var all: [Selector] { get }
 }
 
@@ -22,6 +25,8 @@ struct SearchSettingsSelectors: SearchSettingsSelectorsSet {
         static let backButtoniOS26          = AccessibilityIdentifiers.Settings.Search.backButtoniOS26
         static let backButton               = AccessibilityIdentifiers.Settings.Search.backButton
         static let defaultSearchEngineNavBar = "Default Search Engine"
+        static let defaultSearchEngineSectionTitle = "Default Search Engine"
+        static let alternativeSearchEnginesSectionTitle = "Alternative Search Engines"
     }
 
     let NAVBAR = Selector.navigationBarId(
@@ -60,7 +65,30 @@ struct SearchSettingsSelectors: SearchSettingsSelectorsSet {
         groups: ["settings", "search"]
     )
 
+    let DEFAULT_SEARCH_ENGINE_SECTION_TITLE = Selector.staticTextByExactLabel(
+        IDs.defaultSearchEngineSectionTitle,
+        description: "Section title for the default search engine on Settings → Search",
+        groups: ["settings", "search"]
+    )
+
+    let ALTERNATIVE_SEARCH_ENGINES_SECTION_TITLE = Selector.staticTextByExactLabel(
+        IDs.alternativeSearchEnginesSectionTitle,
+        description: "Section title for alternative search engines on Settings → Search",
+        groups: ["settings", "search"]
+    )
+
+    func searchEngineRow(named engineName: String) -> Selector {
+        Selector.staticTextInTablesByLabel(
+            engineName,
+            description: "Row for '\(engineName)' search engine on Settings → Search",
+            groups: ["settings", "search"]
+        )
+    }
+
     var all: [Selector] {
-        [NAVBAR, BACK_BUTTON_iOS26, BACK_BUTTON, TRENDING_SEARCH_SWITCH, RECENT_SEARCH_SWITCH, DEFAULT_SEARCH_ENGINE_NAVBAR]
+        [
+            NAVBAR, BACK_BUTTON_iOS26, BACK_BUTTON, TRENDING_SEARCH_SWITCH, RECENT_SEARCH_SWITCH,
+            DEFAULT_SEARCH_ENGINE_NAVBAR, DEFAULT_SEARCH_ENGINE_SECTION_TITLE, ALTERNATIVE_SEARCH_ENGINES_SECTION_TITLE
+        ]
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5790)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Firefox iOS lists the following search engine choices: Google, Bing, DuckDuckGo, Perplexity, Wikipedia and eBay.
<img width="400" alt="Simulator Screenshot - iPhone 17e - 2026-08-07 at 18 02 23" src="https://github.com/user-attachments/assets/9ffcbe36-0b85-4397-8822-4b5ad50e7bfd" />
https://mozilla.testrail.io/index.php?/cases/view/3209706

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

