### PR TITLE
Bugfix FXIOS-16486 [WebCompat] Fix the URL field label and alignment

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
@@ -13,7 +13,6 @@ final class WebCompatURLCell: UICollectionViewListCell,
                               UITextFieldDelegate,
                               Notifiable {
     private var editingEndedHandler: ((String) -> Void)?
-    private var placeholder = ""
 
     private lazy var titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.body.scaledFont()
@@ -83,18 +82,15 @@ final class WebCompatURLCell: UICollectionViewListCell,
     func applyStackLayout(isAccessibilityCategory: Bool) {
         stackView.axis = isAccessibilityCategory ? .vertical : .horizontal
         stackView.alignment = isAccessibilityCategory ? .fill : .center
-        textField.textAlignment = isAccessibilityCategory ? .natural : .right
     }
 
     func configure(
         title: String,
         text: String,
-        placeholder: String,
         a11yIdentifier: String,
         onEditingEnded: @escaping (String) -> Void
     ) {
         editingEndedHandler = onEditingEnded
-        self.placeholder = placeholder
         titleLabel.text = title
         textField.accessibilityIdentifier = a11yIdentifier
         // The field is the accessibility element; carry the label onto it so
@@ -115,10 +111,6 @@ final class WebCompatURLCell: UICollectionViewListCell,
         titleLabel.textColor = theme.colors.textSecondary
         textField.textColor = theme.colors.textPrimary
         textField.tintColor = theme.colors.actionPrimary
-        textField.attributedPlaceholder = NSAttributedString(
-            string: placeholder,
-            attributes: [.foregroundColor: theme.colors.textSecondary]
-        )
     }
 
     // MARK: - Notifiable

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
@@ -5,8 +5,6 @@
 import Common
 import UIKit
 
-/// Editable URL row: leading label + single-line field, stacking vertically at
-/// accessibility sizes. Reports the typed value on editing-end, not per keystroke.
 final class WebCompatURLCell: UICollectionViewListCell,
                               ThemeApplicable,
                               ReusableCell,
@@ -28,7 +26,6 @@ final class WebCompatURLCell: UICollectionViewListCell,
         field.keyboardType = .URL
         field.autocapitalizationType = .none
         field.autocorrectionType = .no
-        // Native clear button carries a system-localized accessibility label for free.
         field.clearButtonMode = .whileEditing
         field.returnKeyType = .done
         field.delegate = self
@@ -57,7 +54,7 @@ final class WebCompatURLCell: UICollectionViewListCell,
         stackView.addArrangedSubview(textField)
         contentView.addSubview(stackView)
         let margins = contentView.layoutMarginsGuide
-        // .defaultHigh (not required) avoids the self-sizing vs. min-height constraint conflict.
+        // .defaultHigh avoids conflicting with the self-sizing pass.
         let topConstraint = stackView.topAnchor.constraint(equalTo: margins.topAnchor)
         let bottomConstraint = stackView.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
         topConstraint.priority = .defaultHigh
@@ -78,7 +75,6 @@ final class WebCompatURLCell: UICollectionViewListCell,
         applyStackLayout(isAccessibilityCategory: traitCollection.preferredContentSizeCategory.isAccessibilityCategory)
     }
 
-    /// Horizontal at standard sizes; vertical (field below the label) at accessibility sizes.
     func applyStackLayout(isAccessibilityCategory: Bool) {
         stackView.axis = isAccessibilityCategory ? .vertical : .horizontal
         stackView.alignment = isAccessibilityCategory ? .fill : .center
@@ -93,11 +89,9 @@ final class WebCompatURLCell: UICollectionViewListCell,
         editingEndedHandler = onEditingEnded
         titleLabel.text = title
         textField.accessibilityIdentifier = a11yIdentifier
-        // The field is the accessibility element; carry the label onto it so
-        // VoiceOver announces "<title>, text field" instead of a bare field.
         titleLabel.isAccessibilityElement = false
         textField.accessibilityLabel = title
-        // Don't overwrite the field mid-edit; the value round-trips on end.
+        // The value round-trips on editing-end, so don't overwrite mid-edit.
         if !textField.isFirstResponder {
             textField.text = text
         }

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -28,7 +28,7 @@ private func previewURLSection() -> WebCompatReportViewModel.Section {
         WebCompatReportViewModel.Row(
             id: "url",
             title: "URL",
-            kind: .urlField(text: "https://houseandhome.com/recipe/croque-monsieur", placeholder: "Website address"),
+            kind: .urlField(text: "https://houseandhome.com/recipe/croque-monsieur"),
             a11yIdentifier: "url"
         )
     ])

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -252,11 +252,10 @@ public final class WebCompatReportSheetViewController: UIViewController,
     private func urlCellRegistration()
     -> UICollectionView.CellRegistration<WebCompatURLCell, WebCompatReportViewModel.Row> {
         return UICollectionView.CellRegistration { [weak self] cell, _, row in
-            guard let self, case let .urlField(text, placeholder) = row.kind else { return }
+            guard let self, case let .urlField(text) = row.kind else { return }
             cell.configure(
                 title: row.title,
                 text: text,
-                placeholder: placeholder,
                 a11yIdentifier: row.a11yIdentifier
             ) { [weak self] text in
                 self?.delegate?.webCompatReportSheetDidEditText(id: row.id, text: text)

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
@@ -59,7 +59,7 @@ public struct WebCompatReportViewModel: Equatable, Sendable {
             case plain
             case categoryMenu(isPlaceholder: Bool, options: [MenuOption])
             case subOption(isSelected: Bool)
-            case urlField(text: String, placeholder: String)
+            case urlField(text: String)
             case detailsField(text: String, placeholder: String)
             case sendButton(isEnabled: Bool)
             case toggle(isOn: Bool)

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -388,7 +388,7 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
                 WebCompatReportViewModel.Row(
                     id: "url",
                     title: "URL",
-                    kind: .urlField(text: "https://example.com", placeholder: "Website address"),
+                    kind: .urlField(text: "https://example.com"),
                     a11yIdentifier: "url"
                 )
             ]),

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatURLCellTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatURLCellTests.swift
@@ -14,7 +14,6 @@ final class WebCompatURLCellTests: XCTestCase {
         subject.configure(
             title: "URL",
             text: "https://example.com",
-            placeholder: "Website address",
             a11yIdentifier: "WebCompatReporter.URLField",
             onEditingEnded: { _ in }
         )
@@ -27,18 +26,29 @@ final class WebCompatURLCellTests: XCTestCase {
 
     func testApplyStackLayout_switchesAxisAndAlignmentBetweenStandardAndAccessibilitySizes() throws {
         let subject = createSubject()
-        subject.configure(title: "URL", text: "", placeholder: "", a11yIdentifier: "url", onEditingEnded: { _ in })
+        subject.configure(title: "URL", text: "", a11yIdentifier: "url", onEditingEnded: { _ in })
         let stack = try XCTUnwrap(firstSubview(ofType: UIStackView.self, in: subject.contentView))
-        let field = try XCTUnwrap(firstSubview(ofType: UITextField.self, in: subject.contentView))
 
         subject.applyStackLayout(isAccessibilityCategory: false)
         XCTAssertEqual(stack.axis, .horizontal)
         XCTAssertEqual(stack.alignment, .center)
-        XCTAssertEqual(field.textAlignment, .right)
 
         subject.applyStackLayout(isAccessibilityCategory: true)
         XCTAssertEqual(stack.axis, .vertical)
         XCTAssertEqual(stack.alignment, .fill)
+    }
+
+    /// The leading label already reads "URL", so a cleared field must not repeat it, and a
+    /// short address has to read from the leading edge instead of jumping to the trailing one.
+    func testConfigure_clearedFieldShowsNoPlaceholderAndReadsFromTheLeadingEdge() throws {
+        let subject = createSubject()
+
+        subject.configure(title: "URL", text: "ebay.com", a11yIdentifier: "url", onEditingEnded: { _ in })
+        subject.applyTheme(theme: LightTheme())
+
+        let field = try XCTUnwrap(firstSubview(ofType: UITextField.self, in: subject.contentView))
+        XCTAssertNil(field.placeholder)
+        XCTAssertNil(field.attributedPlaceholder)
         XCTAssertEqual(field.textAlignment, .natural)
     }
 

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatURLCellTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatURLCellTests.swift
@@ -38,8 +38,6 @@ final class WebCompatURLCellTests: XCTestCase {
         XCTAssertEqual(stack.alignment, .fill)
     }
 
-    /// The leading label already reads "URL", so a cleared field must not repeat it, and a
-    /// short address has to read from the leading edge instead of jumping to the trailing one.
     func testConfigure_clearedFieldShowsNoPlaceholderAndReadsFromTheLeadingEdge() throws {
         let subject = createSubject()
 

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -168,7 +168,7 @@ final class WebCompatReportViewController: UINavigationController,
                 WebCompatReportViewModel.Row(
                     id: RowID.url.rawValue,
                     title: .WebCompatReporter.Fields.URLLabel,
-                    kind: .urlField(text: state.url, placeholder: .WebCompatReporter.Fields.URLPlaceholder),
+                    kind: .urlField(text: state.url),
                     a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.urlField
                 )
             ]

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
@@ -24,9 +24,9 @@ struct WebCompatReporterState: ScreenState, Equatable {
     var canPreview: Bool { selectedCategory != nil }
     var showsAdditionalDetails: Bool { selectedCategory != nil }
 
-    /// Send needs a sub-option too, except for "Other", which has none.
+    /// Send needs an address to report against and a sub-option, except for "Other", which has none.
     var canSubmit: Bool {
-        guard let selectedCategory else { return false }
+        guard let selectedCategory, !url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
         return selectedCategory.subOptions.isEmpty || selectedSubOptionID != nil
     }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -9356,6 +9356,13 @@ extension String {
                 value: "Theme",
                 comment: "Title in main app settings for Theme settings")
         }
+        struct v156 {
+            public static let WebCompatReporterFieldsURLPlaceholder = MZLocalizedString(
+                key: "WebCompatReporter.Fields.URLPlaceholder.v154",
+                tableName: "WebCompatReporter",
+                value: "URL",
+                comment: "Placeholder shown in the URL field when no web address has been entered, in the Report a Website Issue form.")
+        }
     }
 }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4496,12 +4496,6 @@ extension String {
                 value: "URL",
                 comment: "Leading label of the editable row showing the web address being reported, in the Report a Website Issue form."
             )
-            public static let URLPlaceholder = MZLocalizedString(
-                key: "WebCompatReporter.Fields.URLPlaceholder.v154",
-                tableName: "WebCompatReporter",
-                value: "URL",
-                comment: "Placeholder shown in the URL field when no web address has been entered, in the Report a Website Issue form."
-            )
             public static let DetailsPlaceholder = MZLocalizedString(
                 key: "WebCompatReporter.Fields.DetailsPlaceholder.v154",
                 tableName: "WebCompatReporter",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -261,7 +261,7 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(advanced?.rows.map(\.kind), [.toggle(isOn: false)])
         XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: false)])
 
-        guard case let .urlField(text, _) = sections.first?.rows.first?.kind else {
+        guard case let .urlField(text) = sections.first?.rows.first?.kind else {
             return XCTFail("Expected a URL field row")
         }
         XCTAssertEqual(text, "https://example.com")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
@@ -44,6 +44,11 @@ final class WebCompatReporterStateTests: XCTestCase {
         XCTAssertTrue(makeState(category: .other).canSubmit)
     }
 
+    func test_canSubmit_falseWhenTheURLHasBeenClearedOrIsBlank() {
+        XCTAssertFalse(makeState(category: .other, url: "").canSubmit)
+        XCTAssertFalse(makeState(category: .other, url: "   ").canSubmit)
+    }
+
     // MARK: - Reducer - didLoadInitialDraft
 
     func test_didLoadInitialDraft_seedsURL() {
@@ -389,11 +394,12 @@ final class WebCompatReporterStateTests: XCTestCase {
 
     private func makeState(
         category: WebCompatIssueCategory,
-        subOption: WebCompatSubOption? = nil
+        subOption: WebCompatSubOption? = nil,
+        url: String = "https://example.com"
     ) -> WebCompatReporterState {
         return WebCompatReporterState(
             windowUUID: .XCTestDefaultUUID,
-            url: "https://example.com",
+            url: url,
             selectedCategory: category,
             selectedSubOptionID: subOption?.rawValue
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16486)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35021)

## :bulb: Description
The row label and the field placeholder were both the string `URL`, so clearing the field showed the word twice. The field was also right-aligned, which parked a short address against the trailing edge, so it now uses `UITextField`'s default leading alignment to match the [mock](https://www.figma.com/design/BVqEYexibOA2betNVUMrfl/?node-id=23608-66247). A long address looks the same either way, since it overflows the field and truncates at the tail regardless of alignment. Also disables Send while the URL is blank, which previously let an empty `url` reach the ping.

`WebCompatReporter.Fields.URLPlaceholder.v154` is no longer used, so it moves to `OldStrings.v156` with its key intact.

## :movie_camera: Demos
| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

## Testing
1. Load any web page, then Menu → More → Report Broken Site.
2. Check the URL row shows the address starting right after the `URL` label, head first, with the tail truncated.
3. Tap the field and tap the clear button. `URL` should appear once, not twice.
4. Type a short address such as `ebay.com`. It should sit next to the label, not against the right edge.
5. With the field cleared, pick an issue type and confirm Send Report stays disabled.
