### PR TITLE
Add MTE-5798 Switch tabs while downloading a PDF file

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -176,6 +176,7 @@
         "BrowsingPDFTests\/testOpenLinkFromPDF_TAE()",
         "BrowsingPDFTests\/testOpenPDFViewer()",
         "BrowsingPDFTests\/testPinPDFtoTopSites_TAE()",
+        "BrowsingPDFTests\/testSwitchTabsWhileDownloadingPDF()",
         "C_AddressesTests\/testAddNewAddressCityFilled()",
         "C_AddressesTests\/testAddNewAddressCountry()",
         "C_AddressesTests\/testAddNewAddressEmailFilled()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -400,6 +400,12 @@ class BaseTestCase: XCTestCase {
         }
     }
 
+    func waitUntilDownloadStarts() {
+        let app = XCUIApplication()
+        let progressIndicator = app.progressIndicators.element(boundBy: 0)
+        mozWaitForElementToExist(progressIndicator)
+    }
+
     func waitForTabsButton() {
         mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton])
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -13,6 +13,15 @@ let PDF_website = [
     "longUrlValue": "http://www.education.gov.yk.ca/"
 ]
 
+let largePDF1 = [
+    "url": "https://storage.googleapis.com/mobile_test_assets/public/10MB-TESTFILE.ORG.pdf",
+    "pdfValue": "storage.googleapis.com"
+]
+let largePDF2 = [
+    "url": "https://storage.googleapis.com/mobile_test_assets/public/20MB-TESTFILE.ORG.pdf",
+    "pdfValue": "storage.googleapis.com"
+]
+
 class BrowsingPDFTests: BaseTestCase {
     let url = XCUIApplication().textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
     private var topSites: TopSitesScreen!
@@ -20,6 +29,7 @@ class BrowsingPDFTests: BaseTestCase {
     private var pdf: PDFScreen!
     private var contextMenu: ContextMenuScreen!
     private var library: LibraryScreen!
+    private var tabTrayScreen: TabTrayScreen!
 
     override func setUp() async throws {
         // Test name looks like: "[Class testFunc]", parse out the function name
@@ -29,6 +39,7 @@ class BrowsingPDFTests: BaseTestCase {
         pdf = PDFScreen(app: app)
         browser = BrowserScreen(app: app)
         library = LibraryScreen(app: app)
+        tabTrayScreen = TabTrayScreen(app: app)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307116
@@ -178,6 +189,25 @@ class BrowsingPDFTests: BaseTestCase {
 
         // Assert that the bookmarked item exists
         library.assertBookmarkExists(named: PDF_website["bookmarkLabel"]!)
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/3168443
+    // Regression
+    func testSwitchTabsWhileDownloadingPDF() {
+        // Step 1: Open a large PDF in a tab. The PDF starts downloading.
+        navigator.openURL(largePDF2["url"]!)
+        waitUntilDownloadStarts()
+
+        // Step 2: Switch to another tab and open another large PDF. All PDF files load properly.
+        navigator.openNewURL(urlString: largePDF1["url"]!)
+        waitUntilPageLoad()
+        browser.assertAddressBarContains(value: largePDF1["pdfValue"]!)
+
+        // Step 3: Return to the first PDF tab. It should be loading or loaded.
+        navigator.goto(TabTray)
+        tabTrayScreen.tapTabAtIndex(index: 0)
+        waitUntilPageLoad()
+        browser.assertAddressBarContains(value: largePDF2["pdfValue"]!)
     }
 
     private func longPressOnPdfLink() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -14,7 +14,7 @@ let PDF_website = [
 ]
 
 let largePDF1 = [
-    "url": "https://storage.googleapis.com/mobile_test_assets/public/10MB-TESTFILE.ORG.pdf",
+    "url": "https://storage.googleapis.com/mobile_test_assets/public/50MB-TESTFILE.ORG.pdf",
     "pdfValue": "storage.googleapis.com"
 ]
 let largePDF2 = [
@@ -195,19 +195,19 @@ class BrowsingPDFTests: BaseTestCase {
     // Regression
     func testSwitchTabsWhileDownloadingPDF() {
         // Step 1: Open a large PDF in a tab. The PDF starts downloading.
-        navigator.openURL(largePDF2["url"]!)
+        navigator.openURL(largePDF1["url"]!)
         waitUntilDownloadStarts()
 
         // Step 2: Switch to another tab and open another large PDF. All PDF files load properly.
-        navigator.openNewURL(urlString: largePDF1["url"]!)
+        navigator.openNewURL(urlString: largePDF2["url"]!)
         waitUntilPageLoad()
-        browser.assertAddressBarContains(value: largePDF1["pdfValue"]!)
+        browser.assertAddressBarContains(value: largePDF2["pdfValue"]!)
 
         // Step 3: Return to the first PDF tab. It should be loading or loaded.
         navigator.goto(TabTray)
         tabTrayScreen.tapTabAtIndex(index: 0)
         waitUntilPageLoad()
-        browser.assertAddressBarContains(value: largePDF2["pdfValue"]!)
+        browser.assertAddressBarContains(value: largePDF1["pdfValue"]!)
     }
 
     private func longPressOnPdfLink() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5798)
[TestRail case](https://mozilla.testrail.io/index.php?/cases/view/3168443)

## :bulb: Description
Adds `testSwitchTabsWhileDownloadingPDF` to `BrowsingPDFTests.swift`.
 https://mozilla.testrail.io/index.php?/cases/view/3168443

## :movie_camera: Demos
N/A — automated UI test only, no product UI changes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code