### PR TITLE
Add FXIOS-16555 Add a shadow to the pan up gesture tab preview

### DIFF
--- a/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
+++ b/firefox-ios/Client/TabManagement/SwipeUpTabWebViewPreview.swift
@@ -241,7 +241,7 @@ class SwipeUpTabWebViewPreview: UIView, ThemeApplicable {
             closeButton.configuration?.baseBackgroundColor = nil
         }
         closeButton.configuration?.baseForegroundColor = theme.colors.actionCritical
-        screenshotViewContainer.layer.shadowColor = theme.colors.shadowStrong.cgColor
+        screenshotViewContainer.applyShadow(FxShadow.shadow200, theme: theme)
     }
 
     // MARK: - Private Functions


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16555)
<!-- [Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO) -->

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Added FxShadow.shadow200 to the tab preview used during the pan-up gesture

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <img width="1320" height="2868" alt="noShadow" src="https://github.com/user-attachments/assets/f0c78691-cfee-4f71-8506-d1c460f6b9e9" /> | <img width="1320" height="2868" alt="shadow" src="https://github.com/user-attachments/assets/dfd348aa-a14c-47a9-8eff-d5075a69e021" /> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

