### PR TITLE
Bugfix FXIOS-16475 [Favicon] Preserve non-default ports in fallback URLs

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/URLExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/URLExtension.swift
@@ -334,7 +334,8 @@ extension URL {
     /// favicon.ico appended).
     public func faviconUrl() -> URL? {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false),
-              components.host != nil
+              let host = components.host,
+              !host.isEmpty
         else { return nil }
 
         components.scheme = components.scheme ?? "https"

--- a/BrowserKit/Sources/Common/Extensions/URLExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/URLExtension.swift
@@ -333,10 +333,17 @@ extension URL {
     /// Returns the standard location of the website's favicon. (This is the base directory path with
     /// favicon.ico appended).
     public func faviconUrl() -> URL? {
-        if let host = host, let rootDirectoryURL = URL(string: (scheme ?? "https") + "://" + host) {
-            return rootDirectoryURL.appendingPathComponent("favicon.ico")
-        }
-        return nil
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false),
+              components.host != nil
+        else { return nil }
+
+        components.scheme = components.scheme ?? "https"
+        components.user = nil
+        components.password = nil
+        components.path = "/favicon.ico"
+        components.query = nil
+        components.fragment = nil
+        return components.url
     }
 
     // MARK: Reader mode

--- a/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
+++ b/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
@@ -505,6 +505,18 @@ final class URLExtensionTests: XCTestCase {
         XCTAssertEqual(favicon3, URL(string: "scheme://another.website.net/favicon.ico")!)
     }
 
+    func testFaviconRootDirectoryURLPreservesPort() {
+        let url = URL(string: "https://some.domain.com:8443/path/subpath")
+
+        XCTAssertEqual(url?.faviconUrl(), URL(string: "https://some.domain.com:8443/favicon.ico")!)
+    }
+
+    func testFaviconRootDirectoryURLPreservesIPv6HostAndPort() {
+        let url = URL(string: "http://[::1]:8080/path/subpath")
+
+        XCTAssertEqual(url?.faviconUrl(), URL(string: "http://[::1]:8080/favicon.ico")!)
+    }
+
     // MARK: normalizedHostWithLRI
     func testNormalizedHostWithLRIHandlesRTLDomainAppropriately() throws {
         let testURL = "https://xn--mgb.google.com.xn--mgb.suspicious-domain.abc/download.apk"

--- a/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
+++ b/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
@@ -517,6 +517,12 @@ final class URLExtensionTests: XCTestCase {
         XCTAssertEqual(url?.faviconUrl(), URL(string: "http://[::1]:8080/favicon.ico")!)
     }
 
+    func testFaviconRootDirectoryURLWithoutHostReturnsNil() {
+        let url = URL(string: "file:///Users/a/b.html")
+
+        XCTAssertNil(url?.faviconUrl())
+    }
+
     // MARK: normalizedHostWithLRI
     func testNormalizedHostWithLRIHandlesRTLDomainAppropriately() throws {
         let testURL = "https://xn--mgb.google.com.xn--mgb.suspicious-domain.abc/download.apk"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16475)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34989)

## :bulb: Description
Fixes #34989.

`getFaviconRootDirectoryURL()` rebuilt the fallback URL from only the scheme and host, which silently dropped non-default ports. This caused Firefox to request `/favicon.ico` from the wrong origin for sites running on ports such as `:8080`.

This change uses `URLComponents` to preserve the origin's port while still producing a clean root favicon URL. It also keeps IPv6 hosts valid and removes user information, query parameters, and fragments from the fallback URL.

Regression tests cover a regular hostname with a non-default port, an IPv6 host with a port, and a URL without a host.

## :movie_camera: Demos
Not applicable; this change only affects fallback URL construction.

## :white_check_mark: Testing
Ran `URLExtensionTests` with the Common scheme on an iOS simulator: 88 tests passed with 0 failures.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow the PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [x] No UI or accessibility changes
- [x] No telemetry changes
- [x] No string changes
- [x] No documentation updates are needed
