### PR TITLE
Add Bug-2062665 [Suggest] Add new suggestionId field on Suggestion.amp

### DIFF
--- a/MozillaRustComponents/Package.swift
+++ b/MozillaRustComponents/Package.swift
@@ -1,13 +1,13 @@
 // swift-tools-version: 5.10
 import PackageDescription
 
-let checksum = "d3db9f3e646a3f68bf1d5a7bbef6ecfa63f1755e6f42e0cd19ebbc75a4b06b0a"
-let version = "157.0.20260902050201"
-let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.157.20260902050201/artifacts/public/build/MozillaRustComponents.xcframework.zip"
+let checksum = "f9ddc73f554d210316b4a318c655114f7779541f0485292894807189890579e9"
+let version = "157.0.20260903050205"
+let url = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.157.20260903050205/artifacts/public/build/MozillaRustComponents.xcframework.zip"
 
 // Focus xcframework
-let focusChecksum = "b7355a8b3dc63ed14e226d9ab6e8dd9c0edf6c546960447e9ff65ad03319f3cb"
-let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.157.20260902050201/artifacts/public/build/FocusRustComponents.xcframework.zip"
+let focusChecksum = "e08b9ead234c515056933984c8d7807561f37d460b68308eea304a6876a61a3d"
+let focusUrl = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.swift.157.20260903050205/artifacts/public/build/FocusRustComponents.xcframework.zip"
 
 let package = Package(
     name: "MozillaRustComponentsSwift",

--- a/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/FocusRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 9, day: 2, hour: 5, minute: 28, second: 49))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 9, day: 3, hour: 5, minute: 37, second: 32))
     }
 
     enum NimbusEvents {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/Metrics/Metrics.swift
@@ -23,7 +23,7 @@ extension GleanMetrics {
             // Intentionally left private, no external user can instantiate a new global object.
         }
 
-        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 9, day: 2, hour: 5, minute: 28, second: 47))
+        public static let info = BuildInfo(buildDate: DateComponents(calendar: Calendar.current, timeZone: TimeZone(abbreviation: "UTC"), year: 2026, month: 9, day: 3, hour: 5, minute: 37, second: 30))
     }
 
     enum AdsClient {

--- a/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/suggest.swift
+++ b/MozillaRustComponents/Sources/MozillaRustComponentsWrapper/Generated/suggest.swift
@@ -2797,7 +2797,7 @@ public func FfiConverterTypeSuggestProviderConfig_lower(_ value: SuggestProvider
 
 public enum Suggestion: Equatable, Hashable {
     
-    case amp(title: String, url: String, rawUrl: String, icon: Data?, iconMimetype: String?, fullKeyword: String, blockId: Int64, advertiser: String, iabCategory: String, categories: [Int32], impressionUrl: String, clickUrl: String, rawClickUrl: String, score: Double, ftsMatchInfo: FtsMatchInfo?
+    case amp(title: String, url: String, rawUrl: String, icon: Data?, iconMimetype: String?, fullKeyword: String, blockId: Int64, advertiser: String, iabCategory: String, categories: [Int32], impressionUrl: String, clickUrl: String, rawClickUrl: String, score: Double, ftsMatchInfo: FtsMatchInfo?, suggestionId: String
     )
     case wikipedia(title: String, url: String, icon: Data?, iconMimetype: String?, fullKeyword: String
     )
@@ -2838,7 +2838,7 @@ public struct FfiConverterTypeSuggestion: FfiConverterRustBuffer {
         let variant: Int32 = try readInt(&buf)
         switch variant {
         
-        case 1: return .amp(title: try FfiConverterString.read(from: &buf), url: try FfiConverterString.read(from: &buf), rawUrl: try FfiConverterString.read(from: &buf), icon: try FfiConverterOptionData.read(from: &buf), iconMimetype: try FfiConverterOptionString.read(from: &buf), fullKeyword: try FfiConverterString.read(from: &buf), blockId: try FfiConverterInt64.read(from: &buf), advertiser: try FfiConverterString.read(from: &buf), iabCategory: try FfiConverterString.read(from: &buf), categories: try FfiConverterSequenceInt32.read(from: &buf), impressionUrl: try FfiConverterString.read(from: &buf), clickUrl: try FfiConverterString.read(from: &buf), rawClickUrl: try FfiConverterString.read(from: &buf), score: try FfiConverterDouble.read(from: &buf), ftsMatchInfo: try FfiConverterOptionTypeFtsMatchInfo.read(from: &buf)
+        case 1: return .amp(title: try FfiConverterString.read(from: &buf), url: try FfiConverterString.read(from: &buf), rawUrl: try FfiConverterString.read(from: &buf), icon: try FfiConverterOptionData.read(from: &buf), iconMimetype: try FfiConverterOptionString.read(from: &buf), fullKeyword: try FfiConverterString.read(from: &buf), blockId: try FfiConverterInt64.read(from: &buf), advertiser: try FfiConverterString.read(from: &buf), iabCategory: try FfiConverterString.read(from: &buf), categories: try FfiConverterSequenceInt32.read(from: &buf), impressionUrl: try FfiConverterString.read(from: &buf), clickUrl: try FfiConverterString.read(from: &buf), rawClickUrl: try FfiConverterString.read(from: &buf), score: try FfiConverterDouble.read(from: &buf), ftsMatchInfo: try FfiConverterOptionTypeFtsMatchInfo.read(from: &buf), suggestionId: try FfiConverterString.read(from: &buf)
         )
         
         case 2: return .wikipedia(title: try FfiConverterString.read(from: &buf), url: try FfiConverterString.read(from: &buf), icon: try FfiConverterOptionData.read(from: &buf), iconMimetype: try FfiConverterOptionString.read(from: &buf), fullKeyword: try FfiConverterString.read(from: &buf)
@@ -2867,7 +2867,7 @@ public struct FfiConverterTypeSuggestion: FfiConverterRustBuffer {
         switch value {
         
         
-        case let .amp(title,url,rawUrl,icon,iconMimetype,fullKeyword,blockId,advertiser,iabCategory,categories,impressionUrl,clickUrl,rawClickUrl,score,ftsMatchInfo):
+        case let .amp(title,url,rawUrl,icon,iconMimetype,fullKeyword,blockId,advertiser,iabCategory,categories,impressionUrl,clickUrl,rawClickUrl,score,ftsMatchInfo,suggestionId):
             writeInt(&buf, Int32(1))
             FfiConverterString.write(title, into: &buf)
             FfiConverterString.write(url, into: &buf)
@@ -2884,6 +2884,7 @@ public struct FfiConverterTypeSuggestion: FfiConverterRustBuffer {
             FfiConverterString.write(rawClickUrl, into: &buf)
             FfiConverterDouble.write(score, into: &buf)
             FfiConverterOptionTypeFtsMatchInfo.write(ftsMatchInfo, into: &buf)
+            FfiConverterString.write(suggestionId, into: &buf)
             
         
         case let .wikipedia(title,url,icon,iconMimetype,fullKeyword):

--- a/firefox-ios/Storage/Rust/RustFirefoxSuggestion.swift
+++ b/firefox-ios/Storage/Rust/RustFirefoxSuggestion.swift
@@ -66,6 +66,7 @@ public struct RustFirefoxSuggestion: Equatable {
             clickUrlString,
             _,
             _,
+            _,
             _
         ) = suggestion {
             // This use of `URL(string:)` is OK; we don't need to use


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/SPONS-177)

## :bulb: Description

This PR is to support an `application-services` `suggest` rust component change that adds a new `suggestion_id` field to the sponsored suggestion, for improved business telemetry. 

Once this is in place, the plan is to send back the `suggestion_id` field with the `fx-suggest` glean ping across all clients for online and offline modes (Desktop online `quicksuggest` has already recently added this ([glean dictionary link](https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/quick_suggest_suggestion_id)), working on the rest).

See the [application-services PR here](https://github.com/mozilla/application-services/pull/7554)


## :movie_camera: Demos

This is an internal change that doesn't surface in the app yet.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [] If needed, I updated documentation and added comments to complex code

