### PR TITLE
Bugfix FXIOS-15182 New TemporaryDocument handling

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1494,14 +1494,66 @@ final class BrowserCoordinator: BaseCoordinator,
         forShareTab tab: ShareTab
     ) async -> ShareType {
         guard let temporaryDocument = tab.temporaryDocument,
-              !temporaryDocument.isDownloading,
-              let fileURL = await temporaryDocument.download() else {
+              !temporaryDocument.isDownloading else {
+            // If no temporary document, share the tab as usual with a web URL
+            return .tab(url: tabURL, tab: tab)
+        }
+
+        // [FXIOS-15182]: Read document data straight from the already-authenticated WebView, instead of re-downloading it.
+        if WebViewDocumentFetch.isEnabled,
+           let fileURL = await documentFileFromWebView(tab, tabURL: tabURL) {
+            return .file(url: fileURL, remoteURL: tabURL)
+        }
+
+        guard let fileURL = await temporaryDocument.download() else {
             // If no file was downloaded, simply share the tab as usual with a web URL
             return .tab(url: tabURL, tab: tab)
         }
 
         // If we successfully got a temp file URL, share it like a downloaded file
         return .file(url: fileURL, remoteURL: tabURL)
+    }
+
+    /// Reads the rendered document from the tab WebView, and writes the data to a temporary file for sharing.
+    /// Because the data is pulled directly from the WebView, any auth already performed is honored.
+    private func documentFileFromWebView(_ tab: ShareTab, tabURL: URL) async -> URL? {
+        guard let webView = tab.webView else { return nil }
+
+        let readDocumentJS = """
+        const embed = document.querySelector('embed');
+        const src = embed ? embed.src : window.location.href;
+        const response = await fetch(src);
+        const blob = await response.blob();
+        return await new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onloadend = () => resolve(reader.result.split(',')[1]);
+            reader.onerror = () => reject(reader.error);
+            reader.readAsDataURL(blob);
+        });
+        """
+
+        do {
+            let result = try await webView.callAsyncJavaScript(readDocumentJS, contentWorld: .defaultClient)
+            guard let base64 = result as? String,
+                  let data = Data(base64Encoded: base64) else { return nil }
+            let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(Self.shareableFilename(for: tabURL))
+            try data.write(to: fileURL)
+            return fileURL
+        } catch {
+            logger.log("WebView document fetch failed: \(error.localizedDescription)",
+                       level: .warning,
+                       category: .shareSheet)
+            return nil
+        }
+    }
+
+    private static func shareableFilename(for url: URL) -> String {
+        let lastComponent = url.lastPathComponent
+        if !lastComponent.isEmpty, !(lastComponent as NSString).pathExtension.isEmpty {
+            return lastComponent
+        }
+        return "document.pdf"
     }
 
     /// Utility. Performs the supplied action if a coordinator of the indicated type

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1500,7 +1500,7 @@ final class BrowserCoordinator: BaseCoordinator,
         }
 
         // [FXIOS-15182]: Read document data straight from the already-authenticated WebView, instead of re-downloading it.
-        if WebViewDocumentFetch.isEnabled,
+        if featureFlagsProvider.isEnabled(.webViewDocumentFetchRefactor),
            let fileURL = await documentFileFromWebView(tab, tabURL: tabURL) {
             return .file(url: fileURL, remoteURL: tabURL)
         }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1537,7 +1537,7 @@ final class BrowserCoordinator: BaseCoordinator,
             guard let base64 = result as? String,
                   let data = Data(base64Encoded: base64) else { return nil }
             let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
-                .appendingPathComponent(Self.shareableFilename(for: tabURL))
+                .appendingPathComponent(Self.shareableFilename(for: tabURL, mimeType: tab.mimeType))
             try data.write(to: fileURL)
             return fileURL
         } catch {
@@ -1548,12 +1548,15 @@ final class BrowserCoordinator: BaseCoordinator,
         }
     }
 
-    private static func shareableFilename(for url: URL) -> String {
+    private static func shareableFilename(for url: URL, mimeType: String?) -> String {
         let lastComponent = url.lastPathComponent
         if !lastComponent.isEmpty, !(lastComponent as NSString).pathExtension.isEmpty {
             return lastComponent
         }
-        return "document.pdf"
+        if let mimeType, let fileExtension = MIMEType.fileExtensionFromMIMEType(mimeType) {
+            return "document.\(fileExtension)"
+        }
+        return "document"
     }
 
     /// Utility. Performs the supplied action if a coordinator of the indicated type

--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -66,13 +66,7 @@ enum FeatureFlagID: String, CaseIterable {
     case videoIntroOnboarding
     case vpnFeature
     case waybackMachine
-<<<<<<< HEAD
-||||||| parent of a1aa7f5fe3 ([FXIOS-15182] Feature flag)
-    case worldCupWidget
-=======
     case webViewDocumentFetchRefactor
-    case worldCupWidget
->>>>>>> a1aa7f5fe3 ([FXIOS-15182] Feature flag)
 
     /// The user preferences key for features that support user-togglable settings.
     /// Returns `nil` for features that are not user-configurable.
@@ -141,7 +135,7 @@ enum FeatureFlagID: String, CaseIterable {
                 .unifiedSearch,
                 .vpnFeature,
                 .waybackMachine,
-                .webViewDocumentFetchRefactor,
+                .webViewDocumentFetchRefactor:
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil

--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -66,6 +66,13 @@ enum FeatureFlagID: String, CaseIterable {
     case videoIntroOnboarding
     case vpnFeature
     case waybackMachine
+<<<<<<< HEAD
+||||||| parent of a1aa7f5fe3 ([FXIOS-15182] Feature flag)
+    case worldCupWidget
+=======
+    case webViewDocumentFetchRefactor
+    case worldCupWidget
+>>>>>>> a1aa7f5fe3 ([FXIOS-15182] Feature flag)
 
     /// The user preferences key for features that support user-togglable settings.
     /// Returns `nil` for features that are not user-configurable.
@@ -133,7 +140,8 @@ enum FeatureFlagID: String, CaseIterable {
                 .trendingSearches,
                 .unifiedSearch,
                 .vpnFeature,
-                .waybackMachine:
+                .waybackMachine,
+                .webViewDocumentFetchRefactor,
             return rawValue + PrefsKeys.FeatureFlags.DebugSuffixKey
         default:
             return nil

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -937,7 +937,8 @@ extension BrowserViewController: WKNavigationDelegate {
         // we may end up overriding the "Share Page With..." action to share a temp file that is not
         // representative of the contents of the web view.
         if navigationResponse.isForMainFrame, let tab = tabManager[webView] {
-            if response.mimeType == MIMEType.PDF, let request, !WebViewDocumentFetch.isEnabled {
+            let webViewDocFetchEnabled = featureFlagsProvider.isEnabled(.webViewDocumentFetchRefactor)
+            if response.mimeType == MIMEType.PDF, let request, !webViewDocFetchEnabled {
                 if !tab.shouldDownloadDocument(request) {
                     return .allow
                 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -937,7 +937,7 @@ extension BrowserViewController: WKNavigationDelegate {
         // we may end up overriding the "Share Page With..." action to share a temp file that is not
         // representative of the contents of the web view.
         if navigationResponse.isForMainFrame, let tab = tabManager[webView] {
-            if response.mimeType == MIMEType.PDF, let request {
+            if response.mimeType == MIMEType.PDF, let request, !WebViewDocumentFetch.isEnabled {
                 if !tab.shouldDownloadDocument(request) {
                     return .allow
                 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -945,8 +945,16 @@ extension BrowserViewController: WKNavigationDelegate {
                 handlePDFDownloadRequest(request: request, tab: tab, filename: response.suggestedFilename)
                 return .cancel
             }
-            if response.mimeType != MIMEType.HTML, let request {
-                tab.temporaryDocument = DefaultTemporaryDocument(preflightResponse: response, request: request)
+            if response.mimeType != MIMEType.HTML {
+                if webViewDocFetchEnabled {
+                    // WebView fetch reads the document directly from the view, so no request is required.
+                    tab.temporaryDocument = DefaultTemporaryDocument(preflightResponse: response)
+                } else if let request {
+                    tab.temporaryDocument = DefaultTemporaryDocument(preflightResponse: response,
+                                                                     request: request)
+                } else {
+                    tab.temporaryDocument = nil
+                }
             } else {
                 tab.temporaryDocument = nil
             }

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -339,6 +339,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
             ) { [weak self] _ in
                 self?.reloadView()
             },
+            FeatureFlagsBoolSetting(
+                with: .webViewDocumentFetchRefactor,
+                titleText: format(string: "Webview Document Refactor"),
+                statusText: format(string: "Toggle to enable document sharing to fetch WebView data directly")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
         ]
 
         return SettingSection(

--- a/firefox-ios/Client/Frontend/Share/ShareTab.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareTab.swift
@@ -15,6 +15,8 @@ protocol ShareTab: Sendable {
     var canonicalURL: URL? { get }
     @MainActor
     var webView: TabWebView? { get }
+    @MainActor
+    var mimeType: String? { get }
 
     // Tabs displaying content other than a HTML MIME type can optionally be downloaded and treated as files when shared.
     @MainActor

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -468,7 +468,7 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
     }
 
     private func checkWebViewDocumentFetchRefactor() -> Bool {
-        return nimbus.features.webViewDocumentFetchRefactor.value().enabled
+        return nimbus.features.webViewDocumentFetchRefactorFeature.value().enabled
     }
 
     private func checkVPNFeature() -> Bool {

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -203,6 +203,9 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .waybackMachine:
             return checkWaybackMachineFeature()
 
+        case .webViewDocumentFetchRefactor:
+            return checkWebViewDocumentFetchRefactor()
+
         // This feature flag has no Nimbus configuration because it is only tied to a user setting.
         // Requesting Nimbus configuration for it is a developer error.
         case .hntSponsoredShortcuts:
@@ -462,6 +465,10 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
 
     private func checkWaybackMachineFeature() -> Bool {
         return nimbus.features.waybackMachineFeature.value().enabled
+    }
+
+    private func checkWebViewDocumentFetchRefactor() -> Bool {
+        return nimbus.features.webViewDocumentFetchRefactor.value().enabled
     }
 
     private func checkVPNFeature() -> Bool {

--- a/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
+++ b/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
@@ -103,7 +103,7 @@ final class DefaultTemporaryDocument: NSObject,
                                       URLSessionDownloadDelegate,
                                       @unchecked Sendable {
     private let session: URLSession
-    private let request: URLRequest
+    private let request: URLRequest?
     private let cookies: [HTTPCookie]
     private let credential: URLCredential?
     private var currentDownloadTask: URLSessionDownloadTask?
@@ -122,7 +122,7 @@ final class DefaultTemporaryDocument: NSObject,
     private let logger: Logger
 
     var sourceURL: URL? {
-        return request.url
+        return request?.url
     }
 
     init(
@@ -147,7 +147,7 @@ final class DefaultTemporaryDocument: NSObject,
 
     init(
         preflightResponse: URLResponse,
-        request: URLRequest,
+        request: URLRequest? = nil,
         mimeType: String? = nil,
         session: URLSession = .shared,
         logger: Logger = DefaultLogger.shared
@@ -207,6 +207,7 @@ final class DefaultTemporaryDocument: NSObject,
         if let tempFile = queryTempFile() {
             return tempFile
         }
+        guard let request else { return nil }
         let response = try? await session.download(for: request)
         guard let location = response?.0, let tempFileURL = storeTempDownloadFile(at: location) else { return nil }
 
@@ -217,6 +218,12 @@ final class DefaultTemporaryDocument: NSObject,
         if let tempFile = queryTempFile() {
             ensureMainThread {
                 completion(tempFile)
+            }
+            return
+        }
+        guard let request else {
+            ensureMainThread {
+                completion(nil)
             }
             return
         }
@@ -314,7 +321,10 @@ final class DefaultTemporaryDocument: NSObject,
         let isHTTPAuthChallenge = method == NSURLAuthenticationMethodHTTPBasic
             || method == NSURLAuthenticationMethodHTTPDigest
             || method == NSURLAuthenticationMethodNTLM
-        if let credential, isHTTPAuthChallenge, challenge.protectionSpace.host == request.url?.host {
+        if isHTTPAuthChallenge,
+           let credential,
+           let request,
+           challenge.protectionSpace.host == request.url?.host {
             completionHandler(.useCredential, credential)
         } else {
             completionHandler(.performDefaultHandling, nil)

--- a/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
+++ b/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
@@ -6,6 +6,11 @@ import Foundation
 import WebKit
 import Common
 
+// TODO [FXIOS-15182]
+enum WebViewDocumentFetch {
+    static let isEnabled = true
+}
+
 private let temporaryDocumentOperationQueue = OperationQueue()
 
 protocol TemporaryDocument: Sendable {

--- a/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
+++ b/firefox-ios/Client/TabManagement/Document/TemporaryDocument.swift
@@ -6,11 +6,6 @@ import Foundation
 import WebKit
 import Common
 
-// TODO [FXIOS-15182]
-enum WebViewDocumentFetch {
-    static let isEnabled = true
-}
-
 private let temporaryDocumentOperationQueue = OperationQueue()
 
 protocol TemporaryDocument: Sendable {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockShareTab.swift
@@ -14,6 +14,7 @@ class MockShareTab: ShareTab {
     var url: URL?
     var webView: TabWebView?
     var temporaryDocument: TemporaryDocument?
+    var mimeType: String?
 
     init(
         title: String,
@@ -21,12 +22,14 @@ class MockShareTab: ShareTab {
         canonicalURL: URL?,
         tabUUID: TabUUID = UUID().uuidString,
         withActiveWebView: Bool = true,
-        withTemporaryDocument: TemporaryDocument? = nil
+        withTemporaryDocument: TemporaryDocument? = nil,
+        mimeType: String? = nil
     ) {
         self.displayTitle = title
         self.url = url
         self.canonicalURL = canonicalURL
         self.tabUUID = tabUUID
+        self.mimeType = mimeType
         self.webView = TabWebView(frame: CGRect.zero,
                                   configuration: .init(),
                                   windowUUID: .XCTestDefaultUUID,

--- a/firefox-ios/nimbus-features/webViewDocumentFetchRefactorFeature.yaml
+++ b/firefox-ios/nimbus-features/webViewDocumentFetchRefactorFeature.yaml
@@ -1,0 +1,18 @@
+# The configuration for the webViewDocumentFetchRefactorFeature feature
+features:
+  web-view-document-fetch-refactor-feature:
+    description: >
+      Determines whether we read PDF and document data for sharing directly from the authenticated WebView, rather than re-downloading via URLSession.
+    variables:
+      enabled:
+        description: >
+          Whether or not this feature is enabled
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -56,3 +56,4 @@ include:
   - nimbus-features/trendingSearchesFeature.yaml
   - nimbus-features/vpnFeature.yaml
   - nimbus-features/waybackMachineFeature.yaml
+  - nimbus-features/webViewDocumentFetchRefactorFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15182)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32685)

## :bulb: Description

Adds a new approach for `TemporaryDocument` handling (see https://github.com/mozilla-mobile/firefox-ios/issues/32685 for additional discussion). This refactor is behind a feature flag. In cases where the flag is off, or the new approach (fetching the data from the WebView directly) fails, then we fall back to the previous handling. I'm still investigating a few aspects of this architectural change but I believe this should be at a point where it is safe for initial review.

Note: once this is fully tested and the feature is rolled out, we can remove the previous basic HTTP auth fix added for FXIOS-15160. (see: `httpAuthCredential`)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

