### PR TITLE
Refactor NO_TICKET Move testFirefoxSuggestionsLandscapePrivate to FullFunctionalTestPlan

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -539,6 +539,7 @@
         "SearchTests\/testDismissPromptPresence()",
         "SearchTests\/testDoNotShowSuggestionsWhenEnteringURL()",
         "SearchTests\/testFirefoxSuggest()",
+        "SearchTests\/testFirefoxSuggestionsLandscapePrivate()",
         "SearchTests\/testOpenTabsInSearchSuggestions_TAE()",
         "SearchTests\/testPrivateModeSearchSuggestsOnOffAndGeneralSearchSuggestsOff()",
         "SearchTests\/testPrivateModeSearchSuggestsOnOffAndGeneralSearchSuggestsOn()",


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](NO_TICKET)

## :bulb: Description
`testFirefoxSuggestionsLandscapePrivate` (SearchTests) was running in both Smoketest and FullFunctionalTestPlan. It's tagged as a Regression test rather than a smoke test, so this moves it out of Smoketest's skip list exception and leaves it running only in FullFunctionalTestPlan.

## :movie_camera: Demos
N/A — test-plan configuration change only.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code