### PR TITLE
Bugfix FXIOS-16560 [Tab Tray] Explicitly unsubscribe from Redux store on teardown

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -343,6 +343,8 @@ final class TabDisplayPanelViewController: UIViewController,
     }
 
     func unsubscribeFromRedux() {
+        store.unsubscribe(self)
+
         // Skip if a newer panel has already re-subscribed for this window: removing the shared
         // `.tabsPanel` component here would wipe the state the newly-opened tab tray depends on.
         guard Self.latestSubscriptionGeneration[windowUUID] == subscriptionGeneration else { return }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -402,6 +402,7 @@ final class TabTrayViewController: UIViewController,
                                            actionType: ComponentActionType.removeComponent,
                                            component: .tabsTray)
         store.dispatch(screenAction)
+        store.unsubscribe(self)
     }
 
     func newState(state: TabTrayState) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
@@ -26,6 +26,9 @@ class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
     /// Called when subscriber calls subscribe to the mock store.
     var subscribeCallCount = 0
 
+    /// Called when subscriber calls unsubscribe from the mock store.
+    var unsubscribeCallCount = 0
+
     init(state: State) {
         self.state = state
     }
@@ -46,11 +49,11 @@ class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
     }
 
     func unsubscribe<S>(_ subscriber: S) where S: Redux.StoreSubscriber, State == S.SubscriberStateType {
-        // TODO: if you need it
+        unsubscribeCallCount += 1
     }
 
     func unsubscribe(_ subscriber: any Redux.StoreSubscriber) {
-        // TODO: if you need it
+        unsubscribeCallCount += 1
     }
 
     /// We implemented the lock to ensure that this is thread safe

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
@@ -12,18 +12,17 @@ final class TabDisplayPanelTests: XCTestCase, StoreTestUtility {
 
     override func setUp() async throws {
         try await super.setUp()
-        await DependencyHelperMock().bootstrapDependencies()
-        await setupStore()
+        DependencyHelperMock().bootstrapDependencies()
+        setupStore()
     }
 
     override func tearDown() async throws {
         DependencyHelperMock().reset()
-        await resetStore()
+        resetStore()
         try await super.tearDown()
     }
 
     // MARK: - Redux
-    @MainActor
     func testUnsubscribeFromRedux_unsubscribesFromStore() {
         let subject = createSubject(isPrivateMode: false, emptyTabs: true)
 
@@ -33,18 +32,15 @@ final class TabDisplayPanelTests: XCTestCase, StoreTestUtility {
     }
 
     // MARK: - StoreTestUtility
-    @MainActor
     func setupAppState() -> Client.AppState {
         return AppState()
     }
 
-    @MainActor
     func setupStore() {
         mockStore = MockStoreForMiddleware(state: setupAppState())
         StoreTestUtilityHelper.setupStore(with: mockStore)
     }
 
-    @MainActor
     func resetStore() {
         StoreTestUtilityHelper.resetStore()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
@@ -3,18 +3,50 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Redux
 import XCTest
 
 @testable import Client
-final class TabDisplayPanelTests: XCTestCase {
+final class TabDisplayPanelTests: XCTestCase, StoreTestUtility {
+    private var mockStore: MockStoreForMiddleware<AppState>!
+
     override func setUp() async throws {
         try await super.setUp()
         await DependencyHelperMock().bootstrapDependencies()
+        await setupStore()
     }
 
     override func tearDown() async throws {
         DependencyHelperMock().reset()
+        await resetStore()
         try await super.tearDown()
+    }
+
+    // MARK: - Redux
+    @MainActor
+    func testUnsubscribeFromRedux_unsubscribesFromStore() {
+        let subject = createSubject(isPrivateMode: false, emptyTabs: true)
+
+        subject.unsubscribeFromRedux()
+
+        XCTAssertEqual(mockStore.unsubscribeCallCount, 1)
+    }
+
+    // MARK: - StoreTestUtility
+    @MainActor
+    func setupAppState() -> Client.AppState {
+        return AppState()
+    }
+
+    @MainActor
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    @MainActor
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
@@ -3,21 +3,24 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Redux
 import XCTest
 
 @testable import Client
 
 @MainActor
-final class TabTrayViewControllerTests: XCTestCase {
+final class TabTrayViewControllerTests: XCTestCase, StoreTestUtility {
     var delegate: MockTabTrayViewControllerDelegate!
     var navigationController: DismissableNavigationViewController!
     private var tabManager: MockTabManager!
+    private var mockStore: MockStoreForMiddleware<AppState>!
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
     override func setUp() async throws {
         try await super.setUp()
         let mockTabManager = MockTabManager()
         DependencyHelperMock().bootstrapDependencies(injectedTabManager: mockTabManager)
+        setupStore()
         delegate = MockTabTrayViewControllerDelegate()
         navigationController = DismissableNavigationViewController()
         tabManager = mockTabManager
@@ -27,8 +30,32 @@ final class TabTrayViewControllerTests: XCTestCase {
         delegate = nil
         navigationController = nil
         DependencyHelperMock().reset()
+        resetStore()
 
         try await super.tearDown()
+    }
+
+    // MARK: - Redux
+    func testUnsubscribeFromRedux_unsubscribesFromStore() {
+        let viewController = createSubject()
+
+        viewController.unsubscribeFromRedux()
+
+        XCTAssertEqual(mockStore.unsubscribeCallCount, 1)
+    }
+
+    // MARK: - StoreTestUtility
+    func setupAppState() -> Client.AppState {
+        return AppState()
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
     }
 
     // MARK: Compact layout


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16560)

## :bulb: Description
While investigating #27621 (reported `TabDisplayView` memory leak on repeated tab tray open/close), I did a full static trace of the object graph (closures, delegates, the Redux subscription path) and couldn't find an active retain cycle in the current code — every closure/delegate in the chain already correctly uses `[weak self]`/`weak var`, and a recent contributor also failed to reproduce the leak on latest `main`. Full writeup in my closing comment on the issue.

One real, concrete gap I did find along the way: `TabTrayViewController.unsubscribeFromRedux()` and `TabDisplayPanelViewController.unsubscribeFromRedux()` only dispatch a `removeComponent` action — neither calls `store.unsubscribe(self)`, unlike every other `StoreSubscriber` in the codebase (e.g. `SwipeUpTabPreviewGestureHandler`, `NavigationToolbarContainer`, `AddressToolbarContainer`, `TabSwipeGestureHandler`, `WebCompatReportViewController`). This isn't a strong retain cycle on its own (`SubscriptionWrapper.subscriber` is `weak`), but it leaves a dead `SubscriptionWrapper` entry sitting in the store's subscription set until the next state change happens to prune it. This PR brings both classes in line with the established convention.

Small, self-contained hardening fix — not a fix for the reported leak itself (see issue comment), just cleanup surfaced by the investigation.

## :movie_camera: Demos
N/A — internal Redux subscription cleanup, no UI change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

🤖 Generated with [Claude Code](https://claude.com/claude-code)