### PR TITLE
[no-ticket] Experiment: run UnitTest with 2 parallel simulator clones

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -211,7 +211,7 @@ workflows:
         timeout: 1200
         inputs:
         - destination: platform=iOS Simulator,name=iPhone 17,OS=26.5
-        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"'
+        - xcodebuild_options: '"COMPILER_INDEX_STORE_ENABLE=NO" "CODE_SIGN_IDENTITY=" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO" -parallel-testing-enabled YES -maximum-concurrent-test-simulator-destinations 2'
         - xctestrun: $BITRISE_TEST_BUNDLE_PATH/Fennec_UnitTest_iphonesimulator26.5-arm64.xctestrun
         - maximum_test_repetitions: 2
     - xcode-test-shard-calculation@0:


### PR DESCRIPTION
## :scroll: Tickets
No ticket — CI experiment.

## :bulb: Description
Enables xcodebuild's built-in parallel testing (`-parallel-testing-enabled YES -maximum-concurrent-test-simulator-destinations 2`) for the Fennec UnitTest step in `bitrise.yml`, so unit test classes are distributed across 2 simulator clones instead of running serially on one.

This is a draft to validate actual wall-clock time savings on a real Bitrise run before deciding whether to merge. Downstream steps that consume `$BITRISE_XCRESULT_PATH` / `$BITRISE_XCODE_RAW_RESULT_TEXT_PATH` (warning detection, Danger coverage) shouldn't need changes since this is still a single `xcodebuild` invocation producing one merged result bundle.

## :movie_camera: Demos
N/A — CI config change, will check the Bitrise build log/timing for this PR.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code