### PR TITLE
RMST-379 [Remote Settings] enable uptake telemetry by default

### DIFF
--- a/firefox-ios/Client/Glean/probes/metrics.yaml
+++ b/firefox-ios/Client/Glean/probes/metrics.yaml
@@ -2761,7 +2761,6 @@ nimbus_system:
 remote_settings:
   uptake_remotesettings:
     type: event
-    disabled: true # To be controlled by server knobs due to expected high volume
     description: >
       Was the remote content successfully pulled? This uptake telemetry
       allows to monitor the behaviour of our clients when it comes to


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/RMST-379)

## :bulb: Description

In #34053 we shipped Remote Settings uptake telemetry disabled by default, because we thought we could enable it remotely using Nimbus.

We now realize that server knobs were removed in #26239, which prevents us doing so.
Nimbus rejects our experiment with `Feature glean-server-knobs is not supported by any version in this range.`

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

