### PR TITLE
Refactor NO_TICKET Disable Mergify Queuing with a Checkbox

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -80,3 +80,6 @@ priority_rules:
       - queue-name=rebase-queue
     priority: 2250
     allow_checks_interruption: true
+
+merge_queue:
+  queue_controls_comment: false


### PR DESCRIPTION
## :scroll: Tickets
No Ticket

## :bulb: Description
As per the mergify documentation: https://docs.mergify.com/commands/queue/

This is to get rid of that "check this box to merge the PR" that mergify posts once all PR requirements are green.

There was a convo on Jul 15 in the dev channel about this.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

