### PR TITLE
[MTE-5806] - fix for onboarding failures

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -107,7 +107,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
         navigator.performAction(Action.OpenEmailToSignIn)
         mozWaitForElementToExist(app.webViews.firstMatch, timeout: TIMEOUT_LONG)
         if #available(iOS 17, *) {
-            mozWaitForElementToExist(app.webViews.staticTexts["Continue to your ⁨Mozilla account⁩"], timeout: TIMEOUT_LONG)
+            mozWaitForElementToExist(app.webViews.staticTexts["Continue to your Mozilla account"], timeout: TIMEOUT_LONG)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/OnboardingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/OnboardingScreen.swift
@@ -152,12 +152,12 @@ final class OnboardingScreen {
     func handleTermsOfService() {
         let continueButton = tosContinueButton
         BaseTestCase().mozWaitForElementToExist(continueButton, timeout: TIMEOUT_LONG)
-        // The ToS is presented over full screen with a cross-dissolve transition, so the button
-        // can exist before it is hittable and an early tap gets absorbed. Wait for it to be
-        // hittable, then tap again if the screen has not advanced past the button.
+        // The ToS is presented full screen with a cross-dissolve, so the button lingers in the tree
+        // during the transition; retry only if it never leaves, else a spurious tap hits the card below.
         BaseTestCase().mozWaitElementHittable(element: continueButton, timeout: TIMEOUT)
         continueButton.tap()
-        if continueButton.exists {
+        let dismissed = BaseTestCase().mozWaitForElementToNotExist(continueButton, failOnTimeout: false)
+        if !dismissed {
             continueButton.tap()
         }
     }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5806

## :bulb: Description
https://storage.googleapis.com/mobile-reports/public/firefox-ios-M4/nightly-firefox-ios-full-functional-iphone/result_149/build/reports/index.html
- Root cause: handleTermsOfService() tapped the ToS Continue button, then re-tapped whenever continueButton.exists was still true. During the full-screen cross-dissolve the button lingers in the accessibility tree, so on slower CI timing a second, spurious tap fired into onboarding screen 0 underneath — advancing/covering it — and every assertion for onboarding.0* then timed out. Locally the tree updated before the .exists check, so the second tap never fired; hence CI-only failures.
- Fix: replaced the exists-based retry with mozWaitForElementToNotExist(continueButton, failOnTimeout: false) — it returns the instant the ToS card actually leaves the tree (no added delay in the normal case) and only re-taps if the button genuinely never disappears (the real "first tap absorbed" case).
- Included a small fix for testTapSignInShowsFxAFromTour.