### PR TITLE
Bugfix FXIOS-16482 [WebCompat] Size the issue type selector chevron to the design

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatCategoryMenuCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatCategoryMenuCell.swift
@@ -10,13 +10,22 @@ import UIKit
 final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
     private var selectionHandler: ((String) -> Void)?
     private var chevronSizeConstraints: [NSLayoutConstraint] = []
+    private var chevronUpBottomConstraint: NSLayoutConstraint?
+    private var chevronDownTopConstraint: NSLayoutConstraint?
 
     private var scaledChevronSize: CGFloat {
         return UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.Chevron.size)
     }
 
+    private var scaledChevronVerticalOverlap: CGFloat {
+        return UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.Chevron.verticalOverlap)
+    }
+
     private lazy var menuButton: UIButton = {
-        let button = UIButton(configuration: UIButton.Configuration.plain())
+        var configuration = UIButton.Configuration.plain()
+        // `plain()`'s 12pt leading inset would stack on the cell's own layout margin.
+        configuration.contentInsets.leading = 0
+        let button = UIButton(configuration: configuration)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.contentHorizontalAlignment = .leading
         button.showsMenuAsPrimaryAction = true
@@ -75,6 +84,10 @@ final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
         let bottomConstraint = menuButton.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
         topConstraint.priority = .defaultHigh
         bottomConstraint.priority = .defaultHigh
+        let chevronUpBottom = chevronUpView.bottomAnchor.constraint(equalTo: contentView.centerYAnchor)
+        let chevronDownTop = chevronDownView.topAnchor.constraint(equalTo: contentView.centerYAnchor)
+        chevronUpBottomConstraint = chevronUpBottom
+        chevronDownTopConstraint = chevronDownTop
         NSLayoutConstraint.activate(chevronSizeConstraints + [
             menuButton.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
             topConstraint,
@@ -85,10 +98,10 @@ final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
             ),
 
             chevronUpView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
-            chevronUpView.bottomAnchor.constraint(equalTo: contentView.centerYAnchor),
+            chevronUpBottom,
 
             chevronDownView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
-            chevronDownView.topAnchor.constraint(equalTo: contentView.centerYAnchor)
+            chevronDownTop
         ])
         applyScaledMetrics()
     }
@@ -102,10 +115,13 @@ final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
         }
     }
 
-    /// Keeps the chevron and the button's reserved trailing space in step with
+    /// Keeps the chevron metrics and the button's reserved trailing space in step with
     /// the current Dynamic Type size.
     private func applyScaledMetrics() {
         chevronSizeConstraints.forEach { $0.constant = scaledChevronSize }
+        let halfOverlap = scaledChevronVerticalOverlap / 2
+        chevronUpBottomConstraint?.constant = halfOverlap
+        chevronDownTopConstraint?.constant = -halfOverlap
         menuButton.configuration?.contentInsets.trailing = scaledChevronSize + WebCompatReporterUX.Spacing.interItem
     }
 

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -29,7 +29,11 @@ enum WebCompatReporterUX {
     }
 
     enum Chevron {
-        static let size: CGFloat = 10
+        /// Frame, not arrow: the Acorn PDFs centre a 15 x 7.6pt arrow on a 24pt canvas.
+        static let size: CGFloat = 16
+
+        /// Cancels the canvas padding that would otherwise hold the two arrows apart.
+        static let verticalOverlap: CGFloat = 5
     }
 
     enum DetailsField {


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16482](https://mozilla-hub.atlassian.net/browse/FXIOS-16482)

## :bulb: Description
The chevron frame was 10pt, but the Acorn PDFs centre a 15 x 7.6pt arrow on a 24pt canvas, so it only ever drew a ~6pt arrow and the leftover padding held the two halves apart. This sizes the frame so the visible arrow matches the design, and pulls the pair together to absorb that padding.

`plain()` also ships a 12pt leading inset that stacked on the cell's own layout margin and pushed the title right of every other row in the sheet. That one is now zeroed.

## :movie_camera: Demos

| Before | After |
| - | - |
| <img width="689" height="1500" alt="fxios-16482-before" src="https://github.com/user-attachments/assets/642d243e-03d7-4bee-825a-1664b14a9246" /> | <img width="689" height="1500" alt="fxios-16482-after" src="https://github.com/user-attachments/assets/2c239be8-7df5-45b5-8812-04831ef0e1f0" /> |



## :test_tube: Testing
Open the ⋯ menu → **Report Broken Site** and look at the **Choose issue type…** row. The chevron should match Figma, and the title should line up with the **URL** label above it.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


[FXIOS-16482]: https://mozilla-hub.atlassian.net/browse/FXIOS-16482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ