### PR TITLE
Add FXIOS-16573 Update release notes workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2880,6 +2880,42 @@ workflows:
       bitrise.io:
         machine_type_id: g2.mac.large
 
+  UpdateAppStoreReleaseNotes:
+    description: |-
+      This step writes the "What's New in This Version" text to every App Store Connect
+      locale, replacing the manual copy-paste. It is a separate manually triggered
+      workflow because release notes can only be written once the App Store version
+      record exists in App Store Connect, which happens after release_promotion_push
+      has uploaded the build.
+
+      Start a build with these env vars:
+        RELEASE_NOTES           the text to write to every locale (required, unless
+                                RELEASE_NOTES_FILE or RELEASE_NOTES_JSON is used).
+                                Write \n for a line break and \n\n for a blank line,
+                                so the whole thing fits on one line of the form.
+        RELEASE_NOTES_VERSION   App Store version string to target, for example 154.1.
+                                Optional: when omitted the one editable version is
+                                used, and an ambiguous choice fails. Deliberately not
+                                defaulted from version.txt, which follows the branch
+                                the build ran from rather than the release.
+        RELEASE_NOTES_DRY_RUN   true/1/yes/on to print what would change and write
+                                nothing. An unrecognised value fails rather than
+                                writing to the live App Store listing.
+
+      Run it once with RELEASE_NOTES_DRY_RUN=true first: the log names the target app
+      and version, which is the only check that the right record is being written.
+    before_run:
+    - SPM_Common_Steps
+    steps:
+    - script@1:
+        title: Update App Store Release Notes
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -eo pipefail
+            python3 -m pip install --upgrade pip pyjwt cryptography requests
+            python3 scripts/update_release_notes.py
+
   release_promotion_push:
     before_run:
     - SPM_Common_Steps

--- a/scripts/test_update_release_notes.py
+++ b/scripts/test_update_release_notes.py
@@ -1,0 +1,682 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Tests for update_release_notes.py.
+
+    python3 -m pip install pytest pyjwt cryptography requests
+    python3 -m pytest scripts/test_update_release_notes.py
+
+The App Store Connect API is replaced by FakeSession, so nothing here touches the
+network. The real AppStoreConnectClient is used throughout, so retry, pagination,
+and token handling are exercised rather than stubbed.
+"""
+
+import base64
+import json
+
+import pytest
+import requests
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+import update_release_notes as urn
+
+APP_ID = "989804926"
+
+# A realistic spread: codes that differ from the app's .lproj names, and regional
+# variants that only exist on the App Store side.
+LOCALES = [
+    "ar-SA", "ca", "cs", "da", "de", "el", "en-AU", "en-CA", "en-GB", "en-US",
+    "es-ES", "es-MX", "fi", "fr-CA", "fr-FR", "he", "hi", "hr", "hu", "id",
+    "it", "ja", "ko", "ms", "nl-NL", "no", "pl", "pt-BR", "pt-PT", "ro",
+    "ru", "sk", "sv", "th", "tr", "uk", "vi", "zh-Hans", "zh-Hant",
+]
+
+ENV_NAMES = (
+    "APPSTORECONNECT_APIKEY_ISSUER_ID",
+    "APPSTORECONNECT_APIKEY_KEY_ID",
+    "APPSTORECONNECT_APIKEY_B64",
+    "APPSTORE_APP_ID",
+    "RELEASE_NOTES",
+    "RELEASE_NOTES_FILE",
+    "RELEASE_NOTES_JSON",
+    "RELEASE_NOTES_VERSION",
+    "RELEASE_NOTES_DRY_RUN",
+    "BITRISE_RELEASE_VERSION",
+)
+
+
+@pytest.fixture(scope="session")
+def private_key_pem():
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+class FakeResponse:
+    def __init__(self, status_code, body=None, headers=None, text=None):
+        self.status_code = status_code
+        self._body = body
+        self.headers = headers or {}
+        self.text = text if text is not None else json.dumps(body or {})
+        self.content = self.text.encode()
+
+    @property
+    def ok(self):
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        if self._body is None:
+            raise ValueError("not json")
+        return self._body
+
+
+class FakeSession:
+    """Serves the four App Store Connect endpoints the script uses."""
+
+    def __init__(
+        self,
+        versions,
+        locales=None,
+        page_size=25,
+        existing=None,
+        patch_status=None,
+        transient=None,
+        transport_error=None,
+        app_name="Firefox",
+    ):
+        self.versions = versions
+        self.locales = LOCALES if locales is None else locales
+        self.page_size = page_size
+        self.existing = existing or {}
+        self.patch_status = patch_status or {}
+        self.transient = dict(transient or {})
+        self.transport_error = dict(transport_error or {})
+        self.app_name = app_name
+        self.patches = {}
+        self.calls = []
+        self.tokens = []
+
+    def request(self, method, url, headers=None, params=None, json=None, timeout=None):
+        self.calls.append((method, url, params))
+        self.tokens.append(headers["Authorization"])
+
+        if self.transport_error.get(url, 0) > 0:
+            self.transport_error[url] -= 1
+            raise requests.ConnectionError("connection reset by peer")
+
+        if self.transient.get(url, 0) > 0:
+            self.transient[url] -= 1
+            return FakeResponse(429, {"errors": []}, {"Retry-After": "1"})
+
+        if method == "GET" and url.endswith(f"/apps/{APP_ID}"):
+            return FakeResponse(200, {
+                "data": {"id": APP_ID, "attributes": {
+                    "name": self.app_name, "bundleId": "org.mozilla.ios.Firefox"}}})
+
+        if method == "GET" and url.endswith("/appStoreVersions"):
+            # Apply filter[versionString] like the real API, so a caller that filters
+            # server-side genuinely cannot see the other versions.
+            wanted = (params or {}).get("filter[versionString]")
+            matching = [
+                candidate for candidate in self.versions
+                if not wanted
+                or candidate["attributes"]["versionString"] == wanted
+            ]
+            return FakeResponse(200, {"data": matching, "links": {}})
+
+        if method == "GET" and "appStoreVersionLocalizations" in url:
+            offset = int(url.split("cursor=")[1]) if "cursor=" in url else 0
+            page = self.locales[offset:offset + self.page_size]
+            links = {}
+            if offset + self.page_size < len(self.locales):
+                links["next"] = (
+                    f"{url.split('?')[0]}?cursor={offset + self.page_size}"
+                )
+            return FakeResponse(200, {
+                "data": [
+                    {"id": f"loc-{locale}", "attributes": {
+                        "locale": locale, "whatsNew": self.existing.get(locale)}}
+                    for locale in page
+                ],
+                "links": links,
+            })
+
+        if method == "PATCH":
+            localization_id = url.rsplit("/", 1)[1]
+            status = self.patch_status.get(localization_id)
+            if status:
+                return FakeResponse(status, {"errors": [
+                    {"title": "Conflict", "detail": "not editable",
+                     "code": "STATE_ERROR"}]})
+            self.patches[localization_id] = json["data"]["attributes"]["whatsNew"]
+            return FakeResponse(200, {"data": {"id": localization_id}})
+
+        raise AssertionError(f"unexpected {method} {url}")
+
+    def patch_count(self):
+        return sum(1 for call in self.calls if call[0] == "PATCH")
+
+
+def version(version_string, state, created="2026-08-01T00:00:00Z",
+            state_field="appVersionState"):
+    return {
+        "id": f"ver-{version_string}",
+        "attributes": {
+            "versionString": version_string,
+            state_field: state,
+            "createdDate": created,
+        },
+    }
+
+
+@pytest.fixture
+def run_script(monkeypatch, private_key_pem):
+    """Runs main() against a FakeSession with the real client and no sleeping."""
+    def _run(session, argv=(), **environ):
+        for name in ENV_NAMES:
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("APPSTORECONNECT_APIKEY_ISSUER_ID", "issuer-id")
+        monkeypatch.setenv("APPSTORECONNECT_APIKEY_KEY_ID", "key-id")
+        monkeypatch.setenv(
+            "APPSTORECONNECT_APIKEY_B64",
+            base64.b64encode(private_key_pem.encode()).decode(),
+        )
+        monkeypatch.setenv("APPSTORE_APP_ID", APP_ID)
+        for name, value in environ.items():
+            monkeypatch.setenv(name, value)
+
+        client_class = urn.AppStoreConnectClient
+        monkeypatch.setattr(
+            urn,
+            "AppStoreConnectClient",
+            lambda token_provider: client_class(
+                token_provider, session=session, sleep=lambda _: None
+            ),
+        )
+        return urn.main(list(argv))
+    return _run
+
+
+def editable(version_string="154.1"):
+    return [version(version_string, "PREPARE_FOR_SUBMISSION")]
+
+
+def localization_reads(session):
+    """The collection GETs, whose URLs carry the version id the run chose."""
+    return [
+        call[1]
+        for call in session.calls
+        if call[0] == "GET" and call[1].endswith("appStoreVersionLocalizations")
+    ]
+
+
+# --- writing release notes ---------------------------------------------------
+
+
+def test_writes_the_same_text_to_every_locale(run_script):
+    session = FakeSession(editable())
+    assert run_script(session, ["--version", "154.1", "--notes", "Bug fixes."]) == 0
+    assert len(session.patches) == len(LOCALES)
+    assert set(session.patches.values()) == {"Bug fixes."}
+
+
+def test_pagination_follows_links_next(run_script):
+    session = FakeSession(editable(), page_size=10)
+    assert run_script(session, ["--version", "154.1", "--notes", "x"]) == 0
+    pages = [
+        call for call in session.calls
+        if call[0] == "GET" and "appStoreVersionLocalizations" in call[1]
+    ]
+    assert len(pages) == 4
+    # The cursor URL already carries the query string; resending params would reset it.
+    assert pages[1][2] is None
+    assert len(session.patches) == len(LOCALES)
+
+
+def test_skips_locales_that_already_match(run_script):
+    already = {locale: "Bug fixes." for locale in LOCALES[:12]}
+    session = FakeSession(editable(), existing=already)
+    assert run_script(session, ["--version", "154.1", "--notes", "Bug fixes."]) == 0
+    assert session.patch_count() == len(LOCALES) - 12
+
+
+def test_patch_payload_shape(run_script):
+    session = FakeSession(editable(), locales=["en-US"])
+    run_script(session, ["--version", "154.1", "--notes", "Line one\nLine two"])
+    assert session.patches == {"loc-en-US": "Line one\nLine two"}
+
+
+def test_logs_the_target_app_so_a_wrong_app_id_is_visible(run_script, capsys):
+    session = FakeSession(editable(), locales=["en-US"])
+    run_script(session, ["--version", "154.1", "--notes", "x"])
+    assert "Firefox (org.mozilla.ios.Firefox), id 989804926" in capsys.readouterr().out
+
+
+# --- dry run ----------------------------------------------------------------
+
+
+def test_dry_run_writes_nothing(run_script):
+    session = FakeSession(editable())
+    assert run_script(
+        session, ["--version", "154.1", "--notes", "x", "--dry-run"]
+    ) == 0
+    assert session.patch_count() == 0
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "True", "1", "yes", "on", "ON"])
+def test_dry_run_env_accepts_the_spellings_an_operator_types(run_script, value):
+    session = FakeSession(editable())
+    assert run_script(
+        session, ["--version", "154.1"], RELEASE_NOTES="x", RELEASE_NOTES_DRY_RUN=value
+    ) == 0
+    assert session.patch_count() == 0
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off"])
+def test_dry_run_env_falsy_values_write(run_script, value):
+    session = FakeSession(editable())
+    assert run_script(
+        session, ["--version", "154.1"], RELEASE_NOTES="x", RELEASE_NOTES_DRY_RUN=value
+    ) == 0
+    assert session.patch_count() == len(LOCALES)
+
+
+@pytest.mark.parametrize("value", ["ture", "maybe", "y", "2"])
+def test_unreadable_dry_run_env_fails_instead_of_writing(run_script, value):
+    session = FakeSession(editable())
+    assert run_script(
+        session, ["--version", "154.1"], RELEASE_NOTES="x", RELEASE_NOTES_DRY_RUN=value
+    ) == 1
+    assert session.calls == []
+
+
+# --- choosing the version ---------------------------------------------------
+
+
+def test_version_is_not_taken_from_the_branch_version_txt(run_script):
+    """$BITRISE_RELEASE_VERSION follows the build's branch, not the release."""
+    session = FakeSession([
+        version("154.1", "PREPARE_FOR_SUBMISSION"),
+        version("149.1", "PREPARE_FOR_SUBMISSION"),
+    ])
+    # Two editable versions and no explicit choice, so this must fail rather than
+    # silently pick main's version.txt value.
+    assert run_script(session, [], RELEASE_NOTES="x",
+                      BITRISE_RELEASE_VERSION="154.1") == 1
+    assert session.patch_count() == 0
+
+
+def test_release_notes_version_env_selects_the_version(run_script):
+    session = FakeSession([
+        version("154.1", "PREPARE_FOR_SUBMISSION"),
+        version("149.1", "PREPARE_FOR_SUBMISSION"),
+    ])
+    assert run_script(
+        session, [], RELEASE_NOTES="x", RELEASE_NOTES_VERSION="149.1"
+    ) == 0
+    assert localization_reads(session) == [
+        f"{urn.API_BASE}/appStoreVersions/ver-149.1/appStoreVersionLocalizations"
+    ]
+
+
+def test_explicit_version_wins_over_the_branch_version(run_script):
+    session = FakeSession([
+        version("154.1", "PREPARE_FOR_SUBMISSION"),
+        version("149.1", "PREPARE_FOR_SUBMISSION"),
+    ])
+    assert run_script(
+        session,
+        [],
+        RELEASE_NOTES="x",
+        RELEASE_NOTES_VERSION="149.1",
+        BITRISE_RELEASE_VERSION="154.1",
+    ) == 0
+    assert localization_reads(session) == [
+        f"{urn.API_BASE}/appStoreVersions/ver-149.1/appStoreVersionLocalizations"
+    ]
+
+
+def test_single_editable_version_is_selected_automatically(run_script):
+    session = FakeSession([
+        version("154.1", "PREPARE_FOR_SUBMISSION"),
+        version("154.0", "READY_FOR_DISTRIBUTION"),
+        version("153.0", "REPLACED_WITH_NEW_VERSION"),
+    ])
+    assert run_script(session, ["--notes", "x"]) == 0
+    assert len(session.patches) == len(LOCALES)
+
+
+def test_ambiguous_version_choice_fails(run_script):
+    session = FakeSession([
+        version("154.1", "PREPARE_FOR_SUBMISSION"),
+        version("155.0", "DEVELOPER_REJECTED"),
+    ])
+    assert run_script(session, ["--notes", "x"]) == 1
+    assert session.patch_count() == 0
+
+
+def test_missing_version_error_lists_the_versions_that_do_exist(run_script, capsys):
+    session = FakeSession([
+        version("154.0", "READY_FOR_DISTRIBUTION"),
+        version("153.0", "REPLACED_WITH_NEW_VERSION"),
+    ])
+    assert run_script(session, ["--version", "154.1", "--notes", "x"]) == 1
+    message = capsys.readouterr().err
+    assert "154.0 (READY_FOR_DISTRIBUTION)" in message
+    assert "153.0" in message
+
+
+def test_non_editable_version_is_refused(run_script):
+    session = FakeSession([version("154.0", "READY_FOR_DISTRIBUTION")])
+    assert run_script(session, ["--version", "154.0", "--notes", "x"]) == 1
+    assert session.patch_count() == 0
+
+
+def test_allow_any_state_overrides_the_state_check(run_script):
+    session = FakeSession([version("154.0", "READY_FOR_DISTRIBUTION")])
+    assert run_script(
+        session, ["--version", "154.0", "--notes", "x", "--allow-any-state"]
+    ) == 0
+    assert len(session.patches) == len(LOCALES)
+
+
+def test_legacy_app_store_state_field_is_understood(run_script):
+    session = FakeSession(
+        [version("154.1", "PREPARE_FOR_SUBMISSION", state_field="appStoreState")]
+    )
+    assert run_script(session, ["--notes", "x"]) == 0
+
+
+# --- locale selection -------------------------------------------------------
+
+
+def test_locales_limits_the_update(run_script):
+    session = FakeSession(editable())
+    assert run_script(
+        session, ["--version", "154.1", "--notes", "x", "--locales", "en-US, de"]
+    ) == 0
+    assert set(session.patches) == {"loc-en-US", "loc-de"}
+
+
+def test_misspelled_locale_is_rejected(run_script):
+    session = FakeSession(editable())
+    assert run_script(
+        session, ["--version", "154.1", "--notes", "x", "--locales", "en_US"]
+    ) == 1
+    assert session.patch_count() == 0
+
+
+def test_notes_json_uses_overrides_and_falls_back_to_default(run_script, tmp_path):
+    notes = tmp_path / "notes.json"
+    notes.write_text(json.dumps(
+        {"default": "Bug fixes.", "de": "Fehlerbehebungen.", "zz-ZZ": "dropped"}
+    ))
+    session = FakeSession(editable())
+    assert run_script(session, ["--version", "154.1", "--notes-json", str(notes)]) == 0
+    assert session.patches["loc-de"] == "Fehlerbehebungen."
+    assert session.patches["loc-fr-FR"] == "Bug fixes."
+    # A locale App Store Connect no longer has must warn, not block the release.
+    assert len(session.patches) == len(LOCALES)
+
+
+def test_notes_json_without_default_writes_only_listed_locales(run_script, tmp_path):
+    notes = tmp_path / "notes.json"
+    notes.write_text(json.dumps({"de": "D", "fr-FR": "F"}))
+    session = FakeSession(editable())
+    assert run_script(session, ["--version", "154.1", "--notes-json", str(notes)]) == 0
+    assert set(session.patches) == {"loc-de", "loc-fr-FR"}
+
+
+# --- notes validation -------------------------------------------------------
+
+
+def test_missing_notes_fails_before_calling_the_api(run_script):
+    session = FakeSession(editable())
+    assert run_script(session, ["--version", "154.1"]) == 1
+    assert session.calls == []
+
+
+def test_escaped_newline_in_notes_becomes_a_line_break(run_script):
+    session = FakeSession(editable(), locales=["en-US"])
+    assert run_script(
+        session, ["--version", "154.1"], RELEASE_NOTES="First line.\\nSecond line."
+    ) == 0
+    assert session.patches["loc-en-US"] == "First line.\nSecond line."
+
+
+def test_real_newline_in_notes_is_preserved(run_script):
+    session = FakeSession(editable(), locales=["en-US"])
+    assert run_script(
+        session, ["--version", "154.1"], RELEASE_NOTES="First line.\nSecond line."
+    ) == 0
+    assert session.patches["loc-en-US"] == "First line.\nSecond line."
+
+
+def test_escaped_blank_line_becomes_a_paragraph_break(run_script):
+    session = FakeSession(editable(), locales=["en-US"])
+    assert run_script(
+        session, ["--version", "154.1"], RELEASE_NOTES="First.\\n\\nSecond."
+    ) == 0
+    assert session.patches["loc-en-US"] == "First.\n\nSecond."
+
+
+def test_notes_file_content_is_not_unescaped(run_script, tmp_path):
+    """A file can hold real newlines, so a literal backslash-n stays literal."""
+    notes = tmp_path / "notes.txt"
+    notes.write_text("Real\nbreak and a literal \\n sequence.")
+    session = FakeSession(editable(), locales=["en-US"])
+    assert run_script(
+        session, ["--version", "154.1", "--notes-file", str(notes)]
+    ) == 0
+    assert session.patches["loc-en-US"] == "Real\nbreak and a literal \\n sequence."
+
+
+def test_blank_notes_env_counts_as_unset(run_script):
+    session = FakeSession(editable())
+    assert run_script(session, ["--version", "154.1"], RELEASE_NOTES="   ") == 1
+
+
+def test_two_notes_sources_are_rejected(run_script, tmp_path):
+    notes = tmp_path / "notes.json"
+    notes.write_text(json.dumps({"de": "D"}))
+    session = FakeSession(editable())
+    assert run_script(
+        session, ["--version", "154.1", "--notes", "a", "--notes-json", str(notes)]
+    ) == 1
+
+
+def test_overlong_notes_are_rejected_before_calling_the_api(run_script):
+    session = FakeSession(editable())
+    long_text = "x" * (urn.WHATS_NEW_MAX_LENGTH + 1)
+    assert run_script(session, ["--version", "154.1", "--notes", long_text]) == 1
+    assert session.calls == []
+
+
+# --- failure handling -------------------------------------------------------
+
+
+def test_one_locale_failing_does_not_abandon_the_rest(run_script):
+    session = FakeSession(editable(), patch_status={"loc-de": 422, "loc-ja": 422})
+    assert run_script(session, ["--version", "154.1", "--notes", "x"]) == 1
+    assert len(session.patches) == len(LOCALES) - 2
+
+
+def test_systemic_failure_stops_instead_of_retrying_every_locale(run_script):
+    session = FakeSession(
+        editable(), patch_status={f"loc-{locale}": 409 for locale in LOCALES}
+    )
+    assert run_script(session, ["--version", "154.1", "--notes", "x"]) == 1
+    assert session.patch_count() == 1
+
+
+def test_rate_limited_request_is_retried(run_script):
+    url = (
+        f"{urn.API_BASE}/appStoreVersions/ver-154.1/appStoreVersionLocalizations"
+    )
+    session = FakeSession(editable(), transient={url: 2})
+    assert run_script(session, ["--version", "154.1", "--notes", "x"]) == 0
+    assert len(session.patches) == len(LOCALES)
+
+
+def test_transport_error_is_retried_then_reported_cleanly(run_script, capsys):
+    url = f"{urn.API_BASE}/apps/{APP_ID}"
+    session = FakeSession(editable(), transport_error={url: urn.MAX_ATTEMPTS})
+    assert run_script(session, ["--version", "154.1", "--notes", "x"]) == 1
+    assert "ConnectionError" in capsys.readouterr().err
+
+
+def test_transport_error_that_recovers_completes_the_run(run_script):
+    url = f"{urn.API_BASE}/apps/{APP_ID}"
+    session = FakeSession(editable(), transport_error={url: 1})
+    assert run_script(session, ["--version", "154.1", "--notes", "x"]) == 0
+    assert len(session.patches) == len(LOCALES)
+
+
+def test_non_json_success_body_is_reported_cleanly(run_script, capsys):
+    session = FakeSession(editable())
+
+    def html(method, url, headers=None, params=None, json=None, timeout=None):
+        return FakeResponse(200, None, text="<html>proxy</html>")
+
+    session.request = html
+    assert run_script(session, ["--version", "154.1", "--notes", "x"]) == 1
+    assert "not JSON" in capsys.readouterr().err
+
+
+def test_expired_token_is_reminted_and_the_request_retried(run_script):
+    session = FakeSession(editable(), locales=["en-US"])
+    real_request = session.request
+    state = {"rejected": False}
+
+    def reject_once(method, url, headers=None, **kwargs):
+        if not state["rejected"] and method == "PATCH":
+            state["rejected"] = True
+            session.tokens.append(headers["Authorization"])
+            return FakeResponse(401, {"errors": [{"title": "NOT_AUTHORIZED"}]})
+        return real_request(method, url, headers=headers, **kwargs)
+
+    session.request = reject_once
+    assert run_script(session, ["--version", "154.1", "--notes", "x"]) == 0
+    assert session.patches == {"loc-en-US": "x"}
+
+
+# --- credentials ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing", ENV_NAMES[:4])
+def test_each_missing_credential_is_named(
+    monkeypatch, capsys, private_key_pem, missing
+):
+    for name in ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("APPSTORECONNECT_APIKEY_ISSUER_ID", "issuer-id")
+    monkeypatch.setenv("APPSTORECONNECT_APIKEY_KEY_ID", "key-id")
+    monkeypatch.setenv(
+        "APPSTORECONNECT_APIKEY_B64",
+        base64.b64encode(private_key_pem.encode()).decode(),
+    )
+    monkeypatch.setenv("APPSTORE_APP_ID", APP_ID)
+    monkeypatch.delenv(missing)
+
+    assert urn.main(["--version", "154.1", "--notes", "x"]) == 1
+    assert missing in capsys.readouterr().err
+
+
+def test_key_that_is_valid_base64_but_not_a_key_is_reported(run_script, capsys):
+    session = FakeSession(editable())
+    assert run_script(
+        session,
+        ["--version", "154.1", "--notes", "x"],
+        APPSTORECONNECT_APIKEY_B64=base64.b64encode(b"not a key").decode(),
+    ) == 1
+    assert "not contain a usable" in capsys.readouterr().err
+
+
+def test_key_that_is_not_base64_is_reported(run_script, capsys):
+    session = FakeSession(editable())
+    assert run_script(
+        session,
+        ["--version", "154.1", "--notes", "x"],
+        APPSTORECONNECT_APIKEY_B64="!!! not base64 !!!",
+    ) == 1
+    assert "base64" in capsys.readouterr().err
+
+
+# --- units ------------------------------------------------------------------
+
+
+def test_token_is_reused_then_reminted_at_the_refresh_margin(private_key_pem):
+    clock = [1_000_000.0]
+    provider = urn.TokenProvider(
+        urn.Credentials("issuer", "key", private_key_pem, APP_ID),
+        clock=lambda: clock[0],
+    )
+    first = provider.token()
+    assert provider.token() == first
+    clock[0] += urn.TOKEN_LIFETIME_SECONDS - urn.TOKEN_REFRESH_MARGIN_SECONDS
+    assert provider.token() != first
+
+
+def test_invalidate_forces_a_new_token(monkeypatch, private_key_pem):
+    minted = []
+
+    def fake_encode(*args, **kwargs):
+        minted.append(f"token-{len(minted)}")
+        return minted[-1]
+
+    monkeypatch.setattr(urn.jwt, "encode", fake_encode)
+    provider = urn.TokenProvider(
+        urn.Credentials("issuer", "key", private_key_pem, APP_ID),
+        clock=lambda: 1_000_000.0,
+    )
+
+    first = provider.token()
+    assert provider.token() == first, "an unexpired token must be reused"
+    provider.invalidate()
+    # The clock has not moved, so only invalidate() can explain a second minting.
+    assert provider.token() != first
+    assert len(minted) == 2
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("1", 1),
+        ("30", 30),
+        ("3600", urn.MAX_RETRY_DELAY_SECONDS),
+        ("86400", urn.MAX_RETRY_DELAY_SECONDS),
+        ("0", 1),
+        ("inf", 2),
+        ("nan", 2),
+        ("soon", 2),
+    ],
+)
+def test_retry_delay_is_clamped_and_never_raises(header, expected):
+    response = FakeResponse(429, {}, {"Retry-After": header})
+    assert urn.retry_delay(response, attempt=1) == expected
+
+
+def test_backoff_delay_is_capped():
+    assert urn.backoff_delay(1) == 2
+    assert urn.backoff_delay(20) == urn.MAX_RETRY_DELAY_SECONDS
+
+
+def test_describe_versions_caps_a_long_history():
+    versions = [
+        version(f"1{index}.0", "REPLACED_WITH_NEW_VERSION") for index in range(50)
+    ]
+    described = urn.describe_versions(versions)
+    assert "and 40 more" in described
+
+
+def test_select_version_prefers_the_newest_duplicate_version_string():
+    older = version("154.1", "PREPARE_FOR_SUBMISSION", created="2026-01-01T00:00:00Z")
+    newer = version("154.1", "PREPARE_FOR_SUBMISSION", created="2026-07-01T00:00:00Z")
+    newer["id"] = "ver-newer"
+    chosen = urn.select_version([older, newer], "154.1", allow_any_state=False)
+    assert chosen["id"] == "ver-newer"

--- a/scripts/update_release_notes.py
+++ b/scripts/update_release_notes.py
@@ -1,0 +1,800 @@
+#!/usr/bin/env python
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Writes the App Store "What's New in This Version" text to every locale.
+
+App Store Connect stores release notes as one appStoreVersionLocalization record
+per locale. This script asks the API which locales exist on the version instead
+of hardcoding them, so there is nothing to map from the app's .lproj directories
+onto App Store Connect locale codes (which differ: zh-Hans, pt-BR, en-GB) and
+nothing to update when locales are added or dropped.
+
+The App Store version record must already exist in App Store Connect and still
+be editable. This script fills in release notes; it does not create the version.
+
+App Store Connect API reference for the four calls this makes:
+
+    Sign a JWT
+    https://developer.apple.com/documentation/appstoreconnectapi/generating-tokens-for-api-requests
+
+    Find the version
+    https://developer.apple.com/documentation/appstoreconnectapi/get-v1-apps-_id_-appstoreversions
+
+    List its localizations
+    https://developer.apple.com/documentation/appstoreconnectapi/get-v1-appstoreversions-_id_-appstoreversionlocalizations
+
+    Write the release notes
+    https://developer.apple.com/documentation/appstoreconnectapi/patch-v1-appstoreversionlocalizations-_id_
+
+Supporting reference:
+
+    appStoreVersionLocalization attributes, including whatsNew
+    https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionlocalization
+
+    Version states
+    https://developer.apple.com/documentation/appstoreconnectapi/appversionstate
+    https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionstate
+
+    Cursor pagination via links.next
+    https://developer.apple.com/documentation/appstoreconnectapi/pageddocumentlinks
+
+    Rate limits and error bodies
+    https://developer.apple.com/documentation/appstoreconnectapi/identifying-rate-limits
+    https://developer.apple.com/documentation/appstoreconnectapi/interpreting-and-handling-errors
+
+Credentials come from the same environment variables as
+scripts/nightly_testflight_add_group.py:
+
+    APPSTORECONNECT_APIKEY_ISSUER_ID
+    APPSTORECONNECT_APIKEY_KEY_ID
+    APPSTORECONNECT_APIKEY_B64     base64-encoded .p8 private key
+    APPSTORE_APP_ID
+
+The version is never inferred from version.txt: that file tracks whichever branch
+the build ran from, and main runs ahead of the release branches, so it would point
+at the wrong version record. State it explicitly, or leave it out and let the one
+editable version be found.
+
+Examples:
+
+    # Same text in every locale, targeting the one editable version
+    RELEASE_NOTES="Bug fixes and performance improvements." \\
+        python3 scripts/update_release_notes.py
+
+    # Preview without writing anything
+    python3 scripts/update_release_notes.py --version 154.1 \\
+        --notes-file notes.txt --dry-run
+
+    # Per-locale text, with a fallback for the locales not listed
+    python3 scripts/update_release_notes.py --notes-json notes.json
+"""
+
+import argparse
+import base64
+import binascii
+import json
+import os
+import sys
+import time
+from typing import NamedTuple, Optional
+
+import jwt
+import requests
+
+API_BASE = "https://api.appstoreconnect.apple.com/v1"
+PLATFORM = "IOS"
+
+# App Store Connect truncates release notes past this length.
+WHATS_NEW_MAX_LENGTH = 4000
+
+# App Store Connect rejects tokens that live longer than 20 minutes, and recommends
+# the full 20 for a long-running process making many requests. Writing ~40 locales
+# can outlast a single short-lived token, so tokens are reminted on the fly.
+# https://developer.apple.com/documentation/appstoreconnectapi/generating-tokens-for-api-requests
+TOKEN_LIFETIME_SECONDS = 15 * 60
+TOKEN_REFRESH_MARGIN_SECONDS = 60
+
+MAX_ATTEMPTS = 4
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+# Retry-After on a rate-limited response can name an hour or more, which would park
+# the build in sleep until it times out. Back off, but keep the run interruptible.
+# https://developer.apple.com/documentation/appstoreconnectapi/identifying-rate-limits
+MAX_RETRY_DELAY_SECONDS = 60
+
+# Statuses that mean the whole run is wrong, not one locale: bad credentials, a key
+# without App Manager rights, a deleted version, or a version that stopped being
+# editable. Retrying these against the remaining locales only burns rate limit.
+SYSTEMIC_STATUS_CODES = frozenset({401, 403, 404, 409})
+
+TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+FALSY_ENV_VALUES = frozenset({"0", "false", "no", "off"})
+
+# States in which App Store Connect still accepts metadata edits. Both the current
+# appVersionState and the older appStoreState use these names.
+# https://developer.apple.com/documentation/appstoreconnectapi/appversionstate
+EDITABLE_VERSION_STATES = frozenset(
+    {
+        "PREPARE_FOR_SUBMISSION",
+        "READY_FOR_REVIEW",
+        "DEVELOPER_REJECTED",
+        "REJECTED",
+        "METADATA_REJECTED",
+        "INVALID_BINARY",
+    }
+)
+
+# Key reserved in a --notes-json file for the text used by unlisted locales.
+DEFAULT_NOTES_KEY = "default"
+
+
+class ReleaseNotesError(Exception):
+    """A problem with the inputs, credentials, or the selected App Store version."""
+
+
+class AppStoreConnectError(Exception):
+    """A failure talking to the App Store Connect API.
+
+    status_code is None for transport failures, which have no HTTP status.
+    """
+
+    def __init__(self, message, status_code=None):
+        self.status_code = status_code
+        super().__init__(message)
+
+    @classmethod
+    def from_response(cls, method, url, response):
+        return cls(
+            f"{method} {url} failed with HTTP {response.status_code}: "
+            f"{describe_api_errors(response)}",
+            status_code=response.status_code,
+        )
+
+    @classmethod
+    def from_transport_error(cls, method, url, error):
+        return cls(f"{method} {url} failed: {type(error).__name__}: {error}")
+
+
+def describe_api_errors(response):
+    """Pulls the human-readable parts out of an App Store Connect error body."""
+    try:
+        errors = response.json().get("errors", [])
+    except ValueError:
+        return response.text[:500]
+
+    messages = []
+    for error in errors:
+        parts = [error.get("title"), error.get("detail")]
+        message = " - ".join(part for part in parts if part)
+        code = error.get("code")
+        messages.append(f"{message} [{code}]" if code else message)
+    return "; ".join(messages) or response.text[:500]
+
+
+class Credentials(NamedTuple):
+    issuer_id: str
+    key_id: str
+    private_key: str
+    app_id: str
+
+
+class PlannedUpdate(NamedTuple):
+    localization_id: str
+    locale: str
+    whats_new: str
+    current_whats_new: Optional[str]
+
+    @property
+    def needs_update(self):
+        return self.current_whats_new != self.whats_new
+
+
+class Summary(NamedTuple):
+    updated: int
+    unchanged: int
+    failures: list
+    not_attempted: int = 0
+
+
+class TokenProvider:
+    """Mints App Store Connect JWTs, reminting them as they approach expiry."""
+
+    def __init__(self, credentials, clock=time.time):
+        self._credentials = credentials
+        self._clock = clock
+        self._token = None
+        self._expires_at = 0
+
+    def token(self):
+        now = self._clock()
+        refresh_at = self._expires_at - TOKEN_REFRESH_MARGIN_SECONDS
+        if self._token is None or now >= refresh_at:
+            self._expires_at = int(now) + TOKEN_LIFETIME_SECONDS
+            self._token = jwt.encode(
+                {
+                    "iss": self._credentials.issuer_id,
+                    "exp": self._expires_at,
+                    "aud": "appstoreconnect-v1",
+                },
+                self._credentials.private_key,
+                algorithm="ES256",
+                headers={"kid": self._credentials.key_id, "typ": "JWT"},
+            )
+        return self._token
+
+    def invalidate(self):
+        """Forces the next token() call to mint a fresh token."""
+        self._token = None
+
+
+class AppStoreConnectClient:
+    """Minimal App Store Connect client with retries and cursor pagination."""
+
+    def __init__(self, token_provider, session=None, sleep=time.sleep):
+        self._token_provider = token_provider
+        self._session = session or requests.Session()
+        self._sleep = sleep
+
+    def request(self, method, url, params=None, payload=None):
+        attempt = 0
+        reminted = False
+        while True:
+            attempt += 1
+            try:
+                response = self._session.request(
+                    method,
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {self._token_provider.token()}",
+                        "Content-Type": "application/json",
+                    },
+                    params=params,
+                    json=payload,
+                    timeout=60,
+                )
+            except requests.RequestException as error:
+                # A reset connection or read timeout partway through ~40 sequential
+                # writes is ordinary, so treat it like any other retryable failure.
+                if attempt >= MAX_ATTEMPTS:
+                    raise AppStoreConnectError.from_transport_error(
+                        method, url, error
+                    ) from error
+                delay = backoff_delay(attempt)
+                print(f"  {method} {url} failed: {error}, retrying in {delay}s")
+                self._sleep(delay)
+                continue
+
+            if response.ok:
+                return decode_json(method, url, response)
+
+            # An expired token, or one rejected because the build machine's clock
+            # drifted past the refresh margin, arrives as 401. Mint a new one and
+            # try once before concluding the credentials are wrong.
+            if response.status_code == 401 and not reminted:
+                reminted = True
+                self._token_provider.invalidate()
+                print(f"  {method} {url} returned HTTP 401, retrying with a new token")
+                continue
+
+            retryable = response.status_code in RETRYABLE_STATUS_CODES
+            if retryable and attempt < MAX_ATTEMPTS:
+                delay = retry_delay(response, attempt)
+                print(
+                    f"  {method} {url} returned HTTP {response.status_code}, "
+                    f"retrying in {delay}s"
+                )
+                self._sleep(delay)
+                continue
+            raise AppStoreConnectError.from_response(method, url, response)
+
+    def get_all(self, url, params=None):
+        """Reads every page of a collection, following links.next."""
+        records = []
+        while url:
+            body = self.request("GET", url, params=params)
+            records.extend(body.get("data", []))
+            url = body.get("links", {}).get("next")
+            # links.next already carries the original query string.
+            params = None
+        return records
+
+
+def decode_json(method, url, response):
+    """Decodes a success body, which an egress proxy or error page may not fill in."""
+    if not response.content:
+        return {}
+    try:
+        return response.json()
+    except ValueError as error:
+        raise AppStoreConnectError(
+            f"{method} {url} returned HTTP {response.status_code} with a body that is "
+            f"not JSON: {response.text[:200]}",
+            status_code=response.status_code,
+        ) from error
+
+
+def backoff_delay(attempt):
+    return min(MAX_RETRY_DELAY_SECONDS, 2**attempt)
+
+
+def retry_delay(response, attempt):
+    """Honours Retry-After when present, otherwise backs off exponentially."""
+    retry_after = response.headers.get("Retry-After")
+    if retry_after:
+        try:
+            # int(float(...)) also rejects "inf" and "nan", which would not clamp.
+            return min(MAX_RETRY_DELAY_SECONDS, max(1, int(float(retry_after))))
+        except (ValueError, OverflowError):
+            pass
+    return backoff_delay(attempt)
+
+
+def parse_bool_env(name):
+    """Reads a boolean environment variable, refusing values it cannot interpret.
+
+    An unrecognised value must never be read as "write to production", so a typo
+    like RELEASE_NOTES_DRY_RUN=ture fails instead of silently going live.
+    """
+    value = env(name)
+    if value is None:
+        return False
+    normalized = value.lower()
+    if normalized in TRUTHY_ENV_VALUES:
+        return True
+    if normalized in FALSY_ENV_VALUES:
+        return False
+    raise ReleaseNotesError(
+        f"{name} is set to {value!r}, which is neither true nor false. Use one of: "
+        f"{', '.join(sorted(TRUTHY_ENV_VALUES | FALSY_ENV_VALUES))}."
+    )
+
+
+def env(name):
+    """Reads an environment variable, treating blank values as unset."""
+    value = os.environ.get(name)
+    return value.strip() if value and value.strip() else None
+
+
+def load_credentials():
+    missing = [
+        name
+        for name in (
+            "APPSTORECONNECT_APIKEY_ISSUER_ID",
+            "APPSTORECONNECT_APIKEY_KEY_ID",
+            "APPSTORECONNECT_APIKEY_B64",
+            "APPSTORE_APP_ID",
+        )
+        if not env(name)
+    ]
+    if missing:
+        raise ReleaseNotesError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+
+    encoded_key = env("APPSTORECONNECT_APIKEY_B64")
+    try:
+        # Secret stores sometimes wrap base64 across lines; drop the whitespace.
+        private_key = base64.b64decode(
+            "".join(encoded_key.split()), validate=True
+        ).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError) as error:
+        raise ReleaseNotesError(
+            f"APPSTORECONNECT_APIKEY_B64 is not base64-encoded UTF-8: {error}"
+        ) from error
+
+    credentials = Credentials(
+        issuer_id=env("APPSTORECONNECT_APIKEY_ISSUER_ID"),
+        key_id=env("APPSTORECONNECT_APIKEY_KEY_ID"),
+        private_key=private_key,
+        app_id=env("APPSTORE_APP_ID"),
+    )
+
+    # Valid base64 of the wrong bytes still decodes, so the usual misconfiguration -
+    # a truncated or re-encoded .p8 in the secret store - only shows up when the key
+    # signs something. Sign now so it reports as an error rather than a traceback.
+    try:
+        TokenProvider(credentials).token()
+    except Exception as error:
+        raise ReleaseNotesError(
+            "APPSTORECONNECT_APIKEY_B64 does not contain a usable App Store Connect "
+            f"ES256 private key: {type(error).__name__}: {error}"
+        ) from error
+
+    return credentials
+
+
+def validate_notes(text, label):
+    stripped = text.strip()
+    if not stripped:
+        raise ReleaseNotesError(f"Release notes for {label} are empty.")
+    if len(stripped) > WHATS_NEW_MAX_LENGTH:
+        raise ReleaseNotesError(
+            f"Release notes for {label} are {len(stripped)} characters; App Store "
+            f"Connect allows at most {WHATS_NEW_MAX_LENGTH}."
+        )
+    return stripped
+
+
+def unescape_newlines(text):
+    r"""Turns the two characters \n into a real newline.
+
+    RELEASE_NOTES is typed into a single-line CI field, and newlines in Bitrise
+    variables are unreliable enough that the API key is base64 encoded to avoid
+    them. Only \n is translated, and only for text given directly; --notes-file
+    holds real newlines already and --notes-json gets them from JSON decoding.
+    """
+    return text.replace("\\n", "\n")
+
+
+def read_notes_file(path):
+    try:
+        with open(path, encoding="utf-8") as notes_file:
+            return notes_file.read()
+    except OSError as error:
+        raise ReleaseNotesError(f"Could not read {path}: {error}") from error
+
+
+def resolve_notes(args):
+    """Returns (default text or None, per-locale overrides) from the chosen source."""
+    sources = {
+        "--notes": args.notes,
+        "--notes-file": args.notes_file,
+        "--notes-json": args.notes_json,
+    }
+    provided = sorted(name for name, value in sources.items() if value)
+    if not provided:
+        raise ReleaseNotesError(
+            "No release notes given. Pass one of --notes, --notes-file, or "
+            "--notes-json, or set RELEASE_NOTES, RELEASE_NOTES_FILE, or "
+            "RELEASE_NOTES_JSON."
+        )
+    if len(provided) > 1:
+        raise ReleaseNotesError(
+            f"Release notes given more than once: {', '.join(provided)}. Pick one."
+        )
+
+    if args.notes:
+        return validate_notes(unescape_newlines(args.notes), "all locales"), {}
+    if args.notes_file:
+        return validate_notes(read_notes_file(args.notes_file), args.notes_file), {}
+
+    try:
+        parsed = json.loads(read_notes_file(args.notes_json))
+    except json.JSONDecodeError as error:
+        raise ReleaseNotesError(
+            f"{args.notes_json} is not valid JSON: {error}"
+        ) from error
+    if not isinstance(parsed, dict) or not all(
+        isinstance(value, str) for value in parsed.values()
+    ):
+        raise ReleaseNotesError(
+            f"{args.notes_json} must be a JSON object mapping locale to text, for "
+            f'example {{"{DEFAULT_NOTES_KEY}": "Bug fixes.", "de": "Fehler."}}'
+        )
+
+    overrides = {
+        locale: validate_notes(text, locale)
+        for locale, text in parsed.items()
+        if locale != DEFAULT_NOTES_KEY
+    }
+    default_notes = parsed.get(DEFAULT_NOTES_KEY)
+    if default_notes is not None:
+        default_notes = validate_notes(default_notes, DEFAULT_NOTES_KEY)
+    if not overrides and default_notes is None:
+        raise ReleaseNotesError(f"{args.notes_json} contains no release notes.")
+    return default_notes, overrides
+
+
+def describe_app(client, app_id):
+    """Names the app being written to, so the wrong APPSTORE_APP_ID is visible.
+
+    The value lives in CI secrets and cannot be checked from the repository, and a
+    wrong one can otherwise succeed silently against another app's metadata.
+    """
+    body = client.request("GET", f"{API_BASE}/apps/{app_id}")
+    attributes = body.get("data", {}).get("attributes", {})
+    name = attributes.get("name") or "unknown app"
+    return f"{name} ({attributes.get('bundleId')}), id {app_id}"
+
+
+def version_state(version):
+    attributes = version.get("attributes", {})
+    return attributes.get("appVersionState") or attributes.get("appStoreState")
+
+
+def describe_versions(versions, limit=10):
+    """Renders the most recently created versions for use in error messages."""
+    ordered = sorted(
+        versions,
+        key=lambda version: version["attributes"].get("createdDate") or "",
+        reverse=True,
+    )
+    described = ", ".join(
+        f"{version['attributes'].get('versionString')} ({version_state(version)})"
+        for version in ordered[:limit]
+    )
+    if not described:
+        return "none"
+    if len(ordered) > limit:
+        described += f", and {len(ordered) - limit} more"
+    return described
+
+
+def select_version(versions, version_string, allow_any_state):
+    """Picks the App Store version to write to, or explains why it cannot."""
+    if version_string:
+        matches = [
+            version
+            for version in versions
+            if version["attributes"].get("versionString") == version_string
+        ]
+        if not matches:
+            raise ReleaseNotesError(
+                f"No App Store version {version_string} exists for this app. Create "
+                "the version record in App Store Connect before running this script. "
+                f"Existing versions: {describe_versions(versions)}"
+            )
+        version = max(
+            matches, key=lambda version: version["attributes"].get("createdDate") or ""
+        )
+    else:
+        editable = [
+            version
+            for version in versions
+            if version_state(version) in EDITABLE_VERSION_STATES
+        ]
+        if not editable:
+            raise ReleaseNotesError(
+                "No editable App Store version was found. Create the version record "
+                "in App Store Connect first, or pass --version to target a specific "
+                f"one. Existing versions: {describe_versions(versions)}"
+            )
+        if len(editable) > 1:
+            raise ReleaseNotesError(
+                "Found more than one editable App Store version; pass --version to "
+                f"pick one. Candidates: {describe_versions(editable)}"
+            )
+        version = editable[0]
+
+    state = version_state(version)
+    if state not in EDITABLE_VERSION_STATES and not allow_any_state:
+        raise ReleaseNotesError(
+            f"App Store version {version['attributes'].get('versionString')} is in "
+            f"state {state}, which does not accept metadata edits. Editable states "
+            f"are {', '.join(sorted(EDITABLE_VERSION_STATES))}. Pass "
+            "--allow-any-state to try anyway."
+        )
+    return version
+
+
+def build_plan(localizations, default_notes, overrides, only_locales):
+    """Maps each localization record to the release notes it should end up with."""
+    available = {
+        localization["attributes"]["locale"]: localization
+        for localization in localizations
+    }
+
+    # A bad --locales value is a typo on the command line, so fail on it. A stale
+    # locale in a --notes-json file is config drift and must not block a release.
+    if only_locales:
+        unknown = sorted(set(only_locales) - set(available))
+        if unknown:
+            raise ReleaseNotesError(
+                f"--locales names locales this version does not have: "
+                f"{', '.join(unknown)}. Available: {', '.join(sorted(available))}"
+            )
+    for locale in sorted(set(overrides) - set(available)):
+        print(f"warning: ignoring release notes for unknown locale {locale}")
+
+    plan = []
+    for locale in sorted(available):
+        if only_locales and locale not in only_locales:
+            continue
+        whats_new = overrides.get(locale, default_notes)
+        if whats_new is None:
+            print(f"  {locale}: skipped, no release notes provided")
+            continue
+        attributes = available[locale]["attributes"]
+        plan.append(
+            PlannedUpdate(
+                localization_id=available[locale]["id"],
+                locale=locale,
+                whats_new=whats_new,
+                current_whats_new=attributes.get("whatsNew"),
+            )
+        )
+    return plan
+
+
+def apply_plan(client, plan, dry_run):
+    updated = 0
+    unchanged = 0
+    failures = []
+    not_attempted = 0
+    for index, update in enumerate(plan):
+        if not update.needs_update:
+            unchanged += 1
+            print(f"  {update.locale}: already up to date")
+            continue
+        if dry_run:
+            updated += 1
+            print(f"  {update.locale}: would update")
+            continue
+        try:
+            client.request(
+                "PATCH",
+                f"{API_BASE}/appStoreVersionLocalizations/{update.localization_id}",
+                payload={
+                    "data": {
+                        "type": "appStoreVersionLocalizations",
+                        "id": update.localization_id,
+                        "attributes": {"whatsNew": update.whats_new},
+                    }
+                },
+            )
+        except AppStoreConnectError as error:
+            failures.append((update.locale, str(error)))
+            print(f"  {update.locale}: FAILED - {error}")
+            if error.status_code in SYSTEMIC_STATUS_CODES:
+                not_attempted = len(plan) - index - 1
+                print(
+                    f"  stopping: HTTP {error.status_code} applies to the whole run, "
+                    f"so {not_attempted} remaining locales were not attempted"
+                )
+                break
+            continue
+        updated += 1
+        print(f"  {update.locale}: updated")
+    return Summary(
+        updated=updated,
+        unchanged=unchanged,
+        failures=failures,
+        not_attempted=not_attempted,
+    )
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description=(
+            "Write the App Store 'What's New in This Version' text to every locale "
+            "of an App Store Connect version."
+        ),
+        epilog=(
+            "The App Store version record must already exist in App Store Connect "
+            "and still be editable."
+        ),
+    )
+    # Deliberately not defaulted from $BITRISE_RELEASE_VERSION: that comes from
+    # version.txt on whichever branch the build was started from, and main runs ahead
+    # of the release branches, so it would quietly target the wrong version record.
+    parser.add_argument(
+        "--version",
+        default=env("RELEASE_NOTES_VERSION"),
+        help=(
+            "App Store version string to update, for example 154.1. Defaults to "
+            "$RELEASE_NOTES_VERSION. When unset, the one editable version is used, "
+            "and an ambiguous choice is an error."
+        ),
+    )
+    parser.add_argument(
+        "--notes",
+        default=env("RELEASE_NOTES"),
+        help=(
+            "Release notes text to write to every locale, in which \\n becomes a "
+            "line break. Defaults to $RELEASE_NOTES."
+        ),
+    )
+    parser.add_argument(
+        "--notes-file",
+        default=env("RELEASE_NOTES_FILE"),
+        help=(
+            "File holding the release notes text for every locale. Defaults to "
+            "$RELEASE_NOTES_FILE."
+        ),
+    )
+    parser.add_argument(
+        "--notes-json",
+        default=env("RELEASE_NOTES_JSON"),
+        help=(
+            "JSON file mapping locale to release notes, with an optional "
+            f'"{DEFAULT_NOTES_KEY}" key for the remaining locales. Defaults to '
+            "$RELEASE_NOTES_JSON."
+        ),
+    )
+    parser.add_argument(
+        "--locales",
+        help="Comma-separated locales to limit the update to, for example en-US,de.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=parse_bool_env("RELEASE_NOTES_DRY_RUN"),
+        help=(
+            "Report what would change without writing anything. Also enabled by "
+            "$RELEASE_NOTES_DRY_RUN set to any of: "
+            f"{', '.join(sorted(TRUTHY_ENV_VALUES))}."
+        ),
+    )
+    parser.add_argument(
+        "--allow-any-state",
+        action="store_true",
+        help="Write to the version even if its state normally rejects metadata edits.",
+    )
+    return parser.parse_args(argv)
+
+
+def run(args):
+    credentials = load_credentials()
+    default_notes, overrides = resolve_notes(args)
+    only_locales = (
+        {locale.strip() for locale in args.locales.split(",") if locale.strip()}
+        if args.locales
+        else set()
+    )
+
+    client = AppStoreConnectClient(TokenProvider(credentials))
+
+    print(f"Target app: {describe_app(client, credentials.app_id)}")
+
+    # versionString is matched locally rather than with filter[versionString] so that
+    # the "no such version" error can list the versions that do exist.
+    versions = client.get_all(
+        f"{API_BASE}/apps/{credentials.app_id}/appStoreVersions",
+        {"filter[platform]": PLATFORM, "limit": "50"},
+    )
+    version = select_version(versions, args.version, args.allow_any_state)
+    print(
+        f"Using App Store version {version['attributes'].get('versionString')} "
+        f"(id {version['id']}, state {version_state(version)})"
+    )
+
+    localizations = client.get_all(
+        f"{API_BASE}/appStoreVersions/{version['id']}/appStoreVersionLocalizations",
+        {"limit": "50"},
+    )
+    if not localizations:
+        raise ReleaseNotesError(
+            "This version has no appStoreVersionLocalizations records to write to."
+        )
+    print(f"Found {len(localizations)} locales")
+
+    plan = build_plan(localizations, default_notes, overrides, only_locales)
+    if not plan:
+        raise ReleaseNotesError("No locales left to update.")
+
+    if default_notes:
+        indented = "\n".join(f"    {line}" for line in default_notes.splitlines())
+        print(f"Release notes:\n{indented}")
+    if overrides:
+        print(f"Localized overrides: {', '.join(sorted(overrides))}")
+
+    print(f"{'Previewing' if args.dry_run else 'Writing'} release notes:")
+    summary = apply_plan(client, plan, args.dry_run)
+
+    verb = "would be updated" if args.dry_run else "updated"
+    done = (
+        f"Done: {summary.updated} {verb}, {summary.unchanged} already up to date, "
+        f"{len(summary.failures)} failed"
+    )
+    if summary.not_attempted:
+        done += f", {summary.not_attempted} not attempted"
+    print(done)
+    if summary.failures:
+        print("Failed locales:", ", ".join(locale for locale, _ in summary.failures))
+        return 1
+    return 0
+
+
+def main(argv=None):
+    try:
+        return run(parse_args(argv))
+    except (ReleaseNotesError, AppStoreConnectError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Automates the "What's New in This Version" text that is currently copy-pasted by hand into each of ~40 locales in App Store Connect. Adds scripts/update_release_notes.py, which signs an App Store Connect JWT, finds the target App Store version, lists its appStoreVersionLocalizations, and PATCHes whatsNew on each one; the locale list comes from the API rather than the app's .lproj directories, so there is no locale-code mapping to maintain and no drift when locales are added or dropped. Notes are supplied via RELEASE_NOTES, RELEASE_NOTES_FILE, or a RELEASE_NOTES_JSON locale map, and re-runs are idempotent because locales already holding the target text are skipped. The target version must be stated explicitly through RELEASE_NOTES_VERSION, or is resolved to the single editable version — deliberately never inferred from version.txt, which tracks the build's branch rather than the release being shipped. Writes are refused unless the version is in a state that accepts metadata edits, the target app is logged before anything is written, and RELEASE_NOTES_DRY_RUN previews the plan without calling PATCH. Adds the manually triggered UpdateAppStoreReleaseNotes Bitrise workflow, which reuses the App Store Connect secrets already configured for nightly_testflight_add_group.py; it is kept separate from release_promotion_push because release notes can only be written once the App Store version record exists, which happens after the build is uploaded. Includes scripts/test_update_release_notes.py, covering the write path, version and locale selection, credential and input validation, and the retry, pagination, and failure-handling behaviour against a fake API.

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16573)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)


## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

