### PR TITLE
Bugfix MTE-5587 iPad adjustments for testFirefoxSuggest

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/TabTrayScreen.swift
@@ -278,13 +278,13 @@ final class TabTrayScreen {
                 app.navigationBars.segmentedControls[AccessibilityIdentifiers.TabTray.navBarSegmentedControl],
                 timeout: timeout
             )
-            closeButton = app.cells[title].buttons[StandardImageIdentifiers.Large.cross]
+            closeButton = cell(named: title).buttons[StandardImageIdentifiers.Large.cross]
         } else {
             BaseTestCase().mozWaitForElementToExist(
                 app.otherElements[AccessibilityIdentifiers.TabTray.navBarSegmentedControl],
                 timeout: timeout
             )
-            closeButton = app.cells[title].buttons[AccessibilityIdentifiers.TabTray.closeButton]
+            closeButton = cell(named: title).buttons[AccessibilityIdentifiers.TabTray.closeButton]
         }
 
         BaseTestCase().mozWaitForElementToExist(closeButton, timeout: timeout)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -505,9 +505,9 @@ class SearchTests: FeatureFlaggedTestBase {
             // https://github.com/mozilla-mobile/firefox-ios/issues/35243
             if !iPad() {
                 verifySearchSuggestion(searchTerm: "amazon",
-                                   expectedMatch: "Amazon.com - Official Site",
-                                   hasFirefoxSuggest: true,
-                                   isSponsored: true)
+                                       expectedMatch: "Amazon.com - Official Site",
+                                       hasFirefoxSuggest: true,
+                                       isSponsored: true)
             }
             // Non-sponsored suggestions
             for (term, expectedTitle) in [

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -21,13 +21,16 @@ class SearchTests: FeatureFlaggedTestBase {
     var searchScreen: SearchScreen!
     var searchSettingsScreen: SearchSettingsScreen!
     var settingsScreen: SettingScreen!
+    var tabTrayScreen: TabTrayScreen!
 
     override func setUp() async throws {
         try await super.setUp()
+        toolbarScreen = ToolbarScreen(app: app)
         browserScreen = BrowserScreen(app: app)
         settingsScreen = SettingScreen(app: app)
         searchSettingsScreen = SearchSettingsScreen(app: app)
         searchScreen = SearchScreen(app: app)
+        tabTrayScreen = TabTrayScreen(app: app)
     }
 
     override func tearDown() async throws {
@@ -475,14 +478,21 @@ class SearchTests: FeatureFlaggedTestBase {
         // Create some history
         navigator.openNewURL(urlString: "https://www.example.com")
         waitUntilPageLoad()
-        navigator.performAction(Action.CloseTab)
+        waitForTabsButton()
+        toolbarScreen.tapOnTabsButton()
+        tabTrayScreen.closeTab(title: TestLabels.exampleDomain)
+        tabTrayScreen.assertNewTabButtonExist()
+        tabTrayScreen.tapOnNewTabButton()
 
         // Create a bookmark
         navigator.openNewURL(urlString: "localhost:\(serverPort)/test-fixture/\(TestPages.mozillaBook)")
         waitUntilPageLoad()
         navigator.performAction(Action.Bookmark)
-        navigator.performAction(Action.CloseTab)
-        navigator.performAction(Action.OpenNewTabFromTabTray)
+        waitForTabsButton()
+        toolbarScreen.tapOnTabsButton()
+        tabTrayScreen.closeTab(title: TestLabels.mozillaBook)
+        tabTrayScreen.assertNewTabButtonExist()
+        tabTrayScreen.tapOnNewTabButton()
 
         let siteTable = app.tables["SiteTable"]
 
@@ -491,12 +501,17 @@ class SearchTests: FeatureFlaggedTestBase {
 
             // Firefox Suggest should show up for sponsored suggestion, open tab, history
             // and bookmark.
-            let firefoxSuggestTerms = [
+            var firefoxSuggestTerms = [
                 "amazon": "Amazon.com - Official Site", // Sponsored suggestion
                 "internet": "Internet for people, not profit — Mozilla", // Open tab
                 "example": "www.example.com/", // History
                 "book": "The Book of Mozilla" // Bookmark
             ]
+            // Bug: Sponsored suggest does not show up on iPad
+            // https://github.com/mozilla-mobile/firefox-ios/issues/35243
+            if iPad() {
+                firefoxSuggestTerms.removeValue(forKey: "amazon")
+            }
             for (term, expectedTitle) in firefoxSuggestTerms {
                 browserScreen.tapOnAddressBar()
                 browserScreen.tapClearButtonIfExists()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TestConstants.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TestConstants.swift
@@ -15,4 +15,5 @@ enum TestPages {
 
 enum TestLabels {
     static let exampleDomain = "Example Domain"
+    static let mozillaBook = "The Book of Mozilla"
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5587)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
We can now run `testFirefoxSuggest()` on both iPhone and iPad. Previously, the test only worked on iPhone.

Note: Sponsored suggest may not appear on iPad. See https://github.com/mozilla-mobile/firefox-ios/issues/35243.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->



https://github.com/user-attachments/assets/130b38a7-9bb4-4461-b7a9-69124b319c04


| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

