### PR TITLE
Bugfix - FXIOS-15902 [Crash] Copy web view snapshots before persisting them

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		212985E42A6F078800546684 /* ScreenState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212985E32A6F078800546684 /* ScreenState.swift */; };
 		213046B92F202F27007ECEDA /* UIFontExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213046B82F202F27007ECEDA /* UIFontExtensionsTests.swift */; };
 		213046BB2F212BCC007ECEDA /* CGRectExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213046BA2F212BCC007ECEDA /* CGRectExtensionsTests.swift */; };
+		21A4F1012F400001007ECEDA /* UIImageRenderingUtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A4F1002F400001007ECEDA /* UIImageRenderingUtilitiesTests.swift */; };
 		213046BD2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213046BC2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift */; };
 		213047E62F2153B1007ECEDA /* PageZoomSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213047E52F2153AB007ECEDA /* PageZoomSettingsViewModelTests.swift */; };
 		21365E392F30FD700000C369 /* BrowserViewControllerLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21365E382F30FD580000C369 /* BrowserViewControllerLayoutManager.swift */; };
@@ -3165,6 +3166,7 @@
 		212985E32A6F078800546684 /* ScreenState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenState.swift; sourceTree = "<group>"; };
 		213046B82F202F27007ECEDA /* UIFontExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtensionsTests.swift; sourceTree = "<group>"; };
 		213046BA2F212BCC007ECEDA /* CGRectExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGRectExtensionsTests.swift; sourceTree = "<group>"; };
+		21A4F1002F400001007ECEDA /* UIImageRenderingUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageRenderingUtilitiesTests.swift; sourceTree = "<group>"; };
 		213046BC2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAlertControllerExtensionTests.swift; sourceTree = "<group>"; };
 		213047E52F2153AB007ECEDA /* PageZoomSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageZoomSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		21365E382F30FD580000C369 /* BrowserViewControllerLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerLayoutManager.swift; sourceTree = "<group>"; };
@@ -14703,6 +14705,7 @@
 			isa = PBXGroup;
 			children = (
 				213046BA2F212BCC007ECEDA /* CGRectExtensionsTests.swift */,
+				21A4F1002F400001007ECEDA /* UIImageRenderingUtilitiesTests.swift */,
 				213046B82F202F27007ECEDA /* UIFontExtensionsTests.swift */,
 				8ADED7EB27691351009C19E6 /* CalendarExtensionsTests.swift */,
 				A13E0AA0B57849608FF108CA /* PDFDocumentExtensionTests.swift */,
@@ -21177,6 +21180,7 @@
 				213046BD2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift in Sources */,
 				8A01FE402DF0CE4E002C483B /* MockDateProvider.swift in Sources */,
 				213046BB2F212BCC007ECEDA /* CGRectExtensionsTests.swift in Sources */,
+				21A4F1012F400001007ECEDA /* UIImageRenderingUtilitiesTests.swift in Sources */,
 				8A9BA6BF2F7C4D6000D892C4 /* RemoteTabCreatorTests.swift in Sources */,
 				C27EF61F2EBA395A00BED719 /* MockLanguageSampleSource.swift in Sources */,
 				8A97E6EF2C584C4900F94793 /* AddressLocaleFeatureValidatorTests.swift in Sources */,

--- a/firefox-ios/Client/Extensions/UIImage+RenderingUtilities.swift
+++ b/firefox-ios/Client/Extensions/UIImage+RenderingUtilities.swift
@@ -5,6 +5,43 @@
 import PDFKit
 
 extension UIImage {
+    /// Redraws the image into a bitmap this process owns.
+    ///
+    /// Images vended by `WKWebView.takeSnapshot` are backed by a surface belonging to the web content
+    /// process, and only materialize their pixels the first time something draws them. When that draw is
+    /// deferred to a background actor the surface may already have been recycled or purged, which faults
+    /// inside CoreGraphics rather than failing gracefully. Call this on the main thread, while the source
+    /// is still valid, before handing the image off to be drawn later.
+    ///
+    /// The copy is taken from the source's pixel grid rather than from `size` x `scale`, so it is
+    /// pixel exact and never resampled, even when the point size does not divide evenly.
+    /// - Returns: a copy backed by memory this process owns, or `self` if the image has no `cgImage`
+    /// or no bitmap context can be created for it.
+    func copiedIntoOwnedBitmap() -> UIImage {
+        guard let source = cgImage, source.width > 0, source.height > 0 else { return self }
+
+        // BGRA8 premultiplied is CoreGraphics' fast path. Fall back to a device RGB space when the
+        // source carries one a bitmap context cannot be created with.
+        let bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        let makeContext = { (space: CGColorSpace) in
+            CGContext(data: nil,
+                      width: source.width,
+                      height: source.height,
+                      bitsPerComponent: 8,
+                      bytesPerRow: 0,
+                      space: space,
+                      bitmapInfo: bitmapInfo)
+        }
+
+        guard let context = source.colorSpace.flatMap(makeContext) ?? makeContext(CGColorSpaceCreateDeviceRGB())
+        else { return self }
+
+        context.draw(source, in: CGRect(x: 0, y: 0, width: source.width, height: source.height))
+        guard let copy = context.makeImage() else { return self }
+
+        return UIImage(cgImage: copy, scale: scale, orientation: imageOrientation)
+    }
+
     /// Renders PDF data as a UIImage.
     /// - Parameters:
     ///   - data: the PDF data.

--- a/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/ScreenshotHelper.swift
@@ -116,7 +116,9 @@ class ScreenshotHelper {
                 webView.setPullRefreshVisibility(isVisible: true)
                 if let image, let tab {
                     tab.hasHomeScreenshot = false
-                    tab.setScreenshot(image)
+                    // The snapshot is drawn again off the main actor when it gets persisted, long after the
+                    // web content process may have reclaimed the surface backing it, so take a copy now.
+                    tab.setScreenshot(image.copiedIntoOwnedBitmap())
                     store.dispatch(
                         ScreenshotAction(
                             windowUUID: windowUUID,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/UIImageRenderingUtilitiesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/UIImageRenderingUtilitiesTests.swift
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+final class UIImageRenderingUtilitiesTests: XCTestCase {
+    // MARK: copiedIntoOwnedBitmap
+
+    func testCopiedIntoOwnedBitmap_preservesSizeAndScale() {
+        let subject = makeImage(color: .red, size: CGSize(width: 40, height: 20), scale: 2)
+
+        let result = subject.copiedIntoOwnedBitmap()
+
+        XCTAssertEqual(result.size, subject.size)
+        XCTAssertEqual(result.scale, subject.scale)
+    }
+
+    func testCopiedIntoOwnedBitmap_preservesPixelDimensions() throws {
+        let subject = makeImage(color: .red, size: CGSize(width: 40, height: 20), scale: 2)
+        let sourceBacking = try XCTUnwrap(subject.cgImage)
+
+        let resultBacking = try XCTUnwrap(subject.copiedIntoOwnedBitmap().cgImage)
+
+        XCTAssertEqual(resultBacking.width, sourceBacking.width)
+        XCTAssertEqual(resultBacking.height, sourceBacking.height)
+    }
+
+    func testCopiedIntoOwnedBitmap_returnsDistinctBacking() throws {
+        let subject = makeImage(color: .red, size: CGSize(width: 40, height: 20), scale: 2)
+        let originalBacking = try XCTUnwrap(subject.cgImage)
+
+        let resultBacking = try XCTUnwrap(subject.copiedIntoOwnedBitmap().cgImage)
+
+        XCTAssertFalse(originalBacking === resultBacking)
+    }
+
+    func testCopiedIntoOwnedBitmap_preservesPixelContent() throws {
+        let subject = makeImage(color: .red, size: CGSize(width: 40, height: 20), scale: 2)
+
+        let result = try XCTUnwrap(firstPixel(of: subject.copiedIntoOwnedBitmap()))
+
+        XCTAssertEqual(Int(result.red), 255, accuracy: 2)
+        XCTAssertEqual(Int(result.green), 0, accuracy: 2)
+        XCTAssertEqual(Int(result.blue), 0, accuracy: 2)
+        XCTAssertEqual(Int(result.alpha), 255, accuracy: 2)
+    }
+
+    func testCopiedIntoOwnedBitmap_withZeroSizeImage_returnsSameImage() {
+        let subject = UIImage()
+
+        let result = subject.copiedIntoOwnedBitmap()
+
+        XCTAssertTrue(result === subject)
+    }
+
+    // MARK: - Helpers
+
+    private func makeImage(color: UIColor, size: CGSize, scale: CGFloat) -> UIImage {
+        let format = UIGraphicsImageRendererFormat.preferred()
+        format.scale = scale
+        format.opaque = true
+
+        return UIGraphicsImageRenderer(size: size, format: format).image { context in
+            color.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+
+    private struct Pixel {
+        let red: UInt8
+        let green: UInt8
+        let blue: UInt8
+        let alpha: UInt8
+    }
+
+    /// Averages the image down to a single pixel, which is the image's uniform color for the solid
+    /// fills these tests use.
+    private func firstPixel(of image: UIImage) -> Pixel? {
+        guard let cgImage = image.cgImage else { return nil }
+
+        var pixel = [UInt8](repeating: 0, count: 4)
+        guard let context = CGContext(data: &pixel,
+                                      width: 1,
+                                      height: 1,
+                                      bitsPerComponent: 8,
+                                      bytesPerRow: 4,
+                                      space: CGColorSpaceCreateDeviceRGB(),
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return nil }
+
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: 1, height: 1))
+        return Pixel(red: pixel[0], green: pixel[1], blue: pixel[2], alpha: pixel[3])
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabWebView.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabWebView.swift
@@ -20,6 +20,7 @@ final class MockTabWebView: TabWebView {
     var loadedURL: URL?
     var takeSnapshotWasCalled = false
     var takeSnapshotShouldFail = false
+    var mockSnapshotImage = UIImage.strokedCheckmark
     var mockHasOnlySecureContent = false
     var mockCanGoBack = false
     var mockCanGoForward = false
@@ -115,7 +116,7 @@ final class MockTabWebView: TabWebView {
         if takeSnapshotShouldFail {
             completionHandler(nil, NSError(domain: "", code: 500, userInfo: nil))
         } else {
-            completionHandler(UIImage.strokedCheckmark, nil)
+            completionHandler(mockSnapshotImage, nil)
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ScreenshotHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ScreenshotHelperTests.swift
@@ -96,9 +96,14 @@ final class ScreenshotHelperTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(mockTabWebView.takeSnapshotWasCalled)
         XCTAssertEqual(screenshotAction.tab, tab)
         XCTAssertFalse(tab.hasHomeScreenshot)
-        XCTAssertNotNil(tab.screenshot?.cgImage)
-        XCTAssertEqual(tab.screenshot?.cgImage?.width, mockTabWebView.mockSnapshotImage.cgImage?.width)
-        XCTAssertEqual(tab.screenshot?.cgImage?.height, mockTabWebView.mockSnapshotImage.cgImage?.height)
+guard let screenshotBacking = tab.screenshot?.cgImage,
+      let sourceBacking = mockTabWebView.mockSnapshotImage.cgImage else {
+    XCTFail("Expected source and copied image backings")
+    return
+}
+XCTAssertFalse(screenshotBacking === sourceBacking)
+XCTAssertEqual(screenshotBacking.width, sourceBacking.width)
+XCTAssertEqual(screenshotBacking.height, sourceBacking.height)
     }
 
     private func createSubject() -> ScreenshotHelper {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ScreenshotHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ScreenshotHelperTests.swift
@@ -95,8 +95,10 @@ final class ScreenshotHelperTests: XCTestCase, StoreTestUtility {
 
         XCTAssertTrue(mockTabWebView.takeSnapshotWasCalled)
         XCTAssertEqual(screenshotAction.tab, tab)
-        XCTAssertEqual(tab.screenshot, UIImage.strokedCheckmark)
         XCTAssertFalse(tab.hasHomeScreenshot)
+        XCTAssertNotNil(tab.screenshot?.cgImage)
+        XCTAssertEqual(tab.screenshot?.cgImage?.width, mockTabWebView.mockSnapshotImage.cgImage?.width)
+        XCTAssertEqual(tab.screenshot?.cgImage?.height, mockTabWebView.mockSnapshotImage.cgImage?.height)
     }
 
     private func createSubject() -> ScreenshotHelper {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15902)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33990)

## :bulb: Description
### Problem

Sentry is reporting an unhandled `EXC_BAD_ACCESS` (`SIGSEGV`, null dereference) in
`DefaultDiskImageStore.scaleImageFrom3xTo1x` at `DiskImageStore.swift:111`, on the
`UIGraphicsImageRenderer` draw that downscales a tab screenshot before it is written to disk.
It is reproducing on 153.3, predominantly on iPad.

### Root cause

Tab screenshots for web content are captured with `WKWebView.takeSnapshot` in
`ScreenshotHelper.takeScreenshot`. The returned `UIImage` does not carry a resident bitmap — its
pixels are materialized lazily, the first time something draws it.

That first draw does not happen at capture time. `Tab.setScreenshot` triggers
`TabManagerImplementation.storeScreenshot`, which spawns an unstructured `Task` that hops onto the
`DefaultDiskImageStore` actor. So the pixels are only demanded later, on a background cooperative
thread, at a point we do not control. If the surface backing the image has been reclaimed or purged
in the intervening window, CoreGraphics faults while materializing it rather than failing
gracefully.

The crashing stack shows exactly this — pixel acquisition running inside the draw:

    DiskImageStore.swift:111  image.draw(in:)
      -> ripc_DrawImage
        -> ripc_AcquireRIPImageData
          -> CGSImageDataLock -> img_data_lock -> CGAccessSessionCreate
            -> CGDataProviderRetainData -> imageProvider_retain_data
              -> copy_image_block_set (QuartzCore)
                -> vImagePermuteChannels_ARGB8888   <-- faults

An image whose pixels were already resident would not run provider `retain_data` and a full-image
channel permute at draw time.

Two conditions in the report line up with this: the app was resigning active (`in_foreground: true`,
`is_active: false`), which is when backing stores get purged, and free memory was low (441 MB) while
the source image is roughly 2732x2048 (~22 MB), so the block-set copy needs a large allocation.

### Why the existing guard does not help

`scaleImageFrom3xTo1x` already guards on scale, size and `cgImage != nil` (added in FXIOS-15902).
That guard passes here. A non-nil `cgImage` only proves the object exists, not that its pixels are
still resident or that materializing them will succeed. No additional guard can catch this, because
the failure is a fault inside CoreGraphics' pixel path rather than a value we can test.

### Fix

Redraw the snapshot into a bitmap this process owns, on the main thread, at capture time while the
source is still valid. The later downscale and JPEG encode on the store actor then read memory we
control.

- Adds `UIImage.copiedIntoOwnedBitmap()` to `UIImage+RenderingUtilities.swift`. It preserves size
  and scale, and returns `self` for zero-size images.
- Calls it in the `webView.takeSnapshot` completion in `ScreenshotHelper.swift` before
  `tab.setScreenshot`.

`DiskImageStore` is deliberately untouched.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

