### PR TITLE
Bugfix FXIOS-11496 [Toast] Migrate ButtonToast's button to ActionButton

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -788,6 +788,7 @@
 		61DD72D12F5936C4002BFEA6 /* AIControlsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DD72D02F5936AF002BFEA6 /* AIControlsSetting.swift */; };
 		61DD72D52F5937A6002BFEA6 /* AIControlsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DD72D42F5937A0002BFEA6 /* AIControlsSettingsView.swift */; };
 		61E637852D03615D00E95B63 /* LabelButtonHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E637842D03615D00E95B63 /* LabelButtonHeaderViewTests.swift */; };
+		25FA10010001000100010001 /* ButtonToastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FA10010001000100010002 /* ButtonToastTests.swift */; };
 		61E637872D03615D00E95B63 /* StoryCategoryPickerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E637862D03615D00E95B63 /* StoryCategoryPickerViewTests.swift */; };
 		61F7A4332D136C3A00F7317B /* RouteBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F7A4322D136C3A00F7317B /* RouteBuilderTests.swift */; };
 		630EBE4D301109A30046E9BC /* GradientProgressBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EBE4C301109A10046E9BC /* GradientProgressBarTests.swift */; };
@@ -9301,6 +9302,7 @@
 		61DD72D02F5936AF002BFEA6 /* AIControlsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIControlsSetting.swift; sourceTree = "<group>"; };
 		61DD72D42F5937A0002BFEA6 /* AIControlsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIControlsSettingsView.swift; sourceTree = "<group>"; };
 		61E637842D03615D00E95B63 /* LabelButtonHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelButtonHeaderViewTests.swift; sourceTree = "<group>"; };
+		25FA10010001000100010002 /* ButtonToastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonToastTests.swift; sourceTree = "<group>"; };
 		61E637862D03615D00E95B63 /* StoryCategoryPickerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryCategoryPickerViewTests.swift; sourceTree = "<group>"; };
 		61F7A4322D136C3A00F7317B /* RouteBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteBuilderTests.swift; sourceTree = "<group>"; };
 		623648C2A7D09ECA31155208 /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ka; path = ka.lproj/ErrorPages.strings; sourceTree = "<group>"; };
@@ -16865,9 +16867,18 @@
 				21872A222E3CFEA500241A8A /* TabScrollHandlerTests.swift */,
 				21EA33802EC67FCA00D20D90 /* ToolbarAnimatorTest.swift */,
 				8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */,
+				25FA10010001000100010003 /* Toasts */,
 				E1AEC174286E0CF500062E29 /* WebView */,
 			);
 			path = Browser;
+			sourceTree = "<group>";
+		};
+		25FA10010001000100010003 /* Toasts */ = {
+			isa = PBXGroup;
+			children = (
+				25FA10010001000100010002 /* ButtonToastTests.swift */,
+			);
+			path = Toasts;
 			sourceTree = "<group>";
 		};
 		E1AEC174286E0CF500062E29 /* WebView */ = {
@@ -21210,6 +21221,7 @@
 				967EDABD29D705300089208D /* CreditCardValidatorTests.swift in Sources */,
 				967EDABF29D769A10089208D /* CreditCardInputFieldTests.swift in Sources */,
 				61E637852D03615D00E95B63 /* LabelButtonHeaderViewTests.swift in Sources */,
+				25FA10010001000100010001 /* ButtonToastTests.swift in Sources */,
 				61E637872D03615D00E95B63 /* StoryCategoryPickerViewTests.swift in Sources */,
 				A1F0D0012F70000100ABC001 /* NewsTransitionHeaderCellTests.swift in Sources */,
 				21F2A2D42B0D194A00626AEC /* TabsPanelStateTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Toasts/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/ButtonToast.swift
@@ -126,16 +126,11 @@ class ButtonToast: Toast {
         let viewModel = ActionButtonViewModel(
             title: buttonText,
             a11yIdentifier: nil,
+            horizontalInset: UX.buttonPadding,
+            verticalInset: UX.buttonPadding,
             touchUpAction: { [weak self] _ in self?.buttonPressed() }
         )
         roundedButton.configure(viewModel: viewModel)
-
-        NSLayoutConstraint.activate([
-            roundedButton.heightAnchor.constraint(
-                equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.height + 2 * UX.buttonPadding),
-            roundedButton.widthAnchor.constraint(
-                equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.buttonPadding)
-        ])
     }
 
     override func applyTheme(theme: Theme) {

--- a/firefox-ios/Client/Frontend/Browser/Toasts/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/ButtonToast.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import ComponentLibrary
 import Foundation
 import Shared
 
@@ -51,15 +52,9 @@ class ButtonToast: Toast {
         label.numberOfLines = 0
     }
 
-    private var roundedButton: UIButton = .build { button in
+    private(set) var roundedButton: ActionButton = .build { button in
         button.layer.cornerRadius = UX.buttonBorderRadius
         button.layer.borderWidth = UX.buttonBorderWidth
-        button.titleLabel?.font = FXFontStyles.Regular.subheadline.scaledFont()
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.titleLabel?.numberOfLines = 1
-        button.titleLabel?.lineBreakMode = .byClipping
-        button.titleLabel?.adjustsFontSizeToFitWidth = true
-        button.titleLabel?.minimumScaleFactor = 0.1
     }
 
     // Pass themeManager to call on init
@@ -128,7 +123,12 @@ class ButtonToast: Toast {
         guard let buttonText = buttonText else { return }
 
         stackView.addArrangedSubview(roundedButton)
-        roundedButton.setTitle(buttonText, for: [])
+        let viewModel = ActionButtonViewModel(
+            title: buttonText,
+            a11yIdentifier: nil,
+            touchUpAction: { [weak self] _ in self?.buttonPressed() }
+        )
+        roundedButton.configure(viewModel: viewModel)
 
         NSLayoutConstraint.activate([
             roundedButton.heightAnchor.constraint(
@@ -136,8 +136,6 @@ class ButtonToast: Toast {
             roundedButton.widthAnchor.constraint(
                 equalToConstant: roundedButton.titleLabel!.intrinsicContentSize.width + 2 * UX.buttonPadding)
         ])
-
-        roundedButton.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonPressed)))
     }
 
     override func applyTheme(theme: Theme) {
@@ -146,7 +144,7 @@ class ButtonToast: Toast {
         titleLabel.textColor = theme.colors.textInverted
         descriptionLabel.textColor = theme.colors.textInverted
         imageView.tintColor = theme.colors.textInverted
-        roundedButton.setTitleColor(theme.isNova ? theme.colors.textToast : theme.colors.textInverted, for: [])
+        roundedButton.foregroundColorNormal = theme.isNova ? theme.colors.textToast : theme.colors.textInverted
         roundedButton.layer.borderColor = theme.colors.borderInverted.cgColor
     }
 
@@ -166,7 +164,6 @@ class ButtonToast: Toast {
     }
 
     // MARK: - Button action
-    @objc
     func buttonPressed() {
         completionHandler?(true)
         dismiss(true)

--- a/firefox-ios/Client/Frontend/Browser/Toasts/Toast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/Toast.swift
@@ -115,14 +115,14 @@ class Toast: UIView, ThemeApplicable, Notifiable {
 
         UIView.animate(
             withDuration: UX.toastAnimationDuration,
-            animations: {
-                self.animationConstraint?.constant = UX.toastHeightWithShadow
-                self.layoutIfNeeded()
+            animations: { [weak self] in
+                self?.animationConstraint?.constant = UX.toastHeightWithShadow
+                self?.layoutIfNeeded()
             }
-        ) { finished in
-            self.removeFromSuperview()
+        ) { [weak self] finished in
+            self?.removeFromSuperview()
             if !buttonPressed {
-                self.completionHandler?(false)
+                self?.completionHandler?(false)
             }
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Toasts/ButtonToastTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Toasts/ButtonToastTests.swift
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+
+@testable import Client
+
+@MainActor
+final class ButtonToastTests: XCTestCase {
+    func test_buttonToast_withButtonText_tappingButtonInvokesCompletionHandlerWithTrue() {
+        var completionResult: Bool?
+        let toast = createSubject(buttonText: "Undo") { pressed in
+            completionResult = pressed
+        }
+
+        toast.roundedButton.sendActions(for: .touchUpInside)
+
+        XCTAssertEqual(completionResult, true)
+    }
+
+    func test_buttonToast_withNoButtonText_doesNotAddButtonToView() {
+        let toast = createSubject(buttonText: nil)
+
+        XCTAssertNil(toast.roundedButton.superview)
+    }
+
+    func test_buttonToast_applyTheme_withStandardTheme_setsTextInvertedForegroundColor() {
+        let toast = createSubject(buttonText: "Undo")
+        let theme = DarkTheme()
+
+        toast.applyTheme(theme: theme)
+
+        XCTAssertEqual(toast.roundedButton.foregroundColorNormal, theme.colors.textInverted)
+        XCTAssertEqual(toast.roundedButton.layer.borderColor, theme.colors.borderInverted.cgColor)
+    }
+
+    func test_buttonToast_applyTheme_withNovaTheme_setsTextToastForegroundColor() {
+        let toast = createSubject(buttonText: "Undo")
+        let theme = NovaDarkTheme()
+
+        toast.applyTheme(theme: theme)
+
+        XCTAssertEqual(toast.roundedButton.foregroundColorNormal, theme.colors.textToast)
+    }
+
+    private func createSubject(
+        buttonText: String?,
+        completion: (@MainActor (Bool) -> Void)? = nil
+    ) -> ButtonToast {
+        let viewModel = ButtonToastViewModel(labelText: "Test label", buttonText: buttonText)
+        let toast = ButtonToast(viewModel: viewModel, theme: DarkTheme(), completion: completion)
+        trackForMemoryLeaks(toast)
+        return toast
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11496)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25023)

## :bulb: Description
Part of #25023 (refactor all Toasts with a button to use `ActionButton` from ComponentLibrary). This PR migrates `ButtonToast.roundedButton` from a hand-rolled `UIButton` (manual corner radius/border, `UITapGestureRecognizer` instead of `touchUpInside`) to `ActionButton`, following the pattern already used in `LabelButtonHeaderView`.

- `roundedButton` is now an `ActionButton`, configured via `ActionButtonViewModel` with a `touchUpAction` closure instead of a tap gesture recognizer.
- `applyTheme` now sets `roundedButton.foregroundColorNormal` instead of `setTitleColor`, since configuration-based buttons don't respect `setTitleColor`.
- Added the first unit tests for `ButtonToast` (previously zero coverage): tapping the button invokes the completion handler, no button is added when `buttonText` is nil, and theme colors are applied correctly for standard vs. Nova themes.
- While adding `trackForMemoryLeaks` coverage, discovered that `Toast.dismiss()` captured `self` strongly in its animation closures. In production this is harmless (the toast's superview retains it for the duration of the dismiss animation), but it's unnecessary retention and it's what a leak-detecting unit test without a view hierarchy immediately flags. Switched to `[weak self]`; behavior is unchanged.

`DownloadToast` (the other Toast with a hand-rolled button) is intentionally left for a follow-up PR, per the "split into smaller PRs" note on the parent issue. `PasteControlToast`'s `UIPasteControl` and `TranslationToastHandler`'s legacy `SnackBar` button are unrelated component types and out of scope.

## :movie_camera: Demos
No visual changes intended — this is an internal implementation swap (button class + wiring), not a redesign. Existing button styling (corner radius, border, colors, title) is preserved.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — no accessibility identifiers or traits changed
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review — N/A
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n — N/A
- [x] If needed, I updated documentation and added comments to complex code — N/A, no new comments needed