### PR TITLE
Bugfix FXIOS-16570 [Nova] The background is lighter with addressbar on top

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
@@ -58,8 +58,10 @@ public struct AddressToolbarUXConfiguration {
     func locationContainerBackgroundColor(theme: some Theme) -> UIColor {
         guard !isAddressBarMinimized else { return .clear }
 
+        let alternativeLocationColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layerSurfaceMediumAlt
+
         if hasAlternativeLocationColor {
-            return isLocationTextCentered ? theme.colors.layerSurfaceMediumAlt : theme.colors.layerEmphasis
+            return isLocationTextCentered ? alternativeLocationColor : theme.colors.layerEmphasis
         } else {
             return isLocationTextCentered ? theme.colors.layerSurfaceMedium : theme.colors.layerEmphasis
         }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -758,7 +758,8 @@ final class LocationView: UIView,
     func applyTheme(theme: Theme) {
         self.theme = theme
         let colors = theme.colors
-        let mainBackgroundColor = hasAlternativeLocationColor ? colors.layerSurfaceMediumAlt : colors.layerSurfaceMedium
+        let alternativeLocationColor = theme.isNova ? colors.layerSurfaceMedium : colors.layerSurfaceMediumAlt
+        let mainBackgroundColor = hasAlternativeLocationColor ? alternativeLocationColor : colors.layerSurfaceMedium
         let (primaryColor, secondaryColor) = getPrimaryAndSecondaryColors()
 
         gradientLayer.colors = Gradient(

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -758,8 +758,8 @@ final class LocationView: UIView,
     func applyTheme(theme: Theme) {
         self.theme = theme
         let colors = theme.colors
-        let alternativeLocationColor = theme.isNova ? colors.layerSurfaceMedium : colors.layerSurfaceMediumAlt
-        let mainBackgroundColor = hasAlternativeLocationColor ? alternativeLocationColor : colors.layerSurfaceMedium
+        let usesAlternativeLocationColor = !theme.isNova && hasAlternativeLocationColor
+        let mainBackgroundColor = usesAlternativeLocationColor ? colors.layerSurfaceMediumAlt : colors.layerSurfaceMedium
         let (primaryColor, secondaryColor) = getPrimaryAndSecondaryColors()
 
         gradientLayer.colors = Gradient(


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16570)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
We should use the same token for Nova for address bar background, even if it is top or bottom.

<img width="1243" height="180" alt="Screenshot 2026-08-19 at 17 13 06" src="https://github.com/user-attachments/assets/615dafea-be7c-4162-bb11-c29684a6c741" />



## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

