### PR TITLE
Bugfix FXIOS-16528 [Website Data] Prevent Clear Items title truncation

### DIFF
--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedCenteredTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedCenteredTableViewCell.swift
@@ -46,10 +46,10 @@ class ThemedCenteredTableViewCell: ThemedTableViewCell {
             centeredLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             centeredLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             centeredLabel.leadingAnchor.constraint(
-                greaterThanOrEqualTo: contentView.leadingAnchor,
+                equalTo: contentView.leadingAnchor,
                 constant: UX.labelMargin),
             centeredLabel.trailingAnchor.constraint(
-                lessThanOrEqualTo: contentView.trailingAnchor,
+                equalTo: contentView.trailingAnchor,
                 constant: -UX.labelMargin)
         ])
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16528)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35069)

## :bulb: Description
Ensures the centered Website Data action label uses the full available cell width. This prevents the selected-item count in the Clear Items button from truncating when the title grows after additional websites are selected.

## :movie_camera: Demos
The original issue includes the before-state recording. The change is limited to the action label Auto Layout constraints.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass; no new behavior logic was introduced
- [x] Dynamic Text and VoiceOver semantics remain unchanged; the label now receives the available width
- [x] No telemetry was added or modified
- [x] No strings were added or modified
- [x] No documentation changes or explanatory comments are needed