### PR TITLE
Revert FXIOS-16560 [Tab Tray] Explicitly unsubscribe from Redux store on teardown

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -344,8 +344,6 @@ final class TabDisplayPanelViewController: UIViewController,
     }
 
     func unsubscribeFromRedux() {
-        store.unsubscribe(self)
-
         // Skip if a newer panel has already re-subscribed for this window: removing the shared
         // `.tabsPanel` component here would wipe the state the newly-opened tab tray depends on.
         guard Self.latestSubscriptionGeneration[windowUUID] == subscriptionGeneration else { return }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -445,7 +445,6 @@ final class TabTrayViewController: UIViewController,
                                            actionType: ComponentActionType.removeComponent,
                                            component: .tabsTray)
         store.dispatch(screenAction)
-        store.unsubscribe(self)
     }
 
     func newState(state: TabTrayState) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Mocks/MockStoreForMiddleware.swift
@@ -28,9 +28,6 @@ class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
     /// Called when subscriber calls subscribe to the mock store.
     var subscribeCallCount = 0
 
-    /// Called when subscriber calls unsubscribe from the mock store.
-    var unsubscribeCallCount = 0
-
     init(state: State) {
         self.state = state
     }
@@ -51,11 +48,11 @@ class MockStoreForMiddleware<State: StateType>: DefaultDispatchStore {
     }
 
     func unsubscribe<S>(_ subscriber: S) where S: Redux.StoreSubscriber, State == S.SubscriberStateType {
-        unsubscribeCallCount += 1
+        // TODO: if you need it
     }
 
     func unsubscribe(_ subscriber: any Redux.StoreSubscriber) {
-        unsubscribeCallCount += 1
+        // TODO: if you need it
     }
 
     /// We implemented the lock to ensure that this is thread safe

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayPanelTests.swift
@@ -3,46 +3,18 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import Redux
 import XCTest
 
 @testable import Client
-final class TabDisplayPanelTests: XCTestCase, StoreTestUtility {
-    private var mockStore: MockStoreForMiddleware<AppState>!
-
+final class TabDisplayPanelTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
-        DependencyHelperMock().bootstrapDependencies()
-        setupStore()
+        await DependencyHelperMock().bootstrapDependencies()
     }
 
     override func tearDown() async throws {
         DependencyHelperMock().reset()
-        resetStore()
         try await super.tearDown()
-    }
-
-    // MARK: - Redux
-    func testUnsubscribeFromRedux_unsubscribesFromStore() {
-        let subject = createSubject(isPrivateMode: false, emptyTabs: true)
-
-        subject.unsubscribeFromRedux()
-
-        XCTAssertEqual(mockStore.unsubscribeCallCount, 1)
-    }
-
-    // MARK: - StoreTestUtility
-    func setupAppState() -> Client.AppState {
-        return AppState()
-    }
-
-    func setupStore() {
-        mockStore = MockStoreForMiddleware(state: setupAppState())
-        StoreTestUtilityHelper.setupStore(with: mockStore)
-    }
-
-    func resetStore() {
-        StoreTestUtilityHelper.resetStore()
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabTrayViewControllerTests.swift
@@ -3,24 +3,21 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
-import Redux
 import XCTest
 
 @testable import Client
 
 @MainActor
-final class TabTrayViewControllerTests: XCTestCase, StoreTestUtility {
+final class TabTrayViewControllerTests: XCTestCase {
     var delegate: MockTabTrayViewControllerDelegate!
     var navigationController: DismissableNavigationViewController!
     private var tabManager: MockTabManager!
-    private var mockStore: MockStoreForMiddleware<AppState>!
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
     override func setUp() async throws {
         try await super.setUp()
         let mockTabManager = MockTabManager()
         DependencyHelperMock().bootstrapDependencies(injectedTabManager: mockTabManager)
-        setupStore()
         delegate = MockTabTrayViewControllerDelegate()
         navigationController = DismissableNavigationViewController()
         tabManager = mockTabManager
@@ -30,32 +27,8 @@ final class TabTrayViewControllerTests: XCTestCase, StoreTestUtility {
         delegate = nil
         navigationController = nil
         DependencyHelperMock().reset()
-        resetStore()
 
         try await super.tearDown()
-    }
-
-    // MARK: - Redux
-    func testUnsubscribeFromRedux_unsubscribesFromStore() {
-        let viewController = createSubject()
-
-        viewController.unsubscribeFromRedux()
-
-        XCTAssertEqual(mockStore.unsubscribeCallCount, 1)
-    }
-
-    // MARK: - StoreTestUtility
-    func setupAppState() -> Client.AppState {
-        return AppState()
-    }
-
-    func setupStore() {
-        mockStore = MockStoreForMiddleware(state: setupAppState())
-        StoreTestUtilityHelper.setupStore(with: mockStore)
-    }
-
-    func resetStore() {
-        StoreTestUtilityHelper.resetStore()
     }
 
     // MARK: Compact layout


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16560)

## :bulb: Description
This PR reverts the following [PR](https://github.com/mozilla-mobile/firefox-ios/pull/35123) since the addition of `store.unsubscribe` should be superfluous and i don't want to risk any side effects on this release. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the data stewardship requirements and will request a data review
- [x] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code