### PR TITLE
Add FXIOS-16567 [Quick Answers] Homepage entry point button impression telemetry

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageDiffableDataSource.swift
@@ -81,6 +81,8 @@ final class HomepageDiffableDataSource: UICollectionViewDiffableDataSource<Homep
 
         var telemetryItemType: HomepageTelemetry.ItemType? {
             switch self {
+            case .header(let headerState, _, _):
+                return headerState.showQuickAnswersButton ? .quickAnswersEntryPoint : nil
             case .topSite:
                 return .topSite
             case .jumpBackIn:

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
@@ -83,7 +83,7 @@ final class HomepageMiddleware: FeatureFlaggable, Notifiable {
         }
         switch type {
         case .quickAnswersEntryPoint:
-            self.homepageTelemetry.sendQuickAnswersEntryPointImpressionEvent()
+            self.homepageTelemetry.sendQuickAnswersButtonViewedEvent()
         default:
             self.homepageTelemetry.sendSectionLabeledCounter(for: type)
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageMiddleware.swift
@@ -81,7 +81,12 @@ final class HomepageMiddleware: FeatureFlaggable, Notifiable {
               let type = extras.itemType else {
             return
         }
-        self.homepageTelemetry.sendSectionLabeledCounter(for: type)
+        switch type {
+        case .quickAnswersEntryPoint:
+            self.homepageTelemetry.sendQuickAnswersEntryPointImpressionEvent()
+        default:
+            self.homepageTelemetry.sendSectionLabeledCounter(for: type)
+        }
     }
 
     private func dispatchPrivacyNoticeConfigurationAction(action: Action) {

--- a/firefox-ios/Client/Glean/probes/ai.quick_answers.yaml
+++ b/firefox-ios/Client/Glean/probes/ai.quick_answers.yaml
@@ -30,7 +30,7 @@ ai.quick_answers:
       Recorded at most once per homepage view, see `homepage.viewed` for more details on what is considered
       a homepage view.
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/33376
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16567
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
     notification_emails:

--- a/firefox-ios/Client/Glean/probes/ai.quick_answers.yaml
+++ b/firefox-ios/Client/Glean/probes/ai.quick_answers.yaml
@@ -32,7 +32,7 @@ ai.quick_answers:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16567
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35175
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-12-01"

--- a/firefox-ios/Client/Glean/probes/ai.quick_answers.yaml
+++ b/firefox-ios/Client/Glean/probes/ai.quick_answers.yaml
@@ -23,6 +23,19 @@ $tags:
 # Add your new metrics and/or events here.
 
 ai.quick_answers:
+  entry_point_impression:
+    type: event
+    description: |
+      Recorded when the Quick Answers entry point, the button in the homepage header, is visible to the user.
+      Recorded at most once per homepage view, see `homepage.viewed` for more details on what is considered
+      a homepage view.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/33376
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/TODO
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: "2026-12-01"
   requested:
     type: event
     description: |

--- a/firefox-ios/Client/Glean/probes/ai.quick_answers.yaml
+++ b/firefox-ios/Client/Glean/probes/ai.quick_answers.yaml
@@ -23,7 +23,7 @@ $tags:
 # Add your new metrics and/or events here.
 
 ai.quick_answers:
-  entry_point_impression:
+  button_viewed:
     type: event
     description: |
       Recorded when the Quick Answers entry point, the button in the homepage header, is visible to the user.
@@ -36,6 +36,9 @@ ai.quick_answers:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: "2026-12-01"
+    metadata:
+      tags:
+        - Homepage
   requested:
     type: event
     description: |

--- a/firefox-ios/Client/Glean/probes/ai.quick_answers.yaml
+++ b/firefox-ios/Client/Glean/probes/ai.quick_answers.yaml
@@ -30,7 +30,7 @@ ai.quick_answers:
       Recorded at most once per homepage view, see `homepage.viewed` for more details on what is considered
       a homepage view.
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-16567
+      - https://github.com/mozilla-mobile/firefox-ios/issues/35176
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/35175
     notification_emails:

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -15,6 +15,7 @@ struct HomepageTelemetry {
         case bookmark = "bookmark"
         case bookmarkShowAll = "bookmarks_show_all_button"
         case story = "story"
+        case quickAnswersEntryPoint = "quick_answers_entry_point"
 
         var sectionName: String {
             switch self {
@@ -26,6 +27,8 @@ struct HomepageTelemetry {
                 return "bookmarks"
             case .story:
                 return "stories"
+            case .quickAnswersEntryPoint:
+                return "header"
             }
         }
     }
@@ -120,5 +123,9 @@ struct HomepageTelemetry {
 
     func sendOpenInPrivateTabEventForPocket() {
         gleanWrapper.recordEvent(for: GleanMetrics.Pocket.openInPrivateTab)
+    }
+
+    func sendQuickAnswersEntryPointImpressionEvent() {
+        gleanWrapper.recordEvent(for: GleanMetrics.AiQuickAnswers.entryPointImpression)
     }
 }

--- a/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/HomepageTelemetry.swift
@@ -125,7 +125,7 @@ struct HomepageTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.Pocket.openInPrivateTab)
     }
 
-    func sendQuickAnswersEntryPointImpressionEvent() {
-        gleanWrapper.recordEvent(for: GleanMetrics.AiQuickAnswers.entryPointImpression)
+    func sendQuickAnswersButtonViewedEvent() {
+        gleanWrapper.recordEvent(for: GleanMetrics.AiQuickAnswers.buttonViewed)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
@@ -585,6 +585,25 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
         XCTAssertEqual(snapshot.sectionIdentifiers, expectedSections)
     }
 
+    // MARK: - telemetryItemType
+    func test_telemetryItemType_withQuickAnswersButtonShown_returnsQuickAnswersEntryPoint() {
+        let item = HomepageItem.header(headerState(showQuickAnswersButton: true), nil, false)
+
+        XCTAssertEqual(item.telemetryItemType, .quickAnswersEntryPoint)
+    }
+
+    func test_telemetryItemType_withQuickAnswersButtonHidden_returnsNil() {
+        let item = HomepageItem.header(headerState(showQuickAnswersButton: false), nil, false)
+
+        XCTAssertNil(item.telemetryItemType)
+    }
+
+    private func headerState(showQuickAnswersButton: Bool) -> HeaderState {
+        let quickAnswersStore = MockQuickAnswersStore()
+        quickAnswersStore.isQuickAnswersEnabled = showQuickAnswersButton
+        return HeaderState(windowUUID: .XCTestDefaultUUID, quickAnswersStore: quickAnswersStore)
+    }
+
     private func createSites(count: Int = 30) -> [TopSiteConfiguration] {
         var sites = [TopSiteConfiguration]()
         (0..<count).forEach {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
@@ -234,6 +234,24 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockGleanWrapper?.savedLabel as? String, "top_sites")
     }
 
+    func test_sectionSeenAction_withQuickAnswersEntryPoint_sendsImpressionEvent() throws {
+        let subject = createSubject()
+        let action = HomepageAction(
+            telemetryExtras: HomepageTelemetryExtras(itemType: .quickAnswersEntryPoint, topSitesTelemetryConfig: nil),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: HomepageActionType.sectionSeen
+        )
+
+        subject.homepageProvider.legacyMiddleware(AppState(), action)
+
+        let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
+        let event = GleanMetrics.AiQuickAnswers.entryPointImpression
+
+        XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
+        XCTAssertEqual(mockGleanWrapper.incrementLabeledCounterCalled, 0)
+        XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
+    }
+
     // MARK: - Search Bar
     func test_initializeAction_configuresSearchBar() throws {
         setupNimbusSearchBarTesting(isEnabled: true)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageMiddlewareTests.swift
@@ -234,7 +234,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockGleanWrapper?.savedLabel as? String, "top_sites")
     }
 
-    func test_sectionSeenAction_withQuickAnswersEntryPoint_sendsImpressionEvent() throws {
+    func test_sectionSeenAction_withQuickAnswersEntryPoint_sendsButtonViewedEvent() throws {
         let subject = createSubject()
         let action = HomepageAction(
             telemetryExtras: HomepageTelemetryExtras(itemType: .quickAnswersEntryPoint, topSitesTelemetryConfig: nil),
@@ -245,7 +245,7 @@ final class HomepageMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.homepageProvider.legacyMiddleware(AppState(), action)
 
         let savedMetric = try XCTUnwrap(mockGleanWrapper.savedEvents.first as? EventMetricType<NoExtras>)
-        let event = GleanMetrics.AiQuickAnswers.entryPointImpression
+        let event = GleanMetrics.AiQuickAnswers.buttonViewed
 
         XCTAssertEqual(mockGleanWrapper.recordEventNoExtraCalled, 1)
         XCTAssertEqual(mockGleanWrapper.incrementLabeledCounterCalled, 0)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16567)

## :bulb: Description
Records the new `ai.quick_answers.button_viewed` event when the Quick Answers button in the homepage header is visible to the user. It reuses the existing homepage visible-items impression pipeline.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
