### PR TITLE
[MTE-5779 - automate Long tap on a tab in Tabs Tray]

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -609,6 +609,7 @@
         "TabsTests\/testCloseOneTabUndo()",
         "TabsTests\/testCloseOneTabUndo_tabTrayExperimentOff()",
         "TabsTests\/testCloseOneTab_tabTrayExperimentOff()",
+        "TabsTests\/testLongTapOnTabInTabsTray()",
         "TabsTests\/testLongTapTabCounter_TAE()",
         "TabsTests\/testOpenNewTabLandscape_TAE()",
         "TabsTests\/testOpenTabsViewCurrentTabThumbnail()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -216,6 +216,22 @@ final class BrowserScreen {
         urlElement.waitAndTap()
     }
 
+    // Pastes the clipboard contents into the (already focused) address bar and asserts the resulting
+    // value. Used to verify clipboard content in-app, avoiding the iOS 16+ cross-process paste prompt.
+    func pasteAndAssertAddressBarContains(_ value: String) {
+        let pasteButton = sel.PASTE_BUTTON.element(in: app)
+        if BaseTestCase().iPad() {
+            addressBar.waitAndTap()
+        } else {
+            addressBar.press(forDuration: 1)
+        }
+        if !pasteButton.exists {
+            addressBar.press(forDuration: 1)
+        }
+        pasteButton.waitAndTap()
+        BaseTestCase().mozWaitForValueContains(addressBar, value: value)
+    }
+
     func typeOnSearchBar(text: String) {
         addressBar.typeText(text)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
@@ -232,10 +232,33 @@ final class TabTrayScreen {
         tabCell.press(forDuration: 2)
     }
 
+    // The tab long-press (tab peek) context menu hosts its actions as buttons in a collection view.
+    func assertContextMenuOptionsExist(timeout: TimeInterval = TIMEOUT) {
+        for option in sel.contextMenuOptions {
+            BaseTestCase().mozWaitForElementToExist(option.element(in: app), timeout: timeout)
+        }
+    }
+
+    private func tapContextMenuOption(_ selector: Selector) {
+        let optionButton = selector.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(optionButton)
+        optionButton.waitAndTap()
+    }
+
+    func tapAddToBookmarksFromContextMenu() {
+        tapContextMenuOption(sel.CONTEXT_MENU_ADD_TO_BOOKMARKS)
+    }
+
+    func tapCopyURLFromContextMenu() {
+        tapContextMenuOption(sel.CONTEXT_MENU_COPY_URL)
+    }
+
     func tapCloseTabFromContextMenu() {
-        let closeTabButton = app.collectionViews.buttons["Close Tab"]
-        BaseTestCase().mozWaitForElementToExist(closeTabButton)
-        closeTabButton.waitAndTap()
+        tapContextMenuOption(sel.CONTEXT_MENU_CLOSE_TAB)
+    }
+
+    func assertCellDoesNotExist(named name: String, timeout: TimeInterval = TIMEOUT) {
+        BaseTestCase().mozWaitForElementToNotExist(cell(named: name), timeout: timeout)
     }
 
     func closeFirstTab() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
@@ -26,6 +26,7 @@ protocol BrowserSelectorsSet {
     var SAVE_BUTTON: Selector { get }
     var CLIPBOARD_TOAST: Selector { get }
     var PRIVATE_MODE_HOMEPAGE_TITLE: Selector { get }
+    var PASTE_BUTTON: Selector { get }
     func linkElement(named name: String) -> Selector
     func linkPreview(named preview: String) -> Selector
     func webPageElement(with text: String) -> Selector
@@ -179,6 +180,12 @@ struct BrowserSelectors: BrowserSelectorsSet {
         groups: ["browser", "private-mode"]
     )
 
+    let PASTE_BUTTON = Selector.otherElementsButtonByLabel(
+        "Paste",
+        description: "Paste button in the address bar edit callout",
+        groups: ["browser"]
+    )
+
     func linkElement(named name: String) -> Selector {
         Selector.linkById(
             name,
@@ -208,6 +215,6 @@ struct BrowserSelectors: BrowserSelectorsSet {
                            CLEAR_TEXT_BUTTON, CANCEL_BUTTON_URL_BAR, PRIVATE_BROWSING, CANCEL_BUTTON,
                            LINK_RFC_2606, BOOK_OF_MOZILLA_TEXT, ADDRESSTOOLBAR_LOCKICON, ADDRESSTOOLBAR_LOCKICON_OFF,
                            TOPTABS_COLLECTIONVIEW, MICROSURVEY_CLOSE_BUTTON, BOOK_OF_MOZILLA_TEXT_IN_TABLE,
-                           SAVE_BUTTON, CLIPBOARD_TOAST, PRIVATE_MODE_HOMEPAGE_TITLE]
+                           SAVE_BUTTON, CLIPBOARD_TOAST, PRIVATE_MODE_HOMEPAGE_TITLE, PASTE_BUTTON]
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SelectorHelper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SelectorHelper.swift
@@ -28,6 +28,8 @@ enum SelectorStrategy {
     case collectionViewLinkById(String)
     case cellButtonById(String)
     case navigationBarButtonById(String)
+    case collectionViewButtonByLabel(String)
+    case otherElementsButtonByLabel(String)
 }
 
 // Selector model (with metadata)
@@ -103,6 +105,10 @@ extension Selector {
             return app.cells.buttons[id]
         case .navigationBarButtonById(let id):
             return app.navigationBars.buttons[id]
+        case .collectionViewButtonByLabel:
+            return app.collectionViews.buttons[value]
+        case .otherElementsButtonByLabel:
+            return app.otherElements.buttons[value]
         }
     }
 
@@ -158,6 +164,10 @@ extension Selector {
             return app.cells.buttons.matching(identifier: id)
         case .navigationBarButtonById(let id):
             return app.navigationBars.buttons.matching(identifier: id)
+        case .collectionViewButtonByLabel:
+            return app.collectionViews.buttons.matching(NSPredicate(format: "label == %@", value))
+        case .otherElementsButtonByLabel:
+            return app.otherElements.buttons.matching(NSPredicate(format: "label == %@", value))
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SelectorShortcuts.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SelectorShortcuts.swift
@@ -450,6 +450,14 @@ extension Selector {
           )
     }
 
+    static func collectionViewButtonByLabel(_ label: String, description: String, groups: [String] = []) -> Selector {
+        Selector(strategy: .collectionViewButtonByLabel(label), value: label, description: description, groups: groups)
+    }
+
+    static func otherElementsButtonByLabel(_ label: String, description: String, groups: [String] = []) -> Selector {
+        Selector(strategy: .otherElementsButtonByLabel(label), value: label, description: description, groups: groups)
+    }
+
     static func otherElementByLabel(_ label: String, description: String, groups: [String] = []) -> Selector {
           Selector(strategy: .predicate(
               NSPredicate(

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/TabTraySelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/TabTraySelectors.swift
@@ -11,6 +11,10 @@ protocol TabTraySelectorsSet {
     var FIRST_CELL: Selector { get }
     var NEW_TAB_BUTTON: Selector { get }
     var UNDO_BUTTON: Selector { get }
+    var CONTEXT_MENU_ADD_TO_BOOKMARKS: Selector { get }
+    var CONTEXT_MENU_COPY_URL: Selector { get }
+    var CONTEXT_MENU_CLOSE_TAB: Selector { get }
+    var contextMenuOptions: [Selector] { get }
     func cell(named name: String) -> Selector
     func tabCellWithIndex(_ index: Int, _ urlLabel: String, _ selectedTab: String) -> Selector
     func tabCellAtIndex(index: Int) -> Selector
@@ -63,6 +67,29 @@ struct TabTraySelectors: TabTraySelectorsSet {
         groups: ["tabtray"]
     )
 
+    // Long-press (tab peek) context menu actions. Titles come from `String.TabPeek*` in Strings.swift.
+    let CONTEXT_MENU_ADD_TO_BOOKMARKS = Selector.collectionViewButtonByLabel(
+        "Add to Bookmarks",
+        description: "Add to Bookmarks option in the tab long-press context menu",
+        groups: ["tabtray"]
+    )
+
+    let CONTEXT_MENU_COPY_URL = Selector.collectionViewButtonByLabel(
+        "Copy URL",
+        description: "Copy URL option in the tab long-press context menu",
+        groups: ["tabtray"]
+    )
+
+    let CONTEXT_MENU_CLOSE_TAB = Selector.collectionViewButtonByLabel(
+        "Close Tab",
+        description: "Close Tab option in the tab long-press context menu",
+        groups: ["tabtray"]
+    )
+
+    var contextMenuOptions: [Selector] {
+        [CONTEXT_MENU_ADD_TO_BOOKMARKS, CONTEXT_MENU_COPY_URL, CONTEXT_MENU_CLOSE_TAB]
+    }
+
     func cell(named name: String) -> Selector {
         Selector.staticTextByLabel(
             name,
@@ -103,5 +130,6 @@ struct TabTraySelectors: TabTraySelectorsSet {
 
     var all: [Selector] { [TABSTRAY_CONTAINER, COLLECTION_VIEW,
                            IPHONE_TAB_TRAY_COLLECTION_VIEW, FIRST_CELL, NEW_TAB_BUTTON,
-                            UNDO_BUTTON] }
+                            UNDO_BUTTON, CONTEXT_MENU_ADD_TO_BOOKMARKS,
+                            CONTEXT_MENU_COPY_URL, CONTEXT_MENU_CLOSE_TAB] }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TabsTests.swift
@@ -394,6 +394,57 @@ class TabsTests: BaseTestCase {
         tabTrayScreen.assertNoTabLeakDetected()
     }
 
+    // Regression
+    // https://mozilla.testrail.io/index.php?/cases/view/2306834
+    func testLongTapOnTabInTabsTray() {
+        toolBarScreen = ToolbarScreen(app: app)
+        tabTrayScreen = TabTrayScreen(app: app)
+        browserScreen = BrowserScreen(app: app)
+        let libraryScreen = LibraryScreen(app: app)
+
+        // Launch Firefox and load a page
+        navigator.openURL(urlExample)
+        waitUntilPageLoad()
+        navigator.nowAt(BrowserTab)
+
+        // Open the tabs tray
+        waitForTabsButton()
+        navigator.goto(TabTray)
+        tabTrayScreen.assertFirstCellVisible()
+
+        // Long press the tab and check the context menu options
+        tabTrayScreen.longPressTabCellAtIndex(0)
+        tabTrayScreen.assertContextMenuOptionsExist()
+
+        // Tap "Add to Bookmarks" and verify the page is added to the Bookmarks panel
+        tabTrayScreen.tapAddToBookmarksFromContextMenu()
+        tabTrayScreen.tapTabAtIndex(index: 0)
+        navigator.nowAt(BrowserTab)
+        navigator.goto(LibraryPanel_Bookmarks)
+        libraryScreen.assertBookmarkExists(named: urlLabelExample)
+        libraryScreen.tapDoneButton()
+        navigator.nowAt(BrowserTab)
+
+        // Long press the tab again and tap "Copy URL"
+        waitForTabsButton()
+        navigator.goto(TabTray)
+        tabTrayScreen.longPressTabCellAtIndex(0)
+        tabTrayScreen.tapCopyURLFromContextMenu()
+
+        // Verify the URL was copied by pasting it into the URL bar of a new tab
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        navigator.goto(URLBarOpen)
+        browserScreen.pasteAndAssertAddressBarContains(urlValueLongExample)
+
+        // Long press the tab again and tap "Close Tab", then verify the tab is closed
+        navigator.performAction(Action.CloseURLBarOpen)
+        waitForTabsButton()
+        navigator.goto(TabTray)
+        tabTrayScreen.longPressTabCellAtIndex(0)
+        tabTrayScreen.tapCloseTabFromContextMenu()
+        tabTrayScreen.assertCellDoesNotExist(named: urlLabelExample)
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2306867
     func testCloseOneTabUndo() throws {
         throw XCTSkip("Undo toast no longer available")


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5779

## :bulb: Description
https://mozilla.testrail.io/index.php?/cases/view/2306834
The new UI test opens a page, goes to the Tabs Tray, long-presses the tab, and verifies the context menu works end to end:
- The menu shows Add to Bookmarks, Copy URL, and Close Tab
- Add to Bookmarks actually saves the page (confirmed in the Bookmarks panel)
- Copy URL puts the correct address on the clipboard
- Close Tab closes the tab

