### PR TITLE
Refactor FXIOS-13248 [Default page zoom setting][Accessibility] Fix Specific Sites list for Dynamic Text

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Zoom/ZoomSiteListView.swift
@@ -9,6 +9,7 @@ import Storage
 struct ZoomSiteListView: View {
     let theme: Theme
     @Binding var domainZoomLevels: [DomainZoomLevel]
+    @State private var measuredListHeight: CGFloat = 0
     private let onDelete: (IndexSet) -> Void
     private let resetDomain: () -> Void
 
@@ -21,6 +22,17 @@ struct ZoomSiteListView: View {
         static let dividerHeight: CGFloat = 0.5
         static let cornerRadius: CGFloat = 24
     }
+
+    private struct ListHeightPreferenceKey: PreferenceKey {
+        static let defaultValue: CGFloat = 0
+
+        static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+            value += nextValue()
+        }
+    }
+
+    @ScaledMetric(relativeTo: .body)
+    private var fallbackRowHeight: CGFloat = UX.cellHeight + UX.listPadding
 
     var cellBackground: Color {
         return theme.colors.layer5.color
@@ -38,13 +50,12 @@ struct ZoomSiteListView: View {
         }
     }
 
-    // Calculate list height to avoid scroll in inner list view
-    // Base height calculation with cell height and extra padding
     var listViewHeight: CGFloat {
-        let baseHeight = CGFloat(domainZoomLevels.count) * UX.cellHeight
-        let extraPadding = CGFloat(domainZoomLevels.count) * UX.listPadding
+        if measuredListHeight > 0 {
+            return measuredListHeight
+        }
 
-        return baseHeight + extraPadding
+        return CGFloat(domainZoomLevels.count) * fallbackRowHeight
     }
 
     init(theme: Theme,
@@ -107,6 +118,15 @@ struct ZoomSiteListView: View {
             ForEach(domainZoomLevels, id: \.host) { zoomItem in
                 ZoomLevelCellView(domainZoomLevel: zoomItem,
                                   textColor: theme.colors.textPrimary.color)
+                .background {
+                    GeometryReader { geometry in
+                        Color.clear
+                            .preference(
+                                key: ListHeightPreferenceKey.self,
+                                value: geometry.size.height
+                            )
+                    }
+                }
                 .listRowBackground(cellBackground)
                 .listRowInsets(EdgeInsets())
                 .modifier(CellStyle(theme: theme))
@@ -116,6 +136,11 @@ struct ZoomSiteListView: View {
         .frame(height: listViewHeight)
         .listStyle(.plain)
         .modifier(ListStyle(theme: theme, cellBackground: cellBackground))
+        .onPreferenceChange(ListHeightPreferenceKey.self) { height in
+            guard height > 0 else { return }
+
+            measuredListHeight = height
+        }
     }
 
     private struct CellStyle: ViewModifier {
@@ -138,7 +163,12 @@ struct ZoomSiteListView: View {
         func body(content: Content) -> some View {
             if #available(iOS 26.0, *) {
                 content
-                    .modifier(SectionStyle(theme: theme, cornerRadius: UX.cornerRadius))
+                    .modifier(
+                        SectionStyle(
+                            theme: theme,
+                            cornerRadius: UX.cornerRadius
+                        )
+                    )
             } else {
                 content
                     .background(cellBackground)
@@ -153,7 +183,12 @@ struct ZoomSiteListView: View {
             if #available(iOS 26.0, *) {
                 content
                     .frame(maxWidth: .infinity)
-                    .modifier(SectionStyle(theme: theme, cornerRadius: UX.cornerRadius))
+                    .modifier(
+                        SectionStyle(
+                            theme: theme,
+                            cornerRadius: UX.cornerRadius
+                        )
+                    )
             } else {
                 content
                     .background(theme?.colors.layer5.color)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13248)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28817)

## :bulb: Description
- Fixes the Page Zoom specific sites list height when using larger Dynamic Type sizes
- Instead of relying on a fixed row height, the list now measures the rendered cell heights and adjusts its size accordingly
- This prevents rows from being clipped while also avoiding unnecessary empty space on larger screens
- Tested with text size to the max on iPhone 17 Pro and iPad Pro (M5)

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>iPhone Demo</summary>

### Before

https://github.com/user-attachments/assets/c2574159-ef28-422d-9d5d-061278030d72

### After

https://github.com/user-attachments/assets/9930669a-c754-4b79-8912-7b1c7031e6b1

</details>

<details>
<summary>iPad Pro Demo</summary>

### Before


https://github.com/user-attachments/assets/2d36a92b-b7a6-410c-a1c5-afc87bdf8a17


### After

<img width="643" height="905" alt="Screenshot 2026-08-15 at 1 56 28 PM" src="https://github.com/user-attachments/assets/55c089f1-82bb-4b8f-833b-05012c1657f3" />


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

