### PR TITLE
Add FXIOS-11878 TestRail reference for testSwipeBackFromBookmarkFolder

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -698,6 +698,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
         libraryScreen.assertIdenticalFoldersNamesCreated(identifier: folderName, nrOfFolders: 2)
     }
 
+    // https://mozilla.testrail.io/index.php?/cases/view/4313009
     func testSwipeBackFromBookmarkFolder() throws {
         guard !iPad() else {
             throw XCTSkip("XCUITest cannot drive the pop gesture in the inset iPad panel, it works manually")


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11878)

## :bulb: Description
Follow-up to #35157 ("Bugfix FXIOS-11878 Enable swipe navigation in bookmark folders"), which merged `testSwipeBackFromBookmarkFolder` without a TestRail case reference, unlike its neighboring tests in the same file.

Adds the missing TestRail comment:
```
// https://mozilla.testrail.io/index.php?/cases/view/4313009
```

## :movie_camera: Demos
N/A — test-only comment addition, no product or test-logic changes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code