### PR TITLE
Bugfix FXIOS-13501 [OHTTP] Make OhttpManager an actor to fix key cache data race

### DIFF
--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/ASOhttpClient/OhttpManager.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/ASOhttpClient/OhttpManager.swift
@@ -4,17 +4,22 @@
 
 import Foundation
 
-public class OhttpManager {
+/// Performs Oblivious HTTP round-trips via a Gateway and Relay.
+///
+/// This is an actor rather than a class because callers drive it concurrently:
+/// each Glean ping upload runs in its own task. Isolation protects the key cache
+/// below, and keeps `OhttpSession` creation in `data(for:)` from overlapping.
+public actor OhttpManager {
     // The OhttpManager communicates with the relay and key server using
     // URLSession.shared.data unless an alternative networking method is
     // provided with this signature.
     public typealias NetworkFunction = (_: URLRequest) async throws -> (Data, URLResponse)
 
-    // Global cache to caching Gateway encryption keys. Stale entries are
-    // ignored and on Gateway errors the key used should be purged and retrieved
-    // again next at next network attempt.
-    // FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6
-    static nonisolated(unsafe) var keyCache = [URL: ([UInt8], Date)]()
+    // Cache of Gateway encryption keys, alongside the time each was stored so
+    // staleness can be evaluated on read. Stale entries are ignored, and on
+    // Gateway errors the key used is purged and retrieved again at the next
+    // network attempt.
+    private var keyCache = [URL: (key: [UInt8], storedAt: Date)]()
 
     private var configUrl: URL
     private var relayUrl: URL
@@ -27,6 +32,29 @@ public class OhttpManager {
         self.configUrl = configUrl
         self.relayUrl = relayUrl
         self.network = network
+    }
+
+    /// Returns the cached key when one is present and still within `ttl`,
+    /// dropping it when stale. `nil` means the caller should fetch a fresh key.
+    func cachedKey(for gatewayConfigUrl: URL, ttl: TimeInterval) -> [UInt8]? {
+        guard let entry = keyCache[gatewayConfigUrl] else { return nil }
+
+        guard Date() < entry.storedAt + ttl else {
+            keyCache.removeValue(forKey: gatewayConfigUrl)
+            return nil
+        }
+
+        return entry.key
+    }
+
+    func store(key: [UInt8], for gatewayConfigUrl: URL) {
+        keyCache[gatewayConfigUrl] = (key: key, storedAt: Date())
+    }
+
+    /// Purges a key so the next network attempt retrieves a fresh one, which is
+    /// how Gateway errors are recovered from.
+    func invalidateKey(for gatewayConfigUrl: URL) {
+        keyCache.removeValue(forKey: gatewayConfigUrl)
     }
 
     private func fetchKey(url: URL) async throws -> [UInt8] {
@@ -42,23 +70,15 @@ public class OhttpManager {
     }
 
     private func keyForGateway(gatewayConfigUrl: URL, ttl: TimeInterval) async throws -> [UInt8] {
-        if let (data, timestamp) = Self.keyCache[gatewayConfigUrl] {
-            if Date() < timestamp + ttl {
-                // Cache Hit!
-                return data
-            }
-
-            Self.keyCache.removeValue(forKey: gatewayConfigUrl)
+        if let key = cachedKey(for: gatewayConfigUrl, ttl: ttl) {
+            // Cache Hit!
+            return key
         }
 
         let data = try await fetchKey(url: gatewayConfigUrl)
-        Self.keyCache[gatewayConfigUrl] = (data, Date())
+        store(key: data, for: gatewayConfigUrl)
 
         return data
-    }
-
-    private func invalidateKey() {
-        Self.keyCache.removeValue(forKey: configUrl)
     }
 
     public func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
@@ -66,7 +86,14 @@ public class OhttpManager {
         let config = try await keyForGateway(gatewayConfigUrl: configUrl,
                                              ttl: TimeInterval(3600))
 
-        // Create an encryption session for a request-response round-trip
+        // Create an encryption session for a request-response round-trip.
+        //
+        // Actor isolation is load-bearing here: this synchronous call cannot
+        // interleave with another, and the first session created in a process
+        // triggers one-time NSS initialization inside the Rust component, which
+        // crashes when entered from two threads at once. That holds as long as a
+        // single OhttpManager serves the process; a process-wide guarantee needs
+        // application-services to initialize NSS up front.
         let session = try OhttpSession(config: config)
 
         // Encapsulate the URLRequest for the Target
@@ -91,7 +118,7 @@ public class OhttpManager {
            httpResponse.statusCode == 400 ||
            httpResponse.statusCode == 401
         {
-            invalidateKey()
+            invalidateKey(for: configUrl)
         }
 
         guard let httpResponse = response as? HTTPURLResponse,

--- a/MozillaRustComponents/Tests/MozillaRustComponentsTests/OhttpManagerTests.swift
+++ b/MozillaRustComponents/Tests/MozillaRustComponentsTests/OhttpManagerTests.swift
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+@testable import MozillaAppServices
+import XCTest
+
+final class OhttpManagerTests: XCTestCase {
+    private let configUrl = URL(string: "https://example.com/ohttp-configs")!
+    private let otherConfigUrl = URL(string: "https://other.example.com/ohttp-configs")!
+    private let relayUrl = URL(string: "https://relay.example.com/")!
+
+    /// The key cache is exercised directly, so the network is never reached.
+    private func createSubject() -> OhttpManager {
+        return OhttpManager(configUrl: configUrl,
+                            relayUrl: relayUrl,
+                            network: { _ in (Data(), URLResponse()) })
+    }
+
+    func testCachedKeyReturnsNilWhenNothingStored() async {
+        let subject = createSubject()
+
+        let key = await subject.cachedKey(for: configUrl, ttl: 3600)
+
+        XCTAssertNil(key)
+    }
+
+    func testCachedKeyReturnsStoredKeyWithinTTL() async {
+        let subject = createSubject()
+        await subject.store(key: [1, 2, 3], for: configUrl)
+
+        let key = await subject.cachedKey(for: configUrl, ttl: 3600)
+
+        XCTAssertEqual(key, [1, 2, 3])
+    }
+
+    func testCachedKeyIsScopedPerConfigUrl() async {
+        let subject = createSubject()
+        await subject.store(key: [1, 2, 3], for: configUrl)
+
+        let key = await subject.cachedKey(for: otherConfigUrl, ttl: 3600)
+
+        XCTAssertNil(key)
+    }
+
+    func testCachedKeyReturnsNilWhenEntryIsStale() async {
+        let subject = createSubject()
+        await subject.store(key: [1, 2, 3], for: configUrl)
+
+        let key = await subject.cachedKey(for: configUrl, ttl: -1)
+
+        XCTAssertNil(key)
+    }
+
+    func testStaleEntryIsEvictedAndNotReturnedLater() async {
+        let subject = createSubject()
+        await subject.store(key: [1, 2, 3], for: configUrl)
+
+        // Reading with an expired TTL should drop the entry, not just report it stale.
+        _ = await subject.cachedKey(for: configUrl, ttl: -1)
+        let key = await subject.cachedKey(for: configUrl, ttl: 3600)
+
+        XCTAssertNil(key)
+    }
+
+    func testStoreOverwritesPreviousKey() async {
+        let subject = createSubject()
+        await subject.store(key: [1, 2, 3], for: configUrl)
+        await subject.store(key: [4, 5, 6], for: configUrl)
+
+        let key = await subject.cachedKey(for: configUrl, ttl: 3600)
+
+        XCTAssertEqual(key, [4, 5, 6])
+    }
+
+    func testInvalidateKeyRemovesStoredKey() async {
+        let subject = createSubject()
+        await subject.store(key: [1, 2, 3], for: configUrl)
+
+        await subject.invalidateKey(for: configUrl)
+        let key = await subject.cachedKey(for: configUrl, ttl: 3600)
+
+        XCTAssertNil(key)
+    }
+
+    /// Regression cover for the unsynchronised static cache this actor replaced:
+    /// interleaved reads, writes and evictions corrupted it, and the crash
+    /// surfaced while releasing torn values.
+    func testConcurrentAccessKeepsCacheConsistent() async {
+        let subject = createSubject()
+        let urls = [configUrl, otherConfigUrl]
+
+        await withTaskGroup(of: Void.self) { group in
+            for iteration in 0..<500 {
+                let url = urls[iteration % urls.count]
+
+                group.addTask {
+                    await subject.store(key: [UInt8(iteration % 256)], for: url)
+                }
+                group.addTask {
+                    _ = await subject.cachedKey(for: url, ttl: 3600)
+                }
+                group.addTask {
+                    _ = await subject.cachedKey(for: url, ttl: -1)
+                }
+                group.addTask {
+                    await subject.invalidateKey(for: url)
+                }
+            }
+        }
+
+        // The cache must still be usable after the hammering.
+        await subject.store(key: [9], for: configUrl)
+        let key = await subject.cachedKey(for: configUrl, ttl: 3600)
+
+        XCTAssertEqual(key, [9])
+    }
+}

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1509,6 +1509,7 @@
 		ADB10C0F2D900000001AB002 /* ASAdBlockerListFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB10C0E2D900000001AB001 /* ASAdBlockerListFetcher.swift */; };
 		ADB10C112D900000001AB004 /* ASAdBlockerListFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB10C102D900000001AB003 /* ASAdBlockerListFetcherTests.swift */; };
 		AE33D4D2A3E444FD9DCBA2E8 /* TrackingProtectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6741EF98F0E46D595EE4FA9 /* TrackingProtectionViewControllerTests.swift */; };
+		AEC0FF0100000000000000A2 /* AIControlsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC0FF0100000000000000A1 /* AIControlsTests.swift */; };
 		B10997432A97251D00CC8860 /* UrlBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10997422A97251D00CC8860 /* UrlBarTests.swift */; };
 		B10D0B692D38F00E00925997 /* ShareLongPressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10D0B682D38F00E00925997 /* ShareLongPressTests.swift */; };
 		B1158F2A2B5029F200AC9D70 /* URLValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1158F292B5029F200AC9D70 /* URLValidationTests.swift */; };
@@ -2305,7 +2306,6 @@
 		EDDC4F702F68637000E0B8FA /* modernKitOnboardingOn.json in Resources */ = {isa = PBXBuildFile; fileRef = EDDC4F6D2F68637000E0B8FA /* modernKitOnboardingOn.json */; };
 		EDDC4F712F68637000E0B8FA /* modernOrangeAndBlueOnboardingOn.json in Resources */ = {isa = PBXBuildFile; fileRef = EDDC4F6E2F68637000E0B8FA /* modernOrangeAndBlueOnboardingOn.json */; };
 		EDDC4F732F68697E00E0B8FA /* ModernKitOnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDC4F722F68697E00E0B8FA /* ModernKitOnboardingTests.swift */; };
-		AEC0FF0100000000000000A2 /* AIControlsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC0FF0100000000000000A1 /* AIControlsTests.swift */; };
 		EDDEB52D2D35C1A300517783 /* SiteType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDEB52C2D35C1A300517783 /* SiteType.swift */; };
 		EDDF340A2CDD159F008BB6A4 /* SearchEngineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */; };
 		EDDF340B2CDD1B7C008BB6A4 /* SearchEngineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */; };
@@ -10528,6 +10528,7 @@
 		AE60452585A503B032AF13AF /* hsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hsb; path = hsb.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		AEB946A0984D10378CFCF88F /* si */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = si; path = si.lproj/Localizable.strings; sourceTree = "<group>"; };
 		AEBC42E8A9FC00D675AFEB5B /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		AEC0FF0100000000000000A1 /* AIControlsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIControlsTests.swift; sourceTree = "<group>"; };
 		AED14F92AF90DFCE13507BEB /* hy-AM */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "hy-AM"; path = "hy-AM.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		AEEC489CB0D0CFEB20EC02D2 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		AEEF4058B9DAD16B803B48DF /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = "lo.lproj/Default Browser.strings"; sourceTree = "<group>"; };
@@ -12000,7 +12001,6 @@
 		EDDC4F6D2F68637000E0B8FA /* modernKitOnboardingOn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = modernKitOnboardingOn.json; sourceTree = "<group>"; };
 		EDDC4F6E2F68637000E0B8FA /* modernOrangeAndBlueOnboardingOn.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = modernOrangeAndBlueOnboardingOn.json; sourceTree = "<group>"; };
 		EDDC4F722F68697E00E0B8FA /* ModernKitOnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernKitOnboardingTests.swift; sourceTree = "<group>"; };
-		AEC0FF0100000000000000A1 /* AIControlsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIControlsTests.swift; sourceTree = "<group>"; };
 		EDDEB52C2D35C1A300517783 /* SiteType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteType.swift; sourceTree = "<group>"; };
 		EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineModel.swift; sourceTree = "<group>"; };
 		EDEE4CC7BD65892525632A4E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Today.strings; sourceTree = "<group>"; };

--- a/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/UnitTest.xctestplan
@@ -140,6 +140,11 @@
           "containerPath" : "container:..\/BrowserKit",
           "identifier" : "QuickAnswersKit",
           "name" : "QuickAnswersKit"
+        },
+        {
+          "containerPath" : "container:..\/MozillaRustComponents",
+          "identifier" : "MozillaRustComponents",
+          "name" : "MozillaRustComponents"
         }
       ]
     },


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13501)

## :bulb: Description

`OhttpManager` kept its Gateway encryption key cache in a `static nonisolated(unsafe) var`, carrying a `FIXME: FXIOS-13501 Unprotected shared mutable state is an error in Swift 6`. That cache is driven concurrently: `GleanOhttpUploader.uploadOhttpRequest` spawns one unstructured `Task` per ping upload, so reads, writes and evictions interleave and can tear the dictionary.

This shows up in Sentry as `EXC_BAD_ACCESS` at garbage addresses inside `swift::RefCounts::doDecrementSlow` / `_swift_release_dealloc` — releasing torn values read out of the cache:

- [FIREFOX-IOS-31VD](https://mozilla.sentry.io/issues/FIREFOX-IOS-31VD) — culprit `OhttpManager.keyForGateway`, 32 events / 6 users, regressed
- [FIREFOX-IOS-3027](https://mozilla.sentry.io/issues/FIREFOX-IOS-3027) — culprit `OhttpManager.data`, 161 events / 54 users, ongoing

### What changed

`OhttpManager` becomes a `public actor` and the cache becomes an instance property, so isolation protects it and the `static` disappears. The cache primitives (`cachedKey(for:ttl:)`, `store(key:for:)`, `invalidateKey(for:)`) are `internal` rather than `private` so they can be unit tested without touching the network or the Rust component.

An actor on the existing type was preferred over introducing a separate synchronising object: there is exactly one `OhttpManager` per process, constructed once in `TelemetryWrapper`, so moving the cache off `static` does not change caching behaviour.

Caching semantics are unchanged — hit within TTL, evict and refetch when stale, invalidate on Gateway 400/401. Two concurrent cold callers can still both fetch a key, exactly as before.

`data(for:)`'s signature is unchanged, so `GleanOhttpUploader`, `GleanPingUploader` and `MockASOHttpManager` need no edits.

### Secondary benefit, and its limit

Isolation also prevents `OhttpSession` creation from overlapping. The first session in a process triggers one-time NSS initialization inside the Rust component, and NSPR's implicit initialization is not thread safe — entering it from two threads at once crashes in `PR_Lock` → `pthread_mutex_lock(NULL)`. That is [FIREFOX-IOS-2XQ3](https://mozilla.sentry.io/issues/FIREFOX-IOS-2XQ3) (91k events / 33k users), whose stack runs through `OhttpManager.data` → `OhttpSession::new` → `NSS_NoDB_Init`.

This narrows that window rather than closing it: the guarantee holds only while a single `OhttpManager` serves the process, and it cannot help if OHTTP races a *different* NSS consumer. A real fix wants application-services to initialize NSS up front (`nss::ensure_initialized()`); worth filing upstream separately. The relevant line carries a comment saying so, since it is not obvious that a plain `let session = try OhttpSession(...)` is load-bearing.

## :movie_camera: Demos

Not applicable — no user-visible change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code — **tests written but not yet run locally**, see note below
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — n/a
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review — n/a, this is the telemetry upload path but adds no telemetry
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n — n/a
- [x] If needed, I updated documentation and added comments to complex code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
