### PR TITLE
[MTE-5826] - Fix flaky onboarding UI tests

### DIFF
--- a/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
+++ b/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
@@ -23,6 +23,9 @@ public struct LaunchArguments {
     public static let ServerPort = "GCDWEBSERVER_PORT:"
     public static let SkipAddingGoogleTopSite = "SKIP_ADDING_GOOGLE_TOP_SITE"
     public static let SkipDefaultBrowserOnboarding = "SKIP_DEFAULT_BROWSER_ONBOARDING"
+    /// Forces the "is default browser" state to false and prevents the iOS 18.2+ system API from
+    /// re-querying it at launch, so the default-browser onboarding card renders deterministically.
+    public static let ResetDefaultBrowserStatus = "RESET_DEFAULT_BROWSER_STATUS"
     public static let LoadExperiment = "LOAD_EXPERIMENT"
     public static let ExperimentFeatureName = "EXPERIMENT_FEATURE_NAME"
     public static let DisableAnimations = "DISABLE_ANIMATIONS"

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -33,7 +33,10 @@ final class AppLaunchUtil: FeatureFlaggable, Sendable {
             logger.copyLogsToDocuments()
         }
 
-        DefaultBrowserUtility().processUserDefaultState(isFirstRun: introScreenManager.shouldShowIntroScreen)
+        // Tests can force a deterministic default-browser state; skip the system API so it isn't overwritten.
+        if !ProcessInfo.processInfo.arguments.contains(LaunchArguments.ResetDefaultBrowserStatus) {
+            DefaultBrowserUtility().processUserDefaultState(isFirstRun: introScreenManager.shouldShowIntroScreen)
+        }
         DefaultBrowserUtility().migrateDefaultBrowserStatusIfNeeded(isFirstRun: introScreenManager.shouldShowIntroScreen)
         if #available(iOS 26, *) {
             AppleIntelligenceUtil().processAvailabilityState()

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -235,6 +235,12 @@ class UITestAppDelegate: AppDelegate {
             resetApplication()
         }
 
+        // ClearProfile does not reset UserDefaults.standard, so the default-browser flag leaks across
+        // tests on a shared simulator. Force it false here so the default-browser onboarding card renders.
+        if ProcessInfo.processInfo.arguments.contains(LaunchArguments.ResetDefaultBrowserStatus) {
+            UserDefaults.standard.set(false, forKey: DefaultBrowserUtility.UserDefaultsKey.isBrowserDefault)
+        }
+
         // Opt-in: WKWebView cookies/site data live in WKWebsiteDataStore, which ClearProfile does not
         // clear. Only cleared when this argument is present so it doesn't reset web state for every test.
         if ProcessInfo.processInfo.arguments.contains(LaunchArguments.ClearWebData) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yOnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/A11yOnboardingTests.swift
@@ -13,7 +13,8 @@ class A11yOnboardingTests: BaseTestCase {
 
     override func setUp() async throws {
         launchArguments = [LaunchArguments.ClearProfile,
-                           LaunchArguments.DisableAnimations]
+                           LaunchArguments.DisableAnimations,
+                           LaunchArguments.ResetDefaultBrowserStatus]
         try await super.setUp()
         onboardingScreen = OnboardingScreen(app: app, flowType: .legacy)
         firefoxHomePageScreen = FirefoxHomePageScreen(app: app)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LegacyOnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LegacyOnboardingTests.swift
@@ -19,7 +19,8 @@ class LegacyOnboardingTests: FeatureFlaggedTestSuite {
 
         launchArguments = [
             LaunchArguments.ClearProfile,
-            LaunchArguments.DisableAnimations
+            LaunchArguments.DisableAnimations,
+            LaunchArguments.ResetDefaultBrowserStatus
         ]
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ModernKitOnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ModernKitOnboardingTests.swift
@@ -20,7 +20,8 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
     override func setUpExperimentVariables() {
         launchArguments = [
             LaunchArguments.ClearProfile,
-            LaunchArguments.DisableAnimations
+            LaunchArguments.DisableAnimations,
+            LaunchArguments.ResetDefaultBrowserStatus
         ]
 
         jsonFileName = flowType.jsonFeatureOverrideFileName


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5826

## :bulb: Description
The onboarding XCUITests were failing on the nightly full-functional CI run: the first onboarding screen — the default-browser welcome card ("Open all your links with built-in privacy") — was not shown, so CI saw only 3 screens where 4 are expected.

This is not a product bug. The welcome card is intentionally filtered out when Firefox is already the default browser (shouldShowWelcomeCardForDefaultBrowser in NimbusOnboardingKitFeatureLayer.swift), which reads DefaultBrowserUtility.isDefaultBrowser (the UserDefaults.standard key com.moz.isBrowserDefault.key).

The real problem is test isolation. That flag flips to true via an http/https deeplink (RouteBuilder) or the iOS 18.2+ application.isDefault(.webBrowser) API queried on every launch (AppLaunchUtil). FIREFOX_CLEAR_PROFILE / resetApplication() does not clear UserDefaults.standard, so on CI's shared-simulator full-functional run the value leaked to true across tests and persisted into the onboarding suites, dropping the first card. Locally, running a suite in isolation on a fresh simulator leaves it false, so all 4 screens appear — hence the CI-vs-local mismatch. The onboarding tests never pinned this state, making them non-deterministic.

Changes:
- Added a test-only launch argument RESET_DEFAULT_BROWSER_STATUS (LaunchArguments.ResetDefaultBrowserStatus).
- UITestAppDelegate forces com.moz.isBrowserDefault.key = false at willFinishLaunching when the arg is present.
- AppLaunchUtil skips processUserDefaultState under the arg so the iOS 18.2+ system API can't overwrite the forced value.

Production behavior is unchanged — the card is still correctly hidden when Firefox really is the default browser; the pin only applies under the test-only launch argument.

The fix was verified on CI machine also, where the actual problem occurred, and all the tests are passing.