### PR TITLE
Add FXIOS-16432 [WebCompat] Add the Report Preview summary strings

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4604,8 +4604,8 @@ extension String {
                 public static let UserAgent = MZLocalizedString(
                     key: "WebCompatReporter.Preview.Data.UserAgent.v155",
                     tableName: "WebCompatReporter",
-                    value: "Your browser’s user agent, which includes your iOS version, Firefox version, and browser engine version",
-                    comment: "Bullet on the Report Preview screen. Those three versions are only ever sent as tokens inside the user agent, never as fields of their own."
+                    value: "Your browser’s user agent, which includes your iOS version, %@ version, and browser engine version",
+                    comment: "Bullet on the Report Preview screen. Those three versions are only ever sent as tokens inside the user agent, never as fields of their own. %@ is the app name (e.g. Firefox)."
                 )
                 public static let TrackingProtectionSetting = MZLocalizedString(
                     key: "WebCompatReporter.Preview.Data.TrackingProtectionSetting.v155",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4574,6 +4574,106 @@ extension String {
                 value: "Close",
                 comment: "Accessibility label for the button that closes the full-screen screenshot viewer on the Report Preview screen."
             )
+            public static let TechnicalData = MZLocalizedString(
+                key: "WebCompatReporter.Preview.TechnicalData.v155",
+                tableName: "WebCompatReporter",
+                value: "Technical Data",
+                comment: "Row on the Report Preview screen that opens the Technical Data screen, and that screen's title."
+            )
+            /// One bullet per field the report can carry, in plain language. A bullet is shown only
+            /// when the report actually carries that field.
+            public struct Data {
+                public static let PageURL = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.PageURL.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Page URL",
+                    comment: "Bullet on the Report Preview screen. The reported page's address is shown underneath it."
+                )
+                public static let IssueAndDescription = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.IssueAndDescription.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Issue type you selected and any description you added",
+                    comment: "Bullet on the Report Preview screen, for the problem picked and the details typed."
+                )
+                public static let IsTablet = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.IsTablet.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Whether or not your device is a tablet",
+                    comment: "Bullet on the Report Preview screen. Only tablet or not is sent, no device make or model."
+                )
+                public static let OperatingSystemVersion = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.OperatingSystemVersion.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Operating system version number",
+                    comment: "Bullet on the Report Preview screen. The iOS version is sent inside the user agent."
+                )
+                public static let AppVersion = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.AppVersion.v155",
+                    tableName: "WebCompatReporter",
+                    value: "App version number",
+                    comment: "Bullet on the Report Preview screen. The app version is sent inside the user agent."
+                )
+                public static let BrowserEngineVersion = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.BrowserEngineVersion.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Browser engine version",
+                    comment: "Bullet on the Report Preview screen. The engine version is sent inside the user agent."
+                )
+                public static let TrackingProtectionSetting = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.TrackingProtectionSetting.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Enhanced Tracking Protection setting for this site",
+                    comment: "Bullet on the Report Preview screen, for the tracking protection strength the user has chosen."
+                )
+                public static let BlockedTrackers = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.BlockedTrackers.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Hostnames of trackers blocked on this page",
+                    comment: "Bullet on the Report Preview screen, for trackers blocked on the reported page."
+                )
+                public static let PrivateBrowsingStatus = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.PrivateBrowsingStatus.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Private browsing status: on or off",
+                    comment: "Bullet on the Report Preview screen, for whether the page was open in private browsing."
+                )
+                public static let AvailableMemory = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.AvailableMemory.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Your device’s available memory",
+                    comment: "Bullet on the Report Preview screen, for the amount of memory the device has."
+                )
+                public static let PixelDensity = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.PixelDensity.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Your screen’s pixel density",
+                    comment: "Bullet on the Report Preview screen, for the screen's physical pixels per layout point."
+                )
+                public static let HasTouchscreen = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.HasTouchscreen.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Whether your device has a touchscreen",
+                    comment: "Bullet on the Report Preview screen, for whether the device has a touchscreen."
+                )
+                public static let PageLanguages = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.PageLanguages.v155",
+                    tableName: "WebCompatReporter",
+                    value: "The language settings sent with this page",
+                    comment: "Bullet on the Report Preview screen, for the languages the page was requested in."
+                )
+                public static let DeviceLocale = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.DeviceLocale.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Primary language and country of your device",
+                    comment: "Bullet on the Report Preview screen, for the device's own language and region settings."
+                )
+                public static let PageElements = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.PageElements.v155",
+                    tableName: "WebCompatReporter",
+                    value: "Information about page elements that have been known to cause site issues",
+                    comment: "Bullet on the Report Preview screen, for web frameworks known to break mobile pages."
+                )
+            }
         }
         public struct Toast {
             public static let ReportSent = MZLocalizedString(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4601,23 +4601,11 @@ extension String {
                     value: "Whether or not your device is a tablet",
                     comment: "Bullet on the Report Preview screen. Only tablet or not is sent, no device make or model."
                 )
-                public static let OperatingSystemVersion = MZLocalizedString(
-                    key: "WebCompatReporter.Preview.Data.OperatingSystemVersion.v155",
+                public static let UserAgent = MZLocalizedString(
+                    key: "WebCompatReporter.Preview.Data.UserAgent.v155",
                     tableName: "WebCompatReporter",
-                    value: "Operating system version number",
-                    comment: "Bullet on the Report Preview screen. The iOS version is sent inside the user agent."
-                )
-                public static let AppVersion = MZLocalizedString(
-                    key: "WebCompatReporter.Preview.Data.AppVersion.v155",
-                    tableName: "WebCompatReporter",
-                    value: "App version number",
-                    comment: "Bullet on the Report Preview screen. The app version is sent inside the user agent."
-                )
-                public static let BrowserEngineVersion = MZLocalizedString(
-                    key: "WebCompatReporter.Preview.Data.BrowserEngineVersion.v155",
-                    tableName: "WebCompatReporter",
-                    value: "Browser engine version",
-                    comment: "Bullet on the Report Preview screen. The engine version is sent inside the user agent."
+                    value: "Your browser’s user agent, which includes your iOS version, Firefox version, and browser engine version",
+                    comment: "Bullet on the Report Preview screen. Those three versions are only ever sent as tokens inside the user agent, never as fields of their own."
                 )
                 public static let TrackingProtectionSetting = MZLocalizedString(
                     key: "WebCompatReporter.Preview.Data.TrackingProtectionSetting.v155",
@@ -4659,7 +4647,7 @@ extension String {
                     key: "WebCompatReporter.Preview.Data.PageLanguages.v155",
                     tableName: "WebCompatReporter",
                     value: "The language settings sent with this page",
-                    comment: "Bullet on the Report Preview screen, for the languages the page was requested in."
+                    comment: "Bullet on the Report Preview screen, for the page's navigator.languages, the language list the page itself reads. Distinct from the device's own languages, which have their own bullet."
                 )
                 public static let DeviceLocale = MZLocalizedString(
                     key: "WebCompatReporter.Preview.Data.DeviceLocale.v155",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4646,8 +4646,8 @@ extension String {
                 public static let PageLanguages = MZLocalizedString(
                     key: "WebCompatReporter.Preview.Data.PageLanguages.v155",
                     tableName: "WebCompatReporter",
-                    value: "The language settings sent with this page",
-                    comment: "Bullet on the Report Preview screen, for the page's navigator.languages, the language list the page itself reads. Distinct from the device's own languages, which have their own bullet."
+                    value: "Language preferences sent to this page",
+                    comment: "Bullet on the Report Preview screen, for a list of the user's preferred languages for websites as they were communicated by the browser to the page"
                 )
                 public static let DeviceLocale = MZLocalizedString(
                     key: "WebCompatReporter.Preview.Data.DeviceLocale.v155",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16432)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34960)

## :bulb: Description
Strings for the plain-language Report Preview screen: one bullet per field the report can carry, plus the row label that opens Technical Data. Copy is Emily Wachowiak's, written against the data-collection audit on the ticket.

No call sites. They land alone so l10n can export them, and [#35095](https://github.com/mozilla-mobile/firefox-ios/pull/35095) picks them up.

Stacked on [#35096](https://github.com/mozilla-mobile/firefox-ios/pull/35096).

## :movie_camera: Demos
Nothing user-visible. The strings are not referenced yet.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

