### PR TITLE
BugFix FXIOS-10152 [Toast] Fix missing Paste label at large Dynamic Type sizes

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1873,6 +1873,8 @@
 		CAA3B7E62497DCB60094E3C1 /* LoginDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA3B7E52497DCB60094E3C1 /* LoginDataSource.swift */; };
 		CAC458F1249429C20042561A /* PasswordManagerSelectionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC458F0249429C20042561A /* PasswordManagerSelectionHelper.swift */; };
 		CB4BB1112F954E8B003A181D /* NativeErrorPageHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4BB1102F954E8B003A181D /* NativeErrorPageHelperTests.swift */; };
+		A4EAEAC4B22B0B21B04986E6 /* PasteControlToastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFB98AD7CFFF4965F21C157 /* PasteControlToastTests.swift */; };
+		69800B26366FB50C927D0593 /* ButtonToastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C16907DD6522D8F88E18FBB /* ButtonToastTests.swift */; };
 		CB5541872F51E1B100256DA1 /* CertificateHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5541862F51E1B100256DA1 /* CertificateHelperTests.swift */; };
 		CBC398772F4F455E00CD4EAD /* CertificateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC398762F4F455E00CD4EAD /* CertificateHelper.swift */; };
 		CDB3BE8724746787009320EE /* FirefoxAccountSignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3BE8624746787009320EE /* FirefoxAccountSignInViewController.swift */; };
@@ -11025,6 +11027,8 @@
 		CAB7414DA1BA84F4CD08A8F8 /* kk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kk; path = kk.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		CAC458F0249429C20042561A /* PasswordManagerSelectionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordManagerSelectionHelper.swift; sourceTree = "<group>"; };
 		CB4BB1102F954E8B003A181D /* NativeErrorPageHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeErrorPageHelperTests.swift; sourceTree = "<group>"; };
+		FAFB98AD7CFFF4965F21C157 /* PasteControlToastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteControlToastTests.swift; sourceTree = "<group>"; };
+		2C16907DD6522D8F88E18FBB /* ButtonToastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonToastTests.swift; sourceTree = "<group>"; };
 		CB5541862F51E1B100256DA1 /* CertificateHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateHelperTests.swift; sourceTree = "<group>"; };
 		CB664443A893E97243385395 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		CBA242528C97816D5BCF4473 /* co */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = co; path = co.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
@@ -13810,6 +13814,15 @@
 				630EBE4C301109A10046E9BC /* GradientProgressBarTests.swift */,
 			);
 			path = Widgets;
+			sourceTree = "<group>";
+		};
+		9345D88A82332CF22A1A40B8 /* Toasts */ = {
+			isa = PBXGroup;
+			children = (
+				FAFB98AD7CFFF4965F21C157 /* PasteControlToastTests.swift */,
+				2C16907DD6522D8F88E18FBB /* ButtonToastTests.swift */,
+			);
+			path = Toasts;
 			sourceTree = "<group>";
 		};
 		630FE1332C7FB42500D9D6B2 /* NativeErrorPage */ = {
@@ -16704,6 +16717,7 @@
 				21872A222E3CFEA500241A8A /* TabScrollHandlerTests.swift */,
 				21EA33802EC67FCA00D20D90 /* ToolbarAnimatorTest.swift */,
 				8A5BD9582878871B000FE773 /* TopSitesHelperTests.swift */,
+				9345D88A82332CF22A1A40B8 /* Toasts */,
 				E1AEC174286E0CF500062E29 /* WebView */,
 			);
 			path = Browser;
@@ -19098,7 +19112,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "SWIFTLINT_ROOT=\"${SRCROOT}/..\"\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\n# The version is pinned in .swiftlint-version and installed by bootstrap.sh\nSWIFTLINT=$(\"${SWIFTLINT_ROOT}/scripts/install-swiftlint.sh\" --path-only)\n\nif [ -n \"${SWIFTLINT}\" ]; then\n    # Move to the location of the root Swiftlint config file in\n    # order to use nested configurations\n    cd ${SWIFTLINT_ROOT}\n\n    \"${SWIFTLINT}\" lint ${MODIFIED_FILES}\nelse\n    echo \"warning: pinned SwiftLint not installed, run ./bootstrap.sh from the repo root\"\nfi\n";
+			shellScript = "SWIFTLINT_ROOT=\"${SRCROOT}/..\"\n\nMODIFIED_FILES=$(git diff --name-only --diff-filter=ACM | grep -e '\\.swift$')\n\n# The version is pinned in .swiftlint-version and installed by bootstrap.sh\nSWIFTLINT=$(\"${SWIFTLINT_ROOT}/scripts/install-swiftlint.sh\" --path-only)\n\nif [ -n \"${SWIFTLINT}\" ]; then\n    # Move to the location of the root Swiftlint config file in\n    # order to use nested configurations\n    cd \"${SWIFTLINT_ROOT}\"\n\n    \"${SWIFTLINT}\" lint ${MODIFIED_FILES}\nelse\n    echo \"warning: pinned SwiftLint not installed, run ./bootstrap.sh from the repo root\"\nfi\n";
 		};
 		D48146712E26CB3300231244 /* Populate test-fixtures script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -20784,6 +20798,8 @@
 				5A70EF19295E2E1600790249 /* DependencyHelperMock.swift in Sources */,
 				61497F3C2F687B5A00BC5ACA /* AIControlsSettingTests.swift in Sources */,
 				CB4BB1112F954E8B003A181D /* NativeErrorPageHelperTests.swift in Sources */,
+				A4EAEAC4B22B0B21B04986E6 /* PasteControlToastTests.swift in Sources */,
+				69800B26366FB50C927D0593 /* ButtonToastTests.swift in Sources */,
 				8A96C4BB28F9E7B300B75884 /* XCTestCaseRootViewController.swift in Sources */,
 				8A8482F02BE1602500F9007B /* MicrosurveyPromptStateTests.swift in Sources */,
 				EC4F28183011A6BF00BAD351 /* CertificatesFetcherTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Toasts/ButtonToast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/ButtonToast.swift
@@ -32,14 +32,14 @@ class ButtonToast: Toast {
 
     private var imageView: UIImageView = .build { imageView in }
 
-    private var labelStackView: UIStackView = .build { stackView in
+    private(set) var labelStackView: UIStackView = .build { stackView in
         stackView.axis = .vertical
         stackView.alignment = .leading
         stackView.setContentCompressionResistancePriority(.required, for: .vertical)
-        stackView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        stackView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     }
 
-    private var titleLabel: UILabel = .build { label in
+    private(set) var titleLabel: UILabel = .build { label in
         label.font = FXFontStyles.Regular.subheadline.scaledFont()
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
@@ -106,6 +106,7 @@ class ButtonToast: Toast {
             titleLabel.lineBreakMode = .byClipping
             titleLabel.numberOfLines = 1 // if showing a description we can't wrap to the second line
             titleLabel.adjustsFontSizeToFitWidth = true
+            titleLabel.minimumScaleFactor = 0.7
 
             descriptionLabel.text = descriptionText
             labelStackView.addArrangedSubview(descriptionLabel)
@@ -178,7 +179,7 @@ class PasteControlToast: ButtonToast {
     private var theme: Theme?
     private var pasteControlTarget: UIViewController?
 
-    private lazy var pasteControl: UIPasteControl = {
+    private(set) lazy var pasteControl: UIPasteControl = {
         let pasteControlConfig = UIPasteControl.Configuration()
         pasteControlConfig.displayMode = .labelOnly
         pasteControlConfig.baseForegroundColor = theme?.colors.textInverted
@@ -205,7 +206,8 @@ class PasteControlToast: ButtonToast {
 
     override func setupPaddedButton(stackView: UIStackView, buttonText: String?) {
         stackView.addArrangedSubview(pasteControl)
-        pasteControl.setContentCompressionResistancePriority(.required, for: .horizontal)
+        pasteControl.setContentCompressionResistancePriority(UILayoutPriority(999), for: .horizontal)
+        pasteControl.setContentHuggingPriority(UILayoutPriority(751), for: .horizontal)
     }
 
     override func applyTheme(theme: Theme) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Toasts/ButtonToastTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Toasts/ButtonToastTests.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import TestKit
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class ButtonToastTests: XCTestCase {
+    func test_buttonToast_withDescriptionText_setsMinimumScaleFactorForTitleLabel() {
+        let toast = createSubject(descriptionText: "https://example.com")
+
+        XCTAssertGreaterThan(toast.titleLabel.minimumScaleFactor, 0)
+    }
+
+    private func createSubject(descriptionText: String?) -> ButtonToast {
+        let viewModel = ButtonToastViewModel(
+            labelText: "Test label",
+            descriptionText: descriptionText,
+            buttonText: "Undo"
+        )
+        let toast = ButtonToast(viewModel: viewModel, theme: DarkTheme())
+        trackForMemoryLeaks(toast)
+        return toast
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Toasts/PasteControlToastTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/Toasts/PasteControlToastTests.swift
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import TestKit
+import XCTest
+
+@testable import Client
+
+@available(iOS 16.0, *)
+@MainActor
+final class PasteControlToastTests: XCTestCase {
+    func test_pasteControlToast_pasteControlResistsCompressionMoreThanLabelStack() {
+        let toast = createSubject()
+
+        let pasteControlPriority = toast.pasteControl.contentCompressionResistancePriority(for: .horizontal)
+        let labelStackPriority = toast.labelStackView.contentCompressionResistancePriority(for: .horizontal)
+
+        XCTAssertGreaterThan(pasteControlPriority.rawValue, labelStackPriority.rawValue)
+    }
+
+    func test_pasteControlToast_pasteControlHugsMoreThanLabelStack() {
+        let toast = createSubject()
+
+        let pasteControlPriority = toast.pasteControl.contentHuggingPriority(for: .horizontal)
+        let labelStackPriority = toast.labelStackView.contentHuggingPriority(for: .horizontal)
+
+        XCTAssertGreaterThan(pasteControlPriority.rawValue, labelStackPriority.rawValue)
+    }
+
+    private func createSubject() -> PasteControlToast {
+        let viewModel = ButtonToastViewModel(labelText: "Test label")
+        let toast = PasteControlToast(viewModel: viewModel, theme: DarkTheme(), target: nil)
+        trackForMemoryLeaks(toast)
+        return toast
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-10152)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/22247)

## :bulb: Description
On iOS 16+, the "Go to copied link?" clipboard toast (`PasteControlToast`) substitutes a system `UIPasteControl` for the normal action button. Both the title label stack and the paste control were given `.required` horizontal compression resistance in the same `UIStackView`. Whenever the title needed more width than was available (large Dynamic Type sizes, longer localized strings, or narrower devices), Auto Layout had to break a required constraint to resolve the conflict — and it was ambiguous which side lost. In practice this could reach into `UIPasteControl`'s own internal layout, dropping its "Paste" label entirely, which is the exact symptom reported in #22247.

(Git history shows the toast originally used a hardcoded `90pt` width for the paste control, which had the same "doesn't scale with Dynamic Type" problem; that was fixed in a later commit by switching to `.required` compression resistance on both sides — which fixed the original repro but introduced this narrower, still-live conflict.)

**Fix:** rebalance the priorities so the title yields first instead of the system control:
- Title label stack: `.required` → `.defaultLow` horizontal compression resistance, so it wraps/shrinks under pressure (it already supports multi-line wrapping).
- Paste control: compression resistance set to `999` (not `.required`) so it strongly resists shrinking below its intrinsic size, but without forcing UIKit to break `UIPasteControl`'s own internal constraints in a genuinely impossible layout.
- Paste control: added a higher content-hugging priority (`751`) so it doesn't stretch to fill extra space on wide layouts (e.g. iPad).
- `titleLabel.minimumScaleFactor` is now set, since `adjustsFontSizeToFitWidth` was silently a no-op without it — needed now that the description-present path (legacy pre-iOS-16 toast) can actually compress the title instead of always winning the former required-vs-required tie.

**Testing:** `UIPasteControl` is an opaque, system-rendered control — its actual rendered glyphs aren't inspectable from a unit test, and its rendering also depends on live pasteboard state, so asserting on its rendered size directly gave a false-positive pass against the *unfixed* code in an early draft of this fix. The tests instead assert on the underlying priority configuration, which is what deterministically drives the behavior:
- `PasteControlToastTests`: paste control's compression resistance/hugging priority are strictly greater than the label stack's (both were previously tied at `.required`/`.defaultLow`, which is what caused the ambiguity).
- `ButtonToastTests`: `titleLabel.minimumScaleFactor > 0` on the description-present path.

Both were written test-first (confirmed RED against the current code, then GREEN after the fix).

**Not yet verified:** an on-device/simulator visual repro of the exact reported symptom (large Dynamic Type + clipboard toast). This requires enabling the "Offer to Open Copied Links" setting and a full background/foreground cycle, which needs manual interaction — automated CLI reproduction wasn't feasible in the environment this was developed in. Would appreciate a manual QA pass on this before merge, ideally on a narrower device (iPhone SE-class) with a longer locale string (e.g. German) or accessibility text sizes, since that's where the residual conflict is most likely to reproduce.

## :movie_camera: Demos
Not included — see "Not yet verified" note above. Happy to add before/after screenshots once manually verified, or if a reviewer can confirm on-device.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — Dynamic Text is the subject of the fix; VoiceOver behavior of `UIPasteControl` is unchanged by this PR and not separately verified
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review — N/A, no telemetry changes
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n — N/A, no string changes
- [ ] If needed, I updated documentation and added comments to complex code — N/A
