### PR TITLE
Bugfix FXIOS-16357 Remove unused Storage imports

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/PasswordManagerListViewController.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import Storage
 import Shared
 import Common
 

--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Storage
 import Shared
 import Common
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16357)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34792)

## :bulb: Description
Removes the unused `Storage` imports from:

- `PasswordManagerListViewController.swift`
- `PasswordDetailViewController.swift`

The remaining files originally listed in the issue still use types from `Storage` and were intentionally left unchanged.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — Not applicable
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review — Not applicable
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-h