### PR TITLE
Bugfix FXIOS-16414 [Bookmarks] Cache groupSections in GroupedEditFolderViewController

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
@@ -385,8 +385,18 @@ final class GroupedEditFolderViewController: UIViewController,
 
     // MARK: - Helpers
 
-    // TODO: FXIOS-16414 Add a caching mechanism to avoid constant computation
+    private var cachedGroupSections: (folderGroups: [FolderGroup], sections: [(groupIndex: Int, blockIndex: Int)])?
+
     private var groupSections: [(groupIndex: Int, blockIndex: Int)] {
+        if let cachedGroupSections, cachedGroupSections.folderGroups == viewModel.folderGroups {
+            return cachedGroupSections.sections
+        }
+        let sections = computeGroupSections()
+        cachedGroupSections = (viewModel.folderGroups, sections)
+        return sections
+    }
+
+    private func computeGroupSections() -> [(groupIndex: Int, blockIndex: Int)] {
         var result: [(groupIndex: Int, blockIndex: Int)] = []
         for (groupIndex, group) in viewModel.folderGroups.enumerated() {
             guard group.isExpanded, !group.folders.isEmpty else {

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/GroupedFolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/GroupedFolderHierarchyFetcher.swift
@@ -39,7 +39,7 @@ struct GroupedFolder: Equatable, Hashable {
 struct FolderGroup: Equatable, Identifiable {
     let id: String
     let title: String
-    var folders: [GroupedFolder]
+    let folders: [GroupedFolder]
     var isExpanded: Bool
     let blocks: [Block]
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/GroupedFolderHierarchyFetcher.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Utitlity/GroupedFolderHierarchyFetcher.swift
@@ -41,6 +41,7 @@ struct FolderGroup: Equatable, Identifiable {
     let title: String
     var folders: [GroupedFolder]
     var isExpanded: Bool
+    let blocks: [Block]
 
     static let mobileGroupID = "group.mobile"
     static let desktopGroupID = "group.desktop"
@@ -49,7 +50,15 @@ struct FolderGroup: Equatable, Identifiable {
         let folders: [GroupedFolder]
     }
 
-    var blocks: [Block] {
+    init(id: String, title: String, folders: [GroupedFolder], isExpanded: Bool) {
+        self.id = id
+        self.title = title
+        self.folders = folders
+        self.isExpanded = isExpanded
+        self.blocks = Self.makeBlocks(from: folders)
+    }
+
+    private static func makeBlocks(from folders: [GroupedFolder]) -> [Block] {
         var result: [Block] = []
         var current: [GroupedFolder] = []
         for folder in folders {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewControllerTests.swift
@@ -114,6 +114,59 @@ final class GroupedEditFolderViewControllerTests: XCTestCase {
         XCTAssertEqual(viewModel.folderGroups[0].isExpanded, !wasExpanded)
     }
 
+    func test_toggleGroup_collapsingMultiBlockGroup_updatesSectionCountWithoutStaleCache() {
+        let folderA = GroupedFolder(title: "A", guid: "a", indentation: 0)
+        let folderB = GroupedFolder(title: "B", guid: "b", indentation: 0)
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        fetcher.mockFolderStructures = [folderA, folderB]
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        beginBrowsingAndWait(viewModel, subject: subject)
+        XCTAssertEqual(subject.numberOfSections(in: subject.tableView), 3)
+
+        let header = subject.tableView(subject.tableView, viewForHeaderInSection: 1) as? FolderSectionHeaderView
+        header?.onTap?()
+
+        XCTAssertEqual(subject.numberOfSections(in: subject.tableView), 2)
+    }
+
+    func test_reload_afterNewRootFolderAdded_updatesSectionCountWithoutStaleCache() {
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        fetcher.mockFolderStructures = [GroupedFolder(title: "A", guid: "a", indentation: 0)]
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        beginBrowsingAndWait(viewModel, subject: subject)
+        let sectionsBeforeReload = subject.numberOfSections(in: subject.tableView)
+
+        fetcher.mockFolderStructures = [
+            GroupedFolder(title: "A", guid: "a", indentation: 0),
+            GroupedFolder(title: "B", guid: "b", indentation: 0)
+        ]
+        beginBrowsingAndWait(viewModel, subject: subject)
+
+        XCTAssertEqual(subject.numberOfSections(in: subject.tableView), sectionsBeforeReload + 1)
+    }
+
+    func test_reload_afterNestedFolderAdded_updatesRowCountWithoutStaleCache() {
+        let fetcher = MockGroupedFolderHierarchyFetcher()
+        fetcher.mockFolderStructures = [GroupedFolder(title: "A", guid: "a", indentation: 0)]
+        let viewModel = createViewModel(folderFetcher: fetcher)
+        let subject = createSubject(viewModel: viewModel)
+
+        beginBrowsingAndWait(viewModel, subject: subject)
+        XCTAssertEqual(subject.tableView(subject.tableView, numberOfRowsInSection: 1), 1)
+
+        fetcher.mockFolderStructures = [
+            GroupedFolder(title: "A", guid: "a", indentation: 0),
+            GroupedFolder(title: "A-child", guid: "a-child", indentation: 1)
+        ]
+        beginBrowsingAndWait(viewModel, subject: subject)
+
+        XCTAssertEqual(subject.tableView(subject.tableView, numberOfRowsInSection: 1), 2)
+    }
+
     func test_saveButtonAction_popsViewController() {
         let subject = createSubject()
         let navController = UINavigationController()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16414)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35072)

## :bulb: Description
`groupSections` on `GroupedEditFolderViewController` recomputed its full section/block index list from scratch on every table view data source call (`numberOfSections`, `numberOfRowsInSection`, `cellForRowAt`, etc.), and `FolderGroup.blocks` was itself a computed property doing the same work on every access — an O(n) recompute repeated many times per table view layout pass.

This change:
- Makes `FolderGroup.blocks` a stored property, computed once in `FolderGroup.init`.
- Caches `groupSections` in the view controller, keyed on `viewModel.folderGroups`, and only recomputes when `folderGroups` actually changes (new fetch, toggled group expansion, etc.).

No behavior or UI change — this is a performance-only fix. Added regression tests covering cache invalidation on group toggle and on folder structure reload.

## :movie_camera: Demos
No UI change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code