### PR TITLE
Refactor FXIOS-16561 [Technical Debt] [Redux] Redux state ADR #0013 audit - TrackingProtectionState

### DIFF
--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackigProtectionRedux/TrackingProtectionState.swift
@@ -77,8 +77,8 @@ struct TrackingProtectionState: ScreenState {
         shouldClearCookies: Bool,
         shouldUpdateBlockedTrackerStats: Bool,
         shouldUpdateConnectionStatus: Bool,
-        navigateTo: NavType? = nil,
-        displayView: DisplayType? = nil
+        navigateTo: NavType?,
+        displayView: DisplayType?
     ) {
         self.windowUUID = windowUUID
         self.trackingProtectionEnabled = trackingProtectionEnabled
@@ -130,31 +130,23 @@ struct TrackingProtectionState: ScreenState {
 
     private static func handleClearCookiesAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return state
+            .resetTransientState()
             .copy(trackingProtectionEnabled: !state.trackingProtectionEnabled)
             .copy(shouldClearCookies: true)
-            .copy(shouldUpdateBlockedTrackerStats: false)
-            .copy(shouldUpdateConnectionStatus: false)
             .copy(navigateTo: .home)
-            .copy(displayView: nil)
     }
 
     private static func handleNavigateToSettingsAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return state
-            .copy(shouldClearCookies: false)
-            .copy(shouldUpdateBlockedTrackerStats: false)
-            .copy(shouldUpdateConnectionStatus: false)
+            .resetTransientState()
             .copy(navigateTo: .settings)
-            .copy(displayView: nil)
     }
 
     private static func handleShowTrackingProtectionDetailsAction(
         from state: TrackingProtectionState
     ) -> TrackingProtectionState {
         return state
-            .copy(shouldClearCookies: false)
-            .copy(shouldUpdateBlockedTrackerStats: false)
-            .copy(shouldUpdateConnectionStatus: false)
-            .copy(navigateTo: nil)
+            .resetTransientState()
             .copy(displayView: .trackingProtectionDetails)
     }
 
@@ -162,47 +154,33 @@ struct TrackingProtectionState: ScreenState {
         from state: TrackingProtectionState
     ) -> TrackingProtectionState {
         return state
-            .copy(shouldClearCookies: false)
-            .copy(shouldUpdateBlockedTrackerStats: false)
-            .copy(shouldUpdateConnectionStatus: false)
-            .copy(navigateTo: nil)
+            .resetTransientState()
             .copy(displayView: .blockedTrackersDetails)
     }
 
     private static func handleGoBackAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return state
-            .copy(shouldClearCookies: false)
-            .copy(shouldUpdateBlockedTrackerStats: false)
-            .copy(shouldUpdateConnectionStatus: false)
+            .resetTransientState()
             .copy(navigateTo: .back)
-            .copy(displayView: nil)
     }
 
     private static func handleUpdateBlockedTrackerStatsAction(
         from state: TrackingProtectionState
     ) -> TrackingProtectionState {
         return state
+            .resetTransientState()
             .copy(shouldUpdateBlockedTrackerStats: true)
-            .copy(shouldUpdateConnectionStatus: false)
-            .copy(navigateTo: nil)
-            .copy(displayView: nil)
     }
 
     private static func handleUpdateConnectionStatusAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return state
-            .copy(shouldClearCookies: false)
-            .copy(shouldUpdateBlockedTrackerStats: false)
+            .resetTransientState()
             .copy(shouldUpdateConnectionStatus: true)
-            .copy(navigateTo: nil)
-            .copy(displayView: nil)
     }
 
     private static func handleShowAlertAction(from state: TrackingProtectionState) -> TrackingProtectionState {
         return state
-            .copy(shouldClearCookies: false)
-            .copy(shouldUpdateBlockedTrackerStats: false)
-            .copy(shouldUpdateConnectionStatus: false)
-            .copy(navigateTo: nil)
+            .resetTransientState()
             .copy(displayView: .clearCookiesAlert)
     }
 
@@ -210,31 +188,28 @@ struct TrackingProtectionState: ScreenState {
         from state: TrackingProtectionState
     ) -> TrackingProtectionState {
         return state
+            .resetTransientState()
             .copy(trackingProtectionEnabled: !state.trackingProtectionEnabled)
-            .copy(shouldClearCookies: false)
-            .copy(shouldUpdateBlockedTrackerStats: false)
-            .copy(shouldUpdateConnectionStatus: false)
-            .copy(navigateTo: nil)
-            .copy(displayView: nil)
     }
 
     private static func handleDismissTrackingProtectionAction(
         from state: TrackingProtectionState
     ) -> TrackingProtectionState {
         return state
-            .copy(shouldClearCookies: false)
-            .copy(shouldUpdateBlockedTrackerStats: false)
-            .copy(shouldUpdateConnectionStatus: false)
+            .resetTransientState()
             .copy(navigateTo: .close)
-            .copy(displayView: nil)
     }
 
     static func defaultState(from state: TrackingProtectionState) -> TrackingProtectionState {
-        return state
-            .copy(shouldClearCookies: false)
-            .copy(shouldUpdateBlockedTrackerStats: false)
-            .copy(shouldUpdateConnectionStatus: false)
-            .copy(navigateTo: nil)
-            .copy(displayView: nil)
+        return TrackingProtectionState(
+            windowUUID: state.windowUUID,
+            trackingProtectionEnabled: state.trackingProtectionEnabled,
+            connectionSecure: state.connectionSecure,
+            shouldClearCookies: false,
+            shouldUpdateBlockedTrackerStats: false,
+            shouldUpdateConnectionStatus: false,
+            navigateTo: nil,
+            displayView: nil
+        )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16561)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35181)

## :bulb: Description
This PR removes default parameter values from the designated init, rewrites `defaultState()` to use it explicitly instead of a .copy() chain, and replaces manual per-branch transient-state resets with `resetTransientState()` across all 10 handlers in accordance with [ADR 0013](https://github.com/mozilla-mobile/firefox-ios/blob/main/adr/0013-redux-state-reducers-best-practices-initialization-and-transient-state.md). Also fixes a bug in `handleUpdateBlockedTrackerStatsAction`, which never reset `shouldClearCookies` and could silently carry over a stale true value from a prior action.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

