### PR TITLE
Bugfix FXIOS-16606 [Nova] Update page zoom text color

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -14,7 +14,7 @@ protocol ZoomPageBarDelegate: AnyObject {
     func zoomPageDidPressClose()
 }
 
-final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
+final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable, FeatureFlaggable {
     // MARK: - Constants
 
     private struct UX {
@@ -233,7 +233,9 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
 
     func updateZoomLabel(zoomValue: CGFloat) {
         zoomLevel.text = NumberFormatter.localizedString(from: NSNumber(value: zoomValue), number: .percent)
-        zoomLevel.isEnabled = zoomValue == ZoomConstants.defaultZoomLimit ? false : true
+        if !featureFlagsProvider.isEnabled(.novaDesign) {
+            zoomLevel.isEnabled = zoomValue == ZoomConstants.defaultZoomLimit ? false : true
+        }
         gestureRecognizer.isEnabled = !(zoomValue == ZoomConstants.defaultZoomLimit)
         zoomLevel.accessibilityLabel = String(format: .LegacyAppMenu.ZoomPageCurrentZoomLevelAccessibilityLabel,
                                               zoomLevel.text ?? "")
@@ -317,7 +319,6 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         leftSeparator.backgroundColor = separatorBackgroundColor
         rightSeparator.backgroundColor = separatorBackgroundColor
         zoomLevel.tintColor = colors.textPrimary
-        zoomLevel.textColor = colors.textPrimary
         zoomInButton.tintColor = colors.iconPrimary
         let zoomInButtonImageColorTransformer = UIConfigurationColorTransformer({ [weak zoomInButton] baseColor in
             return zoomInButton?.state == .highlighted ? colors.iconDisabled : baseColor

--- a/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
+++ b/firefox-ios/Client/Frontend/Browser/Zoom/ZoomPageBar.swift
@@ -317,6 +317,7 @@ final class ZoomPageBar: UIView, ThemeApplicable, AlphaDimmable {
         leftSeparator.backgroundColor = separatorBackgroundColor
         rightSeparator.backgroundColor = separatorBackgroundColor
         zoomLevel.tintColor = colors.textPrimary
+        zoomLevel.textColor = colors.textPrimary
         zoomInButton.tintColor = colors.iconPrimary
         let zoomInButtonImageColorTransformer = UIConfigurationColorTransformer({ [weak zoomInButton] baseColor in
             return zoomInButton?.state == .highlighted ? colors.iconDisabled : baseColor


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16606)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates color for page zoom text for default to not show as disabled, for Nova only.

<img width="504" height="491" alt="Screenshot 2026-08-18 at 18 02 46" src="https://github.com/user-attachments/assets/5d7c16bb-5fe7-4d42-9bb1-3bb00121e7b0" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

