### PR TITLE
Add FXIOS-16601 Update Nova buttons design

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentTabCell.swift
@@ -199,7 +199,7 @@ final class ExperimentTabCell: UICollectionViewCell, ThemeApplicable, ReusableCe
 
     func applyTheme(theme: Theme) {
         backgroundHolder.backgroundColor = theme.colors.layer1
-        closeButtonImageOverlay.tintColor = theme.isNova ? theme.colors.textOnLight : theme.colors.textOnDark
+        closeButtonImageOverlay.tintColor = theme.isNova ? theme.colors.iconOnColor : theme.colors.textOnDark
         screenshotView.backgroundColor = theme.colors.layer1
         smallFaviconView.tintColor = theme.colors.textPrimary
         setupShadow(theme: theme)

--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -127,6 +127,23 @@ class PasswordDetailViewController: SensitiveViewController,
         let theme = currentTheme()
         tableView.separatorColor = theme.colors.borderPrimary
         tableView.backgroundColor = theme.colors.layer1
+        if #available(iOS 26.0, *), theme.isNova, isEditingFieldData {
+            navigationItem.rightBarButtonItem = makeNovaDoneButton(theme: theme)
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func makeNovaDoneButton(theme: Theme) -> UIBarButtonItem {
+        let doneButton = UIBarButtonItem(
+            image: UIImage(named: StandardImageIdentifiers.Large.checkmark)?
+                .withTintColor(theme.colors.iconInverted, renderingMode: .alwaysOriginal),
+            style: .prominent,
+            target: self,
+            action: #selector(doneEditing)
+        )
+        doneButton.tintColor = theme.colors.actionPrimary
+        doneButton.accessibilityLabel = .SettingsSearchDoneButton
+        return doneButton
     }
 
     // MARK: Notifiable
@@ -430,15 +447,7 @@ extension PasswordDetailViewController {
             )
             return
         }
-        let doneButton = UIBarButtonItem(
-            image: UIImage(named: StandardImageIdentifiers.Large.checkmark)?
-                .withTintColor(theme.colors.iconInverted, renderingMode: .alwaysOriginal),
-            style: .prominent,
-            target: self,
-            action: #selector(doneEditing)
-        )
-        doneButton.tintColor = theme.colors.actionPrimary
-        navigationItem.rightBarButtonItem = doneButton
+        navigationItem.rightBarButtonItem = makeNovaDoneButton(theme: theme)
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -421,11 +421,24 @@ extension PasswordDetailViewController {
         guard let indexPath = viewModel.indexPath(for: LoginDetailCellType.username),
                 let cell = tableView.cellForRow(at: indexPath) as? LoginDetailTableViewCell else { return }
         cell.descriptionLabel.becomeFirstResponder()
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .done,
+        let theme = currentTheme()
+        guard #available(iOS 26.0, *), theme.isNova else {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                barButtonSystemItem: .done,
+                target: self,
+                action: #selector(doneEditing)
+            )
+            return
+        }
+        let doneButton = UIBarButtonItem(
+            image: UIImage(named: StandardImageIdentifiers.Large.checkmark)?
+                .withTintColor(theme.colors.iconInverted, renderingMode: .alwaysOriginal),
+            style: .prominent,
             target: self,
             action: #selector(doneEditing)
         )
+        doneButton.tintColor = theme.colors.actionPrimary
+        navigationItem.rightBarButtonItem = doneButton
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/PasswordDetailViewController.swift
@@ -142,7 +142,7 @@ class PasswordDetailViewController: SensitiveViewController,
             action: #selector(doneEditing)
         )
         doneButton.tintColor = theme.colors.actionPrimary
-        doneButton.accessibilityLabel = .SettingsSearchDoneButton
+        doneButton.accessibilityLabel = .AppSettingsDone
         return doneButton
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
@@ -38,11 +38,25 @@ final class TranslationPickerSettingsViewController: UIViewController,
         action: #selector(didTapEdit)
     )
 
-    private lazy var doneButton = UIBarButtonItem(
-        barButtonSystemItem: .done,
-        target: self,
-        action: #selector(didTapDone)
-    )
+    private lazy var doneButton: UIBarButtonItem = {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        guard #available(iOS 26.0, *), theme.isNova else {
+            return UIBarButtonItem(
+                barButtonSystemItem: .done,
+                target: self,
+                action: #selector(didTapDone)
+            )
+        }
+        let button = UIBarButtonItem(
+            image: UIImage(named: StandardImageIdentifiers.Large.checkmark)?
+                .withTintColor(theme.colors.iconInverted, renderingMode: .alwaysOriginal),
+            style: .prominent,
+            target: self,
+            action: #selector(didTapDone)
+        )
+        button.tintColor = theme.colors.actionPrimary
+        return button
+    }()
 
     private lazy var cancelButton = UIBarButtonItem(
         barButtonSystemItem: .cancel,

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
@@ -55,7 +55,7 @@ final class TranslationPickerSettingsViewController: UIViewController,
             action: #selector(didTapDone)
         )
         button.tintColor = theme.colors.actionPrimary
-        button.accessibilityLabel = .SettingsSearchDoneButton
+        button.accessibilityLabel = .AppSettingsDone
         return button
     }()
 

--- a/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Translation/TranslationPickerSettingsViewController.swift
@@ -55,6 +55,7 @@ final class TranslationPickerSettingsViewController: UIViewController,
             action: #selector(didTapDone)
         )
         button.tintColor = theme.colors.actionPrimary
+        button.accessibilityLabel = .SettingsSearchDoneButton
         return button
     }()
 
@@ -394,6 +395,11 @@ final class TranslationPickerSettingsViewController: UIViewController,
         view.backgroundColor = theme.colors.layer1
         collectionView.setCollectionViewLayout(makeLayout(backgroundColor: theme.colors.layer1), animated: false)
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
+        if #available(iOS 26.0, *), theme.isNova {
+            doneButton.tintColor = theme.colors.actionPrimary
+            doneButton.image = UIImage(named: StandardImageIdentifiers.Large.checkmark)?
+                .withTintColor(theme.colors.iconInverted, renderingMode: .alwaysOriginal)
+        }
         collectionView.visibleCells.forEach { ($0 as? ThemeApplicable)?.applyTheme(theme: theme) }
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16601)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates Done button from editing preferred language screen and from password screen, base on Figma:
Also updates token for close button used on opened tabs.

<img width="289" height="322" alt="Screenshot 2026-08-18 at 14 33 40" src="https://github.com/user-attachments/assets/8dbb8c6e-e966-4c19-8fdc-e109329b8409" />

<img width="275" height="332" alt="Screenshot 2026-08-18 at 14 33 58" src="https://github.com/user-attachments/assets/03832749-e82a-4e0d-b6d8-49f61b6d2704" />
<img width="267" height="327" alt="Screenshot 2026-08-18 at 14 34 17" src="https://github.com/user-attachments/assets/8ac126bb-9a98-44f2-b807-c0b3e7994675" />

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

