### PR TITLE
Fix suggestions dismissal on custom new tabs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -570,6 +570,11 @@ final class AddressToolbarContainer: UIView,
                 let action = ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.didStartTyping)
                 store.dispatch(action)
             }
+
+            let action = ToolbarAction(searchTerm: searchTerm,
+                                       windowUUID: windowUUID,
+                                       actionType: ToolbarActionType.didSetSearchTerm)
+            store.dispatch(action)
         }
         self.searchTerm = searchTerm
         delegate?.searchSuggestions(searchTerm: searchTerm)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -289,6 +289,27 @@ final class AddressToolbarContainerModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasAlternativeLocationColor)
     }
 
+    @MainActor
+    func testSearchSuggestions_updatesReduxSearchTerm() {
+        let delegate = MockAddressToolbarContainerDelegate()
+        let subject = AddressToolbarContainer(toolbarHelper: MockToolbarHelper())
+        subject.configure(windowUUID: windowUUID,
+                          profile: mockProfile,
+                          searchEnginesManager: searchEnginesManager,
+                          delegate: delegate,
+                          isUnifiedSearchEnabled: false,
+                          isBottomSearchBar: false)
+
+        subject.searchSuggestions(searchTerm: "fire")
+
+        let toolbarState = store.state.componentState(
+            ToolbarState.self,
+            for: .toolbar,
+            window: windowUUID
+        )
+        XCTAssertEqual(toolbarState?.addressToolbar.searchTerm, "fire")
+    }
+
     // MARK: - Private helpers
 
     @MainActor
@@ -422,4 +443,17 @@ final class AddressToolbarContainerModelTests: XCTestCase {
 
         return tab
     }
+}
+
+private final class MockAddressToolbarContainerDelegate: AddressToolbarContainerDelegate {
+    func searchSuggestions(searchTerm: String) { }
+    func openBrowser(searchTerm: String) { }
+    func openSuggestions(searchTerm: String) { }
+    func configureContextualHint(for button: UIButton, with contextualHintType: String) { }
+    func addressToolbarDidBeginEditing(searchTerm: String, shouldShowSuggestions: Bool) { }
+    func addressToolbarContainerAccessibilityActions() -> [UIAccessibilityCustomAction]? { nil }
+    func addressToolbarDidEnterOverlayMode(_ view: UIView) { }
+    func addressToolbar(_ view: UIView, didLeaveOverlayModeForReason: URLBarLeaveOverlayModeReason) { }
+    func addressToolbarDidBeginDragInteraction() { }
+    func addressToolbarDidTapSearchEngine(_ searchEngineView: UIView) { }
 }


### PR DESCRIPTION
## Summary

- synchronize address-bar search text with Redux while suggestions are shown
- preserve suggestions when scrolling from a Custom New Tab
- add regression coverage for the toolbar search-term state

## Testing

- Built the Fennec app and test bundle for the iOS Simulator
- Ran `AddressToolbarContainerModelTests`: 12 tests passed

Fixes #28385