### PR TITLE
Refactor FXIOS-16540 how to use keyboardLayoutGuide for to update toolbar related to keybord changes

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/BrowserViewControllerLayoutManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/BrowserViewControllerLayoutManager.swift
@@ -17,6 +17,11 @@ final class BrowserViewControllerLayoutManager {
     private let toolbarHelper: ToolbarHelperInterface
     private weak var scrollController: LegacyTabScrollProvider?
 
+    /// Anchor to keep `overKeyboardContainer` testable. Injectable so tests can supply a fake, fully
+    /// controllable guide instead of depending on a real system keyboard. `nil` in production for now.
+    /// Allows us to have a baseline test before integrating `keyboardLayoutGuide`
+    private let keyboardTopAnchor: NSLayoutYAxisAnchor?
+
     // Constraints to store - header
     var headerTopConstraintReference: ConstraintReference?
     private var headerTopConstraint: NSLayoutConstraint?
@@ -30,6 +35,7 @@ final class BrowserViewControllerLayoutManager {
     private var bottomContentStackViewOverKeyboardConstraint: NSLayoutConstraint?
     private var overKeyboardContainerTopZoomHeightConstraint: NSLayoutConstraint?
     private var overKeyboardContainerTopHeightConstraint: NSLayoutConstraint?
+    private var overKeyboardContainerKeyboardConstraint: NSLayoutConstraint?
 
     init(parentView: UIView,
          headerView: UIView,
@@ -37,7 +43,8 @@ final class BrowserViewControllerLayoutManager {
          overKeyboardContainer: BaseAlphaStackView,
          bottomContentStackView: BaseAlphaStackView,
          navigationToolbarContainer: UIView,
-         toolbarHelper: ToolbarHelperInterface = ToolbarHelper()) {
+         toolbarHelper: ToolbarHelperInterface = ToolbarHelper(),
+         keyboardTopAnchor: NSLayoutYAxisAnchor? = nil) {
         self.parentView = parentView
         self.headerView = headerView
         self.bottomContainer = bottomContainer
@@ -45,6 +52,7 @@ final class BrowserViewControllerLayoutManager {
         self.bottomContentStackView = bottomContentStackView
         self.navigationToolbarContainer = navigationToolbarContainer
         self.toolbarHelper = toolbarHelper
+        self.keyboardTopAnchor = keyboardTopAnchor
     }
 
     func setScrollController(_ scrollController: LegacyTabScrollProvider?) {
@@ -112,11 +120,18 @@ final class BrowserViewControllerLayoutManager {
         ])
 
         let constraint = overKeyboardContainer.bottomAnchor.constraint(equalTo: bottomContainer.topAnchor)
+        constraint.priority = .defaultHigh
         constraint.isActive = true
         let constraintReference = ConstraintReference(native: constraint)
 
         scrollController?.overKeyboardContainerConstraint = constraintReference
         overKeyboardContainerConstraint = constraintReference
+
+        if let keyboardTopAnchor {
+            overKeyboardContainerKeyboardConstraint = overKeyboardContainer.bottomAnchor.constraint(
+                lessThanOrEqualTo: keyboardTopAnchor
+            )
+        }
 
         overKeyboardContainerTopZoomHeightConstraint = overKeyboardContainer.heightAnchor.constraint(
             greaterThanOrEqualToConstant: 0
@@ -158,6 +173,7 @@ final class BrowserViewControllerLayoutManager {
     func updateOverKeyboardContainerConstraints(isBottomSearchBar: Bool, hasZoomPageBar: Bool) {
         overKeyboardContainerTopZoomHeightConstraint?.isActive = false
         overKeyboardContainerTopHeightConstraint?.isActive = false
+        overKeyboardContainerKeyboardConstraint?.isActive = isBottomSearchBar
 
         guard !isBottomSearchBar else { return }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerLayoutManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerLayoutManagerTests.swift
@@ -17,6 +17,8 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
     private var navigationToolbarContainer: UIView!
     private var subviews: [UIView]!
     private var mockTabManager: MockTabManager!
+    private var fakeKeyboardGuide: UILayoutGuide!
+    private var fakeKeyboardHeightConstraint: NSLayoutConstraint!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -40,6 +42,8 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
         overKeyboardContainer = nil
         bottomContentStackView = nil
         navigationToolbarContainer = nil
+        fakeKeyboardGuide = nil
+        fakeKeyboardHeightConstraint = nil
         try await super.tearDown()
     }
 
@@ -319,6 +323,83 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
         XCTAssertTrue(activeHeightConstraints.isEmpty)
     }
 
+    // MARK: - Keyboard Constraint
+
+    func test_setupOverKeyboardContainerConstraints_withoutKeyboardAnchor_doesNotCreateConstraint() {
+        let subject = createSubject()
+        subject.setupBottomContainerConstraints()
+        subject.setupOverKeyboardContainerConstraints()
+        subject.updateOverKeyboardContainerConstraints(isBottomSearchBar: true, hasZoomPageBar: false)
+
+        let avoidanceConstraint = parentView.constraints.first {
+            $0.firstItem === overKeyboardContainer && $0.relation == .lessThanOrEqual
+        }
+        XCTAssertNil(avoidanceConstraint)
+    }
+
+    func test_updateOverKeyboardContainerConstraints_bottomSearchBarWithKeyboardAnchor_activatesConstraint() {
+        setUpFakeKeyboardGuide()
+        let subject = createSubject(keyboardTopAnchor: fakeKeyboardGuide.topAnchor)
+        subject.setupBottomContainerConstraints()
+        subject.setupOverKeyboardContainerConstraints()
+
+        subject.updateOverKeyboardContainerConstraints(isBottomSearchBar: true, hasZoomPageBar: false)
+
+        let avoidanceConstraint = parentView.constraints.first {
+            $0.firstItem === overKeyboardContainer && $0.firstAttribute == .bottom && $0.relation == .lessThanOrEqual
+        }
+        XCTAssertTrue(avoidanceConstraint?.isActive == true)
+    }
+
+    func test_updateOverKeyboardContainerConstraints_topSearchBarWithKeyboardAnchor_deactivatesConstraint() {
+        setUpFakeKeyboardGuide()
+        let subject = createSubject(keyboardTopAnchor: fakeKeyboardGuide.topAnchor)
+        subject.setupBottomContainerConstraints()
+        subject.setupOverKeyboardContainerConstraints()
+        subject.updateOverKeyboardContainerConstraints(isBottomSearchBar: true, hasZoomPageBar: false)
+        let avoidanceConstraint = parentView.constraints.first {
+            $0.firstItem === overKeyboardContainer && $0.firstAttribute == .bottom && $0.relation == .lessThanOrEqual
+        }
+        XCTAssertNotNil(avoidanceConstraint)
+
+        subject.updateOverKeyboardContainerConstraints(isBottomSearchBar: false, hasZoomPageBar: false)
+
+        XCTAssertFalse(avoidanceConstraint?.isActive ?? true)
+    }
+
+    // MARK: - Keyboard Avoidance Layout Behavior
+
+    func test_bottomSearchBar_prefersRestingPositionWhenKeyboardLeavesRoom() {
+        setUpFakeKeyboardGuide()
+        let subject = createSubject(keyboardTopAnchor: fakeKeyboardGuide.topAnchor)
+        subject.setupBottomContainerConstraints()
+        subject.setupOverKeyboardContainerConstraints()
+        subject.updateOverKeyboardContainerConstraints(isBottomSearchBar: true, hasZoomPageBar: false)
+        overKeyboardContainer.heightAnchor.constraint(equalToConstant: 56).isActive = true
+        bottomContainer.heightAnchor.constraint(equalToConstant: 82).isActive = true
+        fakeKeyboardHeightConstraint.constant = 0
+
+        parentView.layoutIfNeeded()
+
+        XCTAssertEqual(overKeyboardContainer.frame.maxY, bottomContainer.frame.minY, accuracy: 0.5)
+    }
+
+    func test_bottomSearchBar_fallsBackToKeyboardTopWhenTighterThanRestingPosition() {
+        setUpFakeKeyboardGuide()
+        let subject = createSubject(keyboardTopAnchor: fakeKeyboardGuide.topAnchor)
+        subject.setupBottomContainerConstraints()
+        subject.setupOverKeyboardContainerConstraints()
+        subject.updateOverKeyboardContainerConstraints(isBottomSearchBar: true, hasZoomPageBar: false)
+        overKeyboardContainer.heightAnchor.constraint(equalToConstant: 56).isActive = true
+        bottomContainer.heightAnchor.constraint(equalToConstant: 0).isActive = true
+        fakeKeyboardHeightConstraint.constant = 300
+
+        parentView.layoutIfNeeded()
+
+        let expectedBottom = parentView.frame.height - fakeKeyboardHeightConstraint.constant
+        XCTAssertEqual(overKeyboardContainer.frame.maxY, expectedBottom, accuracy: 0.5)
+    }
+
     // MARK: - Update BottomContent StackView Constraints
 
     func test_updateBottomContentStackViewConstraints_bottomToolbar_activatesOverKeyboardConstraint() {
@@ -396,7 +477,7 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
 
     // MARK: - Private helpers
 
-    private func createSubject() -> BrowserViewControllerLayoutManager {
+    private func createSubject(keyboardTopAnchor: NSLayoutYAxisAnchor? = nil) -> BrowserViewControllerLayoutManager {
         subviews.forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             parentView.addSubview($0)
@@ -407,7 +488,8 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
                                                          overKeyboardContainer: overKeyboardContainer,
                                                          bottomContentStackView: bottomContentStackView,
                                                          navigationToolbarContainer: navigationToolbarContainer,
-                                                         toolbarHelper: toolbarHelper)
+                                                         toolbarHelper: toolbarHelper,
+                                                         keyboardTopAnchor: keyboardTopAnchor)
         trackForMemoryLeaks(subject)
         return subject
     }
@@ -417,5 +499,19 @@ final class BrowserViewControllerLayoutManagerTests: XCTestCase {
             [.leading, .trailing, .bottom, .height].contains($0.firstAttribute)
         }
         return relevantConstraints.count
+    }
+
+    /// Before integrating `keyboardLayoutGuide` this allows us to have a fully-controllable guide
+    /// so tests don't depend on a real system keyboard.
+    private func setUpFakeKeyboardGuide() {
+        fakeKeyboardGuide = UILayoutGuide()
+        parentView.addLayoutGuide(fakeKeyboardGuide)
+        fakeKeyboardHeightConstraint = fakeKeyboardGuide.heightAnchor.constraint(equalToConstant: 0)
+        NSLayoutConstraint.activate([
+            fakeKeyboardGuide.leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
+            fakeKeyboardGuide.trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
+            fakeKeyboardGuide.bottomAnchor.constraint(equalTo: parentView.bottomAnchor),
+            fakeKeyboardHeightConstraint
+        ])
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16540)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Preparation for replacing the manual keyboard spacer (`addKeyboardSpacer`/`getKeyboardSpacerHeight`) with a `keyboardLayoutGuide`-driven constraint on `overKeyboardContainer`. This PR lands the plumbing and its test coverage; it does not change behavior yet.

Once we integrate `keyboardLayoutGuide` there is no reliably way to trigger in  unit-test target a real system keyboard  so this PR adds support to have LayoutGuide that we could add unit test so once we made the switch we have a baseline of passing test that will catch regression quicker that non existing XCUITest and manual test

What changed:
- `BrowserViewControllerLayoutManager` takes an injectable` keyboardTopAnchor: NSLayoutYAxisAnchor? `(defaults to nil), and can construct an overKeyboardContainer.bottom <= keyboardTopAnchor constraint alongside the existing (now .defaultHigh, was .required) resting-position constraint.
- In production, keyboardTopAnchor is still nil, the BVC.swift call site is unchanged, so the new constraint is never constructed and the priority change has no competing constraint to matter against. **No behavior change for real users.**
- Tests inject a real, fully-controllable `UILayoutGuide` (not the real keyboardLayoutGuide) standing in for the keyboard, and verify the priority-based resolution directly: no anchor → no constraint; anchor + bottom search bar → activates and correctly prefers the resting position or falls back to the keyboard boundary depending on which is tighter.

Next step: a follow-up PR wires `keyboardTopAnchor: view.keyboardLayoutGuide.topAnchor `at the BVC.swift call site and removes the manual spacer mechanism in the same change


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

