### PR TITLE
Add FXIOS-16594 [Nova] Update AI controls screen

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AIControls/AIControlsSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AIControls/AIControlsSettingsView.swift
@@ -13,6 +13,7 @@ struct AIControlsSettingsView: View, ThemeApplicable {
     @Environment(\.themeManager)
     var themeManager
     @State private var themeColors: ThemeColourPalette = LightTheme().colors
+    @State private var isNova = false
 
     private struct UX {
         static let cornerRadius: CGFloat = 32
@@ -39,7 +40,7 @@ struct AIControlsSettingsView: View, ThemeApplicable {
                             .underline()
                             .multilineTextAlignment(.leading)
                             .font(FXFontStyles.Regular.caption1.scaledSwiftUIFont())
-                            .foregroundStyle(themeColors.layerSelectedText.color)
+                            .foregroundStyle(isNova ? themeColors.textAccent.color : themeColors.layerSelectedText.color)
                     }
                     .padding(.leading, UX.padding)
                 }
@@ -86,7 +87,7 @@ struct AIControlsSettingsView: View, ThemeApplicable {
                                 .underline()
                                 .multilineTextAlignment(.leading)
                                 .font(FXFontStyles.Regular.body.scaledSwiftUIFont())
-                                .foregroundStyle(themeColors.layerSelectedText.color)
+                                .foregroundStyle(isNova ? themeColors.textAccent.color : themeColors.layerSelectedText.color)
                         }
                     }
                 }
@@ -123,7 +124,13 @@ struct AIControlsSettingsView: View, ThemeApplicable {
             padding: UX.padding
         ) {
             HStack(alignment: .top) {
-                Image(StandardImageIdentifiers.Large.information)
+                if isNova {
+                    Image(StandardImageIdentifiers.Large.information)
+                        .renderingMode(.template)
+                        .foregroundStyle(themeColors.iconPrimary.color)
+                } else {
+                    Image(StandardImageIdentifiers.Large.information)
+                }
                 Text(verbatim: .Settings.AIControls.BlockedInformation)
                     .font(FXFontStyles.Regular.body.scaledSwiftUIFont())
                     .foregroundStyle(themeColors.textPrimary.color)
@@ -239,7 +246,7 @@ struct AIControlsSettingsView: View, ThemeApplicable {
     func aiFeatureToggleStatus(isEnabled: Bool) -> some View {
         if isEnabled {
             Text(verbatim: .Settings.AIControls.AIPoweredFeaturesSection.AvailableStatus)
-                .foregroundStyle(themeColors.layerSelectedText.color)
+                .foregroundStyle(isNova ? themeColors.textSecondary.color : themeColors.layerSelectedText.color)
                 .font(FXFontStyles.Regular.footnote.scaledSwiftUIFont())
         } else {
             Text(verbatim: .Settings.AIControls.AIPoweredFeaturesSection.BlockedStatus)
@@ -250,6 +257,7 @@ struct AIControlsSettingsView: View, ThemeApplicable {
 
     func applyTheme(theme: any Common.Theme) {
         self.themeColors = theme.colors
+        self.isNova = theme.isNova
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16594)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates AI controls screen to follow Nova design guidelines for specific UI elements based on Figma:

<img width="346" height="444" alt="Screenshot 2026-08-17 at 22 43 39" src="https://github.com/user-attachments/assets/bbaf47df-b9d7-4d19-8e37-716bbce36e3d" />
<img width="357" height="427" alt="Screenshot 2026-08-17 at 22 43 33" src="https://github.com/user-attachments/assets/9f851343-6caf-4c14-9ebd-83706fece545" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

