### PR TITLE
Bugfix #35220 Preserve homepage status bar overlay

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/OverlayModeManager.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/OverlayModeManager.swift
@@ -83,6 +83,7 @@ class DefaultOverlayModeManager: OverlayModeManager {
 
     @MainActor
     func cancelEditing(shouldCancelLoading: Bool) {
+        guard inOverlayMode else { return }
         leaveOverlayMode(reason: .cancelled, shouldCancelLoading: shouldCancelLoading)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -118,6 +118,26 @@ class OverlayModeManagerTests: XCTestCase {
         XCTAssertEqual(subject.leaveOverlayModeCallCount, 1)
     }
 
+    @MainActor
+    func testCancelEditing_WhenNotInOverlayMode_DoesNotLeaveOverlayMode() {
+        subject.setURLBar(urlBarView: urlBar)
+
+        subject.cancelEditing(shouldCancelLoading: true)
+
+        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 0)
+    }
+
+    @MainActor
+    func testCancelEditing_WhenInOverlayMode_LeavesOverlayMode() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openSearch(with: "")
+
+        subject.cancelEditing(shouldCancelLoading: true)
+
+        XCTAssertFalse(subject.inOverlayMode)
+        XCTAssertEqual(urlBar.leaveOverlayModeCallCount, 1)
+    }
+
     // MARK: - Test EnterOverlay for Tab change
     @MainActor
     func testLeaveOverlayMode_ForSwitchTab() {


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12799)  
[GitHub issue](https://github.com/mozilla-mobile/firefox-ios/issues/35220)

## :bulb: Description

Prevents opening the menu on the homepage from incorrectly cancelling URL bar editing when the browser is not in overlay mode.

Previously, this unnecessary cancellation rebuilt the homepage and reset the status bar overlay opacity. The overlay consequently became translucent and remained that way after dismissing the menu.

The overlay mode manager now ignores cancellation requests when overlay mode is inactive. Regression tests cover cancellation both inside and outside overlay mode.

Closes #35220

## :pencil: Checklist

- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — no accessibility behavior changed
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review — not applicable
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n — not applicable
- [x] If needed, I updated documentation and added comments to complex code — not applicable