### PR TITLE
Refactor FXIOS-16139 [Redux Passthrough Reducers] Move isZeroSearch and shouldTriggerImpression into their own sub reducer

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1034,6 +1034,7 @@
 		8A5189C92C1B614E00CDB668 /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A87AEE02C1B4D17007428B2 /* SearchViewModelTests.swift */; };
 		8A5435562D53CB6800501214 /* JumpBackInAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5435552D53CB6600501214 /* JumpBackInAction.swift */; };
 		8A552AC72CB43AB400564C98 /* HomepageStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */; };
+		8A552AD22CB43AB400564C98 /* HomepageTelemetryStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AD12CB43AB400564C98 /* HomepageTelemetryStateTests.swift */; };
 		8A552AC82CB43AB400564C98 /* HeaderStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */; };
 		8A5564022D23317100028CA7 /* ContextMenuAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5564012D23317100028CA7 /* ContextMenuAction.swift */; };
 		8A55E8042BFBA9BE006DBD85 /* MicrosurveyCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E5F3D2BFBA49400DE052B /* MicrosurveyCoordinatorTests.swift */; };
@@ -1305,6 +1306,7 @@
 		8AF117242DDE228700577232 /* TabTrayThemeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF117232DDE228700577232 /* TabTrayThemeAnimator.swift */; };
 		8AF2D0FC2A5F272A00C7DD69 /* ComponentLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = 8AF2D0FB2A5F272A00C7DD69 /* ComponentLibrary */; };
 		8AF347DE2CADD1B200624036 /* HomepageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF347DD2CADD1B200624036 /* HomepageState.swift */; };
+		8AF347E02CADD1B200624036 /* HomepageTelemetryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF347DF2CADD1B200624036 /* HomepageTelemetryState.swift */; };
 		8AF347E02CADD1C300624036 /* HomepageAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF347DF2CADD1C300624036 /* HomepageAction.swift */; };
 		8AF3B15A2AF99B86009BB262 /* HistoryPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF3B1592AF99B86009BB262 /* HistoryPanelTests.swift */; };
 		8AF3B15C2AF99C77009BB262 /* ReadingListPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF3B15B2AF99C77009BB262 /* ReadingListPanelTests.swift */; };
@@ -9793,6 +9795,7 @@
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
 		8A5435552D53CB6600501214 /* JumpBackInAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInAction.swift; sourceTree = "<group>"; };
 		8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomepageStateTests.swift; sourceTree = "<group>"; };
+		8A552AD12CB43AB400564C98 /* HomepageTelemetryStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomepageTelemetryStateTests.swift; sourceTree = "<group>"; };
 		8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderStateTests.swift; sourceTree = "<group>"; };
 		8A5564012D23317100028CA7 /* ContextMenuAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuAction.swift; sourceTree = "<group>"; };
 		8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchCoordinatorDelegate.swift; sourceTree = "<group>"; };
@@ -10057,6 +10060,7 @@
 		8AF10D9029D776190086351D /* MockLaunchScreenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchScreenManager.swift; sourceTree = "<group>"; };
 		8AF117232DDE228700577232 /* TabTrayThemeAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayThemeAnimator.swift; sourceTree = "<group>"; };
 		8AF347DD2CADD1B200624036 /* HomepageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageState.swift; sourceTree = "<group>"; };
+		8AF347DF2CADD1B200624036 /* HomepageTelemetryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageTelemetryState.swift; sourceTree = "<group>"; };
 		8AF347DF2CADD1C300624036 /* HomepageAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageAction.swift; sourceTree = "<group>"; };
 		8AF3B1592AF99B86009BB262 /* HistoryPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryPanelTests.swift; sourceTree = "<group>"; };
 		8AF3B15B2AF99C77009BB262 /* ReadingListPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingListPanelTests.swift; sourceTree = "<group>"; };
@@ -14392,6 +14396,7 @@
 				8AEF41612D15EDBA0013925D /* TopSitesMiddlewareTests.swift */,
 				8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */,
 				8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */,
+				8A552AD12CB43AB400564C98 /* HomepageTelemetryStateTests.swift */,
 				8A454D332CB85C7D009436D9 /* MerinoStateTests.swift */,
 				8A87B42E2CC1A3AA003A9239 /* MerinoMiddlewareTests.swift */,
 				8A09A9E22D77552C0069B005 /* HomepageMiddlewareTests.swift */,
@@ -15099,6 +15104,7 @@
 			isa = PBXGroup;
 			children = (
 				8AF347DD2CADD1B200624036 /* HomepageState.swift */,
+				8AF347DF2CADD1B200624036 /* HomepageTelemetryState.swift */,
 				8AF347DF2CADD1C300624036 /* HomepageAction.swift */,
 				8A008F6C2D70C51B005F4A6C /* HomepageMiddleware.swift */,
 			);
@@ -19721,6 +19727,7 @@
 				8A91D4112F7D6C7800A1B2C3 /* NewsTransitionHeaderCell.swift in Sources */,
 				8A91D4132F7D6C7900A1B2C3 /* StoryCategoryPickerView.swift in Sources */,
 				8AF347DE2CADD1B200624036 /* HomepageState.swift in Sources */,
+				8AF347E02CADD1B200624036 /* HomepageTelemetryState.swift in Sources */,
 				8A75AF9C2DE8A1CF00B2C592 /* StartAtHomeMiddleware.swift in Sources */,
 				C8DC90C92A0675E70008832B /* MarkupParsingUtility.swift in Sources */,
 				CA03B26A247F1D9E00382B62 /* BreachAlertsClient.swift in Sources */,
@@ -21190,6 +21197,7 @@
 				B2C3D4E5F67890123456789A /* FeatureFlagsProviderTests.swift in Sources */,
 				ECD8E56E2FF7ED79002092C6 /* WaybackServiceTests.swift in Sources */,
 				8A552AC72CB43AB400564C98 /* HomepageStateTests.swift in Sources */,
+				8A552AD22CB43AB400564C98 /* HomepageTelemetryStateTests.swift in Sources */,
 				8AABBD032A001CBC0089941E /* MockApplicationHelper.swift in Sources */,
 				8A1E3BE328CBACDD003388C4 /* SponsoredContentFilterUtilityTests.swift in Sources */,
 				C25020822ECDE3240071506F /* TranslationsEngineTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -450,7 +450,7 @@ final class HomepageViewController: UIViewController,
         }
 
         // FXIOS-11523 - Trigger impression when user opens homepage view new tab + scroll to top
-        if state.shouldTriggerImpression {
+        if state.telemetryState.shouldTriggerImpression {
             resetTrackedObjects()
             trackVisibleItemImpressions()
         }
@@ -1101,7 +1101,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private func dispatchOpenPocketAction(at index: Int, actionType: ActionType) {
-        let config = OpenPocketTelemetryConfig(isZeroSearch: homepageState.isZeroSearch, position: index)
+        let config = OpenPocketTelemetryConfig(isZeroSearch: homepageState.telemetryState.isZeroSearch, position: index)
         store.dispatch(
             MerinoAction(
                 telemetryConfig: config,
@@ -1113,7 +1113,7 @@ final class HomepageViewController: UIViewController,
 
     private func dispatchTopSitesAction(at index: Int, config: TopSiteConfiguration, actionType: ActionType) {
         let config = TopSitesTelemetryConfig(
-            isZeroSearch: homepageState.isZeroSearch,
+            isZeroSearch: homepageState.telemetryState.isZeroSearch,
             position: index,
             topSiteConfiguration: config
         )
@@ -1478,7 +1478,7 @@ final class HomepageViewController: UIViewController,
     }
 
     private var canContextHintBePresented: Bool {
-        return presentedViewController == nil && homepageState.isZeroSearch
+        return presentedViewController == nil && homepageState.telemetryState.isZeroSearch
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -228,6 +228,7 @@ struct HomepageState: ScreenState, Equatable {
             .copy(bookmarkState: BookmarksSectionState.reducer.legacyReducer(state.bookmarkState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
+            .copy(telemetryState: HomepageTelemetryState.reducer.legacyReducer(state.telemetryState, action))
     }
 
     static func defaultState(from state: HomepageState) -> HomepageState {

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -246,8 +246,8 @@ struct HomepageState: ScreenState, Equatable {
             bookmarkState: BookmarksSectionState.defaultState(from: state.bookmarkState),
             merinoState: MerinoState.defaultState(from: state.merinoState),
             wallpaperState: WallpaperState.defaultState(from: state.wallpaperState),
-			telemetryState: HomepageTelemetryState.defaultState(from: state.telemetryState),
-            shouldShowPrivacyNotice: state.shouldShowPrivacyNotice,
+            telemetryState: HomepageTelemetryState.defaultState(from: state.telemetryState),
+            shouldShowPrivacyNotice: state.shouldShowPrivacyNotice
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -115,10 +115,6 @@ struct HomepageState: ScreenState, Equatable {
         case HomepageActionType.initialize, HomepageActionType.viewWillTransition:
             return handleInitializeAndViewWillTransitionAction(state: state, action: action)
         case HomepageActionType.embeddedHomepage:
-            guard (action as? HomepageAction)?.isZeroSearch != nil else {
-                return defaultState(from: state)
-            }
-
             return handleEmbeddedHomepageAction(state: state, action: action)
         case HomepageActionType.privacyNoticeCloseButtonTapped:
             return handlePrivacyNoticeCloseButtonTappedAction(state: state, action: action)

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -21,17 +21,7 @@ struct HomepageState: ScreenState, Equatable {
     let merinoState: MerinoState
     let wallpaperState: WallpaperState
 
-    /// FXIOS-11504 - This is mainly used for telemetry for top sites and merino and presenting CFRs.
-    /// At this time, we are keeping `isZeroSearch` the same as legacy. However, we should revisit this value
-    /// and confirm what the expectation is, as it seems inconsistent. See more details in ticket.
-    ///
-    /// FXIOS-6203 - Comment from legacy homepage:
-    /// `isZeroSearch` is true when the homepage is created from the tab tray, a long press
-    /// on the tab bar to open a new tab or by pressing the home page button on the tab bar.
-    /// The zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
-    /// This needs to be set properly for telemetry and the contextual pop overs that appears on homepage
-    let isZeroSearch: Bool
-    let shouldTriggerImpression: Bool
+    let telemetryState: HomepageTelemetryState
 
     /// `shouldShowPrivacyNotice` is true when the homepage should display the privacy notice card. This is the case when a
     /// new privacy notice is available after a user has already accepted the ToS/ToU
@@ -58,8 +48,7 @@ struct HomepageState: ScreenState, Equatable {
             bookmarkState: homepageState.bookmarkState,
             merinoState: homepageState.merinoState,
             wallpaperState: homepageState.wallpaperState,
-            isZeroSearch: homepageState.isZeroSearch,
-            shouldTriggerImpression: homepageState.shouldTriggerImpression,
+            telemetryState: homepageState.telemetryState,
             shouldShowPrivacyNotice: homepageState.shouldShowPrivacyNotice
         )
     }
@@ -76,9 +65,8 @@ struct HomepageState: ScreenState, Equatable {
             bookmarkState: BookmarksSectionState(windowUUID: windowUUID),
             merinoState: MerinoState(windowUUID: windowUUID),
             wallpaperState: WallpaperState(windowUUID: windowUUID),
-            isZeroSearch: false,
-            shouldTriggerImpression: false,
-            shouldShowPrivacyNotice: false
+            telemetryState: HomepageTelemetryState(windowUUID: windowUUID),
+            shouldShowPrivacyNotice: false,
         )
     }
 
@@ -93,8 +81,7 @@ struct HomepageState: ScreenState, Equatable {
         bookmarkState: BookmarksSectionState,
         merinoState: MerinoState,
         wallpaperState: WallpaperState,
-        isZeroSearch: Bool,
-        shouldTriggerImpression: Bool,
+        telemetryState: HomepageTelemetryState,
         shouldShowPrivacyNotice: Bool
     ) {
         self.windowUUID = windowUUID
@@ -107,8 +94,7 @@ struct HomepageState: ScreenState, Equatable {
         self.bookmarkState = bookmarkState
         self.merinoState = merinoState
         self.wallpaperState = wallpaperState
-        self.isZeroSearch = isZeroSearch
-        self.shouldTriggerImpression = shouldTriggerImpression
+        self.telemetryState = telemetryState
         self.shouldShowPrivacyNotice = shouldShowPrivacyNotice
     }
 
@@ -129,11 +115,11 @@ struct HomepageState: ScreenState, Equatable {
         case HomepageActionType.initialize, HomepageActionType.viewWillTransition:
             return handleInitializeAndViewWillTransitionAction(state: state, action: action)
         case HomepageActionType.embeddedHomepage:
-            guard let isZeroSearch = (action as? HomepageAction)?.isZeroSearch else {
+            guard (action as? HomepageAction)?.isZeroSearch != nil else {
                 return defaultState(from: state)
             }
 
-            return handleEmbeddedHomepageAction(state: state, action: action, isZeroSearch: isZeroSearch)
+            return handleEmbeddedHomepageAction(state: state, action: action)
         case HomepageActionType.privacyNoticeCloseButtonTapped:
             return handlePrivacyNoticeCloseButtonTappedAction(state: state, action: action)
         case GeneralBrowserActionType.didSelectedTabChangeToHomepage:
@@ -159,12 +145,11 @@ struct HomepageState: ScreenState, Equatable {
             .copy(bookmarkState: BookmarksSectionState.reducer.legacyReducer(state.bookmarkState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
+            .copy(telemetryState: HomepageTelemetryState.reducer.legacyReducer(state.telemetryState, action))
     }
 
     @MainActor
-    private static func handleEmbeddedHomepageAction(state: HomepageState,
-                                                     action: Action,
-                                                     isZeroSearch: Bool) -> HomepageState {
+    private static func handleEmbeddedHomepageAction(state: HomepageState, action: Action) -> HomepageState {
         return state
             .resetTransientState()
             .copy(headerState: HeaderState.reducer.legacyReducer(state.headerState, action))
@@ -177,7 +162,7 @@ struct HomepageState: ScreenState, Equatable {
             .copy(bookmarkState: BookmarksSectionState.reducer.legacyReducer(state.bookmarkState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
-            .copy(isZeroSearch: isZeroSearch)
+            .copy(telemetryState: HomepageTelemetryState.reducer.legacyReducer(state.telemetryState, action))
     }
 
     @MainActor
@@ -194,6 +179,7 @@ struct HomepageState: ScreenState, Equatable {
             .copy(bookmarkState: BookmarksSectionState.reducer.legacyReducer(state.bookmarkState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
+            .copy(telemetryState: HomepageTelemetryState.reducer.legacyReducer(state.telemetryState, action))
             .copy(shouldShowPrivacyNotice: false)
     }
 
@@ -211,7 +197,7 @@ struct HomepageState: ScreenState, Equatable {
             .copy(bookmarkState: BookmarksSectionState.reducer.legacyReducer(state.bookmarkState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
-            .copy(shouldTriggerImpression: true)
+            .copy(telemetryState: HomepageTelemetryState.reducer.legacyReducer(state.telemetryState, action))
     }
 
     @MainActor
@@ -228,6 +214,7 @@ struct HomepageState: ScreenState, Equatable {
             .copy(bookmarkState: BookmarksSectionState.reducer.legacyReducer(state.bookmarkState, action))
             .copy(merinoState: MerinoState.reducer.legacyReducer(state.merinoState, action))
             .copy(wallpaperState: WallpaperState.reducer.legacyReducer(state.wallpaperState, action))
+            .copy(telemetryState: HomepageTelemetryState.reducer.legacyReducer(state.telemetryState, action))
             .copy(shouldShowPrivacyNotice: true)
     }
 
@@ -259,9 +246,8 @@ struct HomepageState: ScreenState, Equatable {
             bookmarkState: BookmarksSectionState.defaultState(from: state.bookmarkState),
             merinoState: MerinoState.defaultState(from: state.merinoState),
             wallpaperState: WallpaperState.defaultState(from: state.wallpaperState),
-            isZeroSearch: state.isZeroSearch,
-            shouldTriggerImpression: false,
-            shouldShowPrivacyNotice: state.shouldShowPrivacyNotice
+			telemetryState: HomepageTelemetryState.defaultState(from: state.telemetryState),
+            shouldShowPrivacyNotice: state.shouldShowPrivacyNotice,
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageTelemetryState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageTelemetryState.swift
@@ -74,6 +74,7 @@ struct HomepageTelemetryState: StateType, Equatable {
         }
 
         return state
+            .resetTransientState()
             .copy(isZeroSearch: isZeroSearch)
             .copy(shouldTriggerImpression: false)
     }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageTelemetryState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageTelemetryState.swift
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import ModifiedCopy
+import Redux
+
+/// State holding the values the homepage needs for telemetry purposes, such as impressions and zero search.
+@Copyable
+struct HomepageTelemetryState: StateType, Equatable {
+    var windowUUID: WindowUUID
+
+    /// FXIOS-11504 - This is mainly used for telemetry for top sites and merino and presenting CFRs.
+    /// At this time, we are keeping `isZeroSearch` the same as legacy. However, we should revisit this value
+    /// and confirm what the expectation is, as it seems inconsistent. See more details in ticket.
+    ///
+    /// FXIOS-6203 - Comment from legacy homepage:
+    /// `isZeroSearch` is true when the homepage is created from the tab tray, a long press
+    /// on the tab bar to open a new tab or by pressing the home page button on the tab bar.
+    /// The zero search page, aka when the home page is shown by clicking the url bar from a loaded web page.
+    /// This needs to be set properly for telemetry and the contextual pop overs that appears on homepage
+    let isZeroSearch: Bool
+    let shouldTriggerImpression: Bool
+
+    init(windowUUID: WindowUUID) {
+        self.init(
+            windowUUID: windowUUID,
+            isZeroSearch: false,
+            shouldTriggerImpression: false
+        )
+    }
+
+    private init(
+        windowUUID: WindowUUID,
+        isZeroSearch: Bool,
+        shouldTriggerImpression: Bool
+    ) {
+        self.windowUUID = windowUUID
+        self.isZeroSearch = isZeroSearch
+        self.shouldTriggerImpression = shouldTriggerImpression
+    }
+
+    static let reducer: Reducer<Self> = (legacyReducer, modernReducer)
+
+    static let modernReducer: ReducerMethod<Self> = { state, action, actionWindowUUID in
+        // Does not handle any modern actions
+        return defaultState(from: state)
+    }
+
+    static let legacyReducer: LegacyReducerMethod<Self> = { state, action in
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
+        else {
+            return defaultState(from: state)
+        }
+
+        switch action.actionType {
+        case HomepageActionType.embeddedHomepage:
+            return handleEmbeddedHomepageAction(for: state, with: action)
+        case GeneralBrowserActionType.didSelectedTabChangeToHomepage:
+            return state.copy(shouldTriggerImpression: true)
+        default:
+            return defaultState(from: state)
+        }
+    }
+
+    private static func handleEmbeddedHomepageAction(
+        for state: HomepageTelemetryState,
+        with action: Action
+    ) -> HomepageTelemetryState {
+        guard let isZeroSearch = (action as? HomepageAction)?.isZeroSearch else {
+            return defaultState(from: state)
+        }
+
+        return state
+            .copy(isZeroSearch: isZeroSearch)
+            .copy(shouldTriggerImpression: false)
+    }
+
+    /// `shouldTriggerImpression` is reset since impressions should only be triggered once per action that requests it.
+    static func defaultState(from state: HomepageTelemetryState) -> HomepageTelemetryState {
+        return HomepageTelemetryState(
+            windowUUID: state.windowUUID,
+            isZeroSearch: state.isZeroSearch,
+            shouldTriggerImpression: false
+        )
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageTelemetryState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageTelemetryState.swift
@@ -60,6 +60,7 @@ struct HomepageTelemetryState: StateType, Equatable {
             return handleEmbeddedHomepageAction(for: state, with: action)
         case GeneralBrowserActionType.didSelectedTabChangeToHomepage:
             return state.copy(shouldTriggerImpression: true)
+        .resetTransientState()
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageTelemetryState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageTelemetryState.swift
@@ -59,8 +59,9 @@ struct HomepageTelemetryState: StateType, Equatable {
         case HomepageActionType.embeddedHomepage:
             return handleEmbeddedHomepageAction(for: state, with: action)
         case GeneralBrowserActionType.didSelectedTabChangeToHomepage:
-            return state.copy(shouldTriggerImpression: true)
+            return state
         .resetTransientState()
+        .copy(shouldTriggerImpression: true)
         default:
             return defaultState(from: state)
         }
@@ -77,7 +78,6 @@ struct HomepageTelemetryState: StateType, Equatable {
         return state
             .resetTransientState()
             .copy(isZeroSearch: isZeroSearch)
-            .copy(shouldTriggerImpression: false)
     }
 
     /// `shouldTriggerImpression` is reset since impressions should only be triggered once per action that requests it.

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageTelemetryState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageTelemetryState.swift
@@ -32,7 +32,7 @@ struct HomepageTelemetryState: StateType, Equatable {
         )
     }
 
-    private init(
+    init(
         windowUUID: WindowUUID,
         isZeroSearch: Bool,
         shouldTriggerImpression: Bool

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
@@ -300,7 +300,7 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
 
         subject.newState(state: newState)
 
-        XCTAssertTrue(newState.shouldTriggerImpression)
+        XCTAssertTrue(newState.telemetryState.shouldTriggerImpression)
         XCTAssertTrue(mockThrottler.didCallThrottle)
         let actionCalled = try XCTUnwrap(
             mockStore.dispatchedActions.last(where: { $0 is HomepageAction }) as? HomepageAction

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
@@ -39,10 +39,8 @@ final class HomepageStateTests: XCTestCase {
 
         XCTAssertFalse(initialState.headerState.isPrivate)
         XCTAssertFalse(initialState.trackerBlockerModuleState.shouldShowSection)
-        XCTAssertFalse(initialState.isZeroSearch)
-        XCTAssertFalse(initialState.shouldTriggerImpression)
-        XCTAssertEqual(initialState.wallpaperState.availableContentHeight, 0)
-        XCTAssertEqual(initialState.wallpaperState.availableWallpaperHeight, 0)
+        XCTAssertFalse(initialState.telemetryState.isZeroSearch)
+        XCTAssertFalse(initialState.telemetryState.shouldTriggerImpression)
     }
 
     @MainActor
@@ -60,11 +58,8 @@ final class HomepageStateTests: XCTestCase {
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(newState.headerState.isPrivate)
-        XCTAssertFalse(newState.isZeroSearch)
-        XCTAssertFalse(initialState.shouldTriggerImpression)
-        XCTAssertEqual(newState.wallpaperState.availableContentHeight, initialState.wallpaperState.availableContentHeight)
-        XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight,
-                       initialState.wallpaperState.availableWallpaperHeight)
+        XCTAssertFalse(newState.telemetryState.isZeroSearch)
+        XCTAssertFalse(initialState.telemetryState.shouldTriggerImpression)
     }
 
     @MainActor
@@ -82,11 +77,8 @@ final class HomepageStateTests: XCTestCase {
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertTrue(newState.isZeroSearch)
-        XCTAssertFalse(initialState.shouldTriggerImpression)
-        XCTAssertEqual(newState.wallpaperState.availableContentHeight, initialState.wallpaperState.availableContentHeight)
-        XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight,
-                       initialState.wallpaperState.availableWallpaperHeight)
+        XCTAssertTrue(newState.telemetryState.isZeroSearch)
+        XCTAssertFalse(initialState.telemetryState.shouldTriggerImpression)
     }
 
     @MainActor
@@ -104,11 +96,8 @@ final class HomepageStateTests: XCTestCase {
         )
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertFalse(newState.isZeroSearch)
-        XCTAssertFalse(initialState.shouldTriggerImpression)
-        XCTAssertEqual(newState.wallpaperState.availableContentHeight, initialState.wallpaperState.availableContentHeight)
-        XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight,
-                       initialState.wallpaperState.availableWallpaperHeight)
+        XCTAssertFalse(newState.telemetryState.isZeroSearch)
+        XCTAssertFalse(initialState.telemetryState.shouldTriggerImpression)
     }
 
     @MainActor
@@ -123,13 +112,10 @@ final class HomepageStateTests: XCTestCase {
                 actionType: GeneralBrowserActionType.didSelectedTabChangeToHomepage
             )
         )
-        XCTAssertFalse(initialState.shouldTriggerImpression)
+        XCTAssertFalse(initialState.telemetryState.shouldTriggerImpression)
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertFalse(newState.isZeroSearch)
-        XCTAssertTrue(newState.shouldTriggerImpression)
-        XCTAssertEqual(newState.wallpaperState.availableContentHeight, initialState.wallpaperState.availableContentHeight)
-        XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight,
-                       initialState.wallpaperState.availableWallpaperHeight)
+        XCTAssertFalse(newState.telemetryState.isZeroSearch)
+        XCTAssertTrue(newState.telemetryState.shouldTriggerImpression)
     }
 
     @MainActor
@@ -150,8 +136,8 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertEqual(newState.wallpaperState.availableContentHeight, 500)
         XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight, 525)
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertFalse(newState.shouldTriggerImpression)
-        XCTAssertEqual(newState.isZeroSearch, initialState.isZeroSearch)
+        XCTAssertFalse(newState.telemetryState.shouldTriggerImpression)
+        XCTAssertEqual(newState.telemetryState.isZeroSearch, initialState.telemetryState.isZeroSearch)
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
@@ -39,8 +39,6 @@ final class HomepageStateTests: XCTestCase {
 
         XCTAssertFalse(initialState.headerState.isPrivate)
         XCTAssertFalse(initialState.trackerBlockerModuleState.shouldShowSection)
-        XCTAssertFalse(initialState.telemetryState.isZeroSearch)
-        XCTAssertFalse(initialState.telemetryState.shouldTriggerImpression)
     }
 
     @MainActor
@@ -58,46 +56,6 @@ final class HomepageStateTests: XCTestCase {
 
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(newState.headerState.isPrivate)
-        XCTAssertFalse(newState.telemetryState.isZeroSearch)
-        XCTAssertFalse(initialState.telemetryState.shouldTriggerImpression)
-    }
-
-    @MainActor
-    func test_embeddedHomepageAction_withTrueZeroSearch_returnsExpectedState() {
-        let initialState = createSubject()
-        let reducer = homepageReducer()
-
-        let newState = reducer.legacyReducer(
-            initialState,
-            HomepageAction(
-                isZeroSearch: true,
-                windowUUID: .XCTestDefaultUUID,
-                actionType: HomepageActionType.embeddedHomepage
-            )
-        )
-
-        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertTrue(newState.telemetryState.isZeroSearch)
-        XCTAssertFalse(initialState.telemetryState.shouldTriggerImpression)
-    }
-
-    @MainActor
-    func test_embeddedHomepageAction_withFalseZeroSearch_returnsExpectedState() {
-        let initialState = createSubject()
-        let reducer = homepageReducer()
-
-        let newState = reducer.legacyReducer(
-            initialState,
-            HomepageAction(
-                isZeroSearch: false,
-                windowUUID: .XCTestDefaultUUID,
-                actionType: HomepageActionType.embeddedHomepage
-            )
-        )
-
-        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertFalse(newState.telemetryState.isZeroSearch)
-        XCTAssertFalse(initialState.telemetryState.shouldTriggerImpression)
     }
 
     @MainActor
@@ -114,30 +72,6 @@ final class HomepageStateTests: XCTestCase {
         )
         XCTAssertFalse(initialState.telemetryState.shouldTriggerImpression)
         XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertFalse(newState.telemetryState.isZeroSearch)
-        XCTAssertTrue(newState.telemetryState.shouldTriggerImpression)
-    }
-
-    @MainActor
-    func test_handleAvailableContentHeightChangeAction_returnsExpectedState() {
-        let initialState = createSubject()
-        let reducer = homepageReducer()
-
-        let newState = reducer.legacyReducer(
-            initialState,
-            HomepageAction(
-                availableContentHeight: 500,
-                availableWallpaperHeight: 525,
-                windowUUID: .XCTestDefaultUUID,
-                actionType: HomepageActionType.availableContentHeightDidChange
-            )
-        )
-
-        XCTAssertEqual(newState.wallpaperState.availableContentHeight, 500)
-        XCTAssertEqual(newState.wallpaperState.availableWallpaperHeight, 525)
-        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
-        XCTAssertFalse(newState.telemetryState.shouldTriggerImpression)
-        XCTAssertEqual(newState.telemetryState.isZeroSearch, initialState.telemetryState.isZeroSearch)
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageTelemetryStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageTelemetryStateTests.swift
@@ -1,0 +1,141 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import XCTest
+
+@testable import Client
+
+final class HomepageTelemetryStateTests: XCTestCase {
+    func test_initialState_returnsExpectedState() {
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertFalse(initialState.isZeroSearch)
+        XCTAssertFalse(initialState.shouldTriggerImpression)
+    }
+
+    @MainActor
+    func test_embeddedHomepageAction_withTrueZeroSearch_returnsExpectedState() {
+        let initialState = createSubject()
+
+        let newState = reducer().legacyReducer(
+            initialState,
+            HomepageAction(
+                isZeroSearch: true,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.embeddedHomepage
+            )
+        )
+
+        XCTAssertTrue(newState.isZeroSearch)
+        XCTAssertFalse(newState.shouldTriggerImpression)
+    }
+
+    @MainActor
+    func test_embeddedHomepageAction_withFalseZeroSearch_returnsExpectedState() {
+        let initialState = createSubject(isZeroSearch: true)
+
+        let newState = reducer().legacyReducer(
+            initialState,
+            HomepageAction(
+                isZeroSearch: false,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.embeddedHomepage
+            )
+        )
+
+        XCTAssertFalse(newState.isZeroSearch)
+        XCTAssertFalse(newState.shouldTriggerImpression)
+    }
+
+    @MainActor
+    func test_embeddedHomepageAction_withoutZeroSearch_returnsDefaultState() {
+        let initialState = createSubject(isZeroSearch: true)
+
+        let newState = reducer().legacyReducer(
+            initialState,
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.embeddedHomepage
+            )
+        )
+
+        XCTAssertTrue(newState.isZeroSearch)
+        XCTAssertFalse(newState.shouldTriggerImpression)
+    }
+
+    @MainActor
+    func test_didSelectedTabChangeToHomepageAction_returnsExpectedState() {
+        let initialState = createSubject(isZeroSearch: true)
+
+        let newState = reducer().legacyReducer(
+            initialState,
+            GeneralBrowserAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: GeneralBrowserActionType.didSelectedTabChangeToHomepage
+            )
+        )
+
+        XCTAssertTrue(newState.isZeroSearch)
+        XCTAssertTrue(newState.shouldTriggerImpression)
+    }
+
+    @MainActor
+    func test_unrelatedAction_resetsImpressionAndKeepsZeroSearch() {
+        let initialState = createSubject(isZeroSearch: true, shouldTriggerImpression: true)
+
+        let newState = reducer().legacyReducer(
+            initialState,
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.initialize
+            )
+        )
+
+        XCTAssertTrue(newState.isZeroSearch)
+        XCTAssertFalse(newState.shouldTriggerImpression)
+    }
+
+    @MainActor
+    func test_actionForDifferentWindow_returnsDefaultState() {
+        let initialState = createSubject(isZeroSearch: true, shouldTriggerImpression: true)
+
+        let newState = reducer().legacyReducer(
+            initialState,
+            GeneralBrowserAction(
+                windowUUID: WindowUUID(uuidString: "44BA0B7D-097A-484D-8358-91A6E374451D")!,
+                actionType: GeneralBrowserActionType.didSelectedTabChangeToHomepage
+            )
+        )
+
+        XCTAssertTrue(newState.isZeroSearch)
+        XCTAssertFalse(newState.shouldTriggerImpression)
+    }
+
+    func test_defaultState_resetsImpressionAndKeepsZeroSearch() {
+        let initialState = createSubject(isZeroSearch: true, shouldTriggerImpression: true)
+
+        let newState = HomepageTelemetryState.defaultState(from: initialState)
+
+        XCTAssertEqual(newState.windowUUID, .XCTestDefaultUUID)
+        XCTAssertTrue(newState.isZeroSearch)
+        XCTAssertFalse(newState.shouldTriggerImpression)
+    }
+
+    // MARK: - Private
+    private func createSubject(
+        isZeroSearch: Bool = false,
+        shouldTriggerImpression: Bool = false
+    ) -> HomepageTelemetryState {
+        return HomepageTelemetryState(windowUUID: .XCTestDefaultUUID)
+            .copy(isZeroSearch: isZeroSearch)
+            .copy(shouldTriggerImpression: shouldTriggerImpression)
+    }
+
+    private func reducer() -> Reducer<HomepageTelemetryState> {
+        return HomepageTelemetryState.reducer
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageTelemetryStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageTelemetryStateTests.swift
@@ -130,9 +130,11 @@ final class HomepageTelemetryStateTests: XCTestCase {
         isZeroSearch: Bool = false,
         shouldTriggerImpression: Bool = false
     ) -> HomepageTelemetryState {
-        return HomepageTelemetryState(windowUUID: .XCTestDefaultUUID)
-            .copy(isZeroSearch: isZeroSearch)
-            .copy(shouldTriggerImpression: shouldTriggerImpression)
+        return HomepageTelemetryState(
+            windowUUID: .XCTestDefaultUUID,
+            isZeroSearch: isZeroSearch,
+            shouldTriggerImpression: shouldTriggerImpression
+        )
     }
 
     private func reducer() -> Reducer<HomepageTelemetryState> {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16139)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Move `isZeroSearch` and `shouldTriggerImpression` into their own `HomepageTelemetryState` out of `HomepageState` as part of the refactor for passthrough reducers.

### Tested
1. `shouldTriggerImpression` only fires on a new homepage
2. Checked the multi-window scenerio of `shouldTriggerImpression`
3. Check `isZeroSearch` is preserved by defaultState across multiple actions from `HomepageState`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

