### PR TITLE
Add FXIOS-16602 Change border for selected Settings illustrations

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AddressBarSelectionView.swift
@@ -27,6 +27,7 @@ struct AddressBarSelectionView: View {
         HStack(spacing: UX.spacing) {
             ForEach(SearchBarPosition.allCases, id: \.label) { addressBarPosition in
                 GenericImageOption(
+                    theme: theme,
                     isSelected: selectedAddressBarPosition == addressBarPosition,
                     onSelected: {
                         selectedAddressBarPosition = addressBarPosition

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/GenericImageOption.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/GenericImageOption.swift
@@ -25,11 +25,17 @@ struct GenericImageOption: View, FeatureFlaggable {
     }
 
     // Properties
+    let theme: Theme?
     let isSelected: Bool
     let onSelected: (() -> Void)?
     let label: String
     let imageName: String
     let a11yIdentifier: String
+
+    private var selectedBorderColor: Color {
+        guard let theme, theme.isNova else { return UX.selectedBorderColor }
+        return Color(theme.colors.iconAccent)
+    }
 
     var body: some View {
         VStack(spacing: UX.spacing) {
@@ -52,7 +58,7 @@ struct GenericImageOption: View, FeatureFlaggable {
 
     private var selectableOptionVisual: some View {
         RoundedRectangle(cornerRadius: UX.cornerRadius)
-            .stroke(isSelected ? UX.selectedBorderColor : UX.unselectedBorderColor,
+            .stroke(isSelected ? selectedBorderColor : UX.unselectedBorderColor,
                     lineWidth: isSelected ? UX.selectedBorderWidth : UX.unselectedBorderWidth)
             .background(
                 Image(imageName)

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/ThemeOptionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/ThemeOptionView.swift
@@ -7,7 +7,8 @@ import Common
 
 /// A view that represents a selectable theme option.
 struct ThemeOptionView: View {
-    let theme: ThemeSelectionView.ThemeOption
+    let themeOption: ThemeSelectionView.ThemeOption
+    let theme: Theme?
     /// A flag indicating whether this option is currently selected.
     let isSelected: Bool
     /// Callback executed when a new theme option is selected.
@@ -15,11 +16,12 @@ struct ThemeOptionView: View {
 
     var body: some View {
         GenericImageOption(
+            theme: theme,
             isSelected: isSelected,
             onSelected: onSelected,
-            label: theme.rawValue,
-            imageName: imageName(for: theme),
-            a11yIdentifier: identifierName(for: theme)
+            label: themeOption.rawValue,
+            imageName: imageName(for: themeOption),
+            a11yIdentifier: identifierName(for: themeOption)
         )
     }
 

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/ThemeSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/ThemeSelectionView.swift
@@ -44,7 +44,7 @@ struct ThemeSelectionView: View {
     var body: some View {
         HStack(spacing: UX.spacing) {
             ForEach(ThemeOption.allCases, id: \.rawValue) { themeOption in
-                ThemeOptionView(theme: themeOption, isSelected: selectedThemeOption == themeOption) {
+                ThemeOptionView(themeOption: themeOption, theme: theme, isSelected: selectedThemeOption == themeOption) {
                     selectedThemeOption = themeOption
                     onThemeSelected?(themeOption)
                 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16602)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR change border for selected Settings illustrations in order to use violet color only for Nova design system.

<img width="605" height="401" alt="Screenshot 2026-08-18 at 15 14 12" src="https://github.com/user-attachments/assets/52a72188-b285-4e4e-8cf8-fecf6d6e2695" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-18 at 15 09 31" src="https://github.com/user-attachments/assets/cb35e200-62a1-41be-8206-885ecf398f2a" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-18 at 15 09 21" src="https://github.com/user-attachments/assets/3ece5fc5-f372-4c4e-a8af-d2d44be0aabd" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

