### PR TITLE
Remove FXIOS-16362 [Share] Delete unused ViewType and ActivityIdentifiers

### DIFF
--- a/firefox-ios/Client/Frontend/Share/SendToDeviceHelper.swift
+++ b/firefox-ios/Client/Frontend/Share/SendToDeviceHelper.swift
@@ -15,11 +15,6 @@ class SendToDeviceHelper {
         let iconColor: UIColor
     }
 
-    enum ViewType {
-        case instructions
-        case picker
-    }
-
     private var shareItem: ShareItem
     private var profile: Profile
     private var colors: Colors

--- a/firefox-ios/Client/Frontend/Share/ShareManager.swift
+++ b/firefox-ios/Client/Frontend/Share/ShareManager.swift
@@ -9,12 +9,6 @@ import UniformTypeIdentifiers
 import Common
 
 class ShareManager: NSObject, FeatureFlaggable {
-    private struct ActivityIdentifiers {
-        static let pocketIconExtension = "com.ideashower.ReadItLaterPro.AddToPocketExtension"
-        static let pocketActionExtension = "com.ideashower.ReadItLaterPro.Action-Extension"
-        static let whatsApp = "net.whatsapp.WhatsApp.ShareExtension"
-    }
-
     // Black list for activities to which we don't want to share
     private static let excludingActivities: [UIActivity.ActivityType] = [
         UIActivity.ActivityType.addToReadingList


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16362)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34789)

## :bulb: Description
Remove two unused types reported by Periphery:

- `ViewType` in `SendToDeviceHelper.swift`
- `ActivityIdentifiers` in `ShareManager.swift`

Confirmed on current `main` that neither type has callers. Live `ActivityIdentifiers` copies in `URLActivityItemProvider` and `TitleActivityItemProvider` are unchanged.

## :movie_camera: Demos
N/A — unused type deletion, no UI change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code