### PR TITLE
Refactor FXIOS-16545 [Nova] Refactor close button for Site menu

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
@@ -71,7 +71,7 @@ public class CloseButton: UIButton,
     }
 
     @available(iOS 26.0, *)
-    public func applyGlassConfiguration(backgroundColor: UIColor, foregroundColor: UIColor) {
+    public func applyProminentClearGlassConfiguration(backgroundColor: UIColor, foregroundColor: UIColor) {
         var config = UIButton.Configuration.prominentClearGlass()
         config.image = configuration?.image ?? image(for: .normal)
         config.baseBackgroundColor = backgroundColor

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/CloseButton.swift
@@ -70,6 +70,15 @@ public class CloseButton: UIButton,
         updateButtonSizeForDynamicFont()
     }
 
+    @available(iOS 26.0, *)
+    public func applyGlassConfiguration(backgroundColor: UIColor, foregroundColor: UIColor) {
+        var config = UIButton.Configuration.prominentClearGlass()
+        config.image = configuration?.image ?? image(for: .normal)
+        config.baseBackgroundColor = backgroundColor
+        config.baseForegroundColor = foregroundColor
+        configuration = config
+    }
+
     private func updateButtonSizeForDynamicFont() {
         let scaledWidth = UIFontMetrics.default.scaledValue(for: baseSize.width)
         let scaledHeight = UIFontMetrics.default.scaledValue(for: baseSize.height)

--- a/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
@@ -60,13 +60,6 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         button.setImage(UIImage(named: imageName)?.withRenderingMode(.alwaysTemplate) ?? UIImage(), for: .normal)
     }
 
-    private lazy var closeButtonBackground: UIVisualEffectView = .build { view in
-        view.translatesAutoresizingMaskIntoConstraints = true
-        view.clipsToBounds = true
-        view.isUserInteractionEnabled = false
-        view.isHidden = true
-    }
-
     private lazy var siteProtectionsContent: UIStackView = .build { [weak self] stack in
         guard let self else { return }
         stack.isLayoutMarginsRelativeArrangement = true
@@ -122,15 +115,13 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
             siteProtectionsContent.layer.borderWidth = UX.siteProtectionsContentBorderWidth
         }
         siteProtectionsContent.layoutIfNeeded()
-        closeButtonBackground.frame = closeButton.frame
-        closeButtonBackground.layer.cornerRadius = closeButtonBackground.frame.height / 2
         applyNovaProtectionsGradient()
     }
 
     private func setupViews() {
         contentLabels.addArrangedSubview(titleLabel)
         contentLabels.addArrangedSubview(subtitleLabel)
-        addSubviews(contentLabels, favicon, closeButtonBackground, closeButton, siteProtectionsContent)
+        addSubviews(contentLabels, favicon, closeButton, siteProtectionsContent)
         siteProtectionsContent.addArrangedSubview(siteProtectionsIcon)
         siteProtectionsContent.addArrangedSubview(siteProtectionsLabel)
         siteProtectionsContent.addArrangedSubview(siteProtectionsMoreSettingsIcon)
@@ -226,13 +217,9 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
             closeButton.layer.cornerRadius = 0.5 * size
         }
         if #available(iOS 26.0, *), theme.isNova {
-            let glass = UIGlassEffect(style: .regular)
-            glass.tintColor = theme.colors.layer2
-            closeButtonBackground.effect = glass
-            closeButtonBackground.isHidden = false
-            closeButton.backgroundColor = .clear
+            closeButton.applyGlassConfiguration(backgroundColor: theme.colors.layer2,
+                                                foregroundColor: theme.colors.iconPrimary)
         } else {
-            closeButtonBackground.isHidden = true
             let closeBackground = theme.isNova ? theme.colors.layer2 : theme.colors.actionCloseButton
             closeButton.backgroundColor = closeBackground.withAlphaComponent(mainMenuHelper.backgroundAlpha())
         }

--- a/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
@@ -217,8 +217,8 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
             closeButton.layer.cornerRadius = 0.5 * size
         }
         if #available(iOS 26.0, *), theme.isNova {
-            closeButton.applyGlassConfiguration(backgroundColor: theme.colors.layer2,
-                                                foregroundColor: theme.colors.iconPrimary)
+            closeButton.applyProminentClearGlassConfiguration(backgroundColor: theme.colors.layer2,
+                                                              foregroundColor: theme.colors.iconPrimary)
         } else {
             let closeBackground = theme.isNova ? theme.colors.layer2 : theme.colors.actionCloseButton
             closeButton.backgroundColor = closeBackground.withAlphaComponent(mainMenuHelper.backgroundAlpha())

--- a/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
+++ b/firefox-ios/Client/Extensions/UIAlertController+Extension.swift
@@ -158,7 +158,7 @@ extension UIAlertController {
 
     func applyNovaActionTint(_ theme: Theme) {
         // The violet action tint only applies below iOS 26
-        if #available(iOS 26.0, *) { return }
+        guard #unavailable(iOS 26.0) else { return }
         let featureFlagsProvider: FeatureFlagProviding = AppContainer.shared.resolve()
         guard featureFlagsProvider.isEnabled(.novaDesign) else { return }
         view.tintColor = theme.colors.actionPrimary


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16545)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR is a follow up for the code changes related to Nova design for Site menu. This refactors glass configuration for the close button from Site Menu using `prominetClearGlass()`.
This also includes a nit change in `applyNovaActionTint` method suggested in [this PR](https://github.com/mozilla-mobile/firefox-ios/pull/35087).

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

