### PR TITLE
Bugfix FXIOS-16604 [Nova] Update Protection badge on Site Menu

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuSiteBadge.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteBadge.swift
@@ -56,6 +56,8 @@ final class MenuSiteBadge: UIView, ThemeApplicable {
         imageView.contentMode = .scaleAspectFit
     }
     private var iconTintOverride: UIColor?
+    private var textColorOverride: UIColor?
+    private var chevronTintOverride: UIColor?
 
     init(mainMenuHelper: MainMenuInterface) {
         self.mainMenuHelper = mainMenuHelper
@@ -96,7 +98,12 @@ final class MenuSiteBadge: UIView, ThemeApplicable {
         ])
     }
 
-    func configure(text: String, iconName: String, useTemplate: Bool, iconTintColor: UIColor? = nil) {
+    func configure(text: String,
+                   iconName: String,
+                   useTemplate: Bool,
+                   iconTintColor: UIColor? = nil,
+                   textColor: UIColor? = nil,
+                   chevronTintColor: UIColor? = nil) {
         label.text = text
         accessibilityLabel = text
         let image: UIImage = useTemplate
@@ -105,10 +112,12 @@ final class MenuSiteBadge: UIView, ThemeApplicable {
         icon.image = image
         iconTintOverride = iconTintColor
         icon.tintColor = iconTintColor ?? icon.tintColor
+        textColorOverride = textColor
+        chevronTintOverride = chevronTintColor
     }
 
     func applyTheme(theme: Theme) {
-        label.textColor = theme.colors.textSecondary
+        label.textColor = textColorOverride ?? theme.colors.textSecondary
         stack.layer.borderColor = theme.colors.actionSecondaryHover.cgColor
         if #available(iOS 26.0, *) {
             stack.backgroundColor = theme.colors.layerSurfaceMedium
@@ -117,7 +126,7 @@ final class MenuSiteBadge: UIView, ThemeApplicable {
             stack.backgroundColor = .clear
         }
         icon.tintColor = iconTintOverride ?? theme.colors.iconSecondary
-        chevron.tintColor = theme.colors.iconSecondary
+        chevron.tintColor = chevronTintOverride ?? theme.colors.iconSecondary
     }
 
     @objc

--- a/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
+++ b/BrowserKit/Sources/MenuKit/MenuSiteProtectionsHeader.swift
@@ -147,10 +147,7 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
             badgesTopFromFavicon,
             badgesStack.leadingAnchor.constraint(equalTo: favicon.leadingAnchor),
             badgesStack.trailingAnchor.constraint(lessThanOrEqualTo: closeButton.leadingAnchor),
-            badgesStack.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-
-            closeButton.widthAnchor.constraint(equalToConstant: UX.closeButtonSize),
-            closeButton.heightAnchor.constraint(equalToConstant: UX.closeButtonSize)
+            badgesStack.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
 
         closeButton.layer.cornerRadius = 0.5 * UX.closeButtonSize
@@ -164,6 +161,8 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         stateImage: String,
         shouldUseRenderMode: Bool,
         stateIconTintColor: UIColor? = nil,
+        stateTextColor: UIColor? = nil,
+        stateChevronTintColor: UIColor? = nil,
         adBlocker: MenuSiteAdBlockerBadgeData? = nil
     ) {
         titleLabel.text = title
@@ -171,7 +170,9 @@ public final class MenuSiteProtectionsHeader: UIView, ThemeApplicable {
         siteProtectionsBadge.configure(text: state,
                                        iconName: stateImage,
                                        useTemplate: shouldUseRenderMode,
-                                       iconTintColor: stateIconTintColor)
+                                       iconTintColor: stateIconTintColor,
+                                       textColor: stateTextColor,
+                                       chevronTintColor: stateChevronTintColor)
         if let adBlocker {
             if adBlockerBadge.superview == nil {
                 badgesStack.addArrangedSubview(adBlockerBadge)

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -495,7 +495,7 @@ class MainMenuViewController: UIViewController,
         if currentTheme.isNova {
             stateImage = isProtectionsOn
                 ? StandardImageIdentifiers.Small.shieldCheckmarkFillGradient
-                : StandardImageIdentifiers.Small.shieldSlashFillCritical
+                : StandardImageIdentifiers.Small.shieldSlashFillMulticolor
             shouldUseRenderMode = false
         }
 
@@ -527,6 +527,8 @@ class MainMenuViewController: UIViewController,
             stateImage: stateImage,
             shouldUseRenderMode: shouldUseRenderMode,
             stateIconTintColor: protectionsTintColor,
+            stateTextColor: currentTheme.isNova ? currentTheme.colors.textPrimary : nil,
+            stateChevronTintColor: currentTheme.isNova ? currentTheme.colors.iconPrimary : nil,
             adBlocker: adBlocker)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16604)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates Protection badge on Site Menu to follow the latest Nova design and solves a constraint issue that impacted close button for Nova design only (which has a larger size).

<img width="524" height="670" alt="Screenshot 2026-08-18 at 16 53 10" src="https://github.com/user-attachments/assets/eaba5f1d-11b6-4fb2-8fc4-63e612110157" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

