### PR TITLE
Add FXIOS-16589 Update site menu badge active state text color

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
@@ -117,7 +117,7 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
         backgroundColor = theme.colors.layerSurfaceMedium.withAlphaComponent(mainMenuHelper?.backgroundAlpha() ?? 1.0)
         if model.isActive {
             titleLabel.textColor = theme.colors.textAccent
-            infoLabelView.textColor = theme.colors.textPrimary
+            infoLabelView.textColor = theme.isNova ? theme.colors.textInverted : theme.colors.textPrimary
             infoLabelView.backgroundColor = theme.isNova ? theme.colors.actionPrimary : theme.colors.layerInformation
         } else if !model.isEnabled {
             titleLabel.textColor = theme.colors.textDisabled


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16589)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Update site menu badge active state text color

<img width="1248" height="783" alt="Screenshot 2026-08-17 at 18 25 56" src="https://github.com/user-attachments/assets/a98eeb77-8e2a-466c-b3d6-562590879c32" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

