### PR TITLE
Bugfix FXIOS-11115 [Native Error Page] Detect cellular data restricted for app

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -798,6 +798,7 @@
 		630FE1352C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */; };
 		631A369F2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */; };
 		631A36A32CC0B2470044DFEB /* NativeErrorPageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A36A22CC0B2470044DFEB /* NativeErrorPageHelper.swift */; };
+		3801BC7A54199F7A4622270A /* CellularDataStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F3F517CC65B6350683378C /* CellularDataStatusProvider.swift */; };
 		635183FB2CF5555C00EDFCE2 /* NativeErrorPageStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635183FA2CF5555C00EDFCE2 /* NativeErrorPageStateTests.swift */; };
 		63B213282CCA796D00A466DB /* NativeErrorPageAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B213272CCA796D00A466DB /* NativeErrorPageAction.swift */; };
 		63B2132A2CCA797400A466DB /* NativeErrorPageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B213292CCA797400A466DB /* NativeErrorPageState.swift */; };
@@ -1890,6 +1891,7 @@
 		CAA3B7E62497DCB60094E3C1 /* LoginDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA3B7E52497DCB60094E3C1 /* LoginDataSource.swift */; };
 		CAC458F1249429C20042561A /* PasswordManagerSelectionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC458F0249429C20042561A /* PasswordManagerSelectionHelper.swift */; };
 		CB4BB1112F954E8B003A181D /* NativeErrorPageHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4BB1102F954E8B003A181D /* NativeErrorPageHelperTests.swift */; };
+		BBDD7BAA913817750C5BDBB3 /* CellularDataStatusProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD34365BA3121C909CC52E6 /* CellularDataStatusProviderTests.swift */; };
 		CB5541872F51E1B100256DA1 /* CertificateHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5541862F51E1B100256DA1 /* CertificateHelperTests.swift */; };
 		CBC398772F4F455E00CD4EAD /* CertificateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC398762F4F455E00CD4EAD /* CertificateHelper.swift */; };
 		CDB3BE8724746787009320EE /* FirefoxAccountSignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3BE8624746787009320EE /* FirefoxAccountSignInViewController.swift */; };
@@ -9281,6 +9283,7 @@
 		630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeErrorPageViewControllerTests.swift; sourceTree = "<group>"; };
 		631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeErrorPageMiddleware.swift; sourceTree = "<group>"; };
 		631A36A22CC0B2470044DFEB /* NativeErrorPageHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeErrorPageHelper.swift; sourceTree = "<group>"; };
+		A8F3F517CC65B6350683378C /* CellularDataStatusProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellularDataStatusProvider.swift; sourceTree = "<group>"; };
 		631A36A42CC0B2480044DFEB /* CertificateHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateHelper.swift; sourceTree = "<group>"; };
 		634148899F41CAA3BCF71E8B /* or */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = or; path = or.lproj/Localizable.strings; sourceTree = "<group>"; };
 		635183FA2CF5555C00EDFCE2 /* NativeErrorPageStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeErrorPageStateTests.swift; sourceTree = "<group>"; };
@@ -11052,6 +11055,7 @@
 		CAB7414DA1BA84F4CD08A8F8 /* kk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kk; path = kk.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		CAC458F0249429C20042561A /* PasswordManagerSelectionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordManagerSelectionHelper.swift; sourceTree = "<group>"; };
 		CB4BB1102F954E8B003A181D /* NativeErrorPageHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeErrorPageHelperTests.swift; sourceTree = "<group>"; };
+		6AD34365BA3121C909CC52E6 /* CellularDataStatusProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellularDataStatusProviderTests.swift; sourceTree = "<group>"; };
 		CB5541862F51E1B100256DA1 /* CertificateHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateHelperTests.swift; sourceTree = "<group>"; };
 		CB664443A893E97243385395 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		CBA242528C97816D5BCF4473 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
@@ -13876,6 +13880,7 @@
 			children = (
 				EC405C153007E3EC0003DE07 /* NativeErrorRegularContentViewTests.swift */,
 				CB4BB1102F954E8B003A181D /* NativeErrorPageHelperTests.swift */,
+				6AD34365BA3121C909CC52E6 /* CellularDataStatusProviderTests.swift */,
 				CB5541862F51E1B100256DA1 /* CertificateHelperTests.swift */,
 				630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */,
 				635183FA2CF5555C00EDFCE2 /* NativeErrorPageStateTests.swift */,
@@ -13893,6 +13898,7 @@
 				63B213272CCA796D00A466DB /* NativeErrorPageAction.swift */,
 				631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */,
 				631A36A22CC0B2470044DFEB /* NativeErrorPageHelper.swift */,
+				A8F3F517CC65B6350683378C /* CellularDataStatusProvider.swift */,
 				631A36A42CC0B2480044DFEB /* CertificateHelper.swift */,
 				63F7A9AB2C752BB0005846F5 /* NativeErrorPageViewController.swift */,
 				E1A1B0012C752BB0005846F5 /* NativeErrorRegularContentView.swift */,
@@ -19956,6 +19962,7 @@
 				7482205C1DBAB56300EEEA72 /* MailProviders.swift in Sources */,
 				8A93F87029D3A597004159D9 /* SceneCoordinator.swift in Sources */,
 				631A36A32CC0B2470044DFEB /* NativeErrorPageHelper.swift in Sources */,
+				3801BC7A54199F7A4622270A /* CellularDataStatusProvider.swift in Sources */,
 				8A2068372D6D52830063A77B /* ExperimentTabCell.swift in Sources */,
 				C88E7A602A05551B0072E638 /* NimbusOnboardingFeatureLayerProtocol.swift in Sources */,
 				C40046FA1CF8E0B200B08303 /* BackForwardListAnimator.swift in Sources */,
@@ -20948,6 +20955,7 @@
 				5A70EF19295E2E1600790249 /* DependencyHelperMock.swift in Sources */,
 				61497F3C2F687B5A00BC5ACA /* AIControlsSettingTests.swift in Sources */,
 				CB4BB1112F954E8B003A181D /* NativeErrorPageHelperTests.swift in Sources */,
+				BBDD7BAA913817750C5BDBB3 /* CellularDataStatusProviderTests.swift in Sources */,
 				8A96C4BB28F9E7B300B75884 /* XCTestCaseRootViewController.swift in Sources */,
 				8A8482F02BE1602500F9007B /* MicrosurveyPromptStateTests.swift in Sources */,
 				EC4F28183011A6BF00BAD351 /* CertificatesFetcherTests.swift in Sources */,

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -75,6 +75,10 @@ class AppDelegate: UIResponder,
         // before any Application Services component gets used.
         Viaduct.shared.initialize(userAgent: UserAgent.fxaUserAgent)
 
+        // Warm up cellular-restriction state as early as possible; CTCellularData reports
+        // `.restrictedStateUnknown` until it resolves asynchronously after first access.
+        _ = CTCellularDataStatusProvider.shared
+
         logger.log("willFinishLaunchingWithOptions begin",
                    level: .info,
                    category: .lifecycle)

--- a/firefox-ios/Client/Frontend/NativeErrorPage/CellularDataStatusProvider.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/CellularDataStatusProvider.swift
@@ -8,10 +8,33 @@ protocol CellularDataStatusProviding {
     var isCellularDataRestricted: Bool { get }
 }
 
-final class CTCellularDataStatusProvider: CellularDataStatusProviding {
+/// `CTCellularData.restrictedState` reports `.restrictedStateUnknown` until the system
+/// resolves it asynchronously after the object is created, so this is kept as a
+/// long-lived singleton (warmed up at app launch) and caches updates from
+/// `cellularDataRestrictionDidUpdateNotifier` rather than doing a single synchronous read.
+final class CTCellularDataStatusProvider: CellularDataStatusProviding, @unchecked Sendable {
+    static let shared = CTCellularDataStatusProvider()
+
     private let cellularData = CTCellularData()
+    private let lock = NSLock()
+    private var cachedState: CTCellularDataRestrictedState
+
+    private init() {
+        cachedState = cellularData.restrictedState
+        cellularData.cellularDataRestrictionDidUpdateNotifier = { [weak self] state in
+            self?.updateCachedState(state)
+        }
+    }
+
+    private func updateCachedState(_ state: CTCellularDataRestrictedState) {
+        lock.lock()
+        cachedState = state
+        lock.unlock()
+    }
 
     var isCellularDataRestricted: Bool {
-        return cellularData.restrictedState == .restricted
+        lock.lock()
+        defer { lock.unlock() }
+        return cachedState == .restricted
     }
 }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/CellularDataStatusProvider.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/CellularDataStatusProvider.swift
@@ -26,7 +26,7 @@ final class CTCellularDataStatusProvider: CellularDataStatusProviding, @unchecke
         }
     }
 
-    private func updateCachedState(_ state: CTCellularDataRestrictedState) {
+    func updateCachedState(_ state: CTCellularDataRestrictedState) {
         lock.lock()
         cachedState = state
         lock.unlock()

--- a/firefox-ios/Client/Frontend/NativeErrorPage/CellularDataStatusProvider.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/CellularDataStatusProvider.swift
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import CoreTelephony
+
+protocol CellularDataStatusProviding {
+    var isCellularDataRestricted: Bool { get }
+}
+
+final class CTCellularDataStatusProvider: CellularDataStatusProviding {
+    private let cellularData = CTCellularData()
+
+    var isCellularDataRestricted: Bool {
+        return cellularData.restrictedState == .restricted
+    }
+}

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -30,13 +30,15 @@ class NativeErrorPageHelper {
     }
 
     var error: NSError
+    private let cellularDataStatusProvider: CellularDataStatusProviding
 
     var errorDescriptionItem: String {
         return error.localizedDescription
     }
 
-    init(error: NSError) {
+    init(error: NSError, cellularDataStatusProvider: CellularDataStatusProviding = CTCellularDataStatusProvider()) {
         self.error = error
+        self.cellularDataStatusProvider = cellularDataStatusProvider
     }
 
     // MARK: - Static Helpers
@@ -122,7 +124,7 @@ class NativeErrorPageHelper {
         if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
             switch error.code {
             case Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue):
-                return .internetConnection
+                return noConnectionModel
             case NSURLErrorServerCertificateUntrusted,
                  NSURLErrorServerCertificateHasBadDate,
                  NSURLErrorServerCertificateHasUnknownRoot,
@@ -134,8 +136,15 @@ class NativeErrorPageHelper {
                 return .generic(GenericErrorModel(url: url))
             }
         } else {
-            return .internetConnection
+            return noConnectionModel
         }
+    }
+
+    /// Distinguishes a true "no network" state from iOS having blocked this
+    /// app's cellular data access specifically, which surfaces as the same
+    /// NSURLErrorNotConnectedToInternet error but has a distinct fix for the user.
+    private var noConnectionModel: ErrorPageModel {
+        return cellularDataStatusProvider.isCellularDataRestricted ? .cellularDataRestricted : .internetConnection
     }
 
     /// Parses certificate details from the stored error.

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -36,7 +36,7 @@ class NativeErrorPageHelper {
         return error.localizedDescription
     }
 
-    init(error: NSError, cellularDataStatusProvider: CellularDataStatusProviding = CTCellularDataStatusProvider()) {
+    init(error: NSError, cellularDataStatusProvider: CellularDataStatusProviding = CTCellularDataStatusProvider.shared) {
         self.error = error
         self.cellularDataStatusProvider = cellularDataStatusProvider
     }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -140,9 +140,9 @@ class NativeErrorPageHelper {
         }
     }
 
-    /// Distinguishes a true "no network" state from iOS having blocked this
-    /// app's cellular data access specifically, which surfaces as the same
-    /// NSURLErrorNotConnectedToInternet error but has a distinct fix for the user.
+    /// Distinguishes a true "no network" state from the user having blocked cellular data
+    /// access for Firefox in the system settings, which surfaces as the same
+    /// `NSURLErrorNotConnectedToInternet` error but requires a different fix from the user.
     private var noConnectionModel: ErrorPageModel {
         return cellularDataStatusProvider.isCellularDataRestricted ? .cellularDataRestricted : .internetConnection
     }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageModel.swift
@@ -7,12 +7,14 @@ import Shared
 
 enum ErrorPageModel: Equatable {
     case internetConnection
+    case cellularDataRestricted
     case badCertDomain(BadCertDomainModel)
     case generic(GenericErrorModel)
     case wayback(WaybackErrorModel)
     var title: String {
         switch self {
         case .internetConnection: return .NativeErrorPage.NoInternetConnection.TitleLabel
+        case .cellularDataRestricted: return .NativeErrorPage.CellularDataRestricted.TitleLabel
         case .badCertDomain: return String.NativeErrorPage.BadCertDomain.TitleLabel
         case .generic: return .NativeErrorPage.GenericError.TitleLabel
         case .wayback: return .NativeErrorPage.Wayback.TitleLabel
@@ -22,6 +24,7 @@ enum ErrorPageModel: Equatable {
     var description: String {
         switch self {
         case .internetConnection: return .NativeErrorPage.NoInternetConnection.Description
+        case .cellularDataRestricted: return .NativeErrorPage.CellularDataRestricted.Description
         case .badCertDomain: return String.NativeErrorPage.BadCertDomain.Description
         case .generic: return .NativeErrorPage.GenericError.Description
         case .wayback: return String(format: .NativeErrorPage.Wayback.Description, AppName.shortName.description)
@@ -30,7 +33,7 @@ enum ErrorPageModel: Equatable {
 
     var foxImageName: String {
         switch self {
-        case .internetConnection: return ImageIdentifiers.NativeErrorPage.noInternetConnection
+        case .internetConnection, .cellularDataRestricted: return ImageIdentifiers.NativeErrorPage.noInternetConnection
         case .badCertDomain, .generic: return ImageIdentifiers.NativeErrorPage.securityError
         case .wayback: return ImageIdentifiers.NativeErrorPage.noInternetConnection
         }
@@ -38,7 +41,7 @@ enum ErrorPageModel: Equatable {
 
     var url: URL? {
         switch self {
-        case .internetConnection: return nil
+        case .internetConnection, .cellularDataRestricted: return nil
         case .badCertDomain(let model): return model.url
         case .generic(let model): return model.url
         case .wayback(let model): return model.url
@@ -54,7 +57,7 @@ enum ErrorPageModel: Equatable {
 
     var isRegularUI: Bool {
         switch self {
-        case .internetConnection, .generic, .wayback: return true
+        case .internetConnection, .cellularDataRestricted, .generic, .wayback: return true
         case .badCertDomain: return false
         }
     }

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2056,16 +2056,16 @@ extension String {
             public static let TitleLabel = MZLocalizedString(
                 key: "NativeErrorPage.CellularDataRestricted.TitleLabel.v155",
                 tableName: "NativeErrorPage",
-                value: "Cellular data is turned off.",
-                comment: "On error page, this is the title shown when the app can't connect and iOS has cellular data access turned off for this app specifically.")
+                value: "Cellular data is turned off for this app.",
+                comment: "On error page, title shown when the app can't connect because cellular data is turned off " +
+                         "for this specific app in iOS settings.")
             public static let Description = MZLocalizedString(
                 key: "NativeErrorPage.CellularDataRestricted.Description.v155",
                 tableName: "NativeErrorPage",
-                value: "This may be why the page won’t load. Go to Settings > Cellular Data and turn it on for this app. " +
-                       "If that doesn’t help, check your Wi-Fi connection.",
-                comment: "On error page, this is the description shown when the app can't connect and iOS has cellular data " +
-                         "access turned off for this app specifically, telling the user how to fix it. Also suggests " +
-                         "checking Wi-Fi in case that isn't the actual cause.")
+                value: "This may be why the page won’t load. Go to Settings > Cellular Data to turn data on " +
+                       "for this app. If that doesn’t help, check your Wi-Fi connection.",
+                comment: "On error page, message shown when the app can't connect because cellular data is turned off " +
+                         "for the app and explaining to the user how to troubleshoot.")
         }
         public struct GenericError {
             public static let TitleLabel = MZLocalizedString(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2057,12 +2057,15 @@ extension String {
                 key: "NativeErrorPage.CellularDataRestricted.TitleLabel.v155",
                 tableName: "NativeErrorPage",
                 value: "Cellular data is turned off.",
-                comment: "On error page, this is the title shown when the app is offline because iOS has cellular data access turned off for this app specifically.")
+                comment: "On error page, this is the title shown when the app can't connect and iOS has cellular data access turned off for this app specifically.")
             public static let Description = MZLocalizedString(
                 key: "NativeErrorPage.CellularDataRestricted.Description.v155",
                 tableName: "NativeErrorPage",
-                value: "Go to Settings > Cellular Data and turn it on for this app.",
-                comment: "On error page, this is the description shown when the app is offline because iOS has cellular data access turned off for this app specifically, telling the user how to fix it.")
+                value: "This may be why the page won’t load. Go to Settings > Cellular Data and turn it on for this app. " +
+                       "If that doesn’t help, check your Wi-Fi connection.",
+                comment: "On error page, this is the description shown when the app can't connect and iOS has cellular data " +
+                         "access turned off for this app specifically, telling the user how to fix it. Also suggests " +
+                         "checking Wi-Fi in case that isn't the actual cause.")
         }
         public struct GenericError {
             public static let TitleLabel = MZLocalizedString(

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2052,6 +2052,18 @@ extension String {
                 value: "Try connecting on a different device. Check your modem or router. Disconnect and reconnect to Wi-Fi.",
                 comment: "On error page, this is the description for no internet connection.")
         }
+        public struct CellularDataRestricted {
+            public static let TitleLabel = MZLocalizedString(
+                key: "NativeErrorPage.CellularDataRestricted.TitleLabel.v155",
+                tableName: "NativeErrorPage",
+                value: "Cellular data is turned off.",
+                comment: "On error page, this is the title shown when the app is offline because iOS has cellular data access turned off for this app specifically.")
+            public static let Description = MZLocalizedString(
+                key: "NativeErrorPage.CellularDataRestricted.Description.v155",
+                tableName: "NativeErrorPage",
+                value: "Go to Settings > Cellular Data and turn it on for this app.",
+                comment: "On error page, this is the description shown when the app is offline because iOS has cellular data access turned off for this app specifically, telling the user how to fix it.")
+        }
         public struct GenericError {
             public static let TitleLabel = MZLocalizedString(
                 key: "NativeErrorPage.GenericError.TitleLabel.v131",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/CellularDataStatusProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/CellularDataStatusProviderTests.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+final class CellularDataStatusProviderTests: XCTestCase {
+    func testIsCellularDataRestricted_returnsConsistentValueAcrossReads() {
+        let provider: CellularDataStatusProviding = CTCellularDataStatusProvider()
+
+        let first = provider.isCellularDataRestricted
+        let second = provider.isCellularDataRestricted
+
+        XCTAssertEqual(first, second)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/CellularDataStatusProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/CellularDataStatusProviderTests.swift
@@ -7,8 +7,15 @@ import XCTest
 @testable import Client
 
 final class CellularDataStatusProviderTests: XCTestCase {
-    func testIsCellularDataRestricted_returnsConsistentValueAcrossReads() {
-        let provider: CellularDataStatusProviding = CTCellularDataStatusProvider()
+    func testShared_returnsSameInstance() {
+        let first = CTCellularDataStatusProvider.shared
+        let second = CTCellularDataStatusProvider.shared
+
+        XCTAssertTrue(first === second)
+    }
+
+    func testIsCellularDataRestricted_doesNotCrash() {
+        let provider: CellularDataStatusProviding = CTCellularDataStatusProvider.shared
 
         let first = provider.isCellularDataRestricted
         let second = provider.isCellularDataRestricted

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/CellularDataStatusProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/CellularDataStatusProviderTests.swift
@@ -22,4 +22,14 @@ final class CellularDataStatusProviderTests: XCTestCase {
 
         XCTAssertEqual(first, second)
     }
+
+    func testUpdateCachedState_updatesCachedValueForNextRead() {
+        let provider = CTCellularDataStatusProvider.shared
+
+        provider.updateCachedState(.restricted)
+        XCTAssertTrue(provider.isCellularDataRestricted)
+
+        provider.updateCachedState(.notRestricted)
+        XCTAssertFalse(provider.isCellularDataRestricted)
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
@@ -10,6 +10,13 @@ import XCTest
 final class NativeErrorPageHelperTests: XCTestCase {
     // MARK: - Helpers
 
+    private final class MockCellularDataStatusProvider: CellularDataStatusProviding {
+        var isCellularDataRestricted: Bool
+        init(isCellularDataRestricted: Bool = false) {
+            self.isCellularDataRestricted = isCellularDataRestricted
+        }
+    }
+
     private func makeBadCertDomainError(
         code: Int = NSURLErrorServerCertificateUntrusted
     ) -> NSError {
@@ -156,10 +163,14 @@ final class NativeErrorPageHelperTests: XCTestCase {
         let error = NSError(domain: NSURLErrorDomain, code: noInternetCode, userInfo: [
             NSURLErrorFailingURLErrorKey: url
         ])
-        let helper = NativeErrorPageHelper(error: error)
+        let helper = NativeErrorPageHelper(
+            error: error,
+            cellularDataStatusProvider: MockCellularDataStatusProvider()
+        )
 
         let model = helper.parseErrorDetails()
 
+        XCTAssertEqual(model, .internetConnection)
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.noInternetConnection)
         XCTAssertNil(model.url)
         XCTAssertTrue(model.isRegularUI)
@@ -168,12 +179,47 @@ final class NativeErrorPageHelperTests: XCTestCase {
     func testParseErrorDetails_noFailingURL_returnsNoInternetModel() {
         let noInternetCode = Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue)
         let error = NSError(domain: NSURLErrorDomain, code: noInternetCode, userInfo: [:])
-        let helper = NativeErrorPageHelper(error: error)
+        let helper = NativeErrorPageHelper(
+            error: error,
+            cellularDataStatusProvider: MockCellularDataStatusProvider()
+        )
 
         let model = helper.parseErrorDetails()
 
+        XCTAssertEqual(model, .internetConnection)
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.noInternetConnection)
         XCTAssertNil(model.url)
+    }
+
+    func testParseErrorDetails_noInternetError_withRestrictedCellularData_returnsCellularDataRestrictedModel() {
+        let url = URL(string: "https://example.com")!
+        let noInternetCode = Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue)
+        let error = NSError(domain: NSURLErrorDomain, code: noInternetCode, userInfo: [
+            NSURLErrorFailingURLErrorKey: url
+        ])
+        let helper = NativeErrorPageHelper(
+            error: error,
+            cellularDataStatusProvider: MockCellularDataStatusProvider(isCellularDataRestricted: true)
+        )
+
+        let model = helper.parseErrorDetails()
+
+        XCTAssertEqual(model, .cellularDataRestricted)
+        XCTAssertNil(model.url)
+        XCTAssertTrue(model.isRegularUI)
+    }
+
+    func testParseErrorDetails_noFailingURL_withRestrictedCellularData_returnsCellularDataRestrictedModel() {
+        let noInternetCode = Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue)
+        let error = NSError(domain: NSURLErrorDomain, code: noInternetCode, userInfo: [:])
+        let helper = NativeErrorPageHelper(
+            error: error,
+            cellularDataStatusProvider: MockCellularDataStatusProvider(isCellularDataRestricted: true)
+        )
+
+        let model = helper.parseErrorDetails()
+
+        XCTAssertEqual(model, .cellularDataRestricted)
     }
 
     func testParseErrorDetails_certError_withURL_returnsSecurityModel() {
@@ -303,6 +349,17 @@ final class NativeErrorPageHelperTests: XCTestCase {
 
         XCTAssertEqual(model.title, .NativeErrorPage.NoInternetConnection.TitleLabel)
         XCTAssertEqual(model.description, .NativeErrorPage.NoInternetConnection.Description)
+        XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.noInternetConnection)
+        XCTAssertNil(model.url)
+        XCTAssertNil(model.advancedSection)
+        XCTAssertTrue(model.isRegularUI)
+    }
+
+    func testCellularDataRestrictedModel_hasCorrectComputedProperties() {
+        let model = ErrorPageModel.cellularDataRestricted
+
+        XCTAssertEqual(model.title, .NativeErrorPage.CellularDataRestricted.TitleLabel)
+        XCTAssertEqual(model.description, .NativeErrorPage.CellularDataRestricted.Description)
         XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.noInternetConnection)
         XCTAssertNil(model.url)
         XCTAssertNil(model.advancedSection)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageHelperTests.swift
@@ -237,6 +237,24 @@ final class NativeErrorPageHelperTests: XCTestCase {
         XCTAssertTrue(model.isRegularUI)
     }
 
+    func testParseErrorDetails_certError_withRestrictedCellularData_stillReturnsSecurityModel() {
+        let url = URL(string: "https://example.com")!
+        let error = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorServerCertificateUntrusted,
+            userInfo: [NSURLErrorFailingURLErrorKey: url]
+        )
+        let helper = NativeErrorPageHelper(
+            error: error,
+            cellularDataStatusProvider: MockCellularDataStatusProvider(isCellularDataRestricted: true)
+        )
+
+        let model = helper.parseErrorDetails()
+
+        XCTAssertEqual(model.foxImageName, ImageIdentifiers.NativeErrorPage.securityError)
+        XCTAssertTrue(model.isRegularUI)
+    }
+
     func testParseErrorDetails_certErrorBadCertDomain_returnsAdvancedSection() {
         let url = URL(string: "https://example.com")!
         let error = NSError(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11115)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24237)

## :bulb: Description
Users with Wi-Fi off and cellular data on were seeing the generic "internet connection appears to be offline" error even though the device was connected — because iOS had cellular data access turned off for Firefox specifically in Settings. WKWebView returns the same `NSURLErrorNotConnectedToInternet` code for both "truly offline" and "this app is blocked from using cellular," so the native error page couldn't tell them apart.

This adds a `CellularDataStatusProviding` wrapper around `CTCellularData.restrictedState` (injectable for testing) and a new `.cellularDataRestricted` case on `ErrorPageModel`. `NativeErrorPageHelper.parseErrorDetails()` now checks cellular-restriction state whenever it would otherwise fall back to the generic no-connection error, and shows a specific message instead.

Covered by new unit tests in `NativeErrorPageHelperTests` (restricted/unrestricted, with/without failing URL, and confirming the restriction check doesn't leak into cert/generic error paths) and a new `CellularDataStatusProviderTests`.

**Update:** after an initial round of review, two correctness issues were found and fixed:
- `CTCellularData.restrictedState` reports `.restrictedStateUnknown` until the system resolves it asynchronously after the object is created. The original implementation constructed a fresh `CTCellularData` and read it immediately on every error, which would almost always observe the unresolved state and silently fall back to the generic message. `CTCellularDataStatusProvider` is now a long-lived singleton, warmed up at app launch (`AppDelegate`), that caches updates via `cellularDataRestrictionDidUpdateNotifier` instead of doing a single synchronous read.
- The cellular-restricted flag is a persistent per-app setting, not proof the *current* failure was caused by it — e.g. a user could have cellular disabled for Firefox while the real problem is a broken Wi-Fi connection. The copy now hedges on causation ("this may be why...") and keeps a Wi-Fi troubleshooting fallback instead of asserting cellular is definitely the fix.

**Scope note / open question:** this only covers the *native* error page (`isNICErrorPageEnabled`). The legacy HTML error page (`ErrorPageHelper.swift` / `NetError.html`) still just echoes whatever generic message iOS provides, since that path renders a shared, all-localizations HTML template rather than going through `ErrorPageModel`. Also out of scope: routing `NSURLErrorDataNotAllowed` (-1020, the more direct "cellular blocked this request" signal) into the native error page pipeline, and corroborating against the actual active network interface (Wi-Fi vs. cellular) via `NWPathMonitor`. Filing follow-up tickets for these; flagging here in case reviewers want them folded into this PR instead.

## :movie_camera: Demos
N/A — reproducing requires disabling per-app Cellular Data access for Firefox in iOS Settings while on cellular with Wi-Fi off; not practical to demo on Simulator.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [x] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

🤖 Generated with [Claude Code](https://claude.com/claude-code)