### PR TITLE
Add MTE-5796 MTE-5794 Partial matches for sponsored and non-sponsored matches

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxScreenGraph.swift
@@ -89,6 +89,7 @@ let Shortcuts = "Shortcuts"
 let AutoplaySettings = "AutoplaySettings"
 let AppIconSettings = "AppIconSettings"
 let FirefoxSuggestSettings = "FirefoxSuggestSettings"
+let ExperimentsScreen = "ExperimentsScreen"
 
 let HistoryPanelContextMenu = "HistoryPanelContextMenu"
 let TopSitesPanelContextMenu = "TopSitesPanelContextMenu"
@@ -233,6 +234,8 @@ class Action {
     static let OpenSiriFromSettings = "OpenSiriFromSettings"
     static let OpenSecretSettings = "OpenSecretSettings"
     static let IngestNewSuggestionsNow = "IngestNewSuggestionsNow"
+    static let ListAllExperiments = "ListAllExperiments"
+    static let EnrollExperiment = "EnrollExperiment"
 
     static let AcceptClearPrivateData = "AcceptClearPrivateData"
     static let AcceptClearAllWebsiteData = "AcceptClearAllWebsiteData"

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxUserState.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FxUserState.swift
@@ -40,4 +40,5 @@ class FxUserState: MMUserState {
     var localeIsExpectedDifferent = false
 
     var secretSettingsRevealed = false
+    var experimentToEnroll = ""
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -542,7 +542,7 @@ class SearchTests: FeatureFlaggedTestBase {
         navigator.goto(ExperimentsScreen)
         navigator.performAction(Action.ListAllExperiments)
         navigator.userState.experimentToEnroll = "Enhanced Cross-Platform Suggest [iOS] - Phased Roll out 138+"
-        navigator.performAction(Action.EnrollExperiment) 
+        navigator.performAction(Action.EnrollExperiment)
         navigator.goto(SettingsScreen)
         navigator.goto(HomePanelsScreen)
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -484,59 +484,91 @@ class SearchTests: FeatureFlaggedTestBase {
         navigator.performAction(Action.CloseTab)
         navigator.performAction(Action.OpenNewTabFromTabTray)
 
-        let siteTable = app.tables["SiteTable"]
-
         for orientation in [UIDeviceOrientation.portrait, UIDeviceOrientation.landscapeLeft] {
             XCUIDevice.shared.orientation = orientation
 
             // Firefox Suggest should show up for sponsored suggestion, open tab, history
             // and bookmark.
-            let firefoxSuggestTerms = [
-                "amazon": "Amazon.com - Official Site", // Sponsored suggestion
+            // Sponsored suggestion
+            verifySearchSuggestion(searchTerm: "amazon",
+                                   expectedMatch: "Amazon.com - Official Site",
+                                   hasFirefoxSuggest: true,
+                                   isSponsored: true)
+            // Non-sponsored suggestions
+            for (term, expectedTitle) in [
                 "internet": "Internet for people, not profit — Mozilla", // Open tab
                 "example": "www.example.com/", // History
-                "book": "The Book of Mozilla" // Bookmark
-            ]
-            for (term, expectedTitle) in firefoxSuggestTerms {
-                browserScreen.tapOnAddressBar()
-                browserScreen.tapClearButtonIfExists()
-                browserScreen.typeOnSearchBar(text: term)
-                mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
-                mozWaitForElementToExist(siteTable.staticTexts[expectedTitle])
-                let searchEngines = [
-                    "Bing search", "DuckDuckGo search", "Perplexity search", "Wikipedia (en) search", "eBay search"
-                ]
-                for searchEngine in searchEngines {
-                    mozWaitForElementToExist(app.scrollViews.buttons[searchEngine])
-                }
-                // Search engine suggestions
-                mozWaitForElementToExist(siteTable.otherElements["Google Search"])
-                mozWaitForElementToExist(siteTable.staticTexts[term])
-
-                // Firefox Suggest is displayed
-                if XCUIDevice.shared.orientation == UIDeviceOrientation.landscapeLeft {
-                    siteTable.cells.firstMatch.swipeUp()
-                }
-                mozWaitForElementToExist(siteTable.otherElements["Firefox Suggest"])
-                mozWaitForElementToExist(siteTable.staticTexts[expectedTitle])
+                "book of mozilla": "The Book of Mozilla" // Bookmark
+            ] {
+                verifySearchSuggestion(searchTerm: term,
+                                       expectedMatch: expectedTitle,
+                                       hasFirefoxSuggest: true,
+                                       isSponsored: false)
             }
 
             // Non Firefox Suggest result: A random term
             let term = "heeeeeeellllllllllloooooooo"
-            browserScreen.tapOnAddressBar()
-            browserScreen.tapClearButtonIfExists()
-            browserScreen.typeOnSearchBar(text: term)
-            mozWaitForElementToExist(app.scrollViews.buttons["Search Settings"])
-            let searchEngines = [
-                "Bing search", "DuckDuckGo search", "Perplexity search", "Wikipedia (en) search", "eBay search"
-            ]
-            for searchEngine in searchEngines {
-                mozWaitForElementToExist(app.scrollViews.buttons[searchEngine])
-            }
-            // Search engine suggestions
-            mozWaitForElementToExist(siteTable.otherElements["Google Search"])
-            mozWaitForElementToExist(siteTable.staticTexts[term])
+            verifySearchSuggestion(searchTerm: term,
+                                   expectedMatch: "",
+                                   hasFirefoxSuggest: false,
+                                   isSponsored: false)
+        }
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/2753093
+    // Regression
+    func testFirefoxSuggestPartialSponsored() {
+        app.launch()
+        verifySearchSuggestion(searchTerm: "amaz",
+                               expectedMatch: "Amazon.com - Official Site",
+                               hasFirefoxSuggest: true,
+                               isSponsored: true)
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/2753076
+    // Regresssion
+    func testFirefoxSuggestPartialNonSponsored() {
+        app.launch()
+        verifySearchSuggestion(searchTerm: "fifa",
+                               expectedMatch: "Wikipedia - FIFA Club World Cup",
+                               hasFirefoxSuggest: true,
+                               isSponsored: false)
+    }
+
+    private func verifySearchSuggestion(searchTerm: String,
+                                        expectedMatch: String = "",
+                                        hasFirefoxSuggest: Bool = false,
+                                        isSponsored: Bool = false) {
+        let siteTable = app.tables["SiteTable"]
+        browserScreen.tapOnAddressBar()
+        browserScreen.tapClearButtonIfExists()
+        browserScreen.typeOnSearchBar(text: searchTerm)
+
+        for searchEngine in [
+            "Bing search", "DuckDuckGo search", "Perplexity search", "Wikipedia (en) search", "eBay search"
+        ] {
+            mozWaitForElementToExist(app.scrollViews.buttons[searchEngine])
+        }
+
+        // Search engine suggestions
+        mozWaitForElementToExist(siteTable.otherElements["Google Search"])
+        mozWaitForElementToExist(siteTable.staticTexts[searchTerm])
+
+        // Firefox Suggest is displayed
+        if XCUIDevice.shared.orientation == UIDeviceOrientation.landscapeLeft {
+            siteTable.cells.firstMatch.swipeUp()
+        }
+        if hasFirefoxSuggest {
+            mozWaitForElementToExist(siteTable.otherElements["Firefox Suggest"])
+            mozWaitForElementToExist(app.tables.staticTexts[expectedMatch])
+        } else {
             mozWaitForElementToNotExist(siteTable.otherElements["Firefox Suggest"])
+        }
+
+        if isSponsored {
+            mozWaitForElementToExist(siteTable.staticTexts["Sponsored"])
+        } else {
+            mozWaitForElementToNotExist(siteTable.staticTexts["Sponsored"])
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -519,6 +519,13 @@ class SearchTests: FeatureFlaggedTestBase {
     // Regression
     func testFirefoxSuggestPartialSponsored() {
         app.launch()
+        // Workaround: Sponsored suggestions do not show up intermittently.
+        // Ingesting the new suggestions forces the app to have the sponsored
+        // results for Firefox Suggest consistently.
+        navigator.goto(SettingsScreen)
+        navigator.performAction(Action.OpenSecretSettings)
+        navigator.performAction(Action.IngestNewSuggestionsNow)
+        navigator.goto(HomePanelsScreen)
         verifySearchSuggestion(searchTerm: "amaz",
                                expectedMatch: "Amazon.com - Official Site",
                                hasFirefoxSuggest: true,
@@ -529,6 +536,16 @@ class SearchTests: FeatureFlaggedTestBase {
     // Regresssion
     func testFirefoxSuggestPartialNonSponsored() {
         app.launch()
+        // Precondition: Enable enhanced cross-platform suggest experiment
+        navigator.goto(SettingsScreen)
+        navigator.performAction(Action.OpenSecretSettings)
+        navigator.goto(ExperimentsScreen)
+        navigator.performAction(Action.ListAllExperiments)
+        navigator.userState.experimentToEnroll = "Enhanced Cross-Platform Suggest [iOS] - Phased Roll out 138+"
+        navigator.performAction(Action.EnrollExperiment) 
+        navigator.goto(SettingsScreen)
+        navigator.goto(HomePanelsScreen)
+
         verifySearchSuggestion(searchTerm: "fifa",
                                expectedMatch: "Wikipedia - FIFA Club World Cup",
                                hasFirefoxSuggest: true,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerSettingsNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerSettingsNavigation.swift
@@ -237,6 +237,20 @@ func registerSettingsNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApp
         }
         screenState.backAction = navigationControllerBackAction(for: app)
     }
+
+    map.addScreenState(ExperimentsScreen) { screenState in
+        screenState.gesture(forAction: Action.ListAllExperiments) { userState in
+            app.buttons["Edit"].waitAndTap()
+            app.buttons["Reset"].waitAndTap()
+            app.navigationBars.buttons["BackButton"].waitAndTap()
+        }
+        screenState.gesture(forAction: Action.EnrollExperiment) { userState in
+            app.staticTexts[userState.experimentToEnroll].waitAndTap()
+            app.staticTexts["control"].waitAndTap()
+            app.navigationBars.buttons["BackButton"].waitAndTap()
+        }
+        screenState.backAction = navigationControllerBackAction(for: app)
+    }
 }
 
 @MainActor
@@ -252,4 +266,5 @@ private func registerSecretSettingsAccess(
         userState.secretSettingsRevealed = true
     }
     screenState.tap(table.cells["Firefox Suggest"], to: FirefoxSuggestSettings, if: "secretSettingsRevealed == true")
+    screenState.tap(table.cells["Experiments"], to: ExperimentsScreen, if: "secretSettingsRevealed == true")
 }


### PR DESCRIPTION
…rtialSponsored

## :scroll: Tickets
[MTE-5796](https://mozilla-hub.atlassian.net/browse/MTE-5796)
[MTE-5794](https://mozilla-hub.atlassian.net/browse/MTE-5794)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Firefox Suggests should appear once a prefix is entered.
https://mozilla.testrail.io/index.php?/cases/view/2753093
https://mozilla.testrail.io/index.php?/cases/view/2753076

I've also refactored to have `verifySearchSuggestion` to handle typing the search terms and checking the matches.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code



[MTE-5796]: https://mozilla-hub.atlassian.net/browse/MTE-5796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTE-5794]: https://mozilla-hub.atlassian.net/browse/MTE-5794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ