### PR TITLE
Bugfix FXIOS-16550 [Glean] Focus iOS ToU/Usage-Reporting ping not registered before recording metrics to it

### DIFF
--- a/focus-ios/Blockzilla/GleanUsageReportingMetricsService.swift
+++ b/focus-ios/Blockzilla/GleanUsageReportingMetricsService.swift
@@ -146,6 +146,7 @@ final class GleanUsageReportingMetricsService {
     }
 
     func start() {
+        Glean.shared.registerPings(GleanMetrics.Pings.shared)
         lifecycleObserver.gleanUsageReportingApi.setEnabled(true)
         lifecycleObserver.profileIdentifier.checkAndSetProfileId()
         lifecycleObserver.startObserving()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16550)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35121)

## :bulb: Description
Register for Glean pings before recording metrics.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

