### PR TITLE
Bugfix FXIOS-16593 [Nova] Update TabTray segmented controller and buttons glass

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -384,7 +384,7 @@ class TabTraySelectorView: UIView, ThemeApplicable {
             backgroundColor = trackColor.withAlphaComponent(tabTrayUtils.backgroundAlpha())
         } else if theme.isNova, !DeviceInfo.isRunningLiquidGlassEarlyBeta, !(theme is TabTrayPanelSwipeTheme) {
             let glass = UIGlassEffect(style: .regular)
-            glass.tintColor = theme.colors.layerGlassTintNova
+            glass.tintColor = theme.type == .light ? UIColor.clear : theme.colors.layerGlassTintNova
             visualEffectView.effect = glass
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -511,7 +511,7 @@ final class TabTrayViewController: UIViewController,
             applyToolbarGlassButtonTints(theme: theme)
         }
         if theme.isNova {
-            segmentedControl.selectedSegmentTintColor = theme.type == .light ? UIColor.clear : theme.colors.layer2
+            segmentedControl.selectedSegmentTintColor = theme.colors.layer2
             if #unavailable(iOS 26) {
                 segmentedControl.backgroundColor = theme.colors.layerSurfaceLow
             }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -201,7 +201,7 @@ final class TabTrayViewController: UIViewController,
     @available(iOS 26.0, *)
     private func applyToolbarGlassButtonTints(theme: Theme) {
         guard isNovaDesignEnabled else { return }
-        let glassTint = theme.colors.layerGlassTintNova
+        let glassTint = theme.type == .light ? UIColor.clear : theme.colors.layerGlassTintNova
         setProminentGlass(deleteButton,
                           StandardImageIdentifiers.Large.delete,
                           background: glassTint,
@@ -511,7 +511,7 @@ final class TabTrayViewController: UIViewController,
             applyToolbarGlassButtonTints(theme: theme)
         }
         if theme.isNova {
-            segmentedControl.selectedSegmentTintColor = theme.colors.layer2
+            segmentedControl.selectedSegmentTintColor = theme.type == .light ? UIColor.clear : theme.colors.layer2
             if #unavailable(iOS 26) {
                 segmentedControl.backgroundColor = theme.colors.layerSurfaceLow
             }


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16593)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates glass tint for segmented controller and buttons from tab tray to use a clear liquid glass only for Light Mode, as requested in Figma design system.

<img width="671" height="712" alt="Screenshot 2026-08-17 at 22 08 00" src="https://github.com/user-attachments/assets/400294df-ace5-4c6b-87e5-ff0ec104029c" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

