### PR TITLE
Refactor [ToolbarAction refactor] FXIOS-16558 scrollAlphaNeedsUpdate action to ToolbarModernAction

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
@@ -13,16 +13,10 @@ public struct AddressToolbarUXConfiguration {
     let locationTextFieldTrailingPadding: CGFloat
     let shouldBlur: Bool
     let backgroundAlpha: CGFloat
-    /// Alpha value that controls element visibility during scroll-based address bar transitions.
-    /// Changes between 0 (hidden) and 1 (visible) based on scroll direction.
-    let scrollAlpha: CGFloat
-
-    var isAddressBarMinimized: Bool {
-        return scrollAlpha.isZero
-    }
+    let isAddressBarMinimized: Bool
 
     public static func experiment(backgroundAlpha: CGFloat = 1.0,
-                                  scrollAlpha: CGFloat = 1.0,
+                                  isAddressBarMinimized: Bool = false,
                                   shouldBlur: Bool = false,
                                   hasAlternativeLocationColor: Bool = false) -> AddressToolbarUXConfiguration {
         AddressToolbarUXConfiguration(
@@ -32,12 +26,12 @@ public struct AddressToolbarUXConfiguration {
             locationTextFieldTrailingPadding: 0,
             shouldBlur: shouldBlur,
             backgroundAlpha: backgroundAlpha,
-            scrollAlpha: scrollAlpha
+            isAddressBarMinimized: isAddressBarMinimized
         )
     }
 
     public static func `default`(backgroundAlpha: CGFloat = 1.0,
-                                 scrollAlpha: CGFloat = 1.0,
+                                 isAddressBarMinimized: Bool = false,
                                  shouldBlur: Bool = false,
                                  hasAlternativeLocationColor: Bool = false) -> AddressToolbarUXConfiguration {
         AddressToolbarUXConfiguration(
@@ -48,7 +42,7 @@ public struct AddressToolbarUXConfiguration {
             locationTextFieldTrailingPadding: 8.0,
             shouldBlur: shouldBlur,
             backgroundAlpha: backgroundAlpha,
-            scrollAlpha: scrollAlpha
+            isAddressBarMinimized: isAddressBarMinimized
         )
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabScrollHandlerDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabScrollHandlerDelegate.swift
@@ -25,13 +25,9 @@ extension BrowserViewController: TabScrollHandler.Delegate,
 
     func dispatchScrollAlphaChange(alpha: CGFloat) {
         if shouldSendAlphaChangeAction {
-            store.dispatch(
-                ToolbarAction(
-                    scrollAlpha: Float(alpha),
-                    windowUUID: windowUUID,
-                    actionType: ToolbarActionType.scrollAlphaNeedsUpdate
-                )
-            )
+            let shouldBeMinimized = alpha.isZero
+            store.dispatch(ToolbarModernAction.userDidScroll(minimizeAddressBar: shouldBeMinimized),
+                           forWindowUUID: windowUUID)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5010,10 +5010,11 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        // Only restore the address bar to fully shown if it wasn't collapsed (or mid-collapse) by
-        // scrolling. Forcing it back to shown while a scroll gesture is collapsing/has collapsed the
-        // toolbars would leave the address bar full while the bottom containers stay collapsed
-        // (inconsistent state), or fight an in-flight scroll-to-dismiss-keyboard gesture.
+        // minimizeAddressBar: false restores the address bar from its minimized "pill" shape back to
+        // its full toolbar. This undoes the minimization applied for the keyboard accessory view
+        // Only dispatch the action if the toolbar isn't currently collapsed by scrolling, if the
+        // user has scrolled previously, restore the address back here would leave the
+        // address bar full while the bottom containers stay collapsed (inconsistent state).
         if #available(iOS 26.0, *), isBottomSearchBar, scrollController.isToolbarFullyExpanded {
             store.dispatch(ToolbarModernAction.keyboardDidHide(minimizeAddressBar: false), forWindowUUID: windowUUID)
         }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5016,7 +5016,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
         // user has scrolled previously, restore the address back here would leave the
         // address bar full while the bottom containers stay collapsed (inconsistent state).
         if #available(iOS 26.0, *), isBottomSearchBar, scrollController.isToolbarFullyExpanded {
-            store.dispatch(ToolbarModernAction.keyboardDidHide(minimizeAddressBar: false), forWindowUUID: windowUUID)
+            store.dispatch(ToolbarModernAction.keyboardDidHide, forWindowUUID: windowUUID)
         }
         keyboardState = nil
         updateConstraintsForKeyboard()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5010,8 +5010,8 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        // minimizeAddressBar: false restores the address bar from its minimized "pill" shape back to
-        // its full toolbar. This undoes the minimization applied for the keyboard accessory view
+        // Restores the address bar from its minimized "pill" shape back to its full toolbar.
+        // This undoes the minimization applied for the keyboard accessory view
         // Only dispatch the action if the toolbar isn't currently collapsed by scrolling, if the
         // user has scrolled previously, restore the address back here would leave the
         // address bar full while the bottom containers stay collapsed (inconsistent state).

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5010,21 +5010,12 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        // Only restore the address bar to fully shown if it wasn't collapsed by scrolling. When the
-        // keyboard is dismissed via scroll and the toolbars are already collapsed, so forcing scrollAlpha
-        // back to 1 here would leave the address bar full while the bottom containers stay collapsed
-        // (inconsistent state).
-        // This is a legacy-only patch (via the `LegacyTabScrollProvider` cast below); the scroll
-        // controller refactor (TabScrollHandler) will address the underlying issue differently
-        let isToolbarStateCollapsed = (scrollController as? LegacyTabScrollProvider)?.isToolbarStateCollapsed ?? false
-        if #available(iOS 26.0, *), isBottomSearchBar, !isToolbarStateCollapsed {
-            store.dispatch(
-                ToolbarAction(
-                    scrollAlpha: 1,
-                    windowUUID: windowUUID,
-                    actionType: ToolbarActionType.scrollAlphaNeedsUpdate
-                )
-            )
+        // Only restore the address bar to fully shown if it wasn't collapsed (or mid-collapse) by
+        // scrolling. Forcing it back to shown while a scroll gesture is collapsing/has collapsed the
+        // toolbars would leave the address bar full while the bottom containers stay collapsed
+        // (inconsistent state), or fight an in-flight scroll-to-dismiss-keyboard gesture.
+        if #available(iOS 26.0, *), isBottomSearchBar, scrollController.isToolbarFullyExpanded {
+            store.dispatch(ToolbarModernAction.keyboardDidHide(minimizeAddressBar: false), forWindowUUID: windowUUID)
         }
         keyboardState = nil
         updateConstraintsForKeyboard()

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -101,6 +101,10 @@ final class LegacyTabScrollController: NSObject,
         return toolbarState == .collapsed
     }
 
+    var isToolbarFullyExpanded: Bool {
+        return toolbarState == .visible
+    }
+
     private let windowUUID: WindowUUID
     private let logger: Logger
 
@@ -673,13 +677,8 @@ private extension LegacyTabScrollController {
             self.bottomContainerOffset = bottomContainerOffset
 
             if tab?.isFindInPageMode == false && tab?.url?.isReaderModeURL == false {
-                store.dispatch(
-                    ToolbarAction(
-                        scrollAlpha: Float(alpha),
-                        windowUUID: windowUUID,
-                        actionType: ToolbarActionType.scrollAlphaNeedsUpdate
-                    )
-                )
+                let isMinimized = alpha.isZero
+                store.dispatch(ToolbarModernAction.userDidScroll(minimizeAddressBar: isMinimized), forWindowUUID: windowUUID)
             }
 
             overKeyboardContainerOffset = overKeyboardOffset

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -11,6 +11,11 @@ protocol TabScrollHandlerProtocol: AnyObject {
     var tabProvider: TabProviderProtocol? { get set }
     var contentOffset: CGPoint { get }
 
+    /// `true` only when the toolbar is fully expanded and settled, `false` while collapsed
+    /// or mid-transition from a user scroll gesture. Callers that want to restore the address
+    /// bar (keyboard dismissal) should check this value since a scroll gesture may still be resolving.
+    var isToolbarFullyExpanded: Bool { get }
+
     func showToolbars(animated: Bool)
     func hideToolbars(animated: Bool)
     func configureRefreshControl()
@@ -85,6 +90,7 @@ final class TabScrollHandler: NSObject,
     private var scrollDirection: ScrollDirection = .down
     var toolbarDisplayState = ToolbarDisplayState()
     var lastValidState: ToolbarDisplayState = .expanded
+    var isToolbarFullyExpanded: Bool { toolbarDisplayState.isExpanded }
     private var isStatusBarScrollToTop = false
     var didTapChangePreventScrollToTop = false
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -245,13 +245,7 @@ final class AddressToolbarContainer: UIView,
             accessoryViewGradient.frame = CGRect(width: bounds.width, height: height)
             accessoryViewGradient.opacity = 1
             // Dispatch action to change address bar to minimized state
-            store.dispatch(
-                ToolbarAction(
-                    scrollAlpha: 0,
-                    windowUUID: windowUUID,
-                    actionType: ToolbarActionType.scrollAlphaNeedsUpdate
-                )
-            )
+            store.dispatch(ToolbarModernAction.accessoryViewDidShow(minimizeAddressBar: true), forWindowUUID: windowUUID)
         }
         return accessoryViewOffset
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -245,7 +245,7 @@ final class AddressToolbarContainer: UIView,
             accessoryViewGradient.frame = CGRect(width: bounds.width, height: height)
             accessoryViewGradient.opacity = 1
             // Dispatch action to change address bar to minimized state
-            store.dispatch(ToolbarModernAction.accessoryViewDidShow(minimizeAddressBar: true), forWindowUUID: windowUUID)
+            store.dispatch(ToolbarModernAction.accessoryViewDidShow, forWindowUUID: windowUUID)
         }
         return accessoryViewOffset
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -37,10 +37,7 @@ final class AddressToolbarContainerModel: Equatable {
     let shouldAnimate: Bool
     let scrollAlpha: Float
     let hasAlternativeLocationColor: Bool
-
-    var isAddressBarMinimized: Bool {
-        return scrollAlpha.isZero
-    }
+    let isAddressBarMinimized: Bool
 
     let windowUUID: UUID
 
@@ -51,7 +48,7 @@ final class AddressToolbarContainerModel: Equatable {
         let shouldBlur = toolbarHelper.shouldBlur()
         let uxConfiguration: AddressToolbarUXConfiguration = .experiment(
             backgroundAlpha: backgroundAlpha,
-            scrollAlpha: CGFloat(scrollAlpha),
+            isAddressBarMinimized: isAddressBarMinimized,
             shouldBlur: shouldBlur,
             hasAlternativeLocationColor: hasAlternativeLocationColor)
 
@@ -255,6 +252,7 @@ final class AddressToolbarContainerModel: Equatable {
         self.canShowNavigationHint = state.canShowNavigationHint
         self.shouldAnimate = state.shouldAnimate
         self.scrollAlpha = state.scrollAlpha
+        self.isAddressBarMinimized = state.isAddressBarMinimized
         self.hasAlternativeLocationColor = hasAlternativeLocationColor
         self.toolbarLayoutStyle = state.toolbarLayout
         self.toolbarHelper = toolbarHelper
@@ -390,6 +388,7 @@ final class AddressToolbarContainerModel: Equatable {
         lhs.canShowNavigationHint == rhs.canShowNavigationHint &&
         lhs.shouldAnimate == rhs.shouldAnimate &&
         lhs.scrollAlpha == rhs.scrollAlpha &&
+        lhs.isAddressBarMinimized == rhs.isAddressBarMinimized &&
         lhs.hasAlternativeLocationColor == rhs.hasAlternativeLocationColor &&
 
         lhs.windowUUID == rhs.windowUUID

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -108,10 +108,19 @@ struct ToolbarAction: Action {
 }
 
 enum ToolbarModernAction: ModernAction {
-    // Splits the old scrollAlphaNeedsUpdate into three distinct user/system triggers that all
-    // drive the toolbar's minimized state.
+    // Three distinct user/system triggers drive `ToolbarState.isAddressBarMinimized`
+    // (renders the address bar as its full toolbar vs. its minimized "pill" shape).
+
+    /// The user scrolled the page. `true` collapses the toolbar to the pill as the page
+    /// scrolls down; `false` restores it when scrolling back up.
     case userDidScroll(minimizeAddressBar: Bool)
+
+    /// A web form's keyboard accessory view appeared. `true` shrinks the address bar to
+    /// make room for it; not currently dispatched with `false` (see `keyboardDidHide`).
     case accessoryViewDidShow(minimizeAddressBar: Bool)
+
+    /// The keyboard was dismissed. Dispatched with `false` to restore the address bar
+    /// after it was minimized by `accessoryViewDidShow`
     case keyboardDidHide(minimizeAddressBar: Bool)
 }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -115,13 +115,11 @@ enum ToolbarModernAction: ModernAction {
     /// scrolls down; `false` restores it when scrolling back up.
     case userDidScroll(minimizeAddressBar: Bool)
 
-    /// A web form's keyboard accessory view appeared. `true` shrinks the address bar to
-    /// make room for it; not currently dispatched with `false` (see `keyboardDidHide`).
-    case accessoryViewDidShow(minimizeAddressBar: Bool)
+    /// A web form's keyboard accessory view appeared. that shrinks the address bar to the pill shape
+    case accessoryViewDidShow
 
-    /// The keyboard was dismissed. Dispatched with `false` to restore the address bar
-    /// after it was minimized by `accessoryViewDidShow`
-    case keyboardDidHide(minimizeAddressBar: Bool)
+    /// The keyboard was dismissed. Dispatched to restore the address bar after it was minimized by `accessoryViewDidShow`
+    case keyboardDidHide
 }
 
 enum ToolbarActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -107,12 +107,19 @@ struct ToolbarAction: Action {
     }
 }
 
+enum ToolbarModernAction: ModernAction {
+    // Splits the old scrollAlphaNeedsUpdate into three distinct user/system triggers that all
+    // drive the toolbar's minimized state.
+    case userDidScroll(minimizeAddressBar: Bool)
+    case accessoryViewDidShow(minimizeAddressBar: Bool)
+    case keyboardDidHide(minimizeAddressBar: Bool)
+}
+
 enum ToolbarActionType: ActionType {
     case didLoadToolbars
     case numberOfTabsChanged
     case urlDidChange
     case lockIconChanged
-    case scrollAlphaNeedsUpdate
     case didSetTextInLocationView
     case borderPositionChanged
     case toolbarPositionChanged

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -144,10 +144,12 @@ struct ToolbarState: ScreenState, Sendable {
         guard let action = action as? ToolbarModernAction else { return defaultState(from: state) }
 
         switch action {
-        case .userDidScroll(let minimizeAddressBar),
-             .accessoryViewDidShow(let minimizeAddressBar),
-             .keyboardDidHide(let minimizeAddressBar):
+        case .userDidScroll(let minimizeAddressBar):
             return state.copy(isAddressBarMinimized: minimizeAddressBar)
+        case .accessoryViewDidShow:
+            return state.copy(isAddressBarMinimized: true)
+        case .keyboardDidHide:
+            return state.copy(isAddressBarMinimized: false)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -29,10 +29,8 @@ struct ToolbarState: ScreenState, Sendable {
     var isTranslationsEnabled: Bool
     var previousTabScreenshot: UIImage?
     var nextTabScreenshot: UIImage?
-
-    var isAddressBarMinimized: Bool {
-        return scrollAlpha.isZero
-    }
+    // Will replace scrollAlpha
+    var isAddressBarMinimized: Bool
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let toolbarState = appState.componentState(
@@ -63,7 +61,8 @@ struct ToolbarState: ScreenState, Sendable {
                   isTranslucent: toolbarState.isTranslucent,
                   isTranslationsEnabled: toolbarState.isTranslationsEnabled,
                   previousTabScreenshot: toolbarState.previousTabScreenshot,
-                  nextTabScreenshot: toolbarState.nextTabScreenshot
+                  nextTabScreenshot: toolbarState.nextTabScreenshot,
+                  isAddressBarMinimized: toolbarState.isAddressBarMinimized
         )
     }
 
@@ -88,7 +87,8 @@ struct ToolbarState: ScreenState, Sendable {
             isTranslucent: false,
             isTranslationsEnabled: true,
             previousTabScreenshot: nil,
-            nextTabScreenshot: nil
+            nextTabScreenshot: nil,
+            isAddressBarMinimized: false
         )
     }
 
@@ -112,7 +112,8 @@ struct ToolbarState: ScreenState, Sendable {
         isTranslucent: Bool,
         isTranslationsEnabled: Bool = true,
         previousTabScreenshot: UIImage?,
-        nextTabScreenshot: UIImage?
+        nextTabScreenshot: UIImage?,
+        isAddressBarMinimized: Bool
     ) {
         self.windowUUID = windowUUID
         self.toolbarPosition = toolbarPosition
@@ -395,6 +396,7 @@ struct ToolbarState: ScreenState, Sendable {
                             isTranslucent: state.isTranslucent,
                             isTranslationsEnabled: state.isTranslationsEnabled,
                             previousTabScreenshot: state.previousTabScreenshot,
-                            nextTabScreenshot: state.nextTabScreenshot)
+                            nextTabScreenshot: state.nextTabScreenshot,
+                            isAddressBarMinimized: state.isAddressBarMinimized)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -29,7 +29,7 @@ struct ToolbarState: ScreenState, Sendable {
     var isTranslationsEnabled: Bool
     var previousTabScreenshot: UIImage?
     var nextTabScreenshot: UIImage?
-    // Will replace scrollAlpha
+    // Whether the address bar renders as its full toolbar or its minimized "pill" shape
     var isAddressBarMinimized: Bool
 
     init(appState: AppState, uuid: WindowUUID) {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -272,8 +272,10 @@ struct ToolbarState: ScreenState, Sendable {
               browserAction.toastType == .shakeToSummarizeNotAvailable
         else { return defaultState(from: state) }
 
+        // Update to use isAddressBarMinimized so the address bar is shown and the toast isn't presented a minimized bar.
         return state
             .copy(scrollAlpha: 1)
+            .copy(isAddressBarMinimized: false)
     }
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -134,13 +134,20 @@ struct ToolbarState: ScreenState, Sendable {
         self.isTranslationsEnabled = isTranslationsEnabled
         self.previousTabScreenshot = previousTabScreenshot
         self.nextTabScreenshot = nextTabScreenshot
+        self.isAddressBarMinimized = isAddressBarMinimized
     }
 
     static let reducer: Reducer<Self> = (legacyReducer, modernReducer)
 
     static let modernReducer: ReducerMethod<Self> = { state, action, actionWindowUUID in
-        // Does not handle any modern actions
-        return defaultState(from: state)
+        guard let action = action as? ToolbarModernAction else { return defaultState(from: state) }
+
+        switch action {
+        case .userDidScroll(let minimizeAddressBar),
+             .accessoryViewDidShow(let minimizeAddressBar),
+             .keyboardDidHide(let minimizeAddressBar):
+            return state.copy(isAddressBarMinimized: minimizeAddressBar)
+        }
     }
 
     static let legacyReducer: LegacyReducerMethod<Self> = { state, action in
@@ -169,7 +176,7 @@ struct ToolbarState: ScreenState, Sendable {
             ToolbarActionType.didDeleteSearchTerm, ToolbarActionType.didEnterSearchTerm,
             ToolbarActionType.didSetSearchTerm, ToolbarActionType.didStartTyping,
             ToolbarActionType.animationStateChanged, ToolbarActionType.translucencyDidChange,
-            ToolbarActionType.scrollAlphaNeedsUpdate, ToolbarActionType.readerModeStateChanged,
+            ToolbarActionType.readerModeStateChanged,
             ToolbarActionType.navigationMiddleButtonDidChange,
             TranslationsActionType.didStartTranslatingPage,
             TranslationsActionType.translationCompleted,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -957,18 +957,15 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         let initialState = ToolbarState(windowUUID: windowUUID)
         let reducer = ToolbarState.reducer
 
-        let newState = reducer.legacyReducer(
+        let newState = reducer.modernReducer(
             initialState,
-            ToolbarAction(
-                scrollAlpha: 0,
-                windowUUID: windowUUID,
-                actionType: ToolbarActionType.scrollAlphaNeedsUpdate
-            )
+            ToolbarModernAction.userDidScroll(minimizeAddressBar: true),
+            windowUUID
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.scrollAlpha, 0)
-        XCTAssertNotEqual(initialState.scrollAlpha, newState.scrollAlpha)
+        XCTAssertEqual(newState.isAddressBarMinimized, true)
+        XCTAssertNotEqual(initialState.isAddressBarMinimized, newState.isAddressBarMinimized)
     }
 
     func test_cancelEditOnHomepageAction_withURL_returnsExpectedState() {
@@ -1284,7 +1281,8 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
             shouldAnimate: toolbarState.shouldAnimate,
             isTranslucent: toolbarState.isTranslucent,
             previousTabScreenshot: toolbarState.previousTabScreenshot,
-            nextTabScreenshot: toolbarState.nextTabScreenshot)
+            nextTabScreenshot: toolbarState.nextTabScreenshot,
+            isAddressBarMinimized: toolbarState.isAddressBarMinimized)
     }
 
     // MARK: StoreTestUtility

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -952,7 +952,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.lockIconNeedsTheming, true)
     }
 
-    func test_scrollAlphaNeedsUpdateAction_returnsExpectedState() {
+    func test_userDidScrollAction_returnsExpectedState() {
         setupStore()
         let initialState = ToolbarState(windowUUID: windowUUID)
         let reducer = ToolbarState.reducer
@@ -960,6 +960,46 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         let newState = reducer.modernReducer(
             initialState,
             ToolbarModernAction.userDidScroll(minimizeAddressBar: true),
+            windowUUID
+        )
+
+        XCTAssertEqual(newState.windowUUID, windowUUID)
+        XCTAssertEqual(newState.isAddressBarMinimized, true)
+        XCTAssertNotEqual(initialState.isAddressBarMinimized, newState.isAddressBarMinimized)
+    }
+
+    func test_keyboardDidHideAction_returnsExpectedState() {
+        setupStore()
+        var initialState = ToolbarState(windowUUID: windowUUID)
+        let reducer = ToolbarState.reducer
+
+        // Minimize toolbar first
+        initialState = reducer.modernReducer(
+            initialState,
+            ToolbarModernAction.userDidScroll(minimizeAddressBar: true),
+            windowUUID
+        )
+        XCTAssertEqual(initialState.isAddressBarMinimized, true)
+
+        let newState = reducer.modernReducer(
+            initialState,
+            ToolbarModernAction.keyboardDidHide,
+            windowUUID
+        )
+
+        XCTAssertEqual(newState.windowUUID, windowUUID)
+        XCTAssertEqual(newState.isAddressBarMinimized, false)
+        XCTAssertNotEqual(initialState.isAddressBarMinimized, newState.isAddressBarMinimized)
+    }
+
+    func test_accessoryViewDidShowAction_returnsExpectedState() {
+        setupStore()
+        let initialState = ToolbarState(windowUUID: windowUUID)
+        let reducer = ToolbarState.reducer
+
+        let newState = reducer.modernReducer(
+            initialState,
+            ToolbarModernAction.accessoryViewDidShow,
             windowUUID
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -387,7 +387,8 @@ final class AddressToolbarContainerModelTests: XCTestCase {
                             shouldAnimate: false,
                             isTranslucent: false,
                             previousTabScreenshot: nil,
-                            nextTabScreenshot: nil)
+                            nextTabScreenshot: nil,
+                            isAddressBarMinimized: false)
     }
 
     private func createToolbarStateWithAlternativeSearchEngine(searchEngine: SearchEngineModel) -> ToolbarState {
@@ -409,7 +410,8 @@ final class AddressToolbarContainerModelTests: XCTestCase {
                             shouldAnimate: false,
                             isTranslucent: false,
                             previousTabScreenshot: nil,
-                            nextTabScreenshot: nil)
+                            nextTabScreenshot: nil,
+                            isAddressBarMinimized: false)
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
@@ -570,6 +570,29 @@ final class ToolbarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.navigationToolbar, initialState.navigationToolbar)
     }
 
+    func test_showToastAction_forShakeToSummarizeNotAvailable_restoresMinimizedAddressBar() {
+        let initialState = createSubject()
+        let reducer = toolbarReducer()
+
+        let minimizedState = reducer.modernReducer(
+            initialState,
+            ToolbarModernAction.userDidScroll(minimizeAddressBar: true),
+            windowUUID
+        )
+        XCTAssertTrue(minimizedState.isAddressBarMinimized)
+
+        let newState = reducer.legacyReducer(
+            minimizedState,
+            GeneralBrowserAction(
+                toastType: .shakeToSummarizeNotAvailable,
+                windowUUID: windowUUID,
+                actionType: GeneralBrowserActionType.showToast
+            )
+        )
+
+        XCTAssertFalse(newState.isAddressBarMinimized)
+    }
+
     // MARK: - Private
     private func createSubject() -> ToolbarState {
         return ToolbarState(windowUUID: windowUUID)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -1541,7 +1541,8 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
                             shouldAnimate: true,
                             isTranslucent: false,
                             previousTabScreenshot: nil,
-                            nextTabScreenshot: nil
+                            nextTabScreenshot: nil,
+                            isAddressBarMinimized: false
                         )
                     )
                 ]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16558)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35152)

## :bulb: Description
Heads up: this isn't a simple 1:1 Action → ModernAction migration. I got carried away 😱

`scrollAlphaNeedsUpdate` looked like a straightforward candidate for the ADR-0012 migration, but once I started I realized the action itself is the root of a pattern of recurring toolbar bugs (FXIOS-15487, FXIOS-15496, FXIOS-15654, FXIOS-15837, FXIOS-15853, FXIOS-15910 all touched this same mechanism within a few weeks). The single scrollAlpha: Float field was carrying two unrelated meanings: continuous scroll progress and a discrete "minimized because of X" flag (scroll, keyboard accessory, keyboard dismissal), with no way for the reducer to tell which writer set it or why. Migrating the action 1:1 would have carried that ambiguity forward untouched. Since I was already touching every call site, I used the migration to also fix the underlying state instead of just renaming it.

Changes:
1. Split `scrollAlphaNeedsUpdate` into 3 explicit ToolbarModernAction cases: userDidScroll, accessoryViewDidShow, keyboardDidHide, each a named, source-attributed trigger for address-bar minimization instead of one overloaded bit.
2. Added `ToolbarState.isAddressBarMinimized: Bool` as first-class state, replacing the old scrollAlpha.isZero derivation, and threaded it through `AddressToolbarContainerModel` → `AddressToolbarUXConfiguration` so the toolbar-shrink UI (pill shape, shadow, lock icon, etc.) reacts directly to this instead of a value that silently went stale the moment the old action stopped firing.
4. Fixed a real, shipping bug in the keyboard-dismiss "restore address bar" path (BVC.keyboardWillHideWithState): it was unconditionally forcing the bar back to shown even when the user had scrolled it minimized, and it only guarded against that on the legacy scroll controller. Replaced the legacy-only cast with `isToolbarFullyExpanded` on the shared TabScrollHandlerProtocol, implemented by both scroll controllers.


- scrollAlpha itself is not removed yet, deescope of this PR because is present in ~8 files and will make the PR to big
- This PR will fails for now because depends on the changes in this [PR](https://github.com/mozilla-mobile/firefox-ios/pull/35144) to build

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

