### PR TITLE
Refactor FXIOS-16354 [Periphery] Narrow Account imports

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
+++ b/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
@@ -5,8 +5,9 @@
 import UIKit
 import Shared
 import UserNotifications
-import Account
 
+import class Account.Autopush
+import class Account.RustFirefoxAccounts
 import struct MozillaAppServices.ConstellationState
 
 /**

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -5,9 +5,10 @@
 import Common
 import Foundation
 import Shared
-import Account
 import Glean
 import MozillaAppServices
+
+import class Account.RustFirefoxAccounts
 
 final class AppLaunchUtil: FeatureFlaggable, Sendable {
     private let logger: Logger

--- a/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
+++ b/firefox-ios/Client/Application/RemoteSettings/Application Services/ASSearchEngineSelector.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import MozillaAppServices
-import Account
 import Common
 import Shared
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -8,7 +8,6 @@ import UIKit
 import WebKit
 import Shared
 import Storage
-import Account
 import MobileCoreServices
 import Common
 import Redux
@@ -19,6 +18,7 @@ import ActivityKit
 import Glean
 import QuickAnswersKit
 
+import class Account.RustFirefoxAccounts
 import class MozillaAppServices.BookmarkFolderData
 import class MozillaAppServices.BookmarkItemData
 import struct MozillaAppServices.Login

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Redux/MainMenuMiddleware.swift
@@ -4,8 +4,9 @@
 
 import Common
 import Redux
-import Account
 import Shared
+
+import class Account.RustFirefoxAccounts
 
 @MainActor
 final class MainMenuMiddleware {

--- a/firefox-ios/Client/Frontend/Browser/RelayController.swift
+++ b/firefox-ios/Client/Frontend/Browser/RelayController.swift
@@ -4,9 +4,10 @@
 
 import Common
 import MozillaAppServices
-import Account
 import Shared
 import WebKit
+
+import class Account.RustFirefoxAccounts
 
 /// Default RelayControllerProtocol implementation.
 /// Handles account status updates and logic for Relay.

--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -5,9 +5,10 @@
 import UIKit
 import Shared
 import Storage
-import Account
 import SwiftUI
 import Common
+
+import class Account.RustFirefoxAccounts
 
 protocol DevicePickerViewControllerDelegate: AnyObject {
     @MainActor

--- a/firefox-ios/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/AdvancedAccountSettingViewController.swift
@@ -5,7 +5,7 @@
 import UIKit
 import Shared
 
-import Account
+import class Account.RustFirefoxAccounts
 
 private class CustomFxAContentServerEnableSetting: BoolSetting {
       init(prefs: Prefs, settingDidChange: (@MainActor  (Bool?) -> Void)? = nil) {

--- a/firefox-ios/Client/Frontend/Settings/Main/Account/ChinaSyncServiceSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/ChinaSyncServiceSetting.swift
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Account
 import Common
 import Foundation
 import Shared
 import ComponentLibrary
+
+import class Account.RustFirefoxAccounts
 
 class ChinaSyncServiceSetting: Setting {
     private weak var settingsDelegate: SharedSettingsDelegate?

--- a/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Account
 import Common
 import Shared
 import UIKit

--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -6,7 +6,8 @@ import Common
 import Foundation
 import Shared
 import Sync
-import Account
+
+import class Account.RustFirefoxAccounts
 
 final class ManageFxAccountSetting: Setting {
     private var notification: NSObjectProtocol?

--- a/firefox-ios/Providers/Profile.swift
+++ b/firefox-ios/Providers/Profile.swift
@@ -9,11 +9,12 @@
 // increased startup times which may lead to termination by the OS.
 
 import Common
-import Account
 import Shared
 import Storage
 import AuthenticationServices
 
+import class Account.Autopush
+import class Account.RustFirefoxAccounts
 import class MozillaAppServices.RemoteSettingsService
 import struct MozillaAppServices.RemoteSettingsContext
 import enum MozillaAppServices.Level

--- a/firefox-ios/Providers/RustSyncManager.swift
+++ b/firefox-ios/Providers/RustSyncManager.swift
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Account
 import Shared
 import Storage
 import Sync
 import AuthenticationServices
 import Common
 
+import class Account.RustFirefoxAccounts
 import enum MozillaAppServices.OAuthScope
 import enum MozillaAppServices.ServiceStatus
 import enum MozillaAppServices.SyncEngineSelection

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -4,11 +4,11 @@
 
 import WebKit
 import Foundation
-import Account
 import Shared
 import Common
 import PDFKit
 
+import class Account.RustFirefoxAccounts
 import enum MozillaAppServices.OAuthScope
 import struct MozillaAppServices.FxaAuthData
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16354)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34788)

## :bulb: Description
Removes unused broad `import Account` statements reported by Periphery.

Files that directly use Account APIs now import only the required declarations, such as `RustFirefoxAccounts` and `Autopush`. This keeps the main app and app-extension targets compiling while avoiding unnecessary module-wide imports.

The Periphery scheme builds successfully for the arm64 iOS Simulator. The local Periphery scan was skipped because the Periphery executable is not installed.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] No new tests were required for this import-only refactor; the Periphery scheme builds successfully
- [x] Accessibility changes are not applicable because this PR has no UI changes
- [x] Data review is not applicable because this PR does not add or modify telemetry
- [x] String review is not applicable because this PR does not add or modify strings
- [x] Documentation changes are not required