### PR TITLE
MTE-5864 - multiple fixes for flaky tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -24,6 +24,8 @@ let TIMEOUT: TimeInterval = 10
 let TIMEOUT_LONG: TimeInterval = 20
 // Translation is network-bound and can take up to ~1 min to complete
 let TRANSLATION_TIMEOUT: TimeInterval = 90
+// Probe for optional UI that shows up immediately or not at all
+let TIMEOUT_PICKER_PROBE: TimeInterval = 3
 let MAX_SWIPE = 5
 
 @MainActor
@@ -391,12 +393,13 @@ class BaseTestCase: XCTestCase {
         return false
     }
 
-    func waitUntilPageLoad() {
+    /// - Parameter timeout: how long the loading indicator may stay up. Raise it for slow resources.
+    func waitUntilPageLoad(timeout: TimeInterval = 10) {
         let app = XCUIApplication()
         let progressIndicator = app.progressIndicators.element(boundBy: 0)
         if progressIndicator.mozWaitForElementToExist(timeout: 5, failOnTimeout: false) {
             // Wait for the loading indicator to disappear
-            mozWaitForElementToNotExist(progressIndicator, timeout: 10, failOnTimeout: false)
+            mozWaitForElementToNotExist(progressIndicator, timeout: timeout, failOnTimeout: false)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -203,14 +203,14 @@ class BrowsingPDFTests: BaseTestCase {
 
         // Step 2: Switch to another tab and open another large PDF. All PDF files load properly.
         navigator.openNewURL(urlString: largePDF2["url"]!)
-        waitUntilPageLoad()
-        browser.assertAddressBarContains(value: largePDF2["pdfValue"]!)
+        waitUntilPageLoad(timeout: TIMEOUT_LONG)
+        browser.assertAddressBarContains(value: largePDF2["pdfValue"]!, timeout: TIMEOUT_LONG)
 
         // Step 3: Return to the first PDF tab. It should be loading or loaded.
         navigator.goto(TabTray)
         tabTrayScreen.tapTabAtIndex(index: 0)
-        waitUntilPageLoad()
-        browser.assertAddressBarContains(value: largePDF1["pdfValue"]!)
+        waitUntilPageLoad(timeout: TIMEOUT_LONG)
+        browser.assertAddressBarContains(value: largePDF1["pdfValue"]!, timeout: TIMEOUT_LONG)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3168439

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/KeyboardShortcutsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/KeyboardShortcutsTests.swift
@@ -9,6 +9,8 @@ class KeyboardShortcutsTests: BaseTestCase {
     // without masking a shortcut that only works after several presses.
     private let shortcutAttempts = 4
     private let shortcutAttemptTimeout: TimeInterval = 5
+    // Samples the current state instead of waiting for a change
+    private let noWait: TimeInterval = 0
 
     private var toolbarScreen: ToolbarScreen!
     private var homePageScreen: HomePageScreen!
@@ -79,11 +81,13 @@ class KeyboardShortcutsTests: BaseTestCase {
     func testSwitchTabWithKeyboardShortcut() {
         openThreeTabsAndSelectTheFirstOne()
 
-        // The next tab is selected by pressing Control+Tab
+        // The next tab is selected by pressing Control+Tab. Both tab shortcuts cycle, so retrying a
+        // press that landed would step past the expected tab; only a dropped press leaves this tab up.
         pressShortcut(
             XCUIKeyboardKey.tab.rawValue,
             modifierFlags: .control,
             until: { browserScreen.bookOfMozillaPageContentExists(timeout: shortcutAttemptTimeout) },
+            retryOnlyWhile: { browserScreen.exampleDomainTextExists(timeout: noWait) },
             failureMessage: "Control+Tab did not select the next tab"
         )
 
@@ -92,6 +96,7 @@ class KeyboardShortcutsTests: BaseTestCase {
             XCUIKeyboardKey.tab.rawValue,
             modifierFlags: [.control, .shift],
             until: { browserScreen.exampleDomainTextExists(timeout: shortcutAttemptTimeout) },
+            retryOnlyWhile: { browserScreen.bookOfMozillaPageContentExists(timeout: noWait) },
             failureMessage: "Control+Shift+Tab did not select the previous tab"
         )
     }
@@ -119,21 +124,36 @@ class KeyboardShortcutsTests: BaseTestCase {
         XCTAssertTrue(browserScreen.exampleDomainTextExists(), "The first tab was not selected")
     }
 
-    // The simulator drops keyboard events sent while its keyboard connection to the app is still
-    // being established, and how many are lost varies between runs, so the shortcut is sent again
-    // whenever nothing happened. A retry can't apply the shortcut twice because it only fires when
-    // the previous press had no effect at all.
+    // The simulator drops a varying number of keyboard events, so the shortcut is sent again whenever
+    // nothing happened. Retries re-activate the app: keys the app never saw would just be lost again.
     private func pressShortcut(
         _ key: String,
         modifierFlags: XCUIElement.KeyModifierFlags = .command,
         until isSatisfied: () -> Bool,
+        retryOnlyWhile shouldRetry: () -> Bool = { true },
         failureMessage: String
     ) {
-        for _ in 0..<shortcutAttempts {
+        waitUntilAppAcceptsKeyboardShortcuts()
+
+        for attempt in 0..<shortcutAttempts {
+            if attempt > 0 { app.activate() }
             app.typeKey(key, modifierFlags: modifierFlags)
             if isSatisfied() { return }
+            if !shouldRetry() {
+                XCTFail("\(failureMessage), and the app moved to an unexpected state instead")
+                return
+            }
         }
         XCTFail("\(failureMessage) in \(shortcutAttempts) attempts")
+    }
+
+    // Key commands need the browser on screen and owning the responder chain, which setUpApp() does not
+    // wait for. Best effort: a timeout is not worth failing on, the shortcut attempts report that.
+    private func waitUntilAppAcceptsKeyboardShortcuts() {
+        let tabsButton = app.buttons[AccessibilityIdentifiers.Toolbar.tabsButton]
+        let isInteractive = NSPredicate(format: "exists == true && hittable == true")
+        let expectation = XCTNSPredicateExpectation(predicate: isInteractive, object: tabsButton)
+        _ = XCTWaiter().wait(for: [expectation], timeout: TIMEOUT)
     }
 
     // Command+D only bookmarks an actual page, it is a no-op on the homepage, hence visiting one first.

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -443,10 +443,11 @@ class LoginTest: BaseTestCase {
         let passwordCell = app.tables.cells["Password"]
         let editButton = app.buttons["Edit"]
         savedCredentials.waitAndTap()
+        // The passwords list has an "Edit" button of its own, so tapping before the detail screen has
+        // pushed puts the list into selection mode instead of editing the login.
+        mozWaitForElementToExist(app.tables["Login Detail List"])
         editButton.waitAndTap()
         // Focus the username field explicitly; relying on auto-focus after Edit is flaky on CI.
-        // Wait for the detail list to finish presenting first, otherwise the Username cell is
-        // queried mid edit-mode transition and the tap times out (matches testEditOneLoginEntry).
         mozWaitForElementToExist(app.tables["Login Detail List"])
         app.tables["Login Detail List"].cells.elementContainingText("Username").waitAndTap()
         clearAndEnterText(text: "test")
@@ -530,41 +531,47 @@ class LoginTest: BaseTestCase {
         // Long tap on the field and then tap on Copy
         let fieldCell = app.tables.cells.element(boundBy: indexField)
         mozWaitForElementToExist(fieldCell)
-        let copyMenuItem = app.staticTexts["Copy"]
-        revealCalloutMenuItem(copyMenuItem) {
+        revealCalloutMenuItem(labelled: "Copy") {
             fieldCell.press(forDuration: 1.5)
-        }
-        copyMenuItem.waitAndTap()
+        }.waitAndTap()
         // Validate text was copied
         app.buttons["Passwords"].waitAndTap()
         let passwordSearchField = app.searchFields[passwordssQuery.searchPasswords]
-        let pasteMenuItem = app.staticTexts["Paste"]
-        revealCalloutMenuItem(pasteMenuItem) {
+        revealCalloutMenuItem(labelled: "Paste") {
             if #available(iOS 17, *) {
                 passwordSearchField.press(forDuration: 1.5)
             } else {
                 passwordSearchField.waitAndTap()
                 passwordSearchField.waitAndTap()
             }
-        }
-        pasteMenuItem.waitAndTap()
+        }.waitAndTap()
         mozWaitForElementToExist(passwordSearchField)
         XCTAssertEqual(passwordSearchField.value! as? String,
                        copiedText,
                        "The \(field)) text was not copied")
     }
 
-    /// Repeats `gesture` until `menuItem` (an edit-callout entry such as Copy/Paste) appears.
-    /// The callout menu does not reliably show on the first gesture on CI, so retry a few times.
-    private func revealCalloutMenuItem(_ menuItem: XCUIElement, maxAttempts: Int = 3, gesture: () -> Void) {
-        var attempts = maxAttempts
-        repeat {
+    /// Repeats `gesture` until the edit-callout entry named `label` appears, and returns it. The entry
+    /// is a menuItem on some iOS versions and a staticText on others, so both types are polled.
+    private func revealCalloutMenuItem(labelled label: String,
+                                       maxAttempts: Int = 3,
+                                       gesture: () -> Void) -> XCUIElement {
+        let candidates = [app.menuItems[label], app.staticTexts[label]]
+        for _ in 0..<maxAttempts {
             gesture()
-            if menuItem.mozWaitForElementToExist(timeout: 5, failOnTimeout: false) {
-                return
-            }
-            attempts -= 1
-        } while attempts > 0
+            if let revealed = waitForFirstToExist(candidates, timeout: 5) { return revealed }
+        }
+        XCTFail("The '\(label)' callout entry did not appear after \(maxAttempts) gestures")
+        return candidates[0]
+    }
+
+    private func waitForFirstToExist(_ elements: [XCUIElement], timeout: TimeInterval) -> XCUIElement? {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if let existing = elements.first(where: { $0.exists }) { return existing }
+            usleep(10000)
+        } while Date() < deadline
+        return nil
     }
 
     private func clearAndEnterText(text: String) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -107,7 +107,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
         navigator.performAction(Action.OpenEmailToSignIn)
         mozWaitForElementToExist(app.webViews.firstMatch, timeout: TIMEOUT_LONG)
         if #available(iOS 17, *) {
-            mozWaitForElementToExist(app.webViews.staticTexts["Continue to your Mozilla account"], timeout: TIMEOUT_LONG)
+            mozWaitForElementToExist(app.webViews.staticTexts["Continue to your ⁨Mozilla account⁩"], timeout: TIMEOUT_LONG)
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -140,13 +140,19 @@ final class BrowserScreen {
     }
 
     func exampleDomainTextExists(timeout: TimeInterval = TIMEOUT) -> Bool {
-        let exampleDomainText = sel.STATIC_TEXT_EXAMPLE_DOMAIN.element(in: app)
-        return BaseTestCase().mozWaitForElementToExist(exampleDomainText, timeout: timeout, failOnTimeout: false)
+        webViewShowsText(containing: sel.STATIC_TEXT_EXAMPLE_DOMAIN.value, timeout: timeout)
     }
 
     func bookOfMozillaPageContentExists(timeout: TimeInterval = TIMEOUT) -> Bool {
-        let verseText = sel.BOOK_OF_MOZILLA_VERSE_TEXT.element(in: app)
-        return BaseTestCase().mozWaitForElementToExist(verseText, timeout: timeout, failOnTimeout: false)
+        webViewShowsText(containing: sel.BOOK_OF_MOZILLA_VERSE_TEXT.value, timeout: timeout)
+    }
+
+    /// Scoped to the web view: an app-wide text search is also satisfied by a homepage tile or a tab
+    /// label carrying the same page title, which cannot tell which page is on screen.
+    private func webViewShowsText(containing text: String, timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "label CONTAINS %@", text)
+        let webViewText = app.webViews.staticTexts.containing(predicate).element(boundBy: 0)
+        return BaseTestCase().mozWaitForElementToExist(webViewText, timeout: timeout, failOnTimeout: false)
     }
 
     func assertExampleDomainTextExists(timeout: TimeInterval = TIMEOUT) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MarkupScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/MarkupScreen.swift
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@MainActor
+final class MarkupScreen {
+    private let app: XCUIApplication
+    private let sel: MarkupSelectorsSet
+
+    // Entering markup can be ignored while QuickLook is still loading the document, so the control is
+    // tapped again as long as the palette has not shown up.
+    private let markupEntryAttempts = 3
+
+    init(app: XCUIApplication, selectors: MarkupSelectorsSet = MarkupSelectors()) {
+        self.app = app
+        self.sel = selectors
+    }
+
+    private var palette: XCUIElement { sel.PALETTE.element(in: app) }
+    private var penTool: XCUIElement { sel.PEN_TOOL.element(in: app) }
+    private var quickLookMarkupToggle: XCUIElement { sel.QUICK_LOOK_MARKUP_TOGGLE.element(in: app) }
+    private var markupButton: XCUIElement { sel.MARKUP_BUTTON.element(in: app) }
+    private var markupSwitch: XCUIElement { sel.MARKUP_SWITCH.element(in: app) }
+    private var closeButton: XCUIElement { sel.CLOSE_BUTTON.element(in: app) }
+
+    func assertMarkupToolIsOpen() {
+        let base = BaseTestCase()
+        guard #available(iOS 26, *) else {
+            assertMarkupControlIsShown()
+            return
+        }
+        if base.iPad() {
+            // On iPad the palette renders inline and the Markup control is a switch, not a button.
+            base.mozWaitForElementToExist(markupSwitch, timeout: TIMEOUT_LONG)
+            base.mozWaitForElementToExist(closeButton, timeout: TIMEOUT_LONG)
+        } else {
+            assertPaletteIsOpen()
+        }
+    }
+
+    // Share "Markup" either opens PencilKit straight away or opens QuickLook in preview mode behind a
+    // markup control, and which one happens varies by share entry point, so both are handled.
+    private func assertPaletteIsOpen() {
+        for _ in 0..<markupEntryAttempts {
+            if palette.mozWaitForElementToExist(timeout: TIMEOUT, failOnTimeout: false) {
+                BaseTestCase().mozWaitForElementToExist(penTool, timeout: TIMEOUT_LONG)
+                return
+            }
+            guard tapMarkupEntryControl() else { break }
+        }
+        XCTFail("The Markup palette did not open. \(observedMarkupState())")
+    }
+
+    /// Taps whichever markup control QuickLook exposes, and reports `false` when neither is on screen
+    /// so the caller stops retrying.
+    private func tapMarkupEntryControl() -> Bool {
+        for control in [quickLookMarkupToggle, markupButton, markupSwitch] where control.exists {
+            control.waitAndTap()
+            return true
+        }
+        return false
+    }
+
+    private func observedMarkupState() -> String {
+        let onScreen = [
+            ("QuickLook markup toggle", quickLookMarkupToggle),
+            ("Markup button", markupButton),
+            ("Markup switch", markupSwitch),
+            ("Pen tool", penTool)
+        ].filter { $0.1.exists }.map { $0.0 }
+        return onScreen.isEmpty ? "No markup control was on screen" : "On screen: \(onScreen.joined(separator: ", "))"
+    }
+
+    // Before iOS 26 the tool exposes the Markup control itself rather than a PencilKit palette.
+    private func assertMarkupControlIsShown() {
+        guard !markupSwitch.mozWaitForElementToExist(timeout: TIMEOUT_LONG, failOnTimeout: false) else { return }
+        BaseTestCase().mozWaitForElementToExist(markupButton, timeout: TIMEOUT_LONG)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
@@ -199,10 +199,21 @@ final class ToolbarScreen {
     /// Selects English in the translation language picker action sheet when it is shown.
     /// The picker only appears when the language picker feature is enabled and multiple
     /// target languages are available, so this is a no-op when the sheet doesn't show.
-    func selectTranslationLanguageIfPresented(timeout: TimeInterval = TIMEOUT) {
+    /// The probe is short on purpose: waiting the full TIMEOUT lets the translation finish before the
+    /// caller can observe the spinner.
+    func selectTranslationLanguageIfPresented(timeout: TimeInterval = TIMEOUT_PICKER_PROBE) {
         if translateLanguageEnglishOption.mozWaitForElementToExist(timeout: timeout, failOnTimeout: false) {
             translateLanguageEnglishOption.waitAndTap()
         }
+    }
+
+    /// The spinner is transient and a fast translation can pass through it between UI samples, so the
+    /// active button counts too.
+    func assertTranslationInProgressOrCompleted(timeout: TimeInterval = TIMEOUT) {
+        guard !translateLoadingButton.mozWaitForElementToExist(timeout: timeout, failOnTimeout: false) else {
+            return
+        }
+        BaseTestCase().mozWaitForElementToExist(translateActiveButton, timeout: timeout)
     }
 
     func assertTranslateButtonExists(with mode: TranslationButtonType, timeout: TimeInterval = TIMEOUT) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/MarkupSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/MarkupSelectors.swift
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+protocol MarkupSelectorsSet {
+    var PALETTE: Selector { get }
+    var PEN_TOOL: Selector { get }
+    var QUICK_LOOK_MARKUP_TOGGLE: Selector { get }
+    var MARKUP_BUTTON: Selector { get }
+    var MARKUP_SWITCH: Selector { get }
+    var CLOSE_BUTTON: Selector { get }
+    var all: [Selector] { get }
+}
+
+// QuickLook and PencilKit internals, matched the way the share sheet exposes them.
+struct MarkupSelectors: MarkupSelectorsSet {
+    let PALETTE = Selector.otherElementId(
+        "Drawing-Palette",
+        description: "The PencilKit drawing palette shown once markup is open",
+        groups: ["markup"]
+    )
+
+    let PEN_TOOL = Selector.buttonIdOrLabel(
+        "Pen",
+        description: "The pen tool in the PencilKit drawing palette",
+        groups: ["markup"]
+    )
+
+    let QUICK_LOOK_MARKUP_TOGGLE = Selector.switchById(
+        "QLOverlayMarkupButtonAccessibilityIdentifier",
+        description: "The QuickLook overlay control that switches the preview into markup mode",
+        groups: ["markup"]
+    )
+
+    let MARKUP_BUTTON = Selector.buttonIdOrLabel(
+        "Markup",
+        description: "The Markup control exposed as a button",
+        groups: ["markup"]
+    )
+
+    let MARKUP_SWITCH = Selector.switchByIdOrLabel(
+        "Markup",
+        description: "The Markup control exposed as a switch",
+        groups: ["markup"]
+    )
+
+    let CLOSE_BUTTON = Selector.buttonIdOrLabel(
+        "close",
+        description: "The button that dismisses the markup tool",
+        groups: ["markup"]
+    )
+
+    var all: [Selector] {
+        return [PALETTE, PEN_TOOL, QUICK_LOOK_MARKUP_TOGGLE, MARKUP_BUTTON, MARKUP_SWITCH, CLOSE_BUTTON]
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
@@ -180,28 +180,7 @@ class ShareMenuTests: FeatureFlaggedTestBase {
     }
 
     private func validateMarkupTool() {
-        // The Markup tool opens. It can take a little longer to load, so wait longer.
-        if #available(iOS 26, *) {
-            if !iPad() {
-                // Share "Markup" sometimes opens QuickLook in preview mode (a "Markup" pen button, no
-                // palette); tap it to enter markup, then verify the PencilKit Drawing-Palette + Pen.
-                let palette = app.otherElements["Drawing-Palette"]
-                if !palette.mozWaitForElementToExist(timeout: TIMEOUT_LONG, failOnTimeout: false) {
-                    app.switches["QLOverlayMarkupButtonAccessibilityIdentifier"].firstMatch.waitAndTap()
-                }
-                mozWaitForElementToExist(palette, timeout: TIMEOUT_LONG)
-                mozWaitForElementToExist(app.buttons["Pen"], timeout: TIMEOUT_LONG)
-            } else {
-                // On iPad the Markup palette renders inline with no navbar overflow button;
-                // the Markup control is a switch, not a button.
-                mozWaitForElementToExist(app.switches["Markup"], timeout: TIMEOUT_LONG)
-                mozWaitForElementToExist(app.buttons["close"], timeout: TIMEOUT_LONG)
-            }
-        } else {
-            if !app.switches["Markup"].mozWaitForElementToExist(timeout: TIMEOUT_LONG, failOnTimeout: false) {
-                mozWaitForElementToExist(app.buttons["Markup"], timeout: TIMEOUT_LONG)
-            }
-        }
+        MarkupScreen(app: app).assertMarkupToolIsOpen()
     }
 
     private func reachReaderModeShareMenuLayoutAndSelectOption(option: String) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ToolbarTest.swift
@@ -107,39 +107,42 @@ class ToolbarTests: FeatureFlaggedTestBase {
     // the URL bar, tapping again on the status will scroll to the top
     // Skipping for iPad for now, not sure how to implement it there
     // https://mozilla.testrail.io/index.php?/cases/view/2344431
-    func testRevealToolbarWhenTappingOnStatusbar() {
-        app.launch()
-        if !iPad() {
-            // Workaround when testing on iPhone. If the orientation is in landscape on iPhone the tests will fail.
-
-            XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
-            navigator.nowAt(HomePanelsScreen)
-            navigator.goto(URLBarOpen)
-            mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
-
-            navigator.openURL(website1["url"]!, waitForLoading: true)
-            // Wait for the loading indicator to appear
-            waitUntilPageLoad()
-            mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
-            let settingsMenuButton = app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton]
-            let statusbarElement: XCUIElement = XCUIApplication(
-                bundleIdentifier: "com.apple.springboard"
-            ).statusBars.element(boundBy: 1)
-            app.swipeUp()
-            XCTAssertFalse(settingsMenuButton.isHittable)
-            statusbarElement.tap(force: true)
-            XCTAssertTrue(settingsMenuButton.isHittable)
-            statusbarElement.tap(force: true)
-            let topElement = app.webViews
-                .otherElements["Internet for people, not profit — Mozilla"]
-                .children(matching: .other)
-                .matching(identifier: "navigation")
-                .element(boundBy: 0)
-                .staticTexts["Mozilla"]
-            mozWaitForElementToExist(topElement, timeout: 10)
-            XCTAssertTrue(topElement.isHittable)
+    func testRevealToolbarWhenTappingOnStatusbar() throws {
+        if iPad() {
+            throw XCTSkip("iPhone only test")
         }
-   }
+        // Landscape makes this fail on iPhone, so launch in portrait rather than rotating afterwards.
+        XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
+        app.launch()
+
+        // Only NewTabScreen has a direct edge to URLBarOpen; from HomePanelsScreen the route detours
+        // through the tab tray and opens an extra tab.
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(URLBarOpen)
+        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
+
+        navigator.openURL(website1["url"]!, waitForLoading: true)
+        // Wait for the loading indicator to appear
+        waitUntilPageLoad()
+        mozWaitForElementToExist(app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton], timeout: 10)
+        let settingsMenuButton = app.buttons[AccessibilityIdentifiers.Toolbar.settingsMenuButton]
+        let statusbarElement: XCUIElement = XCUIApplication(
+            bundleIdentifier: "com.apple.springboard"
+        ).statusBars.element(boundBy: 1)
+        app.swipeUp()
+        XCTAssertFalse(settingsMenuButton.isHittable)
+        statusbarElement.tap(force: true)
+        XCTAssertTrue(settingsMenuButton.isHittable)
+        statusbarElement.tap(force: true)
+        let topElement = app.webViews
+            .otherElements["Internet for people, not profit — Mozilla"]
+            .children(matching: .other)
+            .matching(identifier: "navigation")
+            .element(boundBy: 0)
+            .staticTexts["Mozilla"]
+        mozWaitForElementToExist(topElement, timeout: 10)
+        XCTAssertTrue(topElement.isHittable)
+    }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3197644
     func testOpenNewTabButtonOnToolbar() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
@@ -39,7 +39,7 @@ final class TranslationsTests: FeatureFlaggedTestBase {
         toolBarScreen.selectTranslationLanguageIfPresented()
 
         // Check that translation icon switches to loading (spinner) and eventually active mode (blue button)
-        toolBarScreen.assertTranslateButtonExists(with: .loading)
+        toolBarScreen.assertTranslationInProgressOrCompleted()
         toolBarScreen.waitForTranslateButtonToBecomeActive()
         browserScreen.assertWebPageText(with: "Example domain")
 


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5864

## :bulb: Description
Fixes XCUITest failures from the full-functional iPhone nightly, run 156 (https://storage.googleapis.com/mobile-reports/public/firefox-ios-M4/nightly-firefox-ios-full-functional-iphone/result_156/build/reports/index.html). Each fix comes from the activity log of the failing test, usually by comparing it against a passing sibling test.

ToolbarTests.testRevealToolbarWhenTappingOnStatusbar — Cannot get from TabTray to OpenNewTabFromTabTray
navigator.nowAt(HomePanelsScreen) + goto(URLBarOpen) has no direct graph edge, so MappaMundi routed via TabTray → new tab → NewTabScreen → URLBarOpen and timed out on newTabButtonTabTray. Switched to nowAt(NewTabScreen), which has a direct edge. Also launches in portrait instead of launching in landscape and rotating, and uses XCTSkip on iPad rather than an empty if !iPad() body.

BrowsingPDFTests.testSwitchTabsWhileDownloadingPDF — address bar asserted before large PDFs finish loading
waitUntilPageLoad() had hardcoded timeouts and no way to override them; it also passes failOnTimeout: false, so it silently returned and the next line failed. Added a timeout parameter (default unchanged at 10s) and raised both waits in this test to TIMEOUT_LONG.

TranslationsTests.testTranslationFlow_withDifferentStates_translationExperimentOn — translateLoadingButton not found
selectTranslationLanguageIfPresented() burned its full 10s timeout when the language picker wasn't shown, by which point the translation had finished and the spinner was gone. Shortened that probe to 3s, and replaced the spinner assertion with assertTranslationInProgressOrCompleted(), which accepts spinner-or-active — the spinner is transient and can pass between UI samples. End-state coverage is unchanged (waitForTranslateButtonToBecomeActive + translated text still assert).

KeyboardShortcutsTests.testOpenPrivateTabWithKeyboardShortcut / testSwitchTabWithKeyboardShortcut — shortcut had no effect in 4 attempts
All 4 key events were synthesized successfully but ignored, so re-sending identical keys couldn't help. pressShortcut now waits for the toolbar to be interactive before the first press (best-effort — setUpApp() only waits for the first element in the window) and calls app.activate() on retries. Added retryOnlyWhile so cycling shortcuts like ⌃⇥ aren't retried once a press has landed — previously retries chased the tab around the cycle, wasting two guaranteed-fail attempts. exampleDomainTextExists/bookOfMozillaPageContentExists are now scoped to app.webViews (they answer "which tab is showing", and an app-wide text search also matches homepage tiles); both are only used by this class.

ShareMenuTests.testShareNormalWebsiteMarkup / testSharePdfFileMarkup — Drawing-Palette not found
validateMarkupTool() is duplicated in ShareMenuTests and ShareToolbarTests and has drifted: each copy knows about only one QuickLook markup control (QLOverlayMarkupButton… vs Markup), gets one attempt, then hard-waits 20s. Extracted PageScreens/MarkupScreen.swift, which tries all three known controls, retries entry 3×, and fails with which controls were actually on screen. ShareToolbarTests is left untouched (13/13 green there).

LoginTest.testDismissedChangesAreNotSaved — Login Detail List not found
The test tapped the credential cell then immediately app.buttons["Edit"], which resolved in 0.06s. That query is ambiguous — the passwords list has its own Edit button (see testSavedLoginSelectUnselect) — so the tap entered list selection mode instead of the detail editor. Added the wait for Login Detail List before tapping Edit, matching the passing testEditOneLoginEntry.

LoginTest.testLoginCopyPaste — "Copy" StaticText not found
revealCalloutMenuItem exhausted 3 long-presses, gave up silently, then the caller timed out for another 10s. It also queried the callout entry as a staticText, while testEditOneLoginEntry queries the same kind of entry as a menuItem — iOS uses either depending on version, so the menu may have been open and simply unmatched. The helper now polls both types, returns the matched element, and fails with a message naming the entry and attempt count.

