### PR TITLE
Bugfix FXIOS-16572 Synced tabs icon is not visible

### DIFF
--- a/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/SyncedTabCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/SyncedTabCell.swift
@@ -307,7 +307,8 @@ class SyncedTabCell: UICollectionViewCell,
         tabItemTitle.textColor = theme.colors.textPrimary
         syncedDeviceLabel.textColor = theme.colors.textSecondary
         syncedTabsButton.tintColor = theme.colors.iconPrimary
-        syncedDeviceImage.image = syncedDeviceImage.image?.tinted(withColor: theme.colors.iconSecondary)
+        let syncedDeviceRawImage = UIImage(named: StandardImageIdentifiers.Large.syncTabs)
+        syncedDeviceImage.image = syncedDeviceRawImage?.tinted(withColor: theme.colors.iconSecondary)
 
         let heroImageColors = HeroImageViewColor(faviconTintColor: theme.colors.iconPrimary,
                                                  faviconBackgroundColor: theme.colors.layer1,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16572)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR fixes the issue where the synced tabs icon in "Tab pickup" was not visible after a theme change, caused by the icon's image becoming nil and not being reset. The icon is now re-tinted from its original asset on every theme update, ensuring it always renders correctly.


<img width="1206" height="2622" alt="simulator_screenshot_19352A74-D279-4656-B806-E2C9660D96B5" src="https://github.com/user-attachments/assets/195d37e8-719d-4e43-9647-f580b683fe7d" />

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

