### PR TITLE
[MTE-5784] - add AI controls tests

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1363,7 +1363,6 @@
 		8C6AF26A2D38FB1500254698 /* GleanLifecycleObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6AF2692D38FB1500254698 /* GleanLifecycleObserverTests.swift */; };
 		8C76F013302344B700D4BC87 /* WebCompatReportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C76F012302344B700D4BC87 /* WebCompatReportCoordinator.swift */; };
 		8C76F015302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C76F014302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift */; };
-		8CE71B433025C458006C7828 /* WebCompatReportPreviewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE71B423025C458006C7828 /* WebCompatReportPreviewCoordinator.swift */; };
 		8C77849F2DF33707001FB8B0 /* OnboardingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C77849E2DF33707001FB8B0 /* OnboardingService.swift */; };
 		8CA4E80D2D22C066007207C1 /* GleanUsageReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */; };
 		8CA4E80F2D22D2C7007207C1 /* GleanUsageReportingLifecycleObserverTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA4E80E2D22D2C7007207C1 /* GleanUsageReportingLifecycleObserverTest.swift */; };
@@ -1380,6 +1379,8 @@
 		8CE1E4382B8C76C80026530B /* LoginListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1E4342B8C76C80026530B /* LoginListViewModel.swift */; };
 		8CE1E4392B8C76C80026530B /* LoginCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1E4352B8C76C80026530B /* LoginCellView.swift */; };
 		8CE1E43A2B8C76C80026530B /* LoginListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1E4362B8C76C80026530B /* LoginListView.swift */; };
+		8CE71B433025C458006C7828 /* WebCompatReportPreviewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE71B423025C458006C7828 /* WebCompatReportPreviewCoordinator.swift */; };
+		8CE71B453025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE71B443025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift */; };
 		8CEDF07E2BFE04B100D2617B /* AddressListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CEDF07D2BFE04B100D2617B /* AddressListViewModelTests.swift */; };
 		8CF40B482DFC22C200DCB7F0 /* OnboardingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF40B472DFC22C200DCB7F0 /* OnboardingServiceTests.swift */; };
 		8CF609272EA8D46E00F069B6 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8CF609262EA8D46E00F069B6 /* UniformTypeIdentifiers.framework */; };
@@ -1594,7 +1595,6 @@
 		C0D3F1000000000000000006 /* MockSystemPhotoPickerTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1000000000000000005 /* MockSystemPhotoPickerTelemetry.swift */; };
 		C209316E2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */; };
 		C20931722F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */; };
-		8CE71B453025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE71B443025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift */; };
 		C2126EF82F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2126EF72F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift */; };
 		C2126EFA2F447A46001C01FE /* SummarizerNimbusUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */; };
 		C21326992F5713F000746393 /* SummarizerLanguageProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21326982F5713F000746393 /* SummarizerLanguageProviderTests.swift */; };
@@ -1688,7 +1688,6 @@
 		C2DFB1452ECE62EE004E20AB /* MockTranslationsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DFB1442ECE62E8004E20AB /* MockTranslationsService.swift */; };
 		C2DFB1472ECE686E004E20AB /* TranslationsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DFB1462ECE6866004E20AB /* TranslationsServiceTests.swift */; };
 		C2E4F4C62F62F959002A8524 /* MockMainMenuCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E4F4C52F62F959002A8524 /* MockMainMenuCoordinatorDelegate.swift */; };
-		C2FA00312FFF000100AD1FBD /* ResetTipsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FA00302FFF000100AD1FBD /* ResetTipsSetting.swift */; };
 		C2EBB68F2E8181F20029E82C /* DismissableNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EBB68E2E8181EF0029E82C /* DismissableNavigationViewController.swift */; };
 		C2F2C19B30044C9600F9B916 /* MockAdBlockerListFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F2C19A30044C8700F9B916 /* MockAdBlockerListFetcher.swift */; };
 		C2F335342ECE33720071588A /* translations-engine.worker.js in Resources */ = {isa = PBXBuildFile; fileRef = C2F335322ECE33720071588A /* translations-engine.worker.js */; };
@@ -1703,6 +1702,8 @@
 		C2FA00022FFF000100AD1FBD /* RemoteQuickAnswersConfigFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FA00012FFF000100AD1FBD /* RemoteQuickAnswersConfigFetcher.swift */; };
 		C2FA00042FFF000100AD1FBD /* RemoteQuickAnswersConfigFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FA00032FFF000100AD1FBD /* RemoteQuickAnswersConfigFetcherTests.swift */; };
 		C2FA00212FFF000100AD1FBD /* QuickAnswersTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FA00202FFF000100AD1FBD /* QuickAnswersTip.swift */; };
+		C2FA00312FFF000100AD1FBD /* ResetTipsSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FA00302FFF000100AD1FBD /* ResetTipsSetting.swift */; };
+		C2FA00332FFF000100AD1FBD /* ResetTipsSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FA00322FFF000100AD1FBD /* ResetTipsSettingTests.swift */; };
 		C32D262AC6733C3D39E149CA /* LaunchPairingFromURLSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6894075BBBAF589F845633D0 /* LaunchPairingFromURLSetting.swift */; };
 		C400467C1CF4E43E00B08303 /* BackForwardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C400467B1CF4E43E00B08303 /* BackForwardListViewController.swift */; };
 		C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40046F91CF8E0B200B08303 /* BackForwardListAnimator.swift */; };
@@ -2303,6 +2304,7 @@
 		EDDC4F702F68637000E0B8FA /* modernKitOnboardingOn.json in Resources */ = {isa = PBXBuildFile; fileRef = EDDC4F6D2F68637000E0B8FA /* modernKitOnboardingOn.json */; };
 		EDDC4F712F68637000E0B8FA /* modernOrangeAndBlueOnboardingOn.json in Resources */ = {isa = PBXBuildFile; fileRef = EDDC4F6E2F68637000E0B8FA /* modernOrangeAndBlueOnboardingOn.json */; };
 		EDDC4F732F68697E00E0B8FA /* ModernKitOnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDC4F722F68697E00E0B8FA /* ModernKitOnboardingTests.swift */; };
+		AEC0FF0100000000000000A2 /* AIControlsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC0FF0100000000000000A1 /* AIControlsTests.swift */; };
 		EDDEB52D2D35C1A300517783 /* SiteType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDEB52C2D35C1A300517783 /* SiteType.swift */; };
 		EDDF340A2CDD159F008BB6A4 /* SearchEngineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */; };
 		EDDF340B2CDD1B7C008BB6A4 /* SearchEngineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */; };
@@ -2389,7 +2391,6 @@
 		FB16062200000000000000A2 /* CameraCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062200000000000000A1 /* CameraCoordinator.swift */; };
 		FB16062200000000000000B2 /* CameraCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB16062200000000000000B1 /* CameraCoordinatorTests.swift */; };
 		FBADD1700000000000000002 /* LaunchPairingFromURLSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBADD1700000000000000001 /* LaunchPairingFromURLSettingTests.swift */; };
-		C2FA00332FFF000100AD1FBD /* ResetTipsSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2FA00322FFF000100AD1FBD /* ResetTipsSettingTests.swift */; };
 		FC16179B00000000000000B1 /* WebCompatReportViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC16179B00000000000000B2 /* WebCompatReportViewControllerTests.swift */; };
 		FF0002AA2F000002000BBBBB /* ClearablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0002AA2F000001000BBBBB /* ClearablesTests.swift */; };
 		FF0005AD2F000004000BBBBB /* MockQuickAnswersStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0005AC2F000003000BBBBB /* MockQuickAnswersStore.swift */; };
@@ -10085,7 +10086,6 @@
 		8C6AF2692D38FB1500254698 /* GleanLifecycleObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanLifecycleObserverTests.swift; sourceTree = "<group>"; };
 		8C76F012302344B700D4BC87 /* WebCompatReportCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportCoordinator.swift; sourceTree = "<group>"; };
 		8C76F014302344B700D4BC87 /* WebCompatReportCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportCoordinatorTests.swift; sourceTree = "<group>"; };
-		8CE71B423025C458006C7828 /* WebCompatReportPreviewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportPreviewCoordinator.swift; sourceTree = "<group>"; };
 		8C77849E2DF33707001FB8B0 /* OnboardingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingService.swift; sourceTree = "<group>"; };
 		8C7A4A32A98AD1B79E3D69BE /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = "ru.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		8CA4E80C2D22C066007207C1 /* GleanUsageReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanUsageReporting.swift; sourceTree = "<group>"; };
@@ -10106,6 +10106,8 @@
 		8CE1E4342B8C76C80026530B /* LoginListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginListViewModel.swift; sourceTree = "<group>"; };
 		8CE1E4352B8C76C80026530B /* LoginCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginCellView.swift; sourceTree = "<group>"; };
 		8CE1E4362B8C76C80026530B /* LoginListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginListView.swift; sourceTree = "<group>"; };
+		8CE71B423025C458006C7828 /* WebCompatReportPreviewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportPreviewCoordinator.swift; sourceTree = "<group>"; };
+		8CE71B443025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportPreviewCoordinatorTests.swift; sourceTree = "<group>"; };
 		8CEDF07D2BFE04B100D2617B /* AddressListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressListViewModelTests.swift; sourceTree = "<group>"; };
 		8CEDF07F2BFE138B00D2617B /* AutofillProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillProvider.swift; sourceTree = "<group>"; };
 		8CF40B472DFC22C200DCB7F0 /* OnboardingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingServiceTests.swift; sourceTree = "<group>"; };
@@ -10702,7 +10704,6 @@
 		C1F24EFFB6E9B114849A4DB3 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		C209316D2F3CA52E00F0B05C /* QuickAnswersCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersCoordinator.swift; sourceTree = "<group>"; };
 		C20931712F3CAB0100F0B05C /* QuickAnswersCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersCoordinatorTests.swift; sourceTree = "<group>"; };
-		8CE71B443025C459006C7828 /* WebCompatReportPreviewCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportPreviewCoordinatorTests.swift; sourceTree = "<group>"; };
 		C2126EF72F4477EE001C01FE /* SummarizerLanguageExpansionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerLanguageExpansionConfiguration.swift; sourceTree = "<group>"; };
 		C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerNimbusUtilsTests.swift; sourceTree = "<group>"; };
 		C21326982F5713F000746393 /* SummarizerLanguageProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerLanguageProviderTests.swift; sourceTree = "<group>"; };
@@ -10803,7 +10804,6 @@
 		C2DFB1462ECE6866004E20AB /* TranslationsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsServiceTests.swift; sourceTree = "<group>"; };
 		C2E4F4C52F62F959002A8524 /* MockMainMenuCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMainMenuCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		C2E645149EB18AD0BDBB9696 /* zh-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/Search.strings"; sourceTree = "<group>"; };
-		C2FA00302FFF000100AD1FBD /* ResetTipsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetTipsSetting.swift; sourceTree = "<group>"; };
 		C2EBB68E2E8181EF0029E82C /* DismissableNavigationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissableNavigationViewController.swift; sourceTree = "<group>"; };
 		C2F2C19A30044C8700F9B916 /* MockAdBlockerListFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAdBlockerListFetcher.swift; sourceTree = "<group>"; };
 		C2F335322ECE33720071588A /* translations-engine.worker.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "translations-engine.worker.js"; sourceTree = "<group>"; };
@@ -10818,6 +10818,8 @@
 		C2FA00012FFF000100AD1FBD /* RemoteQuickAnswersConfigFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteQuickAnswersConfigFetcher.swift; sourceTree = "<group>"; };
 		C2FA00032FFF000100AD1FBD /* RemoteQuickAnswersConfigFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteQuickAnswersConfigFetcherTests.swift; sourceTree = "<group>"; };
 		C2FA00202FFF000100AD1FBD /* QuickAnswersTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersTip.swift; sourceTree = "<group>"; };
+		C2FA00302FFF000100AD1FBD /* ResetTipsSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetTipsSetting.swift; sourceTree = "<group>"; };
+		C2FA00322FFF000100AD1FBD /* ResetTipsSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetTipsSettingTests.swift; sourceTree = "<group>"; };
 		C326435B8F6E47257506096B /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Search.strings; sourceTree = "<group>"; };
 		C3334FC58A76876D8E9F00F3 /* az */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = az; path = az.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		C34D464780B65FD5A9F3118B /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Search.strings; sourceTree = "<group>"; };
@@ -11959,6 +11961,7 @@
 		EDDC4F6D2F68637000E0B8FA /* modernKitOnboardingOn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = modernKitOnboardingOn.json; sourceTree = "<group>"; };
 		EDDC4F6E2F68637000E0B8FA /* modernOrangeAndBlueOnboardingOn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = modernOrangeAndBlueOnboardingOn.json; sourceTree = "<group>"; };
 		EDDC4F722F68697E00E0B8FA /* ModernKitOnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernKitOnboardingTests.swift; sourceTree = "<group>"; };
+		AEC0FF0100000000000000A1 /* AIControlsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIControlsTests.swift; sourceTree = "<group>"; };
 		EDDEB52C2D35C1A300517783 /* SiteType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteType.swift; sourceTree = "<group>"; };
 		EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineModel.swift; sourceTree = "<group>"; };
 		EDEE4CC7BD65892525632A4E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Today.strings; sourceTree = "<group>"; };
@@ -12117,7 +12120,6 @@
 		FB6A4855A7905979E7512411 /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		FB8A4657AF4354C9EFAAE9F9 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		FBADD1700000000000000001 /* LaunchPairingFromURLSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchPairingFromURLSettingTests.swift; sourceTree = "<group>"; };
-		C2FA00322FFF000100AD1FBD /* ResetTipsSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetTipsSettingTests.swift; sourceTree = "<group>"; };
 		FBC14D2DBDDEE2E94CD0E14E /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Menu.strings; sourceTree = "<group>"; };
 		FBF24A9ABAABD821F73259BD /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		FC16179B00000000000000B2 /* WebCompatReportViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReportViewControllerTests.swift; sourceTree = "<group>"; };
@@ -13460,6 +13462,7 @@
 				3D9CA9831EF456A8002434DD /* NightModeTests.swift */,
 				2C4B6BF220349EB800A009C2 /* LegacyOnboardingTests.swift */,
 				EDDC4F722F68697E00E0B8FA /* ModernKitOnboardingTests.swift */,
+				AEC0FF0100000000000000A1 /* AIControlsTests.swift */,
 				B15058802AA0A878008B7382 /* OpeningScreenTests.swift */,
 				D4C35390283500A600F7DC7D /* PerformanceTests.swift */,
 				D81127D71F84023B0050841D /* PhotonActionSheetTests.swift */,
@@ -19353,6 +19356,7 @@
 				2CA16FDE1E5F089100332277 /* SearchTest.swift in Sources */,
 				8A9F0B5827C59E1800FE09AE /* ImageIdentifiers.swift in Sources */,
 				EDDC4F732F68697E00E0B8FA /* ModernKitOnboardingTests.swift in Sources */,
+				AEC0FF0100000000000000A2 /* AIControlsTests.swift in Sources */,
 				3B546EC01D95ECAE00BDBE36 /* ActivityStreamTest.swift in Sources */,
 				2CCB296720A99C9500121DD8 /* LoginsTests.swift in Sources */,
 				3D9CA9841EF456A8002434DD /* NightModeTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
@@ -14,6 +14,7 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "AIControlsTests",
         "ActivityStreamTest",
         "ActivityStreamTest\/testContextMenuInLandscape()",
         "ActivityStreamTest\/testDefaultSites()",

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -88,6 +88,7 @@
         "A11yTabTrayTests",
         "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
+        "AIControlsTests",
         "ActivityStreamTest",
         "AddressesTests",
         "AddressesTests\/testAddNewAddressAllFieldsFilled()",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -55,6 +55,7 @@
         "A11yTabTrayTests",
         "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
+        "AIControlsTests",
         "ActivityStreamTest",
         "AddressesTests",
         "AddressesTests\/testAddNewAddressAllFieldsFilled()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -58,6 +58,7 @@
         "A11yTabTrayTests",
         "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
+        "AIControlsTests",
         "ActivityStreamTest\/testContextMenuInLandscape()",
         "ActivityStreamTest\/testDefaultSitesTAE()",
         "ActivityStreamTest\/testDefaultSites_TAE()",

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
@@ -78,6 +78,7 @@
         "A11yTabTrayTests",
         "A11yTabTrayTests\/testAccessibility()",
         "A11yUtils",
+        "AIControlsTests",
         "ActivityStreamTest",
         "AddressesTests",
         "AddressesTests\/testAddNewAddressAllFieldsFilled()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/AIControlsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/AIControlsTests.swift
@@ -1,0 +1,247 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+
+@MainActor
+final class AIControlsTests: FeatureFlaggedTestBase {
+    var toolBarScreen: ToolbarScreen!
+    var browserScreen: BrowserScreen!
+    var settingsScreen: SettingScreen!
+    var mainMenuScreen: MainMenuScreen!
+    var aiControlsScreen: AIControlsScreen!
+    var translationSettingScreen: TranslationSettingsScreen!
+    var summarizeSettingScreen: SummarizeSettingsScreen!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        toolBarScreen = ToolbarScreen(app: app)
+        browserScreen = BrowserScreen(app: app)
+        settingsScreen = SettingScreen(app: app)
+        mainMenuScreen = MainMenuScreen(app: app)
+        aiControlsScreen = AIControlsScreen(app: app)
+        translationSettingScreen = TranslationSettingsScreen(app: app)
+        summarizeSettingScreen = SummarizeSettingsScreen(app: app)
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/3960880
+    // Regression
+    func testAIFeaturesSetToOffAreNotAvailable() throws {
+        try XCTSkipIf(
+            isFirefox || isFirefoxBeta,
+            "Skipping because on Firefox and FirefoxBeta addLaunchArgument cannot override the default " +
+            "experiment values, so the AI features cannot be forced on/off"
+        )
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "ai-kill-switch-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "translations-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "hosted-summarizer-feature")
+        app.launch()
+
+        // Baseline: with the features enabled, Translation is available on a web page
+        navigateToTranslationTestPage()
+        toolBarScreen.assertTranslateButtonExists(with: .inactive)
+
+        // Configuration 1: Block AI Enhancements ON forces Translation and Page Summaries OFF
+        openSettingsFromToolbarMenu()
+        settingsScreen.openAIControlsSettings()
+        aiControlsScreen.assertScreenShown()
+        // Establish a known "available" baseline before blocking so the transition to off is meaningful
+        aiControlsScreen.setPageSummariesToggle(on: true)
+        aiControlsScreen.turnOnBlockAIEnhancements()
+        aiControlsScreen.assertTranslationToggleIsOff()
+        aiControlsScreen.assertPageSummariesToggleIsOff()
+        settingsScreen.tapBackToSettings()
+        settingsScreen.closeSettingsWithDoneButton()
+
+        assertAIFeaturesAreNotAvailable()
+
+        // Configuration 2: Block AI Enhancements OFF, but each feature toggled OFF individually
+        openSettingsFromToolbarMenu()
+        settingsScreen.openAIControlsSettings()
+        aiControlsScreen.assertScreenShown()
+        // Turning the kill switch off re-enables the features; verify then turn each off individually
+        aiControlsScreen.turnOffBlockAIEnhancements()
+        aiControlsScreen.assertTranslationToggleIsOn()
+        aiControlsScreen.turnOffTranslationToggle()
+        aiControlsScreen.turnOffPageSummariesToggle()
+        aiControlsScreen.assertTranslationToggleIsOff()
+        aiControlsScreen.assertPageSummariesToggleIsOff()
+        settingsScreen.tapBackToSettings()
+        settingsScreen.closeSettingsWithDoneButton()
+
+        assertAIFeaturesAreNotAvailable()
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/3965955
+    // Regression
+    func testTranslationSettingChangesReflectInAIControls() throws {
+        try XCTSkipIf(
+            isFirefox || isFirefoxBeta,
+            "Skipping because on Firefox and FirefoxBeta addLaunchArgument cannot override the default " +
+            "experiment values, so the AI features cannot be forced on/off"
+        )
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "ai-kill-switch-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "translations-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "hosted-summarizer-feature")
+        app.launch()
+
+        navigateToTranslationTestPage()
+
+        // The standalone Translation setting mirrors into AI Controls both with the kill switch untouched
+        // and after it has been used to block AI features
+        verifyStandaloneTranslationMirrorsAIControls(blockAIEnhancementsFirst: false)
+        verifyStandaloneTranslationMirrorsAIControls(blockAIEnhancementsFirst: true)
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/3965956
+    // Regression
+    func testPageSummariesSettingChangesReflectInAIControls() throws {
+        try XCTSkipIf(
+            isFirefox || isFirefoxBeta,
+            "Skipping because on Firefox and FirefoxBeta addLaunchArgument cannot override the default " +
+            "experiment values, so the AI features cannot be forced on/off"
+        )
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "ai-kill-switch-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "translations-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "hosted-summarizer-feature")
+        app.launch()
+
+        navigateToBookOfMozillaPage()
+
+        verifyStandalonePageSummariesMirrorsAIControls(blockAIEnhancementsFirst: false)
+        verifyStandalonePageSummariesMirrorsAIControls(blockAIEnhancementsFirst: true)
+    }
+
+    // MARK: - Helpers
+
+    /// Drives the standalone Translation toggle ON → OFF → ON, asserting after each change that the AI
+    /// Controls Translation toggle mirrors it and the translate toolbar button availability follows.
+    private func verifyStandaloneTranslationMirrorsAIControls(blockAIEnhancementsFirst: Bool) {
+        if blockAIEnhancementsFirst {
+            openSettingsFromToolbarMenu()
+            settingsScreen.openAIControlsSettings()
+            aiControlsScreen.turnOnBlockAIEnhancements()
+            aiControlsScreen.assertTranslationToggleIsOff()
+            settingsScreen.tapBackToSettings()
+            settingsScreen.closeSettingsWithDoneButton()
+        }
+
+        setStandaloneTranslationAndAssertMirror(on: true)
+        toolBarScreen.assertTranslateButtonExists(with: .inactive)
+
+        setStandaloneTranslationAndAssertMirror(on: false)
+        toolBarScreen.assertTranslateButtonDoesNotExist(with: .inactive)
+
+        // Re-enabling returns the feature even after Block AI Enhancements was used
+        setStandaloneTranslationAndAssertMirror(on: true)
+        toolBarScreen.assertTranslateButtonExists(with: .inactive)
+    }
+
+    /// Sets the standalone Translations toggle, then reopens AI Controls to assert it reflects the state.
+    private func setStandaloneTranslationAndAssertMirror(on: Bool) {
+        openSettingsFromToolbarMenu()
+        settingsScreen.openTranslationSettings()
+        translationSettingScreen.setTranslationSwitch(on: on)
+        settingsScreen.tapBackToSettings()
+
+        settingsScreen.openAIControlsSettings()
+        if on {
+            aiControlsScreen.assertTranslationToggleIsOn()
+        } else {
+            aiControlsScreen.assertTranslationToggleIsOff()
+        }
+        settingsScreen.tapBackToSettings()
+        settingsScreen.closeSettingsWithDoneButton()
+    }
+
+    /// Drives the standalone Page Summaries toggle ON → OFF → ON, asserting the AI Controls Page
+    /// Summaries toggle mirrors it. When off, the Summarize main-menu entry is absent.
+    private func verifyStandalonePageSummariesMirrorsAIControls(blockAIEnhancementsFirst: Bool) {
+        if blockAIEnhancementsFirst {
+            openSettingsFromToolbarMenu()
+            settingsScreen.openAIControlsSettings()
+            aiControlsScreen.turnOnBlockAIEnhancements()
+            aiControlsScreen.assertPageSummariesToggleIsOff()
+            settingsScreen.tapBackToSettings()
+            settingsScreen.closeSettingsWithDoneButton()
+        }
+
+        // Availability of the live summarize surface depends on runtime summarizer config (app-attest /
+        // page content) a UI test cannot force, so the enabled state is verified via the toggles only.
+        setStandalonePageSummariesAndAssertMirror(on: true)
+
+        setStandalonePageSummariesAndAssertMirror(on: false)
+
+        // When off, the Summarize main-menu entry is absent; continue into Settings from the same open
+        // menu rather than dismissing and reopening (an in-flight dismiss swallows the reopen tap).
+        toolBarScreen.tapSettingsMenuButton()
+        mainMenuScreen.assertSummarizePageItemDoesNotExist()
+        setStandalonePageSummariesAndAssertMirror(on: true, fromOpenMenu: true)
+    }
+
+    /// Sets the standalone Page Summaries toggle, then reopens AI Controls to assert it reflects the state.
+    private func setStandalonePageSummariesAndAssertMirror(on: Bool, fromOpenMenu: Bool = false) {
+        if fromOpenMenu {
+            mainMenuScreen.tapSettings()
+        } else {
+            openSettingsFromToolbarMenu()
+        }
+        settingsScreen.openSummarizeSettings()
+        summarizeSettingScreen.setSummarizeSwitch(on: on)
+        settingsScreen.tapBackToSettings()
+
+        settingsScreen.openAIControlsSettings()
+        if on {
+            aiControlsScreen.assertPageSummariesToggleIsOn()
+        } else {
+            aiControlsScreen.assertPageSummariesToggleIsOff()
+        }
+        settingsScreen.tapBackToSettings()
+        settingsScreen.closeSettingsWithDoneButton()
+    }
+
+    /// Asserts Translation and Page Summaries are unavailable across every surface reachable in a UI
+    /// test: the address bar, the main menu, and their standalone settings screens.
+    private func assertAIFeaturesAreNotAvailable() {
+        // Address bar: no translate button on the loaded page
+        toolBarScreen.assertTranslateButtonDoesNotExist(with: .inactive)
+
+        // Main menu: no Translate or Summarize entry
+        toolBarScreen.tapSettingsMenuButton()
+        mainMenuScreen.assertTranslatePageItemDoesNotExist()
+        mainMenuScreen.assertSummarizePageItemDoesNotExist()
+
+        // Standalone settings screens: both feature toggles read off
+        mainMenuScreen.tapSettings()
+        settingsScreen.openTranslationSettings()
+        translationSettingScreen.assertTranslationSwitchIsOff()
+        settingsScreen.tapBackToSettings()
+        settingsScreen.openSummarizeSettings()
+        summarizeSettingScreen.assertSummarizeToggleIsOff()
+        settingsScreen.tapBackToSettings()
+        settingsScreen.closeSettingsWithDoneButton()
+    }
+
+    private func openSettingsFromToolbarMenu() {
+        toolBarScreen.tapSettingsMenuButton()
+        mainMenuScreen.tapSettings()
+    }
+
+    private func navigateToTranslationTestPage() {
+        loadTestPage("test-translation.html")
+    }
+
+    private func navigateToBookOfMozillaPage() {
+        loadTestPage("test-mozilla-book.html")
+    }
+
+    private func loadTestPage(_ page: String) {
+        browserScreen.tapOnAddressBar()
+        browserScreen.typeOnSearchBar(text: path(forTestPage: page))
+        browserScreen.typeOnSearchBar(text: "\r")
+        waitUntilPageLoad()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/AIControlsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/AIControlsScreen.swift
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+/// Page object for the Settings → AI Controls screen. Its SwiftUI toggles have no accessibility
+/// identifiers, so each is matched by a fragment of its visible label.
+@MainActor
+final class AIControlsScreen {
+    private let app: XCUIApplication
+
+    init(app: XCUIApplication) {
+        self.app = app
+    }
+
+    /// The "Block AI Enhancements" kill switch. Turning it on force-disables all AI sub-features.
+    private var blockAIEnhancementsToggle: XCUIElement { toggle(labelContaining: "Block AI Enhancements") }
+    private var translationToggle: XCUIElement { toggle(labelContaining: "Translation") }
+    private var pageSummariesToggle: XCUIElement { toggle(labelContaining: "Page Summaries") }
+
+    private func toggle(labelContaining fragment: String) -> XCUIElement {
+        app.switches.matching(NSPredicate(format: "label CONTAINS[c] %@", fragment)).firstMatch
+    }
+
+    func assertScreenShown() {
+        let navBar = app.navigationBars["AI Controls"]
+        BaseTestCase().mozWaitForElementToExist(navBar)
+        BaseTestCase().mozWaitForElementToExist(blockAIEnhancementsToggle)
+    }
+
+    // MARK: - Block AI Enhancements kill switch
+
+    func turnOnBlockAIEnhancements() {
+        setToggle(blockAIEnhancementsToggle, on: true)
+    }
+
+    func turnOffBlockAIEnhancements() {
+        setToggle(blockAIEnhancementsToggle, on: false)
+    }
+
+    // MARK: - Individual feature toggles
+
+    func setPageSummariesToggle(on: Bool) {
+        setToggle(pageSummariesToggle, on: on)
+    }
+
+    func turnOffTranslationToggle() {
+        setToggle(translationToggle, on: false)
+    }
+
+    func turnOffPageSummariesToggle() {
+        setToggle(pageSummariesToggle, on: false)
+    }
+
+    func assertTranslationToggleIsOn() {
+        assertToggle(translationToggle, isOn: true, name: "Translation")
+    }
+
+    func assertTranslationToggleIsOff() {
+        assertToggle(translationToggle, isOn: false, name: "Translation")
+    }
+
+    func assertPageSummariesToggleIsOn() {
+        assertToggle(pageSummariesToggle, isOn: true, name: "Page Summaries")
+    }
+
+    func assertPageSummariesToggleIsOff() {
+        assertToggle(pageSummariesToggle, isOn: false, name: "Page Summaries")
+    }
+
+    // MARK: - Helpers
+
+    private func setToggle(_ toggle: XCUIElement, on: Bool) {
+        BaseTestCase().mozWaitForElementToExist(toggle)
+        if (toggle.value as? String) != (on ? "1" : "0") {
+            toggle.waitAndTap()
+        }
+    }
+
+    private func assertToggle(_ toggle: XCUIElement, isOn: Bool, name: String) {
+        BaseTestCase().mozWaitForElementToExist(toggle)
+        let value = toggle.value as? String
+        let expected = isOn ? "1" : "0"
+        XCTAssertEqual(value,
+                       expected,
+                       "Expected '\(name)' toggle to be \(isOn ? "ON" : "OFF") (\(expected)), got \(String(describing: value))")
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MainMenuScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MainMenuScreen.swift
@@ -78,4 +78,20 @@ final class MainMenuScreen {
         BaseTestCase().mozWaitForElementToExist(history)
         history.waitAndTap()
     }
+
+    func assertTranslatePageItemDoesNotExist() {
+        assertMenuItemDoesNotExist(AccessibilityIdentifiers.MainMenu.translatePage)
+    }
+
+    func assertSummarizePageItemDoesNotExist() {
+        assertMenuItemDoesNotExist(AccessibilityIdentifiers.MainMenu.summarizePage)
+    }
+
+    private func assertMenuItemDoesNotExist(_ identifier: String) {
+        // Wait for a stable Main Menu element to render first, otherwise the absence
+        // check can pass simply because the menu hasn't finished loading yet.
+        BaseTestCase().mozWaitForElementToExist(sel.SETTINGS_CELL.element(in: app))
+        let item = app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+        BaseTestCase().mozWaitForElementToNotExist(item)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
@@ -293,6 +293,18 @@ final class SettingScreen {
         translationCell.waitAndTap()
     }
 
+    func openAIControlsSettings() {
+        let cell = app.tables.cells[AccessibilityIdentifiers.Settings.AIControls.title]
+        BaseTestCase().scrollToElement(cell)
+        cell.waitAndTap()
+    }
+
+    func openSummarizeSettings() {
+        let cell = app.tables.cells[AccessibilityIdentifiers.Settings.Summarize.title]
+        BaseTestCase().scrollToElement(cell)
+        cell.waitAndTap()
+    }
+
     func assertTranslationSettingsDoesNotExist() {
         BaseTestCase().mozWaitForElementToNotExist(translationCell)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SummarizeSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SummarizeSettingsScreen.swift
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+/// Page object for the standalone Settings → Page Summaries screen. Its "Summarize Pages" toggle
+/// carries the summarize content pref key as its accessibility identifier.
+@MainActor
+final class SummarizeSettingsScreen {
+    private let app: XCUIApplication
+
+    init(app: XCUIApplication) {
+        self.app = app
+    }
+
+    private var summarizeToggle: XCUIElement {
+        app.switches[AccessibilityIdentifiers.Settings.Summarize.summarizeContentSwitch]
+    }
+
+    func assertSummarizeToggleIsOff() {
+        BaseTestCase().mozWaitForElementToExist(summarizeToggle)
+        let value = summarizeToggle.value as? String
+        XCTAssertEqual(value, "0", "Expected 'Summarize Pages' switch to be OFF (0), but got \(String(describing: value))")
+    }
+
+    func assertSummarizeToggleIsOn() {
+        BaseTestCase().mozWaitForElementToExist(summarizeToggle)
+        let value = summarizeToggle.value as? String
+        XCTAssertEqual(value, "1", "Expected 'Summarize Pages' switch to be ON (1), but got \(String(describing: value))")
+    }
+
+    func setSummarizeSwitch(on: Bool) {
+        BaseTestCase().mozWaitForElementToExist(summarizeToggle)
+        if (summarizeToggle.value as? String) != (on ? "1" : "0") {
+            summarizeToggle.waitAndTap()
+        }
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TranslationSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TranslationSettingsScreen.swift
@@ -41,6 +41,13 @@ final class TranslationSettingsScreen {
         translationToggle.waitAndTap()
     }
 
+    func setTranslationSwitch(on: Bool) {
+        BaseTestCase().mozWaitForElementToExist(translationToggle)
+        if (translationToggle.value as? String) != (on ? "1" : "0") {
+            translationToggle.waitAndTap()
+        }
+    }
+
     func assertTranslationSwitchIsOff() {
         BaseTestCase().mozWaitForElementToExist(translationToggle)
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5784
https://mozilla-hub.atlassian.net/browse/MTE-5785
https://mozilla-hub.atlassian.net/browse/MTE-5786

## :bulb: Description
https://mozilla.testrail.io/index.php?/cases/view/3960880
https://mozilla.testrail.io/index.php?/cases/view/3965955
https://mozilla.testrail.io/index.php?/cases/view/3965956

Adds automated UI tests covering the AI Controls settings screen and how it interacts with the Translation and Page Summaries features.

The following scenarios are now covered:

- AI features turned off are not usable — when AI features are disabled (both through the "Block AI Enhancements" option and by turning each feature off individually), Translation and Page Summaries no longer appear in the address bar, the menu, or their own settings screens.
- Translation stays in sync — enabling or disabling Translation from its own settings screen is correctly reflected in the AI Controls screen, and the feature becomes available or unavailable accordingly.
- Page Summaries stays in sync — enabling or disabling Page Summaries from its own settings screen is correctly reflected in the AI Controls screen.

Each scenario is verified with the "Block AI Enhancements" option both on and off.
