### PR TITLE
Add FXIOS-16600 [Nova] Update Protection Panel screen

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
@@ -264,13 +264,19 @@ public final class HeaderView: UIView, ThemeApplicable {
     }
 
     public func applyTheme(theme: Theme) {
+        let closeButtonTint = theme.isNova ? theme.colors.iconPrimary : theme.colors.iconSecondary
         let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
-            .withTintColor(theme.colors.iconSecondary)
+            .withTintColor(closeButtonTint)
         subtitleLabel.textColor = theme.colors.textSecondary
         titleLabel.textColor = theme.colors.textPrimary
         self.tintColor = theme.colors.layer2
         closeButton.setImage(buttonImage, for: .normal)
-        closeButton.backgroundColor = theme.colors.layer2
+        if #available(iOS 26.0, *), theme.isNova {
+            closeButton.applyProminentClearGlassConfiguration(backgroundColor: theme.colors.layer2,
+                                                               foregroundColor: closeButtonTint)
+        } else {
+            closeButton.backgroundColor = theme.colors.layer2
+        }
         horizontalLine.backgroundColor = theme.colors.borderPrimary
     }
 }

--- a/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/HeaderView.swift
@@ -273,7 +273,7 @@ public final class HeaderView: UIView, ThemeApplicable {
         closeButton.setImage(buttonImage, for: .normal)
         if #available(iOS 26.0, *), theme.isNova {
             closeButton.applyProminentClearGlassConfiguration(backgroundColor: theme.colors.layer2,
-                                                               foregroundColor: closeButtonTint)
+                                                              foregroundColor: closeButtonTint)
         } else {
             closeButton.backgroundColor = theme.colors.layer2
         }

--- a/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
@@ -148,7 +148,7 @@ public final class NavigationHeaderView: UIView {
         closeButton.setImage(buttonImage, for: .normal)
         if #available(iOS 26.0, *), theme.isNova {
             closeButton.applyProminentClearGlassConfiguration(backgroundColor: theme.colors.layer2,
-                                                               foregroundColor: closeButtonTint)
+                                                              foregroundColor: closeButtonTint)
         } else {
             closeButton.backgroundColor = theme.colors.layer2
         }

--- a/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Headers/NavigationHeaderView.swift
@@ -142,14 +142,20 @@ public final class NavigationHeaderView: UIView {
 
     // MARK: ThemeApplicable
     public func applyTheme(theme: Theme) {
+        let closeButtonTint = theme.isNova ? theme.colors.iconPrimary : theme.colors.iconSecondary
         let buttonImage = UIImage(named: StandardImageIdentifiers.Medium.cross)?
-            .withTintColor(theme.colors.iconSecondary)
+            .withTintColor(closeButtonTint)
         closeButton.setImage(buttonImage, for: .normal)
-        closeButton.backgroundColor = theme.colors.layer2
+        if #available(iOS 26.0, *), theme.isNova {
+            closeButton.applyProminentClearGlassConfiguration(backgroundColor: theme.colors.layer2,
+                                                               foregroundColor: closeButtonTint)
+        } else {
+            closeButton.backgroundColor = theme.colors.layer2
+        }
         backButton.tintColor = theme.colors.iconAccent
         backButton.setTitleColor(theme.colors.textAccent, for: .normal)
         horizontalLine.backgroundColor = theme.colors.borderPrimary
         titleLabel.textColor = theme.colors.textPrimary
-        backgroundColor = theme.colors.layer3
+        backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
     }
 }

--- a/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersHelpers/BlockedTrackerCell.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersHelpers/BlockedTrackerCell.swift
@@ -92,7 +92,7 @@ class BlockedTrackerCell: UITableViewCell,
     }
 
     func applyTheme(theme: Theme) {
-        backgroundColor = theme.colors.layer2
+        backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer2
         trackerLabel.textColor = theme.colors.textPrimary
         trackerImageView.tintColor = theme.colors.iconSecondary
         dividerView.backgroundColor = theme.colors.borderPrimary

--- a/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersHelpers/BlockedTrackersTableView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersHelpers/BlockedTrackersTableView.swift
@@ -54,7 +54,7 @@ class BlockedTrackersTableView: UITableView,
 
     // MARK: Themable
     func applyTheme(theme: Theme) {
-        backgroundColor = theme.colors.layer3
+        backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
         layer.borderColor = theme.colors.borderPrimary.cgColor
     }
 }

--- a/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersTableController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/BlockedTrackersTableController.swift
@@ -292,6 +292,6 @@ class BlockedTrackersTableViewController: UIViewController,
         let theme = currentTheme()
         navigationView.applyTheme(theme: theme)
         trackersTable.applyTheme(theme: theme)
-        view.backgroundColor = theme.colors.layer3
+        view.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
     }
 }

--- a/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/CertificatesViewController.swift
@@ -319,12 +319,13 @@ extension CertificatesViewController {
     func applyTheme() {
         let theme = currentTheme()
         overrideUserInterfaceStyle = theme.type.getInterfaceStyle()
-        view.backgroundColor = theme.colors.layer3
+        let panelBackground = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
+        view.backgroundColor = panelBackground
         titleLabel.textColor = theme.colors.textPrimary
         titleLabel.backgroundColor = theme.colors.layer5
         headerView.applyTheme(theme: theme)
 
-        certificatesTableView.backgroundColor = theme.colors.layer3
+        certificatesTableView.backgroundColor = panelBackground
         certificatesTableView.separatorColor = theme.colors.borderPrimary
 
         for case let cell as CertificatesCell in certificatesTableView.visibleCells {

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/BlockedTrackersLearnMoreViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/BlockedTrackersLearnMoreViewController.swift
@@ -156,6 +156,6 @@ final class BlockedTrackersLearnMoreViewController: UIViewController, Themeable 
     func applyTheme() {
         let theme = currentTheme()
         navigationView.applyTheme(theme: theme)
-        view.backgroundColor = theme.colors.layer3
+        view.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
     }
 }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionStatusView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionStatusView.swift
@@ -93,7 +93,7 @@ class TrackingProtectionStatusView: UIView {
 
     // MARK: ThemeApplicable
     public func applyTheme(theme: Theme) {
-        backgroundColor = theme.colors.layer2
+        backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer2
         connectionStatusLabel.textColor = theme.colors.textPrimary
         dividerView.backgroundColor = theme.colors.borderPrimary
         connectionImage.tintColor = theme.colors.iconSecondary

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionVerifiedByView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingDetailsHelpers/TrackingProtectionVerifiedByView.swift
@@ -53,7 +53,7 @@ class TrackingProtectionVerifiedByView: UIView {
 
     // MARK: ThemeApplicable
     public func applyTheme(theme: Theme) {
-        backgroundColor = theme.colors.layer2
+        backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer2
         verifiedByLabel.textColor = theme.colors.textPrimary
     }
 }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionDetailsViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionDetailsViewController.swift
@@ -266,7 +266,7 @@ class TrackingProtectionDetailsViewController: UIViewController, Themeable {
 extension TrackingProtectionDetailsViewController {
     func applyTheme() {
         let theme = currentTheme()
-        view.backgroundColor =  theme.colors.layer3
+        view.backgroundColor = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
         connectionView.connectionImage.image = model.getLockIcon(theme.type)
         verifiedByView.applyTheme(theme: theme)
         viewCertificatesButton.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionBlockedTrackersView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionBlockedTrackersView.swift
@@ -179,7 +179,7 @@ final class TrackingProtectionBlockedTrackersView: UIView, ThemeApplicable {
     }
 
     func applyTheme(theme: Theme) {
-        self.backgroundColor = theme.colors.layer2
+        self.backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer2
         trackersDetailArrow.tintColor = theme.colors.iconSecondary
         shieldImage.tintColor = theme.colors.iconSecondary
         trackersHorizontalLine.backgroundColor = theme.colors.borderPrimary

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionButton.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionButton.swift
@@ -99,7 +99,7 @@ class TrackingProtectionButton: ResizableButton, ThemeApplicable {
     // MARK: ThemeApplicable
 
     func applyTheme(theme: Theme) {
-        backgroundColorNormal = theme.colors.layer2
+        backgroundColorNormal = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer2
         foregroundColor = theme.colors.textPrimary
         setNeedsUpdateConfiguration()
     }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionConnectionStatusView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionConnectionStatusView.swift
@@ -133,7 +133,7 @@ final class TrackingProtectionConnectionStatusView: UIView, ThemeApplicable {
     }
 
     func applyTheme(theme: Theme) {
-        backgroundColor = theme.colors.layer2
+        backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer2
         connectionDetailArrow.tintColor = theme.colors.iconSecondary
         connectionStatusImage.tintColor = theme.colors.iconSecondary
     }

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionToggleView.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionHelpers/TrackingProtectionToggleView.swift
@@ -153,7 +153,7 @@ final class TrackingProtectionToggleView: UIView, ThemeApplicable {
     }
 
     func applyTheme(theme: Theme) {
-        self.backgroundColor = theme.colors.layer2
+        self.backgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer2
         toggleSwitch.tintColor = theme.colors.actionPrimary
         toggleSwitch.onTintColor = theme.colors.actionPrimary
         toggleStatusLabel.textColor = theme.colors.textSecondary

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -771,7 +771,8 @@ class TrackingProtectionViewController: UIViewController,
     func applyTheme() {
         let theme = currentTheme()
         overrideUserInterfaceStyle = theme.type.getInterfaceStyle()
-        view.backgroundColor = theme.colors.layer3.withAlphaComponent(backgroundAlpha)
+        let panelBackground = theme.isNova ? theme.colors.layer1 : theme.colors.layer3
+        view.backgroundColor = panelBackground.withAlphaComponent(backgroundAlpha)
         headerContainer.applyTheme(theme: theme)
         connectionDetailsHeaderView.applyTheme(theme: theme)
         trackersView.applyTheme(theme: theme)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16600)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updated Protection Panel screen to use Nova colors scheme the same as in Site Menu screen:
`layer`1 for background, rows/cells use `layerSurfaceMedium` and `iconPrimary` tint and iOS 26+ glass implementation for close button, the same as on Site Menu.

<img width="886" height="797" alt="Screenshot 2026-08-18 at 11 11 02" src="https://github.com/user-attachments/assets/08c10b45-cc19-4657-bd0f-89b322400ddd" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-18 at 11 08 26" src="https://github.com/user-attachments/assets/02b04775-1395-4ca7-b3db-0e9bc006f2db" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-18 at 11 08 06" src="https://github.com/user-attachments/assets/2a4768f0-4935-4da7-9554-f84924c19f9c" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

