### PR TITLE
BugFix FXIOS-12799 [Homepage] Status bar overlay disappears when menu opens

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -563,6 +563,10 @@ final class BrowserCoordinator: BaseCoordinator,
         mainMenuCoordinator.startWithNavController()
     }
 
+    func mainMenuDidDismiss() {
+        browserViewController.refreshStatusBarOverlay()
+    }
+
     func openURLInNewTab(_ url: URL?) {
         if let url {
             browserViewController.openURLInNewTab(url, isPrivate: self.tabManager.selectedTab?.isPrivate ?? false)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3922,6 +3922,12 @@ class BrowserViewController: UIViewController,
         return themeManager.getCurrentTheme(for: windowUUID)
     }
 
+    /// Recomputes the status bar overlay's visible state without resetting the user's scroll position.
+    /// Call after presenting/dismissing UI that may have left it stale (e.g. the main menu).
+    func refreshStatusBarOverlay() {
+        statusBarOverlay.refresh()
+    }
+
     func applyTheme() {
         let currentTheme = currentTheme()
         statusBarOverlay.hasTopTabs = toolbarHelper.shouldShowTopTabs(for: traitCollection)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -47,6 +47,10 @@ protocol MainMenuCoordinatorDelegate: AnyObject {
 
     @MainActor
     func showSummarizePanel(_ trigger: SummarizerTrigger, config: SummarizerConfig?)
+
+    /// Called after the main menu has been dismissed, however it was closed.
+    @MainActor
+    func mainMenuDidDismiss()
 }
 
 class MainMenuCoordinator: BaseCoordinator {
@@ -98,6 +102,7 @@ class MainMenuCoordinator: BaseCoordinator {
     func dismissMenuModal(animated: Bool) {
         router.dismiss(animated: animated, completion: nil)
         removeCoordinatorFromParent()
+        navigationHandler?.mainMenuDidDismiss()
     }
 
     func navigateTo(_ destination: MenuNavigationDestination, animated: Bool) {
@@ -107,6 +112,7 @@ class MainMenuCoordinator: BaseCoordinator {
             self.handleDestination(destination)
 
             removeCoordinatorFromParent()
+            navigationHandler?.mainMenuDidDismiss()
         })
     }
 

--- a/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
@@ -85,6 +85,14 @@ final class StatusBarOverlay: UIView,
         updateStatusBarAlpha(isHomepage: isHomepage, needsNoStatusBar: needsNoStatusBar)
     }
 
+    /// Recomputes the overlay's alpha from the current `scrollOffset`, without resetting it.
+    /// Use for ambient state changes (wallpaper, search bar position) on the same content —
+    /// unlike `resetState`, which assumes new content and forces the scroll position back to the top.
+    func refresh() {
+        let isHomepage = savedIsHomepage ?? false
+        updateStatusBarAlpha(isHomepage: isHomepage, needsNoStatusBar: needsNoStatusBar(isHomepage: isHomepage))
+    }
+
     func showOverlay(animated: Bool) {
         guard animated else {
             scrollDelegate?.homepageScrollViewDidScroll(scrollOffset: 1.0)
@@ -188,7 +196,7 @@ final class StatusBarOverlay: UIView,
         switch notification.name {
         case .WallpaperDidChange, .SearchBarPositionDidChange:
             ensureMainThread {
-                self.resetState(isHomepage: self.savedIsHomepage ?? false)
+                self.refresh()
             }
         default: break
         }

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -353,15 +353,12 @@ final class HomepageViewController: UIViewController,
     private func handleScroll(_ scrollView: UIScrollView, isUserInteraction: Bool) {
         updateNewsTransitionHeaderProgress()
 
-        // We only handle status bar overlay alpha if there's a wallpaper applied on the homepage
-        if homepageState.wallpaperState.wallpaperConfiguration.hasImage {
-            let theme = themeManager.getCurrentTheme(for: windowUUID)
-            statusBarScrollDelegate?.scrollViewDidScroll(
-                scrollView,
-                statusBarFrame: statusBarFrame,
-                theme: theme
-            )
-        }
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        statusBarScrollDelegate?.scrollViewDidScroll(
+            scrollView,
+            statusBarFrame: statusBarFrame,
+            theme: theme
+        )
 
         // We only want to proceed if content exceeds the frame (aka scrollable),
         // otherwise we will spamming the redux action (GeneralBrowserMiddlewareAction) below

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1481,6 +1481,22 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertTrue(subject.childCoordinators.isEmpty)
     }
 
+    func testMainMenuDidDismiss_refreshesStatusBarOverlay() {
+        let subject = createSubject()
+        subject.browserViewController = browserViewController
+        subject.browserHasLoaded()
+
+        subject.showMainMenu()
+        guard let menuCoordinator = subject.childCoordinators[0] as? MainMenuCoordinator else {
+            XCTFail("Main menu coordinator was expected to be resolved")
+            return
+        }
+
+        menuCoordinator.dismissMenuModal(animated: false)
+
+        XCTAssertEqual(browserViewController.refreshStatusBarOverlayCalled, 1)
+    }
+
     // MARK: - Search Engine Selection
     func testShowSearchEngineSelection_addsSearchEngineSelectionCoordinator() {
         let subject = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
@@ -80,6 +80,18 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStatusBarScrollDelegate.savedScrollView, scrollView)
     }
 
+    func test_scrollViewDidScroll_withoutWallpaper_stillUpdatesStatusBarScrollDelegate() {
+        let mockStatusBarScrollDelegate = MockStatusBarScrollDelegate()
+        let homepageVC = createSubject(statusBarScrollDelegate: mockStatusBarScrollDelegate)
+        let scrollView = UIScrollView()
+
+        mockStatusBarScrollDelegate.savedScrollView = nil
+
+        homepageVC.scrollViewDidScroll(scrollView)
+
+        XCTAssertEqual(mockStatusBarScrollDelegate.savedScrollView, scrollView)
+    }
+
     func test_scrollToTop_updatesStatusBarScrollDelegate_andSetsCollectionViewOffset() {
         let mockStatusBarScrollDelegate = MockStatusBarScrollDelegate()
         let homepageVC = createSubject(statusBarScrollDelegate: mockStatusBarScrollDelegate)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuCoordinatorTests.swift
@@ -49,6 +49,28 @@ final class MainMenuCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockRouter.dismissCalled, 1)
     }
 
+    func testDismissMenuModal_callsDelegateMainMenuDidDismiss() {
+        let subject = createSubject()
+        let mockDelegate = MockMainMenuCoordinatorDelegate()
+        subject.navigationHandler = mockDelegate
+
+        subject.start()
+        subject.dismissMenuModal(animated: false)
+
+        XCTAssertEqual(mockDelegate.mainMenuDidDismissCalled, 1)
+    }
+
+    func testNavigateTo_callsDelegateMainMenuDidDismiss() {
+        let subject = createSubject()
+        let mockDelegate = MockMainMenuCoordinatorDelegate()
+        subject.navigationHandler = mockDelegate
+
+        subject.navigateTo(MenuNavigationDestination(.readerView), animated: false)
+        mockRouter.savedCompletion?()
+
+        XCTAssertEqual(mockDelegate.mainMenuDidDismissCalled, 1)
+    }
+
     func testHandleNavigation_translatePage_dismissesMenu() {
         let subject = createSubject()
         subject.start()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -44,6 +44,8 @@ class MockBrowserViewController: BrowserViewController {
     var frontEmbeddedContentCalled = 0
     var saveEmbeddedContent: ContentContainable?
 
+    var refreshStatusBarOverlayCalled = 0
+
     var didRequestToOpenInNewTabCalled = false
     var didSelectURLCalled = false
     var lastOpenedURL: URL?
@@ -145,6 +147,10 @@ class MockBrowserViewController: BrowserViewController {
     override func frontEmbeddedContent(_ viewController: ContentContainable) {
         frontEmbeddedContentCalled += 1
         saveEmbeddedContent = viewController
+    }
+
+    override func refreshStatusBarOverlay() {
+        refreshStatusBarOverlayCalled += 1
     }
 
     override func libraryPanelDidRequestToOpenInNewTab(_ url: URL, isPrivate: Bool) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockMainMenuCoordinatorDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockMainMenuCoordinatorDelegate.swift
@@ -21,6 +21,7 @@ class MockMainMenuCoordinatorDelegate: MainMenuCoordinatorDelegate {
     private(set) var showShareSheetForCurrentlySelectedTabCalled = 0
     private(set) var showSummarizePanelCalled = 0
     private(set) var showSummarizePanelTrigger: SummarizerTrigger?
+    private(set) var mainMenuDidDismissCalled = 0
 
     func editBookmarkForCurrentTab() {
         editBookmarkForCurrentTabCalled += 1
@@ -74,5 +75,9 @@ class MockMainMenuCoordinatorDelegate: MainMenuCoordinatorDelegate {
     func showSummarizePanel(_ trigger: SummarizerTrigger, config: SummarizerConfig?) {
         showSummarizePanelCalled += 1
         showSummarizePanelTrigger = trigger
+    }
+
+    func mainMenuDidDismiss() {
+        mainMenuDidDismissCalled += 1
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StatusBarOverlayTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StatusBarOverlayTests.swift
@@ -378,7 +378,74 @@ final class StatusBarOverlayTests: XCTestCase {
         XCTAssertEqual(backgroundColor.cgColor, LightTheme().colors.layerSurfaceLow.cgColor)
     }
 
+    // MARK: Refresh (non-destructive)
+
+    func testRefresh_preservesScrollOffset() throws {
+        let toolbarHelper = createToolbarMock()
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        subject.resetState(isHomepage: true)
+        scroll(subject, toOffsetRatio: 0.5)
+        XCTAssertEqual(subject.scrollOffset, 0.5, accuracy: 0.001)
+
+        subject.refresh()
+
+        XCTAssertEqual(subject.scrollOffset, 0.5, accuracy: 0.001)
+    }
+
+    func testResetState_discardsScrollOffset() throws {
+        let toolbarHelper = createToolbarMock()
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        subject.resetState(isHomepage: true)
+        scroll(subject, toOffsetRatio: 0.5)
+        XCTAssertEqual(subject.scrollOffset, 0.5, accuracy: 0.001)
+
+        subject.resetState(isHomepage: true)
+
+        XCTAssertEqual(subject.scrollOffset, 0)
+    }
+
+    // MARK: Notification handling
+
+    func testHandleNotifications_searchBarPositionDidChange_preservesScrollOffset() throws {
+        let toolbarHelper = createToolbarMock()
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        notificationCenter.notifiableListener = subject
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        subject.resetState(isHomepage: true)
+        scroll(subject, toOffsetRatio: 0.5)
+        XCTAssertEqual(subject.scrollOffset, 0.5, accuracy: 0.001)
+
+        notificationCenter.post(name: .SearchBarPositionDidChange, withObject: nil, withUserInfo: nil)
+
+        XCTAssertEqual(subject.scrollOffset, 0.5, accuracy: 0.001)
+    }
+
+    func testHandleNotifications_wallpaperDidChange_preservesScrollOffset() throws {
+        let toolbarHelper = createToolbarMock()
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        notificationCenter.notifiableListener = subject
+        profile.prefs.setString("bottom", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        subject.resetState(isHomepage: true)
+        scroll(subject, toOffsetRatio: 0.5)
+        XCTAssertEqual(subject.scrollOffset, 0.5, accuracy: 0.001)
+
+        notificationCenter.post(name: .WallpaperDidChange, withObject: nil, withUserInfo: nil)
+
+        XCTAssertEqual(subject.scrollOffset, 0.5, accuracy: 0.001)
+    }
+
     // MARK: Helper
+
+    private func scroll(_ subject: StatusBarOverlay, toOffsetRatio ratio: CGFloat) {
+        let statusBarHeight: CGFloat = 20
+        let scrollView = UIScrollView()
+        scrollView.contentOffset = CGPoint(x: 0, y: statusBarHeight * ratio)
+        subject.scrollViewDidScroll(scrollView,
+                                    statusBarFrame: CGRect(x: 0, y: 0, width: 100, height: statusBarHeight),
+                                    theme: LightTheme())
+    }
 
     private func createSubject(hasTopTabs: Bool = false,
                                toolbarHelper: ToolbarHelperInterface = ToolbarHelper()) -> StatusBarOverlay {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12799)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27882)

## :bulb: Description
**Repro:** on homepage, scroll so the status bar overlay is visible, tap the menu button. The overlay goes translucent/disappears and never comes back after the menu closes.

**Root cause:** `StatusBarOverlay.resetState(isHomepage:)` is destructive — it unconditionally forces `scrollOffset` back to 0 or 1. It gets invoked from `handleNotifications` for `.WallpaperDidChange`/`.SearchBarPositionDidChange`, discarding wherever the user had actually scrolled to. Nothing in the main menu's dismiss path (`MainMenuCoordinator.dismissMenuModal`/`navigateTo`) restored the overlay afterward. Separately, `HomepageViewController.handleScroll` only forwarded scroll events to the status bar delegate when a wallpaper was set, so once the overlay dropped there was no way back for it in the (increasingly common) no-wallpaper + glass-effect toolbar configuration.

**Fix:**
- Split `StatusBarOverlay.resetState()` (destructive, kept for genuinely new content via `embedContent`/`frontEmbeddedContent`) from a new non-destructive `refresh()` that recomputes alpha from the *current* `scrollOffset`. `handleNotifications` now calls `refresh()` instead of `resetState()`.
- Removed the stale wallpaper-only gate in `HomepageViewController.handleScroll` — `StatusBarOverlay.needsNoStatusBar` already accounts for wallpaper state, so `HomepageViewController` shouldn't duplicate that decision.
- Added `MainMenuCoordinatorDelegate.mainMenuDidDismiss()` (mirroring the existing `didFinishSettings(from:)`/`didFinishEnhancedTrackingProtection(from:)` pattern), called from both menu dismiss paths, wired through `BrowserCoordinator` to a new `BrowserViewController.refreshStatusBarOverlay()` — a defensive belt-and-suspenders restore on menu close, regardless of trigger.

## :movie_camera: Demos
_N/A - internal state-management fix, no UI changes._

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code