### PR TITLE
Add FXIOS-16546 [Nova] Update Library panel design - History section

### DIFF
--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -104,7 +104,7 @@ class HistoryPanel: UIViewController,
         searchbar.showsCancelButton = true
     }
 
-    private lazy var tableView: UITableView = .build { [weak self] tableView in
+    private lazy var tableView: UITableView = .build({ [weak self] tableView in
         guard let self = self else { return }
         tableView.dataSource = self.diffableDataSource
         tableView.addGestureRecognizer(self.longPressRecognizer)
@@ -121,6 +121,19 @@ class HistoryPanel: UIViewController,
                            forHeaderFooterViewReuseIdentifier: SiteTableViewHeader.cellIdentifier)
 
         tableView.sectionHeaderTopPadding = 0
+    }, { [weak self] in
+        UITableView(frame: .zero, style: self?.tableViewStyle ?? .plain)
+    })
+
+    private var isNovaDesignEnabled: Bool {
+        (AppContainer.shared.resolve() as FeatureFlagProviding).isEnabled(.novaDesign)
+    }
+
+    private var tableViewStyle: UITableView.Style {
+        if #available(iOS 26.0, *), isNovaDesignEnabled {
+            return .insetGrouped
+        }
+        return .plain
     }
 
     lazy var longPressRecognizer: UILongPressGestureRecognizer = {
@@ -604,6 +617,9 @@ class HistoryPanel: UIViewController,
 
         let theme = currentTheme()
         tableView.backgroundColor = theme.colors.layer1
+        if #available(iOS 26.0, *), isNovaDesignEnabled {
+            tableView.separatorColor = theme.colors.borderPrimary
+        }
         emptyStateOverlayView.backgroundColor = theme.colors.layer1
 
         searchbar.backgroundColor = theme.colors.layer3
@@ -755,6 +771,11 @@ extension HistoryPanel: UITableViewDelegate {
         )
         header.configure(headerViewModel)
         header.applyTheme(theme: currentTheme())
+
+        if #available(iOS 26.0, *), isNovaDesignEnabled {
+            header.showBorder(for: .top, false)
+            header.showBorder(for: .bottom, false)
+        }
 
         // Configure tap to collapse/expand section
         header.tag = section

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -121,8 +121,8 @@ class HistoryPanel: UIViewController,
                            forHeaderFooterViewReuseIdentifier: SiteTableViewHeader.cellIdentifier)
 
         tableView.sectionHeaderTopPadding = 0
-    }, { [weak self] in
-        UITableView(frame: .zero, style: self?.tableViewStyle ?? .plain)
+    }, {
+        UITableView(frame: .zero, style: self.tableViewStyle)
     })
 
     private var isNovaDesignEnabled: Bool {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16546)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35119)

## :bulb: Description
This PR adds rounded islands for History sections, also updates token color for separator only for iOS 26+ and Nova system design. Design requirements based on [Figma](https://www.figma.com/design/XrQf2Lqhpi2s5N03lTtJ5h/2026-03-31-nova?node-id=12537-94129&m=dev)

<img width="192" height="374" alt="Screenshot 2026-08-11 at 13 22 18" src="https://github.com/user-attachments/assets/97cd82fb-551f-4eb6-acc5-1a0039384f25" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

