### PR TITLE
Bugfix FXIOS-14272 - Private browsing mode's toolbar buttons intermittently have no icon symbols

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayThemeAnimator.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayThemeAnimator.swift
@@ -9,7 +9,7 @@ protocol TabTrayAnimationDelegate: AnyObject {
 }
 
 @MainActor
-class TabTrayThemeAnimator {
+final class TabTrayThemeAnimator {
     struct UX {
         static let animationDuration: CFTimeInterval = 0.25
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -512,6 +512,7 @@ final class TabTrayViewController: UIViewController,
         activeExperimentSegmentControl.applyTheme(theme: swipeTheme)
         setupToolBarAppearance(theme: swipeTheme)
         setupNavigationBarAppearance(theme: swipeTheme)
+        updateInterfaceStyle(isPrivateMode: tabTrayState.isPrivateMode)
     }
 
     private func setupToolBarAppearance(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -335,7 +335,12 @@ final class TabTrayViewController: UIViewController,
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        applyTheme()
+
+        // Changing the interface style triggers a trait change, so we end up back here on the transition's first
+        // frame. Re-theming now would flash the destination colors before the animation gets a chance to start.
+        if !themeAnimator.isAnimating && swipeFromIndex == nil {
+            applyTheme()
+        }
 
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass
             || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {
@@ -467,13 +472,22 @@ final class TabTrayViewController: UIViewController,
 
         if shouldUsePrivateOverride {
             activeExperimentSegmentControl.applyTheme(theme: theme)
-
-            let userInterfaceStyle = tabTrayState.isPrivateMode ? .dark : theme.type.getInterfaceStyle()
-            navigationController?.overrideUserInterfaceStyle = userInterfaceStyle
+            updateInterfaceStyle(isPrivateMode: tabTrayState.isPrivateMode)
         }
 
         setupToolBarAppearance(theme: theme)
         setupNavigationBarAppearance(theme: theme)
+    }
+
+    private func updateInterfaceStyle(isPrivateMode: Bool) {
+        guard shouldUsePrivateOverride else { return }
+
+        let style: UIUserInterfaceStyle = if isPrivateMode {
+            .dark
+        } else {
+            themeManager.resolvedTheme(with: false).type.getInterfaceStyle()
+        }
+        navigationController?.overrideUserInterfaceStyle = style
     }
 
     func applyTheme(fromIndex: Int, toIndex: Int, progress: CGFloat) {
@@ -1012,6 +1026,7 @@ final class TabTrayViewController: UIViewController,
 
             let reduceMotionEnabled = UIAccessibility.isReduceMotionEnabled
             if !reduceMotionEnabled {
+                updateInterfaceStyle(isPrivateMode: panelType == .privateTabs)
                 themeAnimator.animateThemeTransition(fromIndex: currentIndex, toIndex: targetIndex)
             }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14272)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30896)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### The Problem
Switching between the Tabs and Private panels in the tab tray left parts of the tray rendering the previous panel's appearance. The selector's colors updated, pill, labels, background, but the material behind it (glass on iOS 26, blur below) did not, so a private tray could show a light-mode glass pill, and vice versa.

### The Fix
Extract the style update into `updateInterfaceStyle(isPrivateMode:)` and call it directly at the start of the panel transition, so it no longer depends on a theme pass running. Applying it up front also puts the material repaint underneath the panel-slide animation, rather than landing on its own after the colors have already settled.

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

### Before

https://github.com/user-attachments/assets/7a86bdac-8895-432b-9a12-1f258f7df949

### After

https://github.com/user-attachments/assets/4c5251d2-483f-4f9f-a763-0ddc3f4a1eab


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

