### PR TITLE
Bugfix FXIOS-11878 Enable swipe navigation in bookmark folders

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -14,6 +14,7 @@ final class BookmarksViewController: SiteTableViewController,
                                      LibraryPanel,
                                      CanRemoveQuickActionBookmark,
                                      UITableViewDropDelegate,
+                                     UIGestureRecognizerDelegate,
                                      Notifiable,
                                      FeatureFlaggable {
     struct UX {
@@ -32,6 +33,7 @@ final class BookmarksViewController: SiteTableViewController,
     let viewModel: BookmarksPanelViewModelProtocol
     private var logger: Logger
     private let bookmarksTelemetry = BookmarksTelemetry()
+    private weak var previousInteractivePopGestureDelegate: (any UIGestureRecognizerDelegate)?
 
     // MARK: - Search Properties
     var keyboardState: KeyboardState?
@@ -227,9 +229,23 @@ final class BookmarksViewController: SiteTableViewController,
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        if let popGesture = navigationController?.interactivePopGestureRecognizer {
+            previousInteractivePopGestureDelegate = popGesture.delegate
+            popGesture.delegate = self
+            popGesture.isEnabled = true
+        }
 
         // Clear any `isTransitioning` state once the user is back on this panel fully
         isTransitioning = false
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        if let popGesture = navigationController?.interactivePopGestureRecognizer,
+           popGesture.delegate === self {
+            popGesture.delegate = previousInteractivePopGestureDelegate
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -239,6 +255,11 @@ final class BookmarksViewController: SiteTableViewController,
         if state == .bookmarks(state: .search) && (isMovingFromParent || isBeingDismissed) {
             exitSearchState()
         }
+    }
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer === navigationController?.interactivePopGestureRecognizer else { return true }
+        return (navigationController?.viewControllers.count ?? 0) > 1 && !isTransitioning
     }
 
     // MARK: - Data

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Library/BookmarksCoordinatorTests.swift
@@ -42,6 +42,29 @@ final class BookmarksCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.pushCalled, 1)
     }
 
+    func testBookmarksAppearanceEnablesInteractivePopGestureAndRestoresItsDelegate() throws {
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let originalGestureDelegate = MockInteractivePopGestureDelegate()
+        navigationController.interactivePopGestureRecognizer?.delegate = originalGestureDelegate
+        router = MockRouter(navigationController: navigationController)
+        let subject = createSubject()
+
+        subject.start(from: LocalDesktopFolder())
+        let controller = try XCTUnwrap(router.pushedViewController as? BookmarksViewController)
+        navigationController.interactivePopGestureRecognizer?.isEnabled = false
+
+        controller.beginAppearanceTransition(true, animated: false)
+        controller.endAppearanceTransition()
+
+        XCTAssertEqual(navigationController.interactivePopGestureRecognizer?.isEnabled, true)
+        XCTAssertTrue(navigationController.interactivePopGestureRecognizer?.delegate === controller)
+
+        controller.beginAppearanceTransition(false, animated: false)
+        controller.endAppearanceTransition()
+
+        XCTAssertTrue(navigationController.interactivePopGestureRecognizer?.delegate === originalGestureDelegate)
+    }
+
     func testShowBookmarksDetail_forFolder() {
         let subject = createSubject()
         let folder = LocalDesktopFolder()
@@ -163,3 +186,5 @@ final class BookmarksCoordinatorTests: XCTestCase {
         return subject
     }
 }
+
+private final class MockInteractivePopGestureDelegate: NSObject, UIGestureRecognizerDelegate { }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -698,6 +698,24 @@ class BookmarksTests: FeatureFlaggedTestBase {
         libraryScreen.assertIdenticalFoldersNamesCreated(identifier: folderName, nrOfFolders: 2)
     }
 
+    func testSwipeBackFromBookmarkFolder() {
+        app.launch()
+        let folderName = "Swipe Back Folder"
+        toolbarScreen.tapSettingsMenuButton()
+        mainMenu.tapBookmarks()
+        libraryScreen.addFreshNewFolder(text: folderName)
+        libraryScreen.tapDoneButton()
+        libraryScreen.tapOnFolder(folderName: folderName)
+        libraryScreen.assertSelectedFolderOpens(folderName: folderName)
+
+        let swipeStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.01, dy: 0.5))
+        let swipeEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.8, dy: 0.5))
+        swipeStart.press(forDuration: 0.1, thenDragTo: swipeEnd)
+
+        mozWaitForElementToExist(app.navigationBars["Bookmarks"])
+        XCTAssertFalse(app.navigationBars[folderName].exists)
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/3168590
     func testUserRedirectToMostRecentlyAccessedFolder() {
         app.launch()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11878)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25890)

## :bulb: Description
Re-enable the navigation controller’s interactive pop gesture after opening a bookmark folder.

Previously, the edge swipe remained disabled, so the bookmarks table handled the gesture and could open the row beneath the user’s finger instead of navigating back.

The navigation behavior is exposed through the existing `NavigationController` abstraction and covered by a coordinator regression test.

## :movie_camera: Demos
Not included. The change restores the standard iOS interactive-pop gesture without changing the visual layout.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked accessibility impact; no accessibility elements were changed
- [x] No telemetry was added
- [x] No user-facing strings were added or modified
- [x] No documentation updates or complex-code comments are needed

## Testing
- Built the `Fennec` configuration for an iPhone 17 Pro simulator running iOS 27
- Ran `ClientTests/BookmarksCoordinatorTests`
- 10 tests passed