### PR TITLE
Bugfix FXIOS-16538 Fix dynamic text for Wayback button

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ResizableButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ResizableButton.swift
@@ -43,6 +43,9 @@ open class ResizableButton: UIButton {
             availableWidth = availableWidth - imageWidth - imagePadding
         }
 
+        guard availableWidth > 0 else {
+            return super.intrinsicContentSize
+        }
         let size = title.sizeThatFits(CGSize(width: availableWidth, height: .greatestFiniteMagnitude))
         return CGSize(width: size.width + widthContentInset,
                       height: size.height + heightContentInset)
@@ -51,8 +54,10 @@ open class ResizableButton: UIButton {
     override public func layoutSubviews() {
         super.layoutSubviews()
         guard let title = titleLabel else { return }
-
-        titleLabel?.preferredMaxLayoutWidth = title.frame.size.width
+        let newWidth = title.frame.size.width
+        guard newWidth > 0, title.preferredMaxLayoutWidth != newWidth else { return }
+        title.preferredMaxLayoutWidth = newWidth
+        invalidateIntrinsicContentSize()
     }
 
     private func commonInit() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16538)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35141)

## :bulb: Description
There was a strange dynamic text bug where the Wayback button would not resize sometimes for bigger texts and other times it would. After some investigation, my theory is that there is a race condition where intrinsicContentSize is sometimes computed before ResizableButton has been assigned a real frame by Auto Layout, which means the available width used to size the title is incorrect, resulting in the wrong size. To resolve this, I added a safety guard that ensures intrinsicContentSize never computes off of a zero or negative available width (which happens on the layout pass before the button has a real frame), falling back to the default UIButton sizing for that pass instead. I also updated layoutSubviews to call invalidateIntrinsicContentSize() once the title label's real width is known, so Auto Layout is forced to ask again for the correct size instead of getting stuck with whatever size was computed on that first premature pass.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

