### PR TITLE
Refactor FXIOS-16561 [Technical Debt] [Redux] Redux state ADR #0013 audit

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -110,7 +110,7 @@ struct ToolbarState: ScreenState, Sendable {
         canShowNavigationHint: Bool,
         shouldAnimate: Bool,
         isTranslucent: Bool,
-        isTranslationsEnabled: Bool = true,
+        isTranslationsEnabled: Bool,
         previousTabScreenshot: UIImage?,
         nextTabScreenshot: UIImage?
     ) {

--- a/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Prompt/MicrosurveyPromptState.swift
@@ -68,19 +68,20 @@ struct MicrosurveyPromptState: StateType, Equatable {
     private static func handleInitializeAction(state: Self, action: Action) -> Self {
         let model = (action as? MicrosurveyPromptMiddlewareAction)?.microsurveyModel
         return state
+            .resetTransientState()
             .copy(showPrompt: true)
-            .copy(showSurvey: false)
             .copy(model: model)
     }
 
     private static func handleClosePromptAction(state: Self) -> Self {
         return state
+            .resetTransientState()
             .copy(showPrompt: false)
-            .copy(showSurvey: false)
     }
 
     private static func handleContinueToSurveyAction(state: Self) -> Self {
         return state
+            .resetTransientState()
             .copy(showPrompt: true)
             .copy(showSurvey: true)
     }

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/MicrosurveyState.swift
@@ -61,11 +61,11 @@ struct MicrosurveyState: ScreenState {
         switch action.actionType {
         case MicrosurveyActionType.closeSurvey:
             return state
+                .resetTransientState()
                 .copy(shouldDismiss: true)
-                .copy(showPrivacy: false)
         case MicrosurveyActionType.tapPrivacyNotice:
             return state
-                .copy(shouldDismiss: false)
+                .resetTransientState()
                 .copy(showPrivacy: true)
         default:
             return defaultState(from: state)

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageState.swift
@@ -27,10 +27,11 @@ struct NativeErrorPageState: ScreenState {
         )
     }
 
-    init(
-        windowUUID: WindowUUID,
-        model: ErrorPageModel? = nil
-    ) {
+    init(windowUUID: WindowUUID) {
+        self.init(windowUUID: windowUUID, model: nil)
+    }
+
+    init(windowUUID: WindowUUID, model: ErrorPageModel?) {
         self.windowUUID = windowUUID
         self.model = model
     }

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorState.swift
@@ -30,11 +30,11 @@ struct PasswordGeneratorState: ScreenState {
         )
     }
 
-    init(
-        windowUUID: WindowUUID,
-        password: String = "",
-        passwordHidden: Bool = false
-    ) {
+    init(windowUUID: WindowUUID) {
+        self.init(windowUUID: windowUUID, password: "", passwordHidden: false)
+    }
+
+    init(windowUUID: WindowUUID, password: String, passwordHidden: Bool) {
         self.windowUUID = windowUUID
         self.password = password
         self.passwordHidden = passwordHidden

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsState.swift
@@ -67,12 +67,12 @@ struct TranslationSettingsState: ScreenState, Equatable {
 
     init(windowUUID: WindowUUID,
          isTranslationsEnabled: Bool,
-         isAutoTranslateEnabled: Bool = false,
-         isEditing: Bool = false,
-         pendingLanguages: [PreferredLanguageDetails]? = nil,
+         isAutoTranslateEnabled: Bool,
+         isEditing: Bool,
+         pendingLanguages: [PreferredLanguageDetails]?,
          preferredLanguages: [PreferredLanguageDetails],
          supportedLanguages: [String],
-         availableLanguages: [String] = []) {
+         availableLanguages: [String]) {
         self.windowUUID = windowUUID
         self.isTranslationsEnabled = isTranslationsEnabled
         self.isAutoTranslateEnabled = isAutoTranslateEnabled

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsState.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationSettingsState.swift
@@ -172,14 +172,4 @@ struct TranslationSettingsState: ScreenState, Equatable {
             availableLanguages: state.availableLanguages
         )
     }
-
-    static func == (lhs: TranslationSettingsState, rhs: TranslationSettingsState) -> Bool {
-        return lhs.isTranslationsEnabled == rhs.isTranslationsEnabled
-            && lhs.isAutoTranslateEnabled == rhs.isAutoTranslateEnabled
-            && lhs.isEditing == rhs.isEditing
-            && lhs.pendingLanguages == rhs.pendingLanguages
-            && lhs.preferredLanguages == rhs.preferredLanguages
-            && lhs.supportedLanguages == rhs.supportedLanguages
-            && lhs.availableLanguages == rhs.availableLanguages
-    }
 }

--- a/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptState.swift
+++ b/firefox-ios/Client/Frontend/Translations/AutoTranslatePromptState.swift
@@ -5,7 +5,9 @@
 import Foundation
 import Redux
 import Common
+import ModifiedCopy
 
+@Copyable
 struct AutoTranslatePromptState: StateType, Equatable {
     var windowUUID: WindowUUID
     var showPrompt: Bool
@@ -33,10 +35,10 @@ struct AutoTranslatePromptState: StateType, Equatable {
 
         switch action.actionType {
         case TranslationsActionType.showAutoTranslatePrompt:
-            return AutoTranslatePromptState(windowUUID: state.windowUUID, showPrompt: true)
+            return state.copy(showPrompt: true)
         case TranslationsActionType.didTapEnableAutoTranslate,
              TranslationsActionType.didDismissAutoTranslatePrompt:
-            return AutoTranslatePromptState(windowUUID: state.windowUUID, showPrompt: false)
+            return state.copy(showPrompt: false)
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AI Controls/AIControlsModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/AI Controls/AIControlsModelTests.swift
@@ -370,14 +370,7 @@ class AIControlsModelTests: XCTestCase, StoreTestUtility {
             presentedComponents: PresentedComponentsState(
                 components: [
                     .translationSettings(
-                        TranslationSettingsState(
-                            windowUUID: .XCTestDefaultUUID,
-                            isTranslationsEnabled: true,
-                            isEditing: false,
-                            pendingLanguages: nil,
-                            preferredLanguages: [],
-                            supportedLanguages: []
-                        )
+                        TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
                     )
                 ]
             )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationPickerSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationPickerSettingsViewControllerTests.swift
@@ -36,26 +36,19 @@ final class TranslationPickerSettingsViewControllerTests: XCTestCase, StoreTestU
     func test_newState_withTranslationsEnabled_doesNotCrash() {
         let subject = createSubject()
         subject.loadViewIfNeeded()
-        subject.newState(state: TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            preferredLanguages: [
+        subject.newState(state: TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(preferredLanguages: [
                 PreferredLanguageDetails(code: "en", mainText: "English", subtitleText: "Device Language"),
                 PreferredLanguageDetails(code: "fr", mainText: "français", subtitleText: "French")
-            ],
-            supportedLanguages: ["en", "fr", "de"]
-        ))
+            ])
+            .copy(supportedLanguages: ["en", "fr", "de"]))
     }
 
     func test_newState_withTranslationsDisabled_doesNotCrash() {
         let subject = createSubject()
         subject.loadViewIfNeeded()
-        subject.newState(state: TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: false,
-            preferredLanguages: [],
-            supportedLanguages: []
-        ))
+        subject.newState(state: TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isTranslationsEnabled: false))
     }
 
     // MARK: - collectionView delegate

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsDiffableDataSourceTests.swift
@@ -83,12 +83,9 @@ final class TranslationSettingsDiffableDataSourceTests: XCTestCase {
             PreferredLanguageDetails(code: "en", mainText: "English", subtitleText: "Device Language"),
             PreferredLanguageDetails(code: "fr", mainText: "français", subtitleText: "French")
         ]
-        let state = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            preferredLanguages: details,
-            supportedLanguages: ["en", "fr"]
-        )
+        let state = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(preferredLanguages: details)
+            .copy(supportedLanguages: ["en", "fr"])
 
         subject.applySnapshot(state: state, animated: false)
 
@@ -107,11 +104,9 @@ final class TranslationSettingsDiffableDataSourceTests: XCTestCase {
 
     private func makeState(isEnabled: Bool, languages: [String]) -> TranslationSettingsState {
         let details = languages.map { PreferredLanguageDetails(code: $0, mainText: $0, subtitleText: nil) }
-        return TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: isEnabled,
-            preferredLanguages: details,
-            supportedLanguages: languages
-        )
+        return TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isTranslationsEnabled: isEnabled)
+            .copy(preferredLanguages: details)
+            .copy(supportedLanguages: languages)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsMiddlewareTests.swift
@@ -458,14 +458,11 @@ final class TranslationSettingsMiddlewareTests: XCTestCase, StoreTestUtility {
             presentedComponents: PresentedComponentsState(
                 components: [
                     .translationSettings(
-                        TranslationSettingsState(
-                            windowUUID: .XCTestDefaultUUID,
-                            isTranslationsEnabled: true,
-                            isEditing: isEditing,
-                            pendingLanguages: pendingLanguages,
-                            preferredLanguages: preferredLanguages,
-                            supportedLanguages: ["en", "fr", "de"]
-                        )
+                        TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+                            .copy(isEditing: isEditing)
+                            .copy(pendingLanguages: pendingLanguages)
+                            .copy(preferredLanguages: preferredLanguages)
+                            .copy(supportedLanguages: ["en", "fr", "de"])
                     )
                 ]
             )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/TranslationSettingsStateTests.swift
@@ -23,12 +23,10 @@ final class TranslationSettingsStateTests: XCTestCase {
 
     func test_initWithAllParameters_returnsConfiguredState() {
         let languages = makeLanguages(["en", "fr"])
-        let subject = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: false,
-            preferredLanguages: languages,
-            supportedLanguages: ["en", "fr", "de"]
-        )
+        let subject = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isTranslationsEnabled: false)
+            .copy(preferredLanguages: languages)
+            .copy(supportedLanguages: ["en", "fr", "de"])
 
         XCTAssertEqual(subject.windowUUID, .XCTestDefaultUUID)
         XCTAssertFalse(subject.isTranslationsEnabled)
@@ -60,12 +58,10 @@ final class TranslationSettingsStateTests: XCTestCase {
 
     func test_didLoadSettings_withNilValues_preservesExistingState() {
         let languages = makeLanguages(["en"])
-        let initialState = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: false,
-            preferredLanguages: languages,
-            supportedLanguages: ["en", "de"]
-        )
+        let initialState = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isTranslationsEnabled: false)
+            .copy(preferredLanguages: languages)
+            .copy(supportedLanguages: ["en", "de"])
         let reducer = translationSettingsReducer()
 
         let action = TranslationSettingsMiddlewareAction(
@@ -98,13 +94,8 @@ final class TranslationSettingsStateTests: XCTestCase {
     }
 
     func test_reduceMiddlewareAction_didLoadSettings_preservesAutoTranslate_whenNil() {
-        let initialState = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            isAutoTranslateEnabled: true,
-            preferredLanguages: [],
-            supportedLanguages: []
-        )
+        let initialState = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isAutoTranslateEnabled: true)
         let reducer = translationSettingsReducer()
 
         let action = TranslationSettingsMiddlewareAction(
@@ -121,12 +112,8 @@ final class TranslationSettingsStateTests: XCTestCase {
 
     func test_enterEditMode_setsIsEditingAndCopiesPreferredToPending() {
         let languages = makeLanguages(["en", "fr"])
-        let initialState = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            preferredLanguages: languages,
-            supportedLanguages: []
-        )
+        let initialState = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(preferredLanguages: languages)
         let reducer = translationSettingsReducer()
 
         let action = TranslationSettingsViewAction(
@@ -144,14 +131,10 @@ final class TranslationSettingsStateTests: XCTestCase {
     // MARK: - Reducer Tests - cancelEditMode
 
     func test_cancelEditMode_clearsIsEditingAndPendingLanguages() {
-        let initialState = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            isEditing: true,
-            pendingLanguages: makeLanguages(["fr"]),
-            preferredLanguages: makeLanguages(["en", "fr"]),
-            supportedLanguages: []
-        )
+        let initialState = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isEditing: true)
+            .copy(pendingLanguages: makeLanguages(["fr"]))
+            .copy(preferredLanguages: makeLanguages(["en", "fr"]))
         let reducer = translationSettingsReducer()
 
         let action = TranslationSettingsViewAction(
@@ -169,14 +152,10 @@ final class TranslationSettingsStateTests: XCTestCase {
     // MARK: - Reducer Tests - reorderLanguages
 
     func test_reorderLanguages_updatesPendingLanguagesWithNewOrder() {
-        let initialState = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            isEditing: true,
-            pendingLanguages: makeLanguages(["en", "fr"]),
-            preferredLanguages: makeLanguages(["en", "fr"]),
-            supportedLanguages: []
-        )
+        let initialState = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isEditing: true)
+            .copy(pendingLanguages: makeLanguages(["en", "fr"]))
+            .copy(preferredLanguages: makeLanguages(["en", "fr"]))
         let reordered = makeLanguages(["fr", "en"])
         let reducer = translationSettingsReducer()
 
@@ -195,14 +174,10 @@ final class TranslationSettingsStateTests: XCTestCase {
     // MARK: - Reducer Tests - removeLanguage
 
     func test_removeLanguage_removesFromPendingLanguages() {
-        let initialState = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            isEditing: true,
-            pendingLanguages: makeLanguages(["en", "fr", "de"]),
-            preferredLanguages: makeLanguages(["en", "fr", "de"]),
-            supportedLanguages: []
-        )
+        let initialState = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isEditing: true)
+            .copy(pendingLanguages: makeLanguages(["en", "fr", "de"]))
+            .copy(preferredLanguages: makeLanguages(["en", "fr", "de"]))
         let reducer = translationSettingsReducer()
 
         let action = TranslationSettingsViewAction(
@@ -218,13 +193,9 @@ final class TranslationSettingsStateTests: XCTestCase {
     }
 
     func test_removeLanguage_whenNoPending_removesFromPreferred() {
-        let initialState = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            isEditing: true,
-            preferredLanguages: makeLanguages(["en", "fr"]),
-            supportedLanguages: []
-        )
+        let initialState = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isEditing: true)
+            .copy(preferredLanguages: makeLanguages(["en", "fr"]))
         let reducer = translationSettingsReducer()
 
         let action = TranslationSettingsViewAction(
@@ -259,12 +230,9 @@ final class TranslationSettingsStateTests: XCTestCase {
 
     func test_didUpdateSettings_preservesLanguagesWhenNil() {
         let languages = makeLanguages(["en", "fr"])
-        let initialState = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            preferredLanguages: languages,
-            supportedLanguages: ["en", "fr", "de"]
-        )
+        let initialState = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(preferredLanguages: languages)
+            .copy(supportedLanguages: ["en", "fr", "de"])
         let reducer = translationSettingsReducer()
 
         let action = TranslationSettingsMiddlewareAction(
@@ -285,12 +253,8 @@ final class TranslationSettingsStateTests: XCTestCase {
     /// FXIOS-15120: the settings reducer reacts to the same `TranslationsAction` the toolbar listens
     /// to, so the toggle flow only needs a single dispatch.
     func test_didTranslationSettingsChange_updatesTranslationsEnabledFromAction() {
-        let initialState = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: false,
-            preferredLanguages: [],
-            supportedLanguages: []
-        )
+        let initialState = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isTranslationsEnabled: false)
         let reducer = translationSettingsReducer()
 
         let action = TranslationsAction(
@@ -308,54 +272,36 @@ final class TranslationSettingsStateTests: XCTestCase {
 
     func test_equality_sameValues_returnsTrue() {
         let languages = makeLanguages(["en"])
-        let state1 = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            preferredLanguages: languages,
-            supportedLanguages: ["en", "fr"]
-        )
-        let state2 = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            preferredLanguages: languages,
-            supportedLanguages: ["en", "fr"]
-        )
+        let state1 = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(preferredLanguages: languages)
+            .copy(supportedLanguages: ["en", "fr"])
+        let state2 = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(preferredLanguages: languages)
+            .copy(supportedLanguages: ["en", "fr"])
 
         XCTAssertEqual(state1, state2)
     }
 
     func test_equality_differentIsTranslationsEnabled_returnsFalse() {
         let state1 = createSubject()
-        let state2 = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: false,
-            preferredLanguages: [],
-            supportedLanguages: []
-        )
+        let state2 = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(isTranslationsEnabled: false)
 
         XCTAssertNotEqual(state1, state2)
     }
 
     func test_equality_differentPreferredLanguages_returnsFalse() {
         let state1 = createSubject()
-        let state2 = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            preferredLanguages: makeLanguages(["en"]),
-            supportedLanguages: []
-        )
+        let state2 = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(preferredLanguages: makeLanguages(["en"]))
 
         XCTAssertNotEqual(state1, state2)
     }
 
     func test_equality_differentSupportedLanguages_returnsFalse() {
         let state1 = createSubject()
-        let state2 = TranslationSettingsState(
-            windowUUID: .XCTestDefaultUUID,
-            isTranslationsEnabled: true,
-            preferredLanguages: [],
-            supportedLanguages: ["en"]
-        )
+        let state2 = TranslationSettingsState(windowUUID: .XCTestDefaultUUID)
+            .copy(supportedLanguages: ["en"])
 
         XCTAssertNotEqual(state1, state2)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -1283,6 +1283,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
             canShowNavigationHint: toolbarState.canShowNavigationHint,
             shouldAnimate: toolbarState.shouldAnimate,
             isTranslucent: toolbarState.isTranslucent,
+            isTranslationsEnabled: toolbarState.isTranslationsEnabled,
             previousTabScreenshot: toolbarState.previousTabScreenshot,
             nextTabScreenshot: toolbarState.nextTabScreenshot)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -386,6 +386,7 @@ final class AddressToolbarContainerModelTests: XCTestCase {
                             canShowNavigationHint: false,
                             shouldAnimate: false,
                             isTranslucent: false,
+                            isTranslationsEnabled: true,
                             previousTabScreenshot: nil,
                             nextTabScreenshot: nil)
     }
@@ -408,6 +409,7 @@ final class AddressToolbarContainerModelTests: XCTestCase {
                             canShowNavigationHint: false,
                             shouldAnimate: false,
                             isTranslucent: false,
+                            isTranslationsEnabled: true,
                             previousTabScreenshot: nil,
                             nextTabScreenshot: nil)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -1540,6 +1540,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
                             canShowNavigationHint: false,
                             shouldAnimate: true,
                             isTranslucent: false,
+                            isTranslationsEnabled: true,
                             previousTabScreenshot: nil,
                             nextTabScreenshot: nil
                         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16561)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35181)

## :bulb: Description
This PR covers `MicrosurveyState`, `AutoTranslatePromptState`, `MicrosurveyPromptState`, `NativeErrorPageState`, `PasswordGeneratorState`, `TranslationSettingsState`, and `ToolbarState`. Adds `@Copyable` where missing, removes default parameter values from designated inits (or splits a combined blank/memberwise init into two where one was doing double duty), and replaces manual per-branch transient-state resets with `resetTransientState()` where applicable in accordance with [ADR 0013](https://github.com/mozilla-mobile/firefox-ios/blob/main/adr/0013-redux-state-reducers-best-practices-initialization-and-transient-state.md). Updates ~25 test call sites across 8 files accordingly.

I tested the all appropriate test files to make sure I did not introduce a regression. I would also watch out if anything fails on bitrise

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

