### PR TITLE
Bugfix FXIOS-16566 - [Toolbar] - The app gets blocked after accessing the tab tray context menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -817,7 +817,10 @@ class BrowserViewController: UIViewController,
             self.displayedPopoverController = nil
         }
         if self.presentedViewController is PhotonActionSheet {
-            self.presentedViewController?.dismiss(animated: true, completion: nil)
+            // Must not be animated: the app can suspend mid-transition, which leaves the sheet's
+            // container view in the window swallowing all touches once we come back to foreground,
+            // making the screen unresponsive.
+            self.presentedViewController?.dismiss(animated: false)
         }
 
         // Formerly these calls were run during AppDelegate.didEnterBackground(), but we have


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16566)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35177)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

### The Problem

When the app entered the background, the `PhotonActionSheet` was dismissed with `animated: true`. The app suspends before that transition finishes, so it is interrupted mid-flight: the animator tears down the sheet's view, but `UIKit` never completes the dismissal. On returning to the foreground the sheet's `UITransitionView` is still installed in the window with no children, a transparent, full-screen view that swallows every touch making the screen unresponsive.

### Fix
Dismiss the sheet with `animated: false` when entering the background. With no animation there
is no transition to interrupt and the container view is torn down correctly.

### View Hierarchy Screenshots.

#### When the `PhotonActionSheet` is on the screen

<img width="1031" height="652" alt="photon-menu-on-screen" src="https://github.com/user-attachments/assets/e9a26b82-ec55-49a0-b021-e29d2ea2ebb8" />

#### When `animated: true` - the `UITransitionView` is still there after going back to foreground.

<img width="1020" height="658" alt="background-foreground-no-input" src="https://github.com/user-attachments/assets/f5b2214b-7339-428d-bb15-225e24e553c8" />

#### When `animate: false` the `UITransitionView` is not longer present in the view hierarchy after going back to foreground leaving the app ready for user input.

<img width="1039" height="630" alt="clean-ready-for-input" src="https://github.com/user-attachments/assets/66e623db-a9f5-4fa1-b828-a6835b10f12d" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

