### PR TITLE
[MTE-5846] - improve testSwipeBackFromBookmarkFolder test

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -698,7 +698,10 @@ class BookmarksTests: FeatureFlaggedTestBase {
         libraryScreen.assertIdenticalFoldersNamesCreated(identifier: folderName, nrOfFolders: 2)
     }
 
-    func testSwipeBackFromBookmarkFolder() {
+    func testSwipeBackFromBookmarkFolder() throws {
+        guard !iPad() else {
+            throw XCTSkip("XCUITest cannot drive the pop gesture in the inset iPad panel, it works manually")
+        }
         app.launch()
         let folderName = "Swipe Back Folder"
         toolbarScreen.tapSettingsMenuButton()
@@ -708,12 +711,8 @@ class BookmarksTests: FeatureFlaggedTestBase {
         libraryScreen.tapOnFolder(folderName: folderName)
         libraryScreen.assertSelectedFolderOpens(folderName: folderName)
 
-        let swipeStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.01, dy: 0.5))
-        let swipeEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.8, dy: 0.5))
-        swipeStart.press(forDuration: 0.1, thenDragTo: swipeEnd)
-
-        mozWaitForElementToExist(app.navigationBars["Bookmarks"])
-        XCTAssertFalse(app.navigationBars[folderName].exists)
+        libraryScreen.swipeBackFromFolder(folderName: folderName)
+        libraryScreen.assertReturnedToBookmarksRoot(fromFolder: folderName)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3168590

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LibraryScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LibraryScreen.swift
@@ -221,6 +221,28 @@ final class LibraryScreen {
         BaseTestCase().mozWaitForElementToExist(app.navigationBars[folderName])
     }
 
+    func swipeBackFromFolder(folderName: String) {
+        let folderNavigationBar = app.navigationBars[folderName]
+        BaseTestCase().mozWaitForElementToExist(folderNavigationBar)
+        // On iPad the panel is presented as a sheet, so the drag is anchored to the panel's own
+        // frame: window relative coordinates start outside of it and the gesture never registers.
+        let panelOrigin = folderNavigationBar.coordinate(withNormalizedOffset: .zero)
+        let dragHeight = folderNavigationBar.frame.height * 2
+        let swipeStart = panelOrigin.withOffset(CGVector(dx: 1, dy: dragHeight))
+        let swipeEnd = panelOrigin.withOffset(CGVector(dx: folderNavigationBar.frame.width * 0.9, dy: dragHeight))
+        // A slow drag held before lift-off gives the pop transition enough movement events to commit,
+        // a plain press-and-drag delivers one jump that UIKit cancels.
+        swipeStart.press(forDuration: 0.05,
+                         thenDragTo: swipeEnd,
+                         withVelocity: .slow,
+                         thenHoldForDuration: 0.2)
+    }
+
+    func assertReturnedToBookmarksRoot(fromFolder folderName: String) {
+        BaseTestCase().mozWaitForElementToExist(app.navigationBars["Bookmarks"])
+        XCTAssertFalse(app.navigationBars[folderName].exists)
+    }
+
     func deleteFolder(folderName: String) {
         app.tables.cells.buttons["Remove \(folderName)"].waitAndTap()
         deleteButton.waitAndTap()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5846

## :bulb: Description
Skipped newly added tests from running on the smoke test plan.

Also improved newly added test testSwipeBackFromBookmarkFolder.
Skipped this test from running on iPad. Tried several solutions with claude to make it pass on iPad, this is the final result:

The original app.coordinate(withNormalizedOffset: CGVector(dx: 0.01, dy: 0.5)) is window-relative. On iPad the library panel is an inset form sheet at x=82, so that start point landed outside the panel entirely. swipeBackFromFolder now anchors the drag to the folder navigation bar's frame, which is the panel's own width on both form factors — correct geometry everywhere.

That alone doesn't make iPad pass: XCUITest can't drive _UIParallaxTransitionPanGestureRecognizer once the panel is inset (18 gesture variants tried; the app's gestureRecognizerShouldBegin is never called on iPad, but fires with result=true on iPhone). The gesture works manually on iPad, so this is an automation limitation, not a product defect — hence XCTSkip on iPad rather than a bug report or an app change.

