### PR TITLE
Refactor FXIOS-16356 [Periphery] Narrow Storage imports

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsManagerAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsManagerAction.swift
@@ -4,7 +4,9 @@
 
 import Common
 import Redux
-import Storage
+
+import struct Storage.RemoteClient
+import struct Storage.RemoteTab
 
 struct RemoteTabConfiguration {
     let client: RemoteClient

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/RemoteTabsPanelAction.swift
@@ -4,9 +4,9 @@
 
 import Common
 import Redux
-import Storage
 
 import struct MozillaAppServices.Device
+import struct Storage.ClientAndTabs
 
 /// Defines actions sent to Redux for Sync tab in tab tray
 struct RemoteTabsPanelAction: Action, Sendable {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/RemoteTabsPanelMiddleware.swift
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import Storage
 import Common
 import Shared
 import Redux
 
 import struct MozillaAppServices.Device
+import struct Storage.ClientAndTabs
 
 @MainActor
 final class RemoteTabsPanelMiddleware: Notifiable {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -5,12 +5,14 @@
 import Common
 import Redux
 import Shared
-import Storage
 import Account
 import SiteImageView
 import SummarizeKit
 
 import enum MozillaAppServices.BookmarkRoots
+import protocol Storage.BookmarksHandler
+import struct Storage.ShareItem
+import struct Storage.Site
 
 @MainActor
 final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -5,9 +5,9 @@
 import Common
 import ModifiedCopy
 import Redux
-import Storage
 
 import struct MozillaAppServices.Device
+import struct Storage.ClientAndTabs
 
 /// Status of Sync tab refresh.
 enum RemoteTabsPanelRefreshState {

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
@@ -3,10 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import Storage
 import SiteImageView
 
 import enum MozillaAppServices.VisitType
+import struct Storage.ClientAndTabs
+import struct Storage.RemoteTab
+import struct Storage.Site
 
 protocol CollapsibleTableViewSection: AnyObject {
     @MainActor

--- a/firefox-ios/Client/TabManagement/RemoteTabCreator.swift
+++ b/firefox-ios/Client/TabManagement/RemoteTabCreator.swift
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Storage
+import struct Storage.RemoteTab
 
 /// Creates a remote tab which is used to sync tabs to a sync account
 struct RemoteTabCreator {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -4,12 +4,13 @@
 
 import Common
 import Foundation
-import Storage
 import Shared
 import SiteImageView
 import WebKit
 import WebEngine
 import TabDataStore
+
+import struct Storage.PageMetadata
 
 #if DEBUG
 private var debugTabCount = 0

--- a/firefox-ios/Client/TabManagement/TabEventHandler.swift
+++ b/firefox-ios/Client/TabManagement/TabEventHandler.swift
@@ -3,9 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Storage
 import Common
 import WebEngine
+
+import struct Storage.PageMetadata
 
 /// A handler can be a plain old swift object. It does not need to extend any
 /// other object, but can.

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -4,10 +4,11 @@
 
 import Foundation
 import TabDataStore
-import Storage
 import Common
 import Shared
 import WebKit
+
+import protocol Storage.DiskImageStore
 
 final class TabManagerImplementation: NSObject,
                                       TabManager,

--- a/firefox-ios/Client/TabManagement/TabWebView.swift
+++ b/firefox-ios/Client/TabManagement/TabWebView.swift
@@ -4,7 +4,8 @@
 
 import Common
 import WebKit
-import Storage
+
+import class Storage.CertStore
 
 protocol TabWebViewDelegate: AnyObject {
     @MainActor


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16356)  
[GitHub issue](https://github.com/mozilla-mobile/firefox-ios/issues/34795)

## :bulb: Description

Removes broad `Storage` module imports from the Tabs feature to address the warnings reported by Periphery.

Where a file directly uses a type from `Storage`, the broad module import has been replaced with a declaration-level import. This keeps dependencies explicit and narrowly scoped without changing application behavior.

## :white_check_mark: Validation

- Fennec simulator build completed successfully
- SwiftLint completed with no violations
- No tests were added because this is an import-only refactor with no behavioral changes

## :pencil: Checklist

- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow the [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured relevant validation passes; no new tests were required
- [x] Accessibility review is not applicable because this change does not affect UI
- [x] Data review is not applicable because this change does not add or modify telemetry
- [x] String review is not applicable because this change does not add or modify localized strings
- [x] Documentation updates are not required for this change
