### PR TITLE
Bugfix FXIOS-16464 [WebCompat] Show "Report sent" in the confirmation toast

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -639,10 +639,7 @@ final class BrowserCoordinator: BaseCoordinator,
     // MARK: - WebCompatReportCoordinatorNavigationDelegate
 
     func webCompatReportDidSubmit() {
-        // TODO: FXIOS-16468 swap in the dedicated "Report sent" string once l10n exports it.
-        browserViewController.showPlainToast(
-            message: String.Microsurvey.Survey.ConfirmationPage.ConfirmationLabel
-        )
+        browserViewController.showPlainToast(message: .WebCompatReporter.Toast.ReportSent)
     }
 
     func presentAdBlockerSettings() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16464)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues) N/A, no synced issue

## :bulb: Description
Swaps the broken-site report toast to `WebCompatReporter.Toast.ReportSent`, so it reads "Report sent" instead of the placeholder Microsurvey string "Thanks for your feedback!".

That placeholder was waiting on l10n, which exported the string in [#34995](https://github.com/mozilla-mobile/firefox-ios/pull/34995). Drops the `TODO: FXIOS-16468`. Styling unchanged, blue confirmed by Megan.

## :movie_camera: Demos

<img height="800" alt="after-report-sent" src="https://github.com/user-attachments/assets/6eca154e-2cbe-40a5-aa22-b5d0dc0889c6" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
