### PR TITLE
Bugfix #27439 [Print] Use page titles for PDF filenames

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/Scripts/PrintContentScript.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/Scripts/PrintContentScript.swift
@@ -21,6 +21,10 @@ final class PrintContentScript: WKContentScript {
 
     func userContentController(didReceiveMessage message: Any) {
         let printController = UIPrintInteractionController.shared
+        let printInfo = UIPrintInfo(dictionary: nil)
+        printInfo.jobName = webView?.title ?? webView?.url?.absoluteString ?? ""
+        printInfo.outputType = .general
+        printController.printInfo = printInfo
         printController.printFormatter = webView?.viewPrintFormatter()
         printController.present(animated: true, completionHandler: nil)
     }

--- a/BrowserKit/Tests/WebEngineTests/Scripts/PrintContentScriptTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/Scripts/PrintContentScriptTests.swift
@@ -21,6 +21,7 @@ final class PrintContentScriptTests: XCTestCase {
 
     override func tearDown() async throws {
         webView = nil
+        UIPrintInteractionController.shared.printInfo = nil
         try await super.tearDown()
     }
 
@@ -33,11 +34,22 @@ final class PrintContentScriptTests: XCTestCase {
     }
 
     func test_userContentController_withMessage_returnsProperDelegateCall() {
+        webView.title = "Mozilla"
         let subject = createSubject()
 
         subject.userContentController(didReceiveMessage: ["any message"])
 
         XCTAssertEqual(webView.viewPrintFormatterCalled, 1)
+        XCTAssertEqual(UIPrintInteractionController.shared.printInfo?.jobName, "Mozilla")
+    }
+
+    func test_userContentController_withoutTitle_usesURLForJobName() {
+        webView.url = URL(string: "https://mozilla.org")
+        let subject = createSubject()
+
+        subject.userContentController(didReceiveMessage: [])
+
+        XCTAssertEqual(UIPrintInteractionController.shared.printInfo?.jobName, "https://mozilla.org")
     }
 
     private func createSubject() -> PrintContentScript {

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -86,7 +86,11 @@ class ShareManager: NSObject, FeatureFlaggable {
 
             // Only show the print activity if the tab's webview is loaded
             if tab.webView != nil {
+                let printInfo = UIPrintInfo(dictionary: nil)
+                printInfo.jobName = tab.displayTitle
+                printInfo.outputType = .general
                 let viewPrintFormatter = tab.webView?.viewPrintFormatter()
+                activityItems.append(printInfo)
                 activityItems.append(
                     TabPrintPageRenderer(
                         tabDisplayTitle: tab.displayTitle,

--- a/firefox-ios/Client/Frontend/TabContentsScripts/PrintHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/PrintHelper.swift
@@ -26,6 +26,10 @@ class PrintHelper: TabContentScript {
     ) {
         if let tab = tab, let webView = tab.webView {
             let printController = UIPrintInteractionController.shared
+            let printInfo = UIPrintInfo(dictionary: nil)
+            printInfo.jobName = tab.displayTitle
+            printInfo.outputType = .general
+            printController.printInfo = printInfo
             printController.printFormatter = webView.viewPrintFormatter()
             printController.present(animated: true, completionHandler: nil)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Sharing/ShareManagerTests.swift
@@ -228,23 +228,26 @@ final class ShareManagerTests: XCTestCase {
             itemForActivityType: testShareActivityType
         )
 
-        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+        let printInfo = try XCTUnwrap(activityItems[safe: 1] as? UIPrintInfo)
+        XCTAssertEqual(printInfo.jobName, testWebpageDisplayTitle)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabPrintPageRenderer)
 
-        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        _ = try XCTUnwrap(activityItems[safe: 3] as? HomePageActivity)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: testShareActivityType
         )
 
-        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 5] as? ShareTelemetryActivityItemProvider)
         let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: testShareActivityType
         )
 
-        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(activityItems.count, 6)
         XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
         XCTAssertEqual(itemForUrlActivity as? URL, testWebURL)
         XCTAssertTrue(
@@ -273,23 +276,26 @@ final class ShareManagerTests: XCTestCase {
             itemForActivityType: testShareActivityType
         )
 
-        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+        let printInfo = try XCTUnwrap(activityItems[safe: 1] as? UIPrintInfo)
+        XCTAssertEqual(printInfo.jobName, testWebpageDisplayTitle)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabPrintPageRenderer)
 
-        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        _ = try XCTUnwrap(activityItems[safe: 3] as? HomePageActivity)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: testShareActivityType
         )
 
-        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 5] as? ShareTelemetryActivityItemProvider)
         let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: testShareActivityType
         )
 
-        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(activityItems.count, 6)
         XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
         XCTAssertEqual(itemForUrlActivity as? URL, testWebURL)
         XCTAssertEqual(
@@ -319,13 +325,16 @@ final class ShareManagerTests: XCTestCase {
             itemForActivityType: testShareActivityType
         )
 
-        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+        let printInfo = try XCTUnwrap(activityItems[safe: 1] as? UIPrintInfo)
+        XCTAssertEqual(printInfo.jobName, testWebpageDisplayTitle)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabPrintPageRenderer)
 
-        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleSubtitleActivityItemProvider)
+        _ = try XCTUnwrap(activityItems[safe: 3] as? HomePageActivity)
 
-        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? TitleSubtitleActivityItemProvider)
+
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 5] as? ShareTelemetryActivityItemProvider)
         let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: testShareActivityType
@@ -333,7 +342,7 @@ final class ShareManagerTests: XCTestCase {
 
         XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
         XCTAssertEqual(itemForURLActivity as? URL, testWebURL)
-        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(activityItems.count, 6)
         XCTAssertEqual(
             titleActivityItemProvider.item as? String,
             testMessage,
@@ -422,23 +431,26 @@ final class ShareManagerTests: XCTestCase {
         )
 
         // The rest of the content should be unchanged from other tests:
-        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+        let printInfo = try XCTUnwrap(activityItems[safe: 1] as? UIPrintInfo)
+        XCTAssertEqual(printInfo.jobName, testWebpageDisplayTitle)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabPrintPageRenderer)
 
-        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        _ = try XCTUnwrap(activityItems[safe: 3] as? HomePageActivity)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: whatsAppActivity
         )
 
-        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 5] as? ShareTelemetryActivityItemProvider)
         let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: whatsAppActivity
         )
 
-        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(activityItems.count, 6)
         XCTAssertEqual(urlDataIdentifier, UTType.plainText.identifier)
         XCTAssertEqual(itemForActivity as? String, expectedShareContentA)
         XCTAssertTrue(
@@ -472,23 +484,26 @@ final class ShareManagerTests: XCTestCase {
         )
 
         // The rest of the content should be unchanged from other tests:
-        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+        let printInfo = try XCTUnwrap(activityItems[safe: 1] as? UIPrintInfo)
+        XCTAssertEqual(printInfo.jobName, testWebpageDisplayTitle)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabPrintPageRenderer)
 
-        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        _ = try XCTUnwrap(activityItems[safe: 3] as? HomePageActivity)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: whatsAppActivity
         )
 
-        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 5] as? ShareTelemetryActivityItemProvider)
         let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: whatsAppActivity
         )
 
-        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(activityItems.count, 6)
         XCTAssertEqual(urlDataIdentifier, UTType.plainText.identifier)
         XCTAssertEqual(itemForActivity as? String, expectedShareContentB)
         XCTAssertTrue(
@@ -520,23 +535,26 @@ final class ShareManagerTests: XCTestCase {
         )
 
         // The rest of the content should be unchanged from other tests:
-        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+        let printInfo = try XCTUnwrap(activityItems[safe: 1] as? UIPrintInfo)
+        XCTAssertEqual(printInfo.jobName, testWebpageDisplayTitle)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabPrintPageRenderer)
 
-        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        _ = try XCTUnwrap(activityItems[safe: 3] as? HomePageActivity)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: mailActivity
         )
 
-        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 5] as? ShareTelemetryActivityItemProvider)
         let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: mailActivity
         )
 
-        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(activityItems.count, 6)
         XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
         XCTAssertEqual(itemForActivity as? URL, testWebURL)
         XCTAssertTrue(
@@ -568,23 +586,26 @@ final class ShareManagerTests: XCTestCase {
         )
 
         // The rest of the content should be unchanged from other tests:
-        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+        let printInfo = try XCTUnwrap(activityItems[safe: 1] as? UIPrintInfo)
+        XCTAssertEqual(printInfo.jobName, testWebpageDisplayTitle)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabPrintPageRenderer)
 
-        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        _ = try XCTUnwrap(activityItems[safe: 3] as? HomePageActivity)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: mailActivity
         )
 
-        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 5] as? ShareTelemetryActivityItemProvider)
         let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: mailActivity
         )
 
-        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(activityItems.count, 6)
         XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
         XCTAssertEqual(itemForActivity as? URL, testWebURL)
         XCTAssertEqual(
@@ -618,23 +639,26 @@ final class ShareManagerTests: XCTestCase {
         )
 
         // The rest of the content should be unchanged from other tests:
-        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+        let printInfo = try XCTUnwrap(activityItems[safe: 1] as? UIPrintInfo)
+        XCTAssertEqual(printInfo.jobName, testWebpageDisplayTitle)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabPrintPageRenderer)
 
-        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        _ = try XCTUnwrap(activityItems[safe: 3] as? HomePageActivity)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: whatsAppActivity
         )
 
-        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 5] as? ShareTelemetryActivityItemProvider)
         let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: whatsAppActivity
         )
 
-        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(activityItems.count, 6)
         XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
         XCTAssertEqual(itemForActivity as? URL, testWebURL)
         XCTAssertEqual(
@@ -676,23 +700,26 @@ final class ShareManagerTests: XCTestCase {
         )
 
         // The rest of the content should be unchanged from other tests:
-        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+        let printInfo = try XCTUnwrap(activityItems[safe: 1] as? UIPrintInfo)
+        XCTAssertEqual(printInfo.jobName, testWebpageDisplayTitle)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabPrintPageRenderer)
 
-        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        _ = try XCTUnwrap(activityItems[safe: 3] as? HomePageActivity)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: whatsAppActivity
         )
 
-        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 5] as? ShareTelemetryActivityItemProvider)
         let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: whatsAppActivity
         )
 
-        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(activityItems.count, 6)
         XCTAssertEqual(urlDataIdentifier, UTType.url.identifier)
         XCTAssertEqual(itemForActivity as? URL, testWebURL)
         XCTAssertEqual(
@@ -736,23 +763,26 @@ final class ShareManagerTests: XCTestCase {
         )
 
         // The rest of the content should be unchanged from other tests:
-        _ = try XCTUnwrap(activityItems[safe: 1] as? TabPrintPageRenderer)
+        let printInfo = try XCTUnwrap(activityItems[safe: 1] as? UIPrintInfo)
+        XCTAssertEqual(printInfo.jobName, testWebpageDisplayTitle)
 
-        _ = try XCTUnwrap(activityItems[safe: 2] as? HomePageActivity)
+        _ = try XCTUnwrap(activityItems[safe: 2] as? TabPrintPageRenderer)
 
-        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 3] as? TitleActivityItemProvider)
+        _ = try XCTUnwrap(activityItems[safe: 3] as? HomePageActivity)
+
+        let titleActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? TitleActivityItemProvider)
         let itemForTitleActivity = titleActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: whatsAppActivity
         )
 
-        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 4] as? ShareTelemetryActivityItemProvider)
+        let telemetryActivityItemProvider = try XCTUnwrap(activityItems[safe: 5] as? ShareTelemetryActivityItemProvider)
         let itemForShareActivity = telemetryActivityItemProvider.activityViewController(
             createStubActivityViewController(),
             itemForActivityType: whatsAppActivity
         )
 
-        XCTAssertEqual(activityItems.count, 5)
+        XCTAssertEqual(activityItems.count, 6)
         XCTAssertEqual(urlDataIdentifier, UTType.plainText.identifier)
         XCTAssertEqual(itemForActivity as? String, expectedShareContentA)
         XCTAssertTrue(


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27439)

Fixes #27439

## :bulb: Description
Firefox already uses the page title as the print job name from the main menu, but the share-sheet and web-content print paths did not provide `UIPrintInfo`. As a result, saving those print jobs as PDFs could fall back to a generic filename.

This change sets the print job name from the current page title for all remaining print entry points:

- Share sheet printing uses the tab display title.
- Legacy `window.print()` handling uses the tab display title.
- BrowserKit `window.print()` handling uses the web view title, with the page URL as a fallback.

The share-sheet and BrowserKit tests now verify the generated print job name.

## :movie_camera: Demos
Not applicable; this changes the suggested filename shown when a print job is saved as a PDF.

## :test_tube: Testing
- `PrintContentScriptTests`: 3 tests passed.
- `ShareManagerTests`: 19 tests passed.
- Repository pre-push SwiftLint check passed with no violations.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — not applicable
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review — not applicable
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n — not applicable
- [x] If needed, I updated documentation and added comments to complex code — not applicable
