### PR TITLE
Bugfix FXIOS-16527 Make strings for Wayback match Figma design

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2150,7 +2150,7 @@ extension String {
             public static let CheckingLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Checking.v154",
                 tableName: "NativeErrorPage",
-                value: "Checking the archive...",
+                value: "Checking the archive…",
                 comment: "Label of the button on the connection error page - displayed if the user clicks on the button to requested an earlier version of the page and the search is in progress.")
             public static let CouldNotReachLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.CouldNotReach.v154",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2031,9 +2031,9 @@ extension String {
 extension String {
     public struct NativeErrorPage {
         public static let ButtonLabel = MZLocalizedString(
-            key: "NativeErrorPage.ButtonLabel.v131",
+            key: "NativeErrorPage.ButtonLabel.v154",
             tableName: "NativeErrorPage",
-            value: "Reload",
+            value: "Try Again",
             comment: "On error page, this is the text on a button that will try to load the page again.")
         public static let GoBackButton = MZLocalizedString(
             key: "NativeErrorPage.GoBackButton.v149",
@@ -2140,7 +2140,7 @@ extension String {
             public static let SearchLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Search.v154",
                 tableName: "NativeErrorPage",
-                value: "Check for earlier version",
+                value: "View archived version",
                 comment: "Button label on the error page when the app is unable to connect to the server - clicking on the button launches a search for an earlier version of the page on the Wayback Machine.")
             public static let WaybackButtonA11yHint = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.WaybackButtonA11yHint.v154",
@@ -2150,12 +2150,12 @@ extension String {
             public static let CheckingLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Checking.v154",
                 tableName: "NativeErrorPage",
-                value: "Checking for page…",
+                value: "Checking the archive...",
                 comment: "Label of the button on the connection error page - displayed if the user clicks on the button to requested an earlier version of the page and the search is in progress.")
             public static let CouldNotReachLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.CouldNotReach.v154",
                 tableName: "NativeErrorPage",
-                value: "Couldn’t reach Wayback Machine",
+                value: "We couldn't reach the archive service.",
                 comment: "Label shown when the app fails to reach the Wayback Machine while searching for an earlier version of a page.")
             public static let RetryButton = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Retry.v154",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2150,7 +2150,7 @@ extension String {
             public static let CheckingLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Checking.v155",
                 tableName: "NativeErrorPage",
-                value: "Checking the archive…",
+                value: "Checking the Archive…",
                 comment: "Label of the button on the connection error page - displayed if the user clicks on the button to requested an earlier version of the page and the search is in progress.")
             public static let CouldNotReachLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.CouldNotReach.v155",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2155,7 +2155,7 @@ extension String {
             public static let CouldNotReachLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.CouldNotReach.v154",
                 tableName: "NativeErrorPage",
-                value: "We couldn't reach the archive service.",
+                value: "We couldn’t reach the archive service.",
                 comment: "Label shown when the app fails to reach the Wayback Machine while searching for an earlier version of a page.")
             public static let RetryButton = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Retry.v154",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2140,7 +2140,7 @@ extension String {
             public static let SearchLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Search.v155",
                 tableName: "NativeErrorPage",
-                value: "View archived version",
+                value: "View Archived Version",
                 comment: "Button label on the error page when the app is unable to connect to the server - clicking on the button launches a search for an earlier version of the page on the Wayback Machine.")
             public static let WaybackButtonA11yHint = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.WaybackButtonA11yHint.v154",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2031,7 +2031,7 @@ extension String {
 extension String {
     public struct NativeErrorPage {
         public static let ButtonLabel = MZLocalizedString(
-            key: "NativeErrorPage.ButtonLabel.v154",
+            key: "NativeErrorPage.ButtonLabel.v155",
             tableName: "NativeErrorPage",
             value: "Try Again",
             comment: "On error page, this is the text on a button that will try to load the page again.")
@@ -2138,7 +2138,7 @@ extension String {
                 value: "The site may be busy or unavailable. Try again later. If other pages won’t load, check your Wi-Fi or data connection. %@ can also search the Wayback Machine for an earlier version of this page.",
                 comment: "Description of the error page when the app is unable to connect to the server and will show a wayback fallback. %@ is the app name (e.g. Firefox).")
             public static let SearchLabel = MZLocalizedString(
-                key: "NativeErrorPage.Wayback.Error.Search.v154",
+                key: "NativeErrorPage.Wayback.Error.Search.v155",
                 tableName: "NativeErrorPage",
                 value: "View archived version",
                 comment: "Button label on the error page when the app is unable to connect to the server - clicking on the button launches a search for an earlier version of the page on the Wayback Machine.")
@@ -2148,12 +2148,12 @@ extension String {
                 value: "Searches the Wayback Machine for an archived version of this page.",
                 comment: "Accessibility hint read by VoiceOver describing what happens when the 'Check for earlier version' button is clicked.")
             public static let CheckingLabel = MZLocalizedString(
-                key: "NativeErrorPage.Wayback.Error.Checking.v154",
+                key: "NativeErrorPage.Wayback.Error.Checking.v155",
                 tableName: "NativeErrorPage",
                 value: "Checking the archive…",
                 comment: "Label of the button on the connection error page - displayed if the user clicks on the button to requested an earlier version of the page and the search is in progress.")
             public static let CouldNotReachLabel = MZLocalizedString(
-                key: "NativeErrorPage.Wayback.Error.CouldNotReach.v154",
+                key: "NativeErrorPage.Wayback.Error.CouldNotReach.v155",
                 tableName: "NativeErrorPage",
                 value: "We couldn’t reach the archive service.",
                 comment: "Label shown when the app fails to reach the Wayback Machine while searching for an earlier version of a page.")

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2165,7 +2165,7 @@ extension String {
             public static let NotFoundLabel = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.NotFound.v155",
                 tableName: "NativeErrorPage",
-                value: "No archived version found",
+                value: "No archived version found.",
                 comment: "Label shown when wayback responds and says no snapshot was found.")
             public static let SearchButton = MZLocalizedString(
                 key: "NativeErrorPage.Wayback.Error.Search.v155",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16527)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35076)

## :bulb: Description
This PR makes the strings for the Wayback feature match the following [Figma](https://www.figma.com/design/BVqEYexibOA2betNVUMrfl/Mobile-Assembly-File-2026?node-id=10645-9909&p=f&t=Jg6fwyZYCbAUHOnz-0)

Also I was not sure weather to put the strings in OldStrings or not, although I believe these strings are all gated behind feature flags so should be fine if I don't right?

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

