### PR TITLE
Bugfix FXIOS-16491 [WebCompat] Dismiss the keyboard when tapping outside a field

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -77,6 +77,7 @@ public final class WebCompatReportSheetViewController: UIViewController,
         super.viewDidLoad()
         setupNavigationItem()
         setupCollectionView()
+        setupDismissKeyboardGesture()
         configure(with: viewModel)
         applyTheme(theme: theme)
         startObservingNotifications(
@@ -119,6 +120,12 @@ public final class WebCompatReportSheetViewController: UIViewController,
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+    }
+
+    private func setupDismissKeyboardGesture() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
     }
 
     // MARK: - Keyboard
@@ -391,6 +398,11 @@ public final class WebCompatReportSheetViewController: UIViewController,
     private func didTapPreview() {
         view.endEditing(true)
         delegate?.webCompatReportSheetDidTapPreview()
+    }
+
+    @objc
+    private func dismissKeyboard() {
+        view.endEditing(true)
     }
 
     // MARK: - Notifiable


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16491)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues) N/A

## :bulb: Description
The sheet used `keyboardDismissMode = .onDrag`, so only dragging the list closed the keyboard.

Adds a tap gesture on the root view calling `view.endEditing(true)`. `cancelsTouchesInView`
stays `false`, so taps still land underneath: with the keyboard up, tapping the issue-type
button closes it and opens the menu.

## :movie_camera: Demos

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

## :test_tube: Testing
1. 3-dot menu > More > Report Broken Site.
2. Edit the URL field, tap the "Site Issue" heading. Keyboard drops, text stays.
3. Same with the description field.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
