### PR TITLE
Bugfix FXIOS-16559 Add custom spinner for Wayback search button

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ArcActivityIndicatorView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ArcActivityIndicatorView.swift
@@ -61,28 +61,26 @@ final class ArcActivityIndicatorView: UIView, ThemeApplicable {
         arcLayer.frame = bounds
     }
 
-    func startAnimating() {
+    @discardableResult
+    func startAnimating() -> Bool {
         let isNewSpinner = layer.animation(forKey: "rotation") == nil
         isHidden = false
-        guard isNewSpinner else { return }
+        guard isNewSpinner else { return false }
         let animation = CABasicAnimation(keyPath: "transform.rotation.z")
         animation.fromValue = 0
         animation.toValue = CGFloat.pi * 2
         animation.duration = UX.rotationDuration
         animation.repeatCount = .infinity
         layer.add(animation, forKey: "rotation")
-        if UIAccessibility.isVoiceOverRunning {
-            UIAccessibility.post(notification: .layoutChanged, argument: self)
-        }
+        return true
     }
 
-    func stopAnimating() {
+    @discardableResult
+    func stopAnimating() -> Bool {
         let hadSpinner = layer.animation(forKey: "rotation") != nil
         isHidden = true
         layer.removeAnimation(forKey: "rotation")
-        if hadSpinner && UIAccessibility.isVoiceOverRunning {
-            UIAccessibility.post(notification: .layoutChanged, argument: self)
-        }
+        return hadSpinner
     }
 
     func applyTheme(theme: any Theme) {

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ArcActivityIndicatorView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ArcActivityIndicatorView.swift
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+final class ArcActivityIndicatorView: UIView {
+    private struct UX {
+        static let lineWidth: CGFloat = 2
+        static let rotationDuration: CFTimeInterval = 0.8
+        static let arcFraction: CGFloat = 0.25
+    }
+
+    private let trackLayer = CAShapeLayer()
+    private let arcLayer = CAShapeLayer()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+
+        trackLayer.fillColor = UIColor.clear.cgColor
+        trackLayer.lineWidth = UX.lineWidth
+
+        arcLayer.fillColor = UIColor.clear.cgColor
+        arcLayer.lineWidth = UX.lineWidth
+        arcLayer.lineCap = .round
+
+        layer.addSublayer(trackLayer)
+        layer.addSublayer(arcLayer)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let radius = min(bounds.width, bounds.height) / 2 - UX.lineWidth / 2
+        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+
+        trackLayer.path = UIBezierPath(
+            arcCenter: center,
+            radius: radius,
+            startAngle: 0,
+            endAngle: 2 * .pi,
+            clockwise: true
+        ).cgPath
+        trackLayer.frame = bounds
+
+        let startAngle = -CGFloat.pi / 2
+        let endAngle = startAngle + (2 * .pi * UX.arcFraction)
+        arcLayer.path = UIBezierPath(
+            arcCenter: center,
+            radius: radius,
+            startAngle: startAngle,
+            endAngle: endAngle,
+            clockwise: true
+        ).cgPath
+        arcLayer.frame = bounds
+    }
+
+    func setColors(track: UIColor, arc: UIColor) {
+        trackLayer.strokeColor = track.cgColor
+        arcLayer.strokeColor = arc.cgColor
+    }
+
+    func startAnimating() {
+        isHidden = false
+        guard layer.animation(forKey: "rotation") == nil else { return }
+        let animation = CABasicAnimation(keyPath: "transform.rotation.z")
+        animation.fromValue = 0
+        animation.toValue = CGFloat.pi * 2
+        animation.duration = UX.rotationDuration
+        animation.repeatCount = .infinity
+        layer.add(animation, forKey: "rotation")
+    }
+
+    func stopAnimating() {
+        isHidden = true
+        layer.removeAnimation(forKey: "rotation")
+    }
+}

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ArcActivityIndicatorView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ArcActivityIndicatorView.swift
@@ -3,8 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import Common
 
-final class ArcActivityIndicatorView: UIView {
+final class ArcActivityIndicatorView: UIView, ThemeApplicable {
     private struct UX {
         static let lineWidth: CGFloat = 2
         static let rotationDuration: CFTimeInterval = 0.8
@@ -18,21 +19,21 @@ final class ArcActivityIndicatorView: UIView {
         super.init(frame: frame)
         isUserInteractionEnabled = false
         backgroundColor = .clear
-
-        trackLayer.fillColor = UIColor.clear.cgColor
-        trackLayer.lineWidth = UX.lineWidth
-
-        arcLayer.fillColor = UIColor.clear.cgColor
-        arcLayer.lineWidth = UX.lineWidth
-        arcLayer.lineCap = .round
-
-        layer.addSublayer(trackLayer)
-        layer.addSublayer(arcLayer)
+        setupLayers()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    private func setupLayers() {
+            for shape in [trackLayer, arcLayer] {
+                shape.fillColor = UIColor.clear.cgColor
+                shape.lineWidth = UX.lineWidth
+                layer.addSublayer(shape)
+            }
+            arcLayer.lineCap = .round
+        }
 
     override func layoutSubviews() {
         super.layoutSubviews()
@@ -60,24 +61,32 @@ final class ArcActivityIndicatorView: UIView {
         arcLayer.frame = bounds
     }
 
-    func setColors(track: UIColor, arc: UIColor) {
-        trackLayer.strokeColor = track.cgColor
-        arcLayer.strokeColor = arc.cgColor
-    }
-
     func startAnimating() {
+        let isNewSpinner = layer.animation(forKey: "rotation") == nil
         isHidden = false
-        guard layer.animation(forKey: "rotation") == nil else { return }
+        guard isNewSpinner else { return }
         let animation = CABasicAnimation(keyPath: "transform.rotation.z")
         animation.fromValue = 0
         animation.toValue = CGFloat.pi * 2
         animation.duration = UX.rotationDuration
         animation.repeatCount = .infinity
         layer.add(animation, forKey: "rotation")
+        if UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .layoutChanged, argument: self)
+        }
     }
 
     func stopAnimating() {
+        let hadSpinner = layer.animation(forKey: "rotation") != nil
         isHidden = true
         layer.removeAnimation(forKey: "rotation")
+        if hadSpinner && UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .layoutChanged, argument: self)
+        }
     }
+
+    func applyTheme(theme: any Theme) {
+            trackLayer.strokeColor = theme.colors.borderSecondary.cgColor
+            arcLayer.strokeColor = theme.colors.actionPrimary.cgColor
+        }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -16,6 +16,8 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         }
         static let buttonVerticalInset: CGFloat = 12
         static let buttonHorizontalInset: CGFloat = 16
+        static let spinnerSize: CGFloat = 20
+        static let spinnerTitleSpacing: CGFloat = 8
 
         static let contentInsets = NSDirectionalEdgeInsets(
             top: buttonVerticalInset,
@@ -28,6 +30,18 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
     private var highlightedBackgroundColor: UIColor?
     private var normalBackgroundColor: UIColor?
     private var foregroundColor: UIColor?
+    private var spinnerTrackColor: UIColor?
+    private var spinnerArcColor: UIColor?
+
+    private lazy var spinnerView: ArcActivityIndicatorView = {
+        let view = ArcActivityIndicatorView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true
+        return view
+    }()
+
+    private var didConstrainSpinner = false
+    private var showsSpinner = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -36,10 +50,26 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         titleLabel?.adjustsFontForContentSizeCategory = true
         isUserInteractionEnabled = true
         isAccessibilityElement = true
+
+        addSubview(spinnerView)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override public func layoutSubviews() {
+        super.layoutSubviews()
+        guard !didConstrainSpinner, let titleLabel else { return }
+        didConstrainSpinner = true
+        NSLayoutConstraint.activate([
+            spinnerView.trailingAnchor.constraint(
+                equalTo: titleLabel.leadingAnchor, constant: -UX.spinnerTitleSpacing
+            ),
+            spinnerView.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+            spinnerView.widthAnchor.constraint(equalToConstant: UX.spinnerSize),
+            spinnerView.heightAnchor.constraint(equalToConstant: UX.spinnerSize)
+        ])
     }
 
     override public func updateConfiguration() {
@@ -81,6 +111,24 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         accessibilityIdentifier = viewModel.a11yIdentifier
 
         configuration = updatedConfiguration
+    }
+
+    public func setShowsSpinner(_ shows: Bool) {
+        showsSpinner = shows
+        guard var updatedConfiguration = configuration else { return }
+
+        var insets = UX.contentInsets
+        if shows {
+            insets.leading += UX.spinnerSize + UX.spinnerTitleSpacing
+        }
+        updatedConfiguration.contentInsets = insets
+        configuration = updatedConfiguration
+
+        if shows {
+            spinnerView.startAnimating()
+        } else {
+            spinnerView.stopAnimating()
+        }
     }
 
     /// To keep alignment && spacing consistent between the buttons on pages,
@@ -125,5 +173,7 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
 
             setNeedsUpdateConfiguration()
         }
+
+        spinnerView.setColors(track: theme.colors.borderSecondary, arc: theme.colors.actionPrimary)
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -117,10 +117,14 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         updatedConfiguration.contentInsets = insets
         configuration = updatedConfiguration
 
+        let didChange: Bool
         if shows {
-            spinnerView.startAnimating()
+            didChange = spinnerView.startAnimating()
         } else {
-            spinnerView.stopAnimating()
+            didChange = spinnerView.stopAnimating()
+        }
+        if didChange && UIAccessibility.isVoiceOverRunning {
+            UIAccessibility.post(notification: .layoutChanged, argument: self)
         }
     }
 

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -30,18 +30,12 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
     private var highlightedBackgroundColor: UIColor?
     private var normalBackgroundColor: UIColor?
     private var foregroundColor: UIColor?
-    private var spinnerTrackColor: UIColor?
-    private var spinnerArcColor: UIColor?
 
-    private lazy var spinnerView: ArcActivityIndicatorView = {
-        let view = ArcActivityIndicatorView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.isHidden = true
-        return view
-    }()
+    private lazy var spinnerView: ArcActivityIndicatorView = .build { view in
+            view.isHidden = true
+    }
 
     private var didConstrainSpinner = false
-    private var showsSpinner = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -114,7 +108,6 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
     }
 
     public func setShowsSpinner(_ shows: Bool) {
-        showsSpinner = shows
         guard var updatedConfiguration = configuration else { return }
 
         var insets = UX.contentInsets
@@ -174,6 +167,6 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
             setNeedsUpdateConfiguration()
         }
 
-        spinnerView.setColors(track: theme.colors.borderSecondary, arc: theme.colors.actionPrimary)
+        spinnerView.applyTheme(theme: theme)
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/SecondaryRoundedButton.swift
@@ -107,7 +107,7 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         configuration = updatedConfiguration
     }
 
-    public func setShowsSpinner(_ shows: Bool) {
+    public func setShowsSpinner(_ shows: Bool, announcesChange: Bool = true) {
         guard var updatedConfiguration = configuration else { return }
 
         var insets = UX.contentInsets
@@ -123,7 +123,7 @@ public final class SecondaryRoundedButton: ResizableButton, ThemeApplicable {
         } else {
             didChange = spinnerView.stopAnimating()
         }
-        if didChange && UIAccessibility.isVoiceOverRunning {
+        if announcesChange && didChange && UIAccessibility.isVoiceOverRunning {
             UIAccessibility.post(notification: .layoutChanged, argument: self)
         }
     }

--- a/BrowserKit/Tests/ComponentLibraryTests/ArcvActivityIndicatorViewTests.swift
+++ b/BrowserKit/Tests/ComponentLibraryTests/ArcvActivityIndicatorViewTests.swift
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+@testable import ComponentLibrary
+
+@MainActor
+final class ArcActivityIndicatorViewTests: XCTestCase {
+    private var view: ArcActivityIndicatorView!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        view = ArcActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
+    }
+
+    override func tearDown() async throws {
+        view = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Initial State Tests
+    func testInit_disablesUserInteraction() {
+        XCTAssertFalse(view.isUserInteractionEnabled)
+    }
+
+    func testInit_setsClearBackground() {
+        XCTAssertEqual(view.backgroundColor, .clear)
+    }
+
+    func testInit_addsTrackAndArcSublayers() {
+        XCTAssertEqual(view.layer.sublayers?.count, 2)
+    }
+
+    // MARK: - startAnimating Tests
+    func testStartAnimating_unhidesView() {
+        view.isHidden = true
+
+        view.startAnimating()
+
+        XCTAssertFalse(view.isHidden)
+    }
+
+    func testStartAnimating_firstCall_returnsTrue() {
+        let didChange = view.startAnimating()
+
+        XCTAssertTrue(didChange)
+    }
+
+    func testStartAnimating_calledAgainWhileAnimating_returnsFalse() {
+        view.startAnimating()
+        let didChangeSecondTime = view.startAnimating()
+
+        XCTAssertFalse(didChangeSecondTime)
+    }
+
+    func testStartAnimating_addsRotationAnimationToLayer() {
+        view.startAnimating()
+
+        XCTAssertNotNil(view.layer.animation(forKey: "rotation"))
+    }
+
+    // MARK: - stopAnimating Tests
+    func testStopAnimating_hidesView() {
+        view.startAnimating()
+
+        view.stopAnimating()
+
+        XCTAssertTrue(view.isHidden)
+    }
+
+    func testStopAnimating_afterAnimating_returnsTrue() {
+        view.startAnimating()
+        let didChange = view.stopAnimating()
+
+        XCTAssertTrue(didChange)
+    }
+
+    func testStopAnimating_whenNotAnimating_returnsFalse() {
+        let didChange = view.stopAnimating()
+
+        XCTAssertFalse(didChange)
+    }
+
+    func testStopAnimating_removesRotationAnimationFromLayer() {
+        view.startAnimating()
+
+        view.stopAnimating()
+
+        XCTAssertNil(view.layer.animation(forKey: "rotation"))
+    }
+
+    // MARK: - Layout Tests
+    func testLayoutSubviews_computesPathsForBothLayers() {
+        view.layoutIfNeeded()
+
+        let sublayers = view.layer.sublayers as? [CAShapeLayer]
+        XCTAssertNotNil(sublayers?.first?.path)
+        XCTAssertNotNil(sublayers?.last?.path)
+    }
+
+    func testLayoutSubviews_withZeroFrame_doesNotCrash() {
+        let zeroFrameView = ArcActivityIndicatorView(frame: .zero)
+
+        zeroFrameView.layoutIfNeeded()
+
+        XCTAssertNotNil(zeroFrameView)
+    }
+
+    // MARK: - Theme Tests
+    func testApplyTheme_setsTrackLayerStrokeColor() {
+        let theme = LightTheme()
+
+        view.applyTheme(theme: theme)
+
+        let sublayers = view.layer.sublayers as? [CAShapeLayer]
+        XCTAssertEqual(sublayers?.first?.strokeColor, theme.colors.borderSecondary.cgColor)
+    }
+
+    func testApplyTheme_setsArcLayerStrokeColor() {
+        let theme = LightTheme()
+
+        view.applyTheme(theme: theme)
+
+        let sublayers = view.layer.sublayers as? [CAShapeLayer]
+        XCTAssertEqual(sublayers?.last?.strokeColor, theme.colors.actionPrimary.cgColor)
+    }
+}

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
@@ -239,10 +239,10 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable, UITextViewDe
         )
         waybackButton.configure(viewModel: viewModel)
         waybackButton.isEnabled = enabled
-        waybackButton.configuration?.showsActivityIndicator = showsSpinner
         waybackButton.configuration?.imagePadding = UX.waybackButtonImagePadding
         waybackButton.configuration?.imagePlacement = .leading
         waybackButton.accessibilityHint = enabled ? .NativeErrorPage.Wayback.WaybackButtonA11yHint : nil
+        waybackButton.setShowsSpinner(showsSpinner)
     }
 
     private func configureWaybackErrorCard(reason: WaybackButtonState.Reason) {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
@@ -239,8 +239,6 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable, UITextViewDe
         )
         waybackButton.configure(viewModel: viewModel)
         waybackButton.isEnabled = enabled
-        waybackButton.configuration?.imagePadding = UX.waybackButtonImagePadding
-        waybackButton.configuration?.imagePlacement = .leading
         waybackButton.accessibilityHint = enabled ? .NativeErrorPage.Wayback.WaybackButtonA11yHint : nil
         waybackButton.setShowsSpinner(showsSpinner)
     }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
@@ -37,7 +37,6 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable, UITextViewDe
         static let waybackErrorMessageRowSpacing: CGFloat = 6
         static let waybackErrorTextStackSpacing: CGFloat = 2
         static let waybackErrorContentStackSpacing: CGFloat = 2
-        static let waybackButtonImagePadding: CGFloat = 8
     }
 
     private static let waybackLinkURL = URL(string: "https://web.archive.org")!
@@ -228,7 +227,11 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable, UITextViewDe
         case .failed(let reason):
             waybackButton.isHidden = true
             waybackErrorCard.isHidden = false
+            waybackButton.setShowsSpinner(false, announcesChange: false)
             configureWaybackErrorCard(reason: reason)
+            if UIAccessibility.isVoiceOverRunning {
+                UIAccessibility.post(notification: .layoutChanged, argument: waybackErrorLabel)
+            }
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16559)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35165)

## :bulb: Description
This PR adds an optional custom spinner to the secondary rounded button and uses it for the Wayback machine button. To test, turn on the native error page and Wayback feature flags, and then go to veropedia.org and search for a archived version.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

