### PR TITLE
Bugfix FXIOS-16487 [WebCompat] Show an error for an invalid URL

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
@@ -31,9 +31,40 @@ final class WebCompatURLCell: UICollectionViewListCell,
         field.delegate = self
     }
 
-    private lazy var stackView: UIStackView = .build { stack in
+    private lazy var errorLabel: UILabel = .build { label in
+        label.font = FXFontStyles.Regular.subheadline.scaledFont()
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+    }
+
+    private lazy var errorIcon: UIImageView = .build { imageView in
+        imageView.image = UIImage(named: StandardImageIdentifiers.Large.warning)?.withRenderingMode(.alwaysTemplate)
+        imageView.contentMode = .scaleAspectFit
+        imageView.isAccessibilityElement = false
+    }
+
+    private lazy var errorStackView: UIStackView = .build { stack in
+        stack.axis = .horizontal
+        stack.alignment = .top
+        stack.spacing = WebCompatReporterUX.Spacing.interItem
+        stack.isHidden = true
+    }
+
+    private lazy var fieldStackView: UIStackView = .build { stack in
         stack.spacing = WebCompatReporterUX.Spacing.interItem
     }
+
+    private lazy var containerStackView: UIStackView = .build { stack in
+        stack.axis = .vertical
+        stack.spacing = WebCompatReporterUX.Spacing.interItem
+    }
+
+    private var scaledIconSize: CGFloat {
+        return UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.ErrorMessage.iconSize)
+    }
+
+    private lazy var iconWidthConstraint = errorIcon.widthAnchor.constraint(equalToConstant: scaledIconSize)
+    private lazy var iconHeightConstraint = errorIcon.heightAnchor.constraint(equalToConstant: scaledIconSize)
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -50,23 +81,29 @@ final class WebCompatURLCell: UICollectionViewListCell,
     }
 
     private func setupLayout() {
-        stackView.addArrangedSubview(titleLabel)
-        stackView.addArrangedSubview(textField)
-        contentView.addSubview(stackView)
+        fieldStackView.addArrangedSubview(titleLabel)
+        fieldStackView.addArrangedSubview(textField)
+        errorStackView.addArrangedSubview(errorIcon)
+        errorStackView.addArrangedSubview(errorLabel)
+        containerStackView.addArrangedSubview(fieldStackView)
+        containerStackView.addArrangedSubview(errorStackView)
+        contentView.addSubview(containerStackView)
         let margins = contentView.layoutMarginsGuide
         // .defaultHigh avoids conflicting with the self-sizing pass.
-        let topConstraint = stackView.topAnchor.constraint(equalTo: margins.topAnchor)
-        let bottomConstraint = stackView.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
+        let topConstraint = containerStackView.topAnchor.constraint(equalTo: margins.topAnchor)
+        let bottomConstraint = containerStackView.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
         topConstraint.priority = .defaultHigh
         bottomConstraint.priority = .defaultHigh
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+            containerStackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+            containerStackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
             topConstraint,
             bottomConstraint,
-            stackView.heightAnchor.constraint(
+            fieldStackView.heightAnchor.constraint(
                 greaterThanOrEqualToConstant: WebCompatReporterUX.Control.minimumTapTarget
-            )
+            ),
+            iconWidthConstraint,
+            iconHeightConstraint
         ])
         updateStackAxis()
     }
@@ -76,13 +113,14 @@ final class WebCompatURLCell: UICollectionViewListCell,
     }
 
     func applyStackLayout(isAccessibilityCategory: Bool) {
-        stackView.axis = isAccessibilityCategory ? .vertical : .horizontal
-        stackView.alignment = isAccessibilityCategory ? .fill : .center
+        fieldStackView.axis = isAccessibilityCategory ? .vertical : .horizontal
+        fieldStackView.alignment = isAccessibilityCategory ? .fill : .center
     }
 
     func configure(
         title: String,
         text: String,
+        errorMessage: String?,
         a11yIdentifier: String,
         onEditingEnded: @escaping (String) -> Void
     ) {
@@ -91,9 +129,20 @@ final class WebCompatURLCell: UICollectionViewListCell,
         textField.accessibilityIdentifier = a11yIdentifier
         titleLabel.isAccessibilityElement = false
         textField.accessibilityLabel = title
+        errorLabel.text = errorMessage
+        setErrorRowHidden(errorMessage == nil)
         // The value round-trips on editing-end, so don't overwrite mid-edit.
         if !textField.isFirstResponder {
             textField.text = text
+        }
+    }
+
+    /// Outside the list's reconfigure animation, or the stack squashes against the animating height.
+    private func setErrorRowHidden(_ isHidden: Bool) {
+        guard errorStackView.isHidden != isHidden else { return }
+        UIView.performWithoutAnimation {
+            errorStackView.isHidden = isHidden
+            contentView.layoutIfNeeded()
         }
     }
 
@@ -105,6 +154,8 @@ final class WebCompatURLCell: UICollectionViewListCell,
         titleLabel.textColor = theme.colors.textSecondary
         textField.textColor = theme.colors.textPrimary
         textField.tintColor = theme.colors.actionPrimary
+        errorLabel.textColor = theme.colors.textCritical
+        errorIcon.tintColor = theme.colors.textCritical
     }
 
     // MARK: - Notifiable
@@ -112,7 +163,10 @@ final class WebCompatURLCell: UICollectionViewListCell,
     nonisolated func handleNotifications(_ notification: Notification) {
         guard notification.name == UIContentSizeCategory.didChangeNotification else { return }
         ensureMainThread { [weak self] in
-            self?.updateStackAxis()
+            guard let self else { return }
+            self.updateStackAxis()
+            self.iconWidthConstraint.constant = self.scaledIconSize
+            self.iconHeightConstraint.constant = self.scaledIconSize
         }
     }
 

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
@@ -11,6 +11,8 @@ final class WebCompatURLCell: UICollectionViewListCell,
                               UITextFieldDelegate,
                               Notifiable {
     private var editingEndedHandler: ((String) -> Void)?
+    private var iconWidthConstraint: NSLayoutConstraint?
+    private var iconHeightConstraint: NSLayoutConstraint?
 
     private lazy var titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.body.scaledFont()
@@ -63,9 +65,6 @@ final class WebCompatURLCell: UICollectionViewListCell,
         return UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.ErrorMessage.iconSize)
     }
 
-    private lazy var iconWidthConstraint = errorIcon.widthAnchor.constraint(equalToConstant: scaledIconSize)
-    private lazy var iconHeightConstraint = errorIcon.heightAnchor.constraint(equalToConstant: scaledIconSize)
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupLayout()
@@ -94,6 +93,10 @@ final class WebCompatURLCell: UICollectionViewListCell,
         let bottomConstraint = containerStackView.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
         topConstraint.priority = .defaultHigh
         bottomConstraint.priority = .defaultHigh
+        let iconWidthConstraint = errorIcon.widthAnchor.constraint(equalToConstant: scaledIconSize)
+        let iconHeightConstraint = errorIcon.heightAnchor.constraint(equalToConstant: scaledIconSize)
+        self.iconWidthConstraint = iconWidthConstraint
+        self.iconHeightConstraint = iconHeightConstraint
         NSLayoutConstraint.activate([
             containerStackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
             containerStackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
@@ -167,8 +170,8 @@ final class WebCompatURLCell: UICollectionViewListCell,
         ensureMainThread { [weak self] in
             guard let self else { return }
             self.updateStackAxis()
-            self.iconWidthConstraint.constant = self.scaledIconSize
-            self.iconHeightConstraint.constant = self.scaledIconSize
+            self.iconWidthConstraint?.constant = self.scaledIconSize
+            self.iconHeightConstraint?.constant = self.scaledIconSize
         }
     }
 

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatURLCell.swift
@@ -128,7 +128,7 @@ final class WebCompatURLCell: UICollectionViewListCell,
         titleLabel.text = title
         textField.accessibilityIdentifier = a11yIdentifier
         titleLabel.isAccessibilityElement = false
-        textField.accessibilityLabel = title
+        textField.accessibilityLabel = [title, errorMessage].compactMap { $0 }.joined(separator: ", ")
         errorLabel.text = errorMessage
         setErrorRowHidden(errorMessage == nil)
         // The value round-trips on editing-end, so don't overwrite mid-edit.
@@ -144,6 +144,8 @@ final class WebCompatURLCell: UICollectionViewListCell,
             errorStackView.isHidden = isHidden
             contentView.layoutIfNeeded()
         }
+        guard !isHidden, let message = errorLabel.text else { return }
+        UIAccessibility.post(notification: .announcement, argument: message)
     }
 
     // MARK: - ThemeApplicable

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -170,7 +170,7 @@ private func previewFooterSection() -> WebCompatReportViewModel.Section {
 @available(iOS 17.0, *)
 #Preview("Invalid URL") {
     previewSheet(sections: [
-        previewURLSection(text: " .com", errorMessage: "Enter a valid URL"),
+        previewURLSection(text: ".com", errorMessage: "Enter a valid URL"),
         previewCategorySection(selectedTitle: "Site is not usable"),
         previewSendSection(isEnabled: false)
     ], isPreviewEnabled: false)

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -23,12 +23,15 @@ private func previewSheet(
     return UINavigationController(rootViewController: sheet)
 }
 
-private func previewURLSection() -> WebCompatReportViewModel.Section {
+private func previewURLSection(
+    text: String = "https://houseandhome.com/recipe/croque-monsieur",
+    errorMessage: String? = nil
+) -> WebCompatReportViewModel.Section {
     return WebCompatReportViewModel.Section(id: "url", rows: [
         WebCompatReportViewModel.Row(
             id: "url",
             title: "URL",
-            kind: .urlField(text: "https://houseandhome.com/recipe/croque-monsieur"),
+            kind: .urlField(text: text, errorMessage: errorMessage),
             a11yIdentifier: "url"
         )
     ])
@@ -160,6 +163,15 @@ private func previewFooterSection() -> WebCompatReportViewModel.Section {
     previewSheet(sections: [
         previewURLSection(),
         previewCategorySection(selectedTitle: nil),
+        previewSendSection(isEnabled: false)
+    ], isPreviewEnabled: false)
+}
+
+@available(iOS 17.0, *)
+#Preview("Invalid URL") {
+    previewSheet(sections: [
+        previewURLSection(text: " .com", errorMessage: "Enter a valid URL"),
+        previewCategorySection(selectedTitle: "Site is not usable"),
         previewSendSection(isEnabled: false)
     ], isPreviewEnabled: false)
 }

--- a/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Preview/WebCompatReportSheetPreview.swift
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+/// Scaffolding for the Xcode previews below. None of it ships: the view models here stand in for
+/// what the Client-side Redux layer builds at runtime.
 #if DEBUG
 import Common
 import SwiftUI

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -259,10 +259,11 @@ public final class WebCompatReportSheetViewController: UIViewController,
     private func urlCellRegistration()
     -> UICollectionView.CellRegistration<WebCompatURLCell, WebCompatReportViewModel.Row> {
         return UICollectionView.CellRegistration { [weak self] cell, _, row in
-            guard let self, case let .urlField(text) = row.kind else { return }
+            guard let self, case let .urlField(text, errorMessage) = row.kind else { return }
             cell.configure(
                 title: row.title,
                 text: text,
+                errorMessage: errorMessage,
                 a11yIdentifier: row.a11yIdentifier
             ) { [weak self] text in
                 self?.delegate?.webCompatReportSheetDidEditText(id: row.id, text: text)

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
@@ -59,7 +59,7 @@ public struct WebCompatReportViewModel: Equatable, Sendable {
             case plain
             case categoryMenu(isPlaceholder: Bool, options: [MenuOption])
             case subOption(isSelected: Bool)
-            case urlField(text: String)
+            case urlField(text: String, errorMessage: String?)
             case detailsField(text: String, placeholder: String)
             case sendButton(isEnabled: Bool)
             case checkbox(isChecked: Bool)

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReporterUX.swift
@@ -66,6 +66,10 @@ enum WebCompatReporterUX {
         static let bulletDotFontSize: CGFloat = 7
     }
 
+    enum ErrorMessage {
+        static let iconSize: CGFloat = 16
+    }
+
     /// The tilted page card on the Report Preview screen.
     enum Thumbnail {
         static let size = CGSize(width: 150, height: 180)

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatReportSheetViewControllerTests.swift
@@ -404,7 +404,7 @@ final class WebCompatReportSheetViewControllerTests: XCTestCase {
                 WebCompatReportViewModel.Row(
                     id: "url",
                     title: "URL",
-                    kind: .urlField(text: "https://example.com"),
+                    kind: .urlField(text: "https://example.com", errorMessage: nil),
                     a11yIdentifier: "url"
                 )
             ]),

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatURLCellTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatURLCellTests.swift
@@ -14,6 +14,7 @@ final class WebCompatURLCellTests: XCTestCase {
         subject.configure(
             title: "URL",
             text: "https://example.com",
+            errorMessage: nil,
             a11yIdentifier: "WebCompatReporter.URLField",
             onEditingEnded: { _ in }
         )
@@ -26,8 +27,8 @@ final class WebCompatURLCellTests: XCTestCase {
 
     func testApplyStackLayout_switchesAxisAndAlignmentBetweenStandardAndAccessibilitySizes() throws {
         let subject = createSubject()
-        subject.configure(title: "URL", text: "", a11yIdentifier: "url", onEditingEnded: { _ in })
-        let stack = try XCTUnwrap(firstSubview(ofType: UIStackView.self, in: subject.contentView))
+        subject.configure(title: "URL", text: "", errorMessage: nil, a11yIdentifier: "url", onEditingEnded: { _ in })
+        let stack = try fieldStackView(in: subject)
 
         subject.applyStackLayout(isAccessibilityCategory: false)
         XCTAssertEqual(stack.axis, .horizontal)
@@ -41,7 +42,7 @@ final class WebCompatURLCellTests: XCTestCase {
     func testConfigure_clearedFieldShowsNoPlaceholderAndReadsFromTheLeadingEdge() throws {
         let subject = createSubject()
 
-        subject.configure(title: "URL", text: "ebay.com", a11yIdentifier: "url", onEditingEnded: { _ in })
+        subject.configure(title: "URL", text: "ebay.com", errorMessage: nil, a11yIdentifier: "url", onEditingEnded: { _ in })
         subject.applyTheme(theme: LightTheme())
 
         let field = try XCTUnwrap(firstSubview(ofType: UITextField.self, in: subject.contentView))
@@ -50,7 +51,48 @@ final class WebCompatURLCellTests: XCTestCase {
         XCTAssertEqual(field.textAlignment, .natural)
     }
 
+    func testConfigure_showsTheErrorWithTheTypedTextThenHidesItOnRecovery() throws {
+        let subject = createSubject()
+
+        subject.configure(
+            title: "URL",
+            text: " .com",
+            errorMessage: "Enter a valid URL",
+            a11yIdentifier: "url",
+            onEditingEnded: { _ in }
+        )
+
+        let field = try XCTUnwrap(firstSubview(ofType: UITextField.self, in: subject.contentView))
+        XCTAssertEqual(field.text, " .com")
+        XCTAssertEqual(try errorLabel(in: subject).text, "Enter a valid URL")
+        XCTAssertFalse(try errorStackView(in: subject).isHidden)
+
+        subject.configure(
+            title: "URL",
+            text: "https://example.com",
+            errorMessage: nil,
+            a11yIdentifier: "url",
+            onEditingEnded: { _ in }
+        )
+
+        XCTAssertTrue(try errorStackView(in: subject).isHidden)
+    }
+
     // MARK: - Helpers
+
+    private func fieldStackView(in subject: WebCompatURLCell) throws -> UIStackView {
+        let container = try XCTUnwrap(firstSubview(ofType: UIStackView.self, in: subject.contentView))
+        return try XCTUnwrap(container.arrangedSubviews.compactMap { $0 as? UIStackView }.first)
+    }
+
+    private func errorLabel(in subject: WebCompatURLCell) throws -> UILabel {
+        return try XCTUnwrap(errorStackView(in: subject).arrangedSubviews.compactMap { $0 as? UILabel }.first)
+    }
+
+    private func errorStackView(in subject: WebCompatURLCell) throws -> UIStackView {
+        let container = try XCTUnwrap(firstSubview(ofType: UIStackView.self, in: subject.contentView))
+        return try XCTUnwrap(container.arrangedSubviews.compactMap { $0 as? UIStackView }.last)
+    }
 
     private func createSubject() -> WebCompatURLCell {
         return WebCompatURLCell(frame: CGRect(x: 0, y: 0, width: 320, height: 60))

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatURLCellTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatURLCellTests.swift
@@ -56,16 +56,17 @@ final class WebCompatURLCellTests: XCTestCase {
 
         subject.configure(
             title: "URL",
-            text: " .com",
+            text: ".com",
             errorMessage: "Enter a valid URL",
             a11yIdentifier: "url",
             onEditingEnded: { _ in }
         )
 
         let field = try XCTUnwrap(firstSubview(ofType: UITextField.self, in: subject.contentView))
-        XCTAssertEqual(field.text, " .com")
+        XCTAssertEqual(field.text, ".com")
         XCTAssertEqual(try errorLabel(in: subject).text, "Enter a valid URL")
         XCTAssertFalse(try errorStackView(in: subject).isHidden)
+        XCTAssertEqual(field.accessibilityLabel, "URL, Enter a valid URL")
 
         subject.configure(
             title: "URL",
@@ -76,6 +77,7 @@ final class WebCompatURLCellTests: XCTestCase {
         )
 
         XCTAssertTrue(try errorStackView(in: subject).isHidden)
+        XCTAssertEqual(field.accessibilityLabel, "URL")
     }
 
     // MARK: - Helpers

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -168,7 +168,10 @@ final class WebCompatReportViewController: UINavigationController,
                 WebCompatReportViewModel.Row(
                     id: RowID.url.rawValue,
                     title: .WebCompatReporter.Fields.URLLabel,
-                    kind: .urlField(text: state.url),
+                    kind: .urlField(
+                        text: state.url,
+                        errorMessage: state.showsURLError ? .WebCompatReporter.Fields.URLError : nil
+                    ),
                     a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.urlField
                 )
             ]

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatURLValidator.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatURLValidator.swift
@@ -6,13 +6,14 @@ import Common
 import Foundation
 
 enum WebCompatURLValidator {
-    /// `URIFixup` alone turns " .com" into `http://.com`, so empty host labels are rejected too.
-    static func reportableURL(from text: String) -> URL? {
+    /// `URIFixup` alone turns `.com` into `http://.com` and escapes inner spaces instead of
+    /// rejecting them, so hosts carrying an empty or whitespaced label are turned down too.
+    static func isReportable(_ text: String) -> Bool {
         guard let url = URIFixup.getURL(text),
               url.isWebPage(includeDataURIs: false),
-              let host = url.host,
-              host.split(separator: ".", omittingEmptySubsequences: false).allSatisfy({ !$0.isEmpty })
-        else { return nil }
-        return url
+              let host = url.host
+        else { return false }
+        return host.split(separator: ".", omittingEmptySubsequences: false)
+            .allSatisfy { !$0.isEmpty && !$0.contains(where: \.isWhitespace) }
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatURLValidator.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatURLValidator.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+
+enum WebCompatURLValidator {
+    /// `URIFixup` alone turns " .com" into `http://.com`, so empty host labels are rejected too.
+    static func reportableURL(from text: String) -> URL? {
+        guard let url = URIFixup.getURL(text),
+              url.isWebPage(includeDataURIs: false),
+              let host = url.host,
+              host.split(separator: ".", omittingEmptySubsequences: false).allSatisfy({ !$0.isEmpty })
+        else { return nil }
+        return url
+    }
+}

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
@@ -45,12 +45,7 @@ final class WebCompatReporterMiddleware {
             telemetry.reasonSelected(category: category)
 
         case WebCompatReporterViewActionType.preview:
-            telemetry.previewed()
-            store.dispatch(WebCompatReporterMiddlewareAction(
-                previewPayload: makeReport(windowUUID: action.windowUUID, state: state),
-                windowUUID: action.windowUUID,
-                actionType: WebCompatReporterMiddlewareActionType.didBuildPreview
-            ))
+            previewReport(windowUUID: action.windowUUID, state: state)
 
         case WebCompatReporterViewActionType.cancel:
             telemetry.cancelled()
@@ -66,8 +61,20 @@ final class WebCompatReporterMiddleware {
         }
     }
 
+    /// Preview and Send commit the field's edit before firing, so a rejected address can still arrive.
+    private func previewReport(windowUUID: WindowUUID, state: AppState) {
+        guard WebCompatReporterState(appState: state, uuid: windowUUID).isURLValid else { return }
+        telemetry.previewed()
+        store.dispatch(WebCompatReporterMiddlewareAction(
+            previewPayload: makeReport(windowUUID: windowUUID, state: state),
+            windowUUID: windowUUID,
+            actionType: WebCompatReporterMiddlewareActionType.didBuildPreview
+        ))
+    }
+
     private func submitReport(windowUUID: WindowUUID, state: AppState) {
         let reporterState = WebCompatReporterState(appState: state, uuid: windowUUID)
+        guard reporterState.isURLValid else { return }
         recorder.submit(makeReport(windowUUID: windowUUID, state: state))
         // The screenshot option is parked (FXIOS-16450) and no image is transported yet.
         telemetry.created(withBlockedTrackers: reporterState.includeBlockedList, withScreenshot: false)

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
@@ -21,7 +21,7 @@ struct WebCompatReporterState: ScreenState, Equatable {
     var previewPayload: WebCompatReportPayload?
 
     var showsAdditionalDetails: Bool { selectedCategory != nil }
-    var isURLValid: Bool { WebCompatURLValidator.reportableURL(from: url) != nil }
+    var isURLValid: Bool { WebCompatURLValidator.isReportable(url) }
 
     var canPreview: Bool { selectedCategory != nil && isURLValid }
 

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
@@ -20,13 +20,18 @@ struct WebCompatReporterState: ScreenState, Equatable {
     /// The report as the middleware would send it.
     var previewPayload: WebCompatReportPayload?
 
-    /// Preview stays disabled, and the details field stays hidden, until the user picks a category.
-    var canPreview: Bool { selectedCategory != nil }
     var showsAdditionalDetails: Bool { selectedCategory != nil }
+    var isURLValid: Bool { WebCompatURLValidator.reportableURL(from: url) != nil }
 
-    /// Send needs an address to report against and a sub-option, except for "Other", which has none.
+    var canPreview: Bool { selectedCategory != nil && isURLValid }
+
+    var showsURLError: Bool {
+        return !url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isURLValid
+    }
+
+    /// Send needs a reportable address and a sub-option, except for "Other", which has none.
     var canSubmit: Bool {
-        guard let selectedCategory, !url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        guard let selectedCategory, isURLValid else { return false }
         return selectedCategory.subOptions.isEmpty || selectedSubOptionID != nil
     }
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4496,6 +4496,12 @@ extension String {
                 value: "URL",
                 comment: "Leading label of the editable row showing the web address being reported, in the Report a Website Issue form."
             )
+            public static let URLError = MZLocalizedString(
+                key: "WebCompatReporter.Fields.URLError.v155",
+                tableName: "WebCompatReporter",
+                value: "Enter a valid URL",
+                comment: "Error message shown under the URL field when the address typed there is not one that can be reported, in the Report a Website Issue form."
+            )
             public static let DetailsPlaceholder = MZLocalizedString(
                 key: "WebCompatReporter.Fields.DetailsPlaceholder.v154",
                 tableName: "WebCompatReporter",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4500,7 +4500,7 @@ extension String {
                 key: "WebCompatReporter.Fields.URLError.v155",
                 tableName: "WebCompatReporter",
                 value: "Enter a valid URL",
-                comment: "Error message shown under the URL field when the address typed there is not one that can be reported, in the Report a Website Issue form."
+                comment: "Error message shown under the URL field when the address entered has an invalid format, in the Report a Website Issue form."
             )
             public static let DetailsPlaceholder = MZLocalizedString(
                 key: "WebCompatReporter.Fields.DetailsPlaceholder.v154",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -261,14 +261,14 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
     }
 
     func testMakeSections_withAnUnreportableURL_carriesTheErrorAndDisablesSend() throws {
-        let state = WebCompatReporterState(windowUUID: windowUUID, url: " .com", selectedCategory: .other)
+        let state = WebCompatReporterState(windowUUID: windowUUID, url: ".com", selectedCategory: .other)
 
         let sections = WebCompatReportViewController.makeSections(from: state)
 
         guard case let .urlField(text, errorMessage) = sections.first?.rows.first?.kind else {
             return XCTFail("Expected a URL field row")
         }
-        XCTAssertEqual(text, " .com")
+        XCTAssertEqual(text, ".com")
         XCTAssertEqual(errorMessage, .WebCompatReporter.Fields.URLError)
         XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: false)])
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -253,10 +253,32 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(advanced?.rows.map(\.kind), [.checkbox(isChecked: true)])
         XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: false)])
 
-        guard case let .urlField(text) = sections.first?.rows.first?.kind else {
+        guard case let .urlField(text, errorMessage) = sections.first?.rows.first?.kind else {
             return XCTFail("Expected a URL field row")
         }
         XCTAssertEqual(text, "https://example.com")
+        XCTAssertNil(errorMessage)
+    }
+
+    func testMakeSections_withAnUnreportableURL_carriesTheErrorAndDisablesSend() throws {
+        let state = WebCompatReporterState(windowUUID: windowUUID, url: " .com", selectedCategory: .other)
+
+        let sections = WebCompatReportViewController.makeSections(from: state)
+
+        guard case let .urlField(text, errorMessage) = sections.first?.rows.first?.kind else {
+            return XCTFail("Expected a URL field row")
+        }
+        XCTAssertEqual(text, " .com")
+        XCTAssertEqual(errorMessage, .WebCompatReporter.Fields.URLError)
+        XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: false)])
+
+        let cleared = WebCompatReportViewController.makeSections(
+            from: WebCompatReporterState(windowUUID: windowUUID, url: "", selectedCategory: .other)
+        )
+        guard case let .urlField(_, clearedError) = cleared.first?.rows.first?.kind else {
+            return XCTFail("Expected a URL field row")
+        }
+        XCTAssertNil(clearedError)
     }
 
     func testMakeSections_withCategory_addsSubOptionsDetailsAndAdvancedWithSendLast() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -261,7 +261,9 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
     }
 
     func testMakeSections_withAnUnreportableURL_carriesTheErrorAndDisablesSend() throws {
-        let state = WebCompatReporterState(windowUUID: windowUUID, url: ".com", selectedCategory: .other)
+        let state = WebCompatReporterState(windowUUID: windowUUID)
+            .copy(url: ".com")
+            .copy(selectedCategory: .other)
 
         let sections = WebCompatReportViewController.makeSections(from: state)
 
@@ -273,7 +275,9 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(sections.last?.rows.map(\.kind), [.sendButton(isEnabled: false)])
 
         let cleared = WebCompatReportViewController.makeSections(
-            from: WebCompatReporterState(windowUUID: windowUUID, url: "", selectedCategory: .other)
+            from: WebCompatReporterState(windowUUID: windowUUID)
+                .copy(url: "")
+                .copy(selectedCategory: .other)
         )
         guard case let .urlField(_, clearedError) = cleared.first?.rows.first?.kind else {
             return XCTFail("Expected a URL field row")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -276,7 +276,7 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
             presentedComponents: PresentedComponentsState(
                 components: [
                     .webCompatReporter(
-                        WebCompatReporterState(windowUUID: .XCTestDefaultUUID, url: "https://example.com")
+                        WebCompatReporterState(windowUUID: .XCTestDefaultUUID).copy(url: "https://example.com")
                     )
                 ]
             )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -66,6 +66,30 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         releaseMiddlewareProvidersFromMemory(subject)
     }
 
+    func test_submit_withAnUnreportableURL_sendsNothing() {
+        let subject = createSubject()
+        setReportedURL(" .com")
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
+
+        XCTAssertEqual(gleanWrapper.submitPingCalled, 0)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func test_preview_withAnUnreportableURL_buildsNothing() {
+        let subject = createSubject()
+        setReportedURL(" .com")
+
+        subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.preview))
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertEqual(gleanWrapper.recordEventNoExtraCalled, 0)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
     // MARK: - Tab-specific info
 
     func test_submit_whenURLStillMatchesTheTab_includesTabFields() {
@@ -251,7 +275,9 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
         return AppState(
             presentedComponents: PresentedComponentsState(
                 components: [
-                    .webCompatReporter(WebCompatReporterState(windowUUID: .XCTestDefaultUUID))
+                    .webCompatReporter(
+                        WebCompatReporterState(windowUUID: .XCTestDefaultUUID, url: "https://example.com")
+                    )
                 ]
             )
         )

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -68,7 +68,7 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
 
     func test_submit_withAnUnreportableURL_sendsNothing() {
         let subject = createSubject()
-        setReportedURL(" .com")
+        setReportedURL(".com")
 
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
 
@@ -80,7 +80,7 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
 
     func test_preview_withAnUnreportableURL_buildsNothing() {
         let subject = createSubject()
-        setReportedURL(" .com")
+        setReportedURL(".com")
 
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, viewAction(.preview))
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
@@ -51,11 +51,11 @@ final class WebCompatReporterStateTests: XCTestCase {
         for url in ["https://example.com", "example.com", "ebay.com/deals?a=1", "https://sub.example.co.uk"] {
             XCTAssertTrue(makeState(category: .other, url: url).isURLValid, "Expected \(url) to be reportable")
         }
-        for url in [" .com", ".com", "example..com", "example.com.", "https://", "foo", "a b.com"] {
+        for url in [" .com", ".com", "example..com", "example.com.", "https://exa mple.com", "https://", "foo"] {
             XCTAssertFalse(makeState(category: .other, url: url).isURLValid, "Expected \(url) to be rejected")
         }
 
-        let subject = makeState(category: .other, url: " .com")
+        let subject = makeState(category: .other, url: ".com")
         XCTAssertFalse(subject.canSubmit)
         XCTAssertFalse(subject.canPreview)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
@@ -47,6 +47,19 @@ final class WebCompatReporterStateTests: XCTestCase {
         XCTAssertFalse(makeState(category: .other, url: "   ").canSubmit)
     }
 
+    func test_isURLValid_rejectsLookalikesAndBlocksSendAndPreview() {
+        for url in ["https://example.com", "example.com", "ebay.com/deals?a=1", "https://sub.example.co.uk"] {
+            XCTAssertTrue(makeState(category: .other, url: url).isURLValid, "Expected \(url) to be reportable")
+        }
+        for url in [" .com", ".com", "example..com", "example.com.", "https://", "foo", "a b.com"] {
+            XCTAssertFalse(makeState(category: .other, url: url).isURLValid, "Expected \(url) to be rejected")
+        }
+
+        let subject = makeState(category: .other, url: " .com")
+        XCTAssertFalse(subject.canSubmit)
+        XCTAssertFalse(subject.canPreview)
+    }
+
     // MARK: - Reducer - didLoadInitialDraft
 
     func test_didLoadInitialDraft_seedsURL() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16487)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35022)

## :bulb: Description
The URL field took any text, so `.com` stayed in the draft and would have gone out with the report. `URIFixup` turns that into `http://.com`, so `WebCompatURLValidator` also rejects hosts with an empty label: `.com`, `example..com`.

An unreportable address keeps what was typed, shows the reason under the field, and disables Send and Preview. Both buttons commit the field's edit before firing, so the middleware re-checks before it builds a report.

## :movie_camera: Demos

<img width="402" height="874" alt="2-error-invalid-url" src="https://github.com/user-attachments/assets/70a80577-5718-4da1-8c35-14179b5f7a7a" />
<img width="402" height="874" alt="4-error-accessibility-xl-text" src="https://github.com/user-attachments/assets/a90c3b60-4083-4081-a4b8-fb72294fe8d3" />


<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

## Testing
1. Load any web page, then Menu → More → Report Broken Site.
2. Clear the URL field, type `.com`, tap Done. `Enter a valid URL` appears under the field, `.com` stays put, Send Report is disabled.
3. Pick an issue type and a sub-option. Send Report and Preview both stay disabled.
4. Try `example..com`. Same message.
5. Type `mozilla.org`. The message goes away, Preview enables, and Send Report follows once the issue type and sub-option are set.
