### PR TITLE
Add FXIOS-16564 [Nova] iPad Update background for Sync Tab

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
@@ -140,7 +140,7 @@ class RemoteTabsEmptyView: UIView,
         titleLabel.textColor = theme.colors.textPrimary
         instructionsLabel.textColor = theme.colors.textPrimary
         signInButton.applyTheme(theme: theme)
-        backgroundColor = theme.colors.layer3
+        backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -156,10 +156,10 @@ final class RemoteTabsPanel: UIViewController,
 
     func applyTheme() {
         let theme = retrieveTheme()
-        view.backgroundColor = theme.colors.layer4
-        tabsDisplayViewController.tableView.backgroundColor = theme.colors.layer3
+        view.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer4
+        tabsDisplayViewController.tableView.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
         tabsDisplayViewController.tableView.separatorColor = theme.colors.borderPrimary
-        statusBarBackground.backgroundColor = theme.colors.layer3
+        statusBarBackground.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
     }
 
     var shouldUsePrivateOverride: Bool {
@@ -181,10 +181,10 @@ final class RemoteTabsPanel: UIViewController,
     }
 
     func applyTheme(_ theme: Theme) {
-        view.backgroundColor = theme.colors.layer4
-        tabsDisplayViewController.tableView.backgroundColor = theme.colors.layer3
+        view.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer4
+        tabsDisplayViewController.tableView.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
         tabsDisplayViewController.tableView.separatorColor = theme.colors.borderPrimary
-        statusBarBackground.backgroundColor = theme.colors.layer3
+        statusBarBackground.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
     }
 
     // MARK: - Redux

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
@@ -200,7 +200,7 @@ class RemoteTabsViewController: UIViewController,
         let theme = retrieveTheme()
         emptyView.applyTheme(theme: theme)
         tableView.visibleCells.forEach { ($0 as? ThemeApplicable)?.applyTheme(theme: theme) }
-        view.backgroundColor = theme.colors.layer3
+        view.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
     }
 
     private func configureEmptyView(isSyncing: Bool = false) {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16564)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35173)

## :bulb: Description
This PR updates colors for Sync Tab in order to use the Nova design system colors for backgrounds. Also for Remote Tabs empty view for iPad, the token is updated.


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

