### PR TITLE
Refactor FXIOS-15358 [Microsurvey] Use @Copyable macro for MicrosurveyState

### DIFF
--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -4,7 +4,9 @@
 
 import Redux
 import Common
+import CopyWithUpdates
 
+@CopyWithUpdates
 struct MicrosurveyState: ScreenState {
     var windowUUID: WindowUUID
     var shouldDismiss: Bool
@@ -20,11 +22,7 @@ struct MicrosurveyState: ScreenState {
             return
         }
 
-        self.init(
-            windowUUID: microsurveyState.windowUUID,
-            shouldDismiss: microsurveyState.shouldDismiss,
-            showPrivacy: microsurveyState.showPrivacy
-        )
+        self = microsurveyState.copyWithUpdates()
     }
 
     init(
@@ -58,27 +56,15 @@ struct MicrosurveyState: ScreenState {
 
         switch action.actionType {
         case MicrosurveyActionType.closeSurvey:
-            return MicrosurveyState(
-                windowUUID: state.windowUUID,
-                shouldDismiss: true,
-                showPrivacy: false
-            )
+            return state.copyWithUpdates(shouldDismiss: true, showPrivacy: false)
         case MicrosurveyActionType.tapPrivacyNotice:
-            return MicrosurveyState(
-                windowUUID: state.windowUUID,
-                shouldDismiss: false,
-                showPrivacy: true
-            )
+            return state.copyWithUpdates(shouldDismiss: false, showPrivacy: true)
         default:
             return defaultState(from: state)
         }
     }
 
     static func defaultState(from state: MicrosurveyState) -> MicrosurveyState {
-        return MicrosurveyState(
-            windowUUID: state.windowUUID,
-            shouldDismiss: false,
-            showPrivacy: false
-        )
+        return state.copyWithUpdates(shouldDismiss: false, showPrivacy: false)
     }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -4,9 +4,9 @@
 
 import Redux
 import Common
-import CopyWithUpdates
+import ModifiedCopy
 
-@CopyWithUpdates
+@Copyable
 struct MicrosurveyState: ScreenState {
     var windowUUID: WindowUUID
     var shouldDismiss: Bool
@@ -22,7 +22,11 @@ struct MicrosurveyState: ScreenState {
             return
         }
 
-        self = microsurveyState.copyWithUpdates()
+        self.init(
+            windowUUID: microsurveyState.windowUUID,
+            shouldDismiss: microsurveyState.shouldDismiss,
+            showPrivacy: microsurveyState.showPrivacy
+        )
     }
 
     init(
@@ -56,15 +60,15 @@ struct MicrosurveyState: ScreenState {
 
         switch action.actionType {
         case MicrosurveyActionType.closeSurvey:
-            return state.copyWithUpdates(shouldDismiss: true, showPrivacy: false)
+            return state.copy(shouldDismiss: true, showPrivacy: false)
         case MicrosurveyActionType.tapPrivacyNotice:
-            return state.copyWithUpdates(shouldDismiss: false, showPrivacy: true)
+            return state.copy(shouldDismiss: false, showPrivacy: true)
         default:
             return defaultState(from: state)
         }
     }
 
     static func defaultState(from state: MicrosurveyState) -> MicrosurveyState {
-        return state.copyWithUpdates(shouldDismiss: false, showPrivacy: false)
+        return state.copy(shouldDismiss: false, showPrivacy: false)
     }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -73,8 +73,10 @@ struct MicrosurveyState: ScreenState {
     }
 
     static func defaultState(from state: MicrosurveyState) -> MicrosurveyState {
-        return state
-            .copy(shouldDismiss: false)
-            .copy(showPrivacy: false)
+        return MicrosurveyState(
+            windowUUID: state.windowUUID,
+            shouldDismiss: false,
+            showPrivacy: false
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -60,15 +60,21 @@ struct MicrosurveyState: ScreenState {
 
         switch action.actionType {
         case MicrosurveyActionType.closeSurvey:
-            return state.copy(shouldDismiss: true, showPrivacy: false)
+            return state
+                .copy(shouldDismiss: true)
+                .copy(showPrivacy: false)
         case MicrosurveyActionType.tapPrivacyNotice:
-            return state.copy(shouldDismiss: false, showPrivacy: true)
+            return state
+                .copy(shouldDismiss: false)
+                .copy(showPrivacy: true)
         default:
             return defaultState(from: state)
         }
     }
 
     static func defaultState(from state: MicrosurveyState) -> MicrosurveyState {
-        return state.copy(shouldDismiss: false, showPrivacy: false)
+        return state
+            .copy(shouldDismiss: false)
+            .copy(showPrivacy: false)
     }
 }


### PR DESCRIPTION
## :scroll: Tickets 
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15358)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32945)

## :bulb: Description
Refactors `MicrosurveyState` to use the `@CopyWithUpdates` macro instead of manually reconstructing the struct with every field on each state transition. This follows the same pattern applied in #32214 (e.g. `SearchEngineSelectionState`).

- Added `@CopyWithUpdates` to `MicrosurveyState` and imported `CopyWithUpdates`.
- Replaced manual `MicrosurveyState(windowUUID:shouldDismiss:showPrivacy:)` calls in `legacyReducer` and `defaultState(from:)` with `state.copyWithUpdates(...)`, passing only the fields that change.
- Replaced the manual field copy in `init(appState:uuid:)` with `self = microsurveyState.copyWithUpdates()`.

This is a pure refactor — no behavior change, no new public API surface.

## :movie_camera: Demos
Not applicable — internal state/reducer refactor with no UI changes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [[PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [[data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg)](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [[guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog)](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code