### PR TITLE
Refactor FXIOS-16561 [Technical Debt] [Redux] Redux state ADR #0013 audit - TabTrayState and TabPeekState

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabPeekState.swift
@@ -85,6 +85,7 @@ struct TabPeekState: ScreenState {
             guard let tabPeekModel = action.tabPeekModel else { return defaultState(from: state) }
 
             return state
+                .resetTransientState()
                 .copy(showAddToBookmarks: tabPeekModel.canTabBeSaved)
                 .copy(showRemoveBookmark: tabPeekModel.canTabBeRemoved)
                 .copy(showSendToDevice: tabPeekModel.isSyncEnabled && tabPeekModel.canTabBeSaved)
@@ -97,6 +98,15 @@ struct TabPeekState: ScreenState {
     }
 
     static func defaultState(from state: TabPeekState) -> TabPeekState {
-        return TabPeekState(windowUUID: state.windowUUID)
+        return TabPeekState(
+            windowUUID: state.windowUUID,
+            showAddToBookmarks: false,
+            showRemoveBookmark: false,
+            showSendToDevice: false,
+            showCopyURL: true,
+            showCloseTab: true,
+            previewAccessibilityLabel: "",
+            screenshot: UIImage()
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayState.swift
@@ -66,7 +66,10 @@ struct TabTrayState: ScreenState, Equatable {
                   normalTabsCount: "0",
                   privateTabsCount: "0",
                   hasSyncableAccount: false,
-                  toastType: nil)
+                  shouldDismiss: false,
+                  toastType: nil,
+                  showCloseConfirmation: false,
+                  enableDeleteTabsButton: nil)
     }
 
     init(windowUUID: WindowUUID, panelType: TabTrayPanelType) {
@@ -75,7 +78,11 @@ struct TabTrayState: ScreenState, Equatable {
                   selectedPanel: panelType,
                   normalTabsCount: "0",
                   privateTabsCount: "0",
-                  hasSyncableAccount: false)
+                  hasSyncableAccount: false,
+                  shouldDismiss: false,
+                  toastType: nil,
+                  showCloseConfirmation: false,
+                  enableDeleteTabsButton: nil)
     }
 
     init(windowUUID: WindowUUID,
@@ -84,10 +91,10 @@ struct TabTrayState: ScreenState, Equatable {
          normalTabsCount: String,
          privateTabsCount: String,
          hasSyncableAccount: Bool,
-         shouldDismiss: Bool = false,
-         toastType: ToastType? = nil,
-         showCloseConfirmation: Bool = false,
-         enableDeleteTabsButton: Bool? = nil) {
+         shouldDismiss: Bool,
+         toastType: ToastType?,
+         showCloseConfirmation: Bool,
+         enableDeleteTabsButton: Bool?) {
         self.windowUUID = windowUUID
         self.isPrivateMode = isPrivateMode
         self.selectedPanel = selectedPanel
@@ -131,41 +138,31 @@ struct TabTrayState: ScreenState, Equatable {
         case TabTrayActionType.didLoadTabTray:
             guard let tabTrayModel = action.tabTrayModel else { return defaultState(from: state) }
             return state
+                .resetTransientState()
                 .copy(isPrivateMode: tabTrayModel.isPrivateMode)
                 .copy(selectedPanel: tabTrayModel.selectedPanel)
                 .copy(normalTabsCount: tabTrayModel.normalTabsCount)
                 .copy(privateTabsCount: tabTrayModel.privateTabsCount)
                 .copy(hasSyncableAccount: tabTrayModel.hasSyncableAccount)
-                .copy(shouldDismiss: false)
-                .copy(toastType: nil)
-                .copy(showCloseConfirmation: false)
                 .copy(enableDeleteTabsButton: tabTrayModel.enableDeleteTabsButton)
 
         case TabTrayActionType.changePanel:
             guard let panelType = action.panelType else { return defaultState(from: state) }
             return state
+                .resetTransientState()
                 .copy(isPrivateMode: panelType == .privateTabs)
                 .copy(selectedPanel: panelType)
-                .copy(shouldDismiss: false)
-                .copy(toastType: nil)
-                .copy(showCloseConfirmation: false)
-                .copy(enableDeleteTabsButton: nil)
 
         case TabTrayActionType.dismissTabTray:
             return state
+                .resetTransientState()
                 .copy(shouldDismiss: true)
-                .copy(toastType: nil)
-                .copy(showCloseConfirmation: false)
-                .copy(enableDeleteTabsButton: nil)
 
         case TabTrayActionType.firefoxAccountChanged:
             guard let isSyncAccountEnabled = action.hasSyncableAccount else { return defaultState(from: state) }
             return state
+                .resetTransientState()
                 .copy(hasSyncableAccount: isSyncAccountEnabled)
-                .copy(shouldDismiss: false)
-                .copy(toastType: nil)
-                .copy(showCloseConfirmation: false)
-                .copy(enableDeleteTabsButton: nil)
 
         default:
             return defaultState(from: state)
@@ -179,13 +176,11 @@ struct TabTrayState: ScreenState, Equatable {
             guard let tabDisplayModel = action.tabDisplayModel else { return defaultState(from: state) }
             let panelType = tabDisplayModel.isPrivateMode ? TabTrayPanelType.privateTabs : TabTrayPanelType.tabs
             return state
+                .resetTransientState()
                 .copy(isPrivateMode: tabDisplayModel.isPrivateMode)
                 .copy(selectedPanel: panelType)
                 .copy(normalTabsCount: tabDisplayModel.normalTabsCount)
                 .copy(privateTabsCount: "\(tabDisplayModel.tabs.filter({ $0.isPrivate == true }).count)")
-                .copy(shouldDismiss: false)
-                .copy(toastType: nil)
-                .copy(showCloseConfirmation: false)
                 .copy(enableDeleteTabsButton: tabDisplayModel.enableDeleteTabsButton)
 
         case TabPanelMiddlewareActionType.refreshTabs:
@@ -194,11 +189,9 @@ struct TabTrayState: ScreenState, Equatable {
             let isPrivate = tabDisplayModel.tabs.first?.isPrivate ?? false
             let tabCount = isPrivate ? state.normalTabsCount : tabDisplayModel.normalTabsCount
             return state
+                .resetTransientState()
                 .copy(normalTabsCount: tabCount)
                 .copy(privateTabsCount: tabDisplayModel.privateTabsCount)
-                .copy(shouldDismiss: false)
-                .copy(toastType: nil)
-                .copy(showCloseConfirmation: false)
                 .copy(enableDeleteTabsButton: tabDisplayModel.enableDeleteTabsButton)
 
         default:
@@ -211,10 +204,8 @@ struct TabTrayState: ScreenState, Equatable {
         switch action.actionType {
         case TabPanelViewActionType.closeAllTabs:
             return state
-                .copy(shouldDismiss: false)
-                .copy(toastType: nil)
+                .resetTransientState()
                 .copy(showCloseConfirmation: true)
-                .copy(enableDeleteTabsButton: nil)
 
         default:
             return defaultState(from: state)
@@ -227,6 +218,10 @@ struct TabTrayState: ScreenState, Equatable {
                             selectedPanel: state.selectedPanel,
                             normalTabsCount: state.normalTabsCount,
                             privateTabsCount: state.privateTabsCount,
-                            hasSyncableAccount: state.hasSyncableAccount)
+                            hasSyncableAccount: state.hasSyncableAccount,
+                            shouldDismiss: false,
+                            toastType: nil,
+                            showCloseConfirmation: false,
+                            enableDeleteTabsButton: nil)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Redux/TabTrayStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Redux/TabTrayStateTests.swift
@@ -289,34 +289,23 @@ final class TabTrayStateTests: XCTestCase {
 
     // MARK: - Computed Properties
     func test_navigationTitle_forTabsPanel() {
-        let state = TabTrayState(windowUUID: .XCTestDefaultUUID,
-                                 isPrivateMode: false,
-                                 selectedPanel: .tabs,
-                                 normalTabsCount: "5",
-                                 privateTabsCount: "0",
-                                 hasSyncableAccount: false)
+        let state = TabTrayState(windowUUID: .XCTestDefaultUUID, panelType: .tabs)
+            .copy(normalTabsCount: "5")
 
         XCTAssertEqual(state.navigationTitle, TabTrayPanelType.tabs.navTitle)
     }
 
     func test_navigationTitle_forPrivateTabsPanel() {
-        let state = TabTrayState(windowUUID: .XCTestDefaultUUID,
-                                 isPrivateMode: true,
-                                 selectedPanel: .privateTabs,
-                                 normalTabsCount: "0",
-                                 privateTabsCount: "3",
-                                 hasSyncableAccount: false)
+        let state = TabTrayState(windowUUID: .XCTestDefaultUUID, panelType: .privateTabs)
+            .copy(privateTabsCount: "3")
 
         XCTAssertEqual(state.navigationTitle, TabTrayPanelType.privateTabs.navTitle)
     }
 
     func test_navigationTitle_forSyncedTabsPanel() {
-        let state = TabTrayState(windowUUID: .XCTestDefaultUUID,
-                                 isPrivateMode: false,
-                                 selectedPanel: .syncedTabs,
-                                 normalTabsCount: "5",
-                                 privateTabsCount: "0",
-                                 hasSyncableAccount: true)
+        let state = TabTrayState(windowUUID: .XCTestDefaultUUID, panelType: .syncedTabs)
+            .copy(normalTabsCount: "5")
+            .copy(hasSyncableAccount: true)
 
         XCTAssertEqual(state.navigationTitle, TabTrayPanelType.syncedTabs.navTitle)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16561)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35181)

## :bulb: Description
This PR removes default parameter values from designated inits, makes `defaultState()` list every field explicitly, and includes `resetTransientState()` where necessary in accordance with [ADR 0013](https://github.com/mozilla-mobile/firefox-ios/blob/main/adr/0013-redux-state-reducers-best-practices-initialization-and-transient-state.md). Also closes a latent bug in TabPeekState where showCloseTab was never explicitly reset in `loadTabPeek`, silently relying on carryover from a prior state. 

This PR also removes default parameter values from `TabTrayState's` designated init and its two convenience inits, and replaces the same 3-field `.copy()` with `resetTransientState()`.

I ran the appropriate tests to verify my work

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

