### PR TITLE
Add FXIOS-16591 [Nova] Update News card background

### DIFF
--- a/firefox-ios/Client/Frontend/StoriesFeed/StoryCell.swift
+++ b/firefox-ios/Client/Frontend/StoriesFeed/StoryCell.swift
@@ -162,7 +162,7 @@ class StoryCell: UICollectionViewCell,
 
     // MARK: - ThemeApplicable
     func applyTheme(theme: Theme) {
-        contentView.backgroundColor = theme.colors.layer2
+        contentView.backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer2
         titleLabel.textColor = theme.colors.textPrimary
         attributionTitleLabel.textColor = theme.colors.textSecondary
         setupShadow(theme: theme)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16591)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR changes the News card background token for Nova design system in order to a align with the other homepage cards/tiles: layerSurfaceMedium.

<img width="838" height="665" alt="Screenshot 2026-08-17 at 21 49 36" src="https://github.com/user-attachments/assets/79806ea7-09de-4ff2-9ef7-81753db95d12" />



## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

