### PR TITLE
Bugfix FXIOS-16571 [Nova] Toast message background is too light

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/DarkTheme.swift
@@ -145,6 +145,7 @@ private struct DarkColourPalette: ThemeColourPalette {
     var iconOnColorDisabled: UIColor { NovaMissingToken.color("iconOnColorDisabled") }
     var iconPrivate: UIColor { NovaMissingToken.color("iconPrivate") }
     var borderStrong: UIColor { NovaMissingToken.color("borderStrong") }
+    var borderAccentToast: UIColor { NovaMissingToken.color("borderAccentToast") }
     var borderRadioButtonDefault: UIColor { NovaMissingToken.color("borderRadioButtonDefault") }
     var gradient: Gradient { NovaMissingToken.gradient("gradient") }
     var gradientAccent: Gradient { NovaMissingToken.gradient("gradientAccent") }

--- a/BrowserKit/Sources/Common/Theming/LightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/LightTheme.swift
@@ -134,6 +134,7 @@ private struct LightColourPalette: ThemeColourPalette {
     var iconOnColorDisabled: UIColor { NovaMissingToken.color("iconOnColorDisabled") }
     var iconPrivate: UIColor { NovaMissingToken.color("iconPrivate") }
     var borderStrong: UIColor { NovaMissingToken.color("borderStrong") }
+    var borderAccentToast: UIColor { NovaMissingToken.color("borderAccentToast") }
     var borderRadioButtonDefault: UIColor { NovaMissingToken.color("borderRadioButtonDefault") }
     var gradient: Gradient { NovaMissingToken.gradient("gradient") }
     var gradientAccent: Gradient { NovaMissingToken.gradient("gradientAccent") }

--- a/BrowserKit/Sources/Common/Theming/NovaDarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaDarkTheme.swift
@@ -37,7 +37,7 @@ private struct NovaDarkColourPalette: ThemeColourPalette {
     var layerSurfaceMedium = NovaColors.Gray65
     var layerSurfaceMediumAlpha = NovaColors.Gray65.withAlphaComponent(0.4)
     var layerAccentSubtle: UIColor = NovaColors.VioletDesaturated70
-    var layerInverse: UIColor = NovaColors.Gray30.withAlphaComponent(0.9)
+    var layerInverse: UIColor = NovaColors.Gray30
     var layerWarning: UIColor = NovaColors.Yellow70
     var layerSuccess: UIColor = NovaColors.Green70
     var layerCritical: UIColor = NovaColors.Red70
@@ -98,6 +98,7 @@ private struct NovaDarkColourPalette: ThemeColourPalette {
     var borderPrimary: UIColor = NovaColors.Gray60
     var borderStrong: UIColor = NovaColors.Gray55
     var borderInverted: UIColor = NovaColors.Gray15
+    var borderAccentToast: UIColor = NovaColors.Violet70
     var borderRadioButtonDefault: UIColor = NovaColors.Gray45
 
     // MARK: - Shadow

--- a/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
@@ -24,7 +24,7 @@ private struct NovaLightColourPalette: ThemeColourPalette {
     var layerSurfaceMedium = NovaColors.White
     var layerSurfaceMediumAlpha = NovaColors.White.withAlphaComponent(0.4)
     var layerAccentSubtle: UIColor = NovaColors.VioletDesaturated10
-    var layerInverse: UIColor = NovaColors.Gray70.withAlphaComponent(0.8)
+    var layerInverse: UIColor = NovaColors.Gray70
     var layerWarning: UIColor = NovaColors.Yellow10
     var layerSuccess: UIColor = NovaColors.Green10
     var layerCritical: UIColor = NovaColors.Red10
@@ -85,6 +85,7 @@ private struct NovaLightColourPalette: ThemeColourPalette {
     var borderPrimary: UIColor = NovaColors.Gray15
     var borderStrong: UIColor = NovaColors.Gray20
     var borderInverted: UIColor = NovaColors.Gray60
+    var borderAccentToast: UIColor = NovaColors.Violet30
     var borderRadioButtonDefault: UIColor = NovaColors.Gray35
 
     // MARK: - Shadow

--- a/BrowserKit/Sources/Common/Theming/NovaPrivateTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaPrivateTheme.swift
@@ -24,7 +24,7 @@ private struct NovaPrivateColourPalette: ThemeColourPalette {
     var layerSurfaceMedium = NovaColors.VioletDesaturated80
     var layerSurfaceMediumAlpha = NovaColors.VioletDesaturated80.withAlphaComponent(0.4)
     var layerAccentSubtle: UIColor = NovaColors.Violet70
-    var layerInverse: UIColor = NovaColors.Gray30.withAlphaComponent(0.9)
+    var layerInverse: UIColor = NovaColors.Gray30
     var layerWarning: UIColor = NovaColors.Yellow70
     var layerSuccess: UIColor = NovaColors.Green70
     var layerCritical: UIColor = NovaColors.Red70
@@ -85,6 +85,7 @@ private struct NovaPrivateColourPalette: ThemeColourPalette {
     var borderPrimary: UIColor = NovaColors.VioletDesaturated70
     var borderStrong: UIColor = NovaColors.VioletDesaturated60
     var borderInverted: UIColor = NovaColors.Gray15
+    var borderAccentToast: UIColor = NovaColors.Violet70
     var borderRadioButtonDefault: UIColor = NovaColors.Gray45
 
     // MARK: - Shadow

--- a/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
@@ -136,6 +136,7 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     var iconOnColorDisabled: UIColor { NovaMissingToken.color("iconOnColorDisabled") }
     var iconPrivate: UIColor { NovaMissingToken.color("iconPrivate") }
     var borderStrong: UIColor { NovaMissingToken.color("borderStrong") }
+    var borderAccentToast: UIColor { NovaMissingToken.color("borderAccentToast") }
     var borderRadioButtonDefault: UIColor { NovaMissingToken.color("borderRadioButtonDefault") }
     var gradient: Gradient { NovaMissingToken.gradient("gradient") }
     var gradientAccent: Gradient { NovaMissingToken.gradient("gradientAccent") }

--- a/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
@@ -118,6 +118,7 @@ public protocol ThemeColourPalette {
     var iconOnColorDisabled: UIColor { get }
     var iconPrivate: UIColor { get }
     var borderStrong: UIColor { get }
+    var borderAccentToast: UIColor { get }
     var borderRadioButtonDefault: UIColor { get }
     var gradient: Gradient { get }
     var gradientAccent: Gradient { get }

--- a/BrowserKit/Tests/CommonTests/Theming/NovaMissingTokenTests.swift
+++ b/BrowserKit/Tests/CommonTests/Theming/NovaMissingTokenTests.swift
@@ -58,6 +58,7 @@ class NovaMissingTokenTests: XCTestCase {
             ("layerInverse", { _ = $0.layerInverse }),
             ("layerGlassTintNova", { _ = $0.layerGlassTintNova }),
             ("textToast", { _ = $0.textToast }),
+            ("borderAccentToast", { _ = $0.borderAccentToast }),
             ("iconInverted", { _ = $0.iconInverted }),
             ("iconOnColorDisabled", { _ = $0.iconOnColorDisabled }),
             ("iconPrivate", { _ = $0.iconPrivate }),

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
@@ -188,6 +188,7 @@ struct TabTrayPanelSwipePalette: ThemeColourPalette {
     var iconOnColorDisabled: UIColor { base.iconOnColorDisabled }
     var iconPrivate: UIColor { base.iconPrivate }
     var borderStrong: UIColor { base.borderStrong }
+    var borderAccentToast: UIColor { base.borderAccentToast }
     var borderRadioButtonDefault: UIColor { base.borderRadioButtonDefault }
     var gradient: Gradient { base.gradient }
     var gradientAccent: Gradient { base.gradientAccent }

--- a/firefox-ios/Client/Frontend/Browser/Toasts/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/ButtonToast.swift
@@ -147,7 +147,8 @@ class ButtonToast: Toast {
         descriptionLabel.textColor = theme.colors.textInverted
         imageView.tintColor = theme.colors.textInverted
         roundedButton.setTitleColor(theme.isNova ? theme.colors.textToast : theme.colors.textInverted, for: [])
-        roundedButton.layer.borderColor = theme.colors.borderInverted.cgColor
+        let borderColor = theme.isNova ? theme.colors.borderAccentToast : theme.colors.borderInverted
+        roundedButton.layer.borderColor = borderColor.cgColor
     }
 
     override func adjustLayoutForA11ySizeCategory() {
@@ -210,6 +211,7 @@ class PasteControlToast: ButtonToast {
 
     override func applyTheme(theme: Theme) {
         super.applyTheme(theme: theme)
-        pasteControl.layer.borderColor = theme.colors.borderInverted.cgColor
+        let borderColor = theme.isNova ? theme.colors.borderAccentToast : theme.colors.borderInverted
+        pasteControl.layer.borderColor = borderColor.cgColor
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16571)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates toast colors for Nova, based on Figma requirements:
Also, it adds a new token for toast border, that is Nova only.

<img width="432" height="609" alt="Screenshot 2026-08-18 at 11 44 26" src="https://github.com/user-attachments/assets/d1876cd3-21ec-4dc1-b643-d2897cb4572c" />


<img width="814" height="43" alt="Screenshot 2026-08-18 at 11 43 55" src="https://github.com/user-attachments/assets/ecbac644-12fe-4544-9c67-8f70d7582d31" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

