### PR TITLE
Add FXIOS-16611 [Nova] Update background for settings list items

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressAutofillToggle.swift
@@ -116,7 +116,7 @@ struct AddressAutofillToggle: View {
         let color = theme.colors
         textColor = Color(color.textPrimary)
         descriptionTextColor = Color(color.textSecondary)
-        backgroundColor = Color(color.layer2)
+        backgroundColor = Color(theme.isNova ? color.layerSurfaceMedium : color.layer2)
         toggleTintColor = Color(color.actionPrimary)
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressCellView.swift
@@ -125,7 +125,7 @@ struct AddressCellView: View {
         textColor = Color(color.textPrimary)
         customLightGray = Color(color.textSecondary)
         iconPrimary = Color(color.iconPrimary)
-        backgroundColor = Color(color.layer2)
+        backgroundColor = Color(theme.isNova ? color.layerSurfaceMedium : color.layer2)
         highlightColor = Color(color.layer5Hover)
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -90,6 +90,7 @@ struct CreditCardInputView: ThemeableView {
     }
 
     private var form: some View {
+        let listBackgroundColor = Color(theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer2)
         return VStack(spacing: 0) {
             if #unavailable(iOS 26.0) {
                 Divider()
@@ -98,17 +99,17 @@ struct CreditCardInputView: ThemeableView {
             }
 
             name
-                .background(Color(theme.colors.layer2))
+                .background(listBackgroundColor)
                 .modifier(NewStyleRoundedCorners(topLeadingCorner: UX.cornerRadius,
                                                  topTrailingCorner: UX.cornerRadius,
                                                  bottomLeadingCorner: nil,
                                                  bottomTrailingCorner: nil))
 
             number
-                .background(Color(theme.colors.layer2))
+                .background(listBackgroundColor)
 
             expiration
-                .background(Color(theme.colors.layer2))
+                .background(listBackgroundColor)
                 .modifier(NewStyleRoundedCorners(topLeadingCorner: nil,
                                                  topTrailingCorner: nil,
                                                  bottomLeadingCorner: UX.cornerRadius,

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
@@ -16,6 +16,7 @@ struct CreditCardSettingsEmptyView: View {
     @State var subTextColor: Color = .clear
     @State var toggleTextColor: Color = .clear
     @State var imageColor: Color = .clear
+    @State var toggleBackgroundOverride: Color = .white
 
     @ObservedObject var toggleModel: ToggleModel
 
@@ -57,7 +58,7 @@ struct CreditCardSettingsEmptyView: View {
             windowUUID: windowUUID,
             textColor: toggleTextColor,
             model: toggleModel)
-        .background(Color.white)
+        .background(toggleBackgroundOverride)
         .padding(.top, 25)
     }
 
@@ -99,6 +100,7 @@ struct CreditCardSettingsEmptyView: View {
         subTextColor = Color(color.textSecondary)
         toggleTextColor = Color(color.textPrimary)
         imageColor = Color(color.iconSecondary)
+        toggleBackgroundOverride = theme.isNova ? .clear : .white
     }
 }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardSettingsEmptyView.swift
@@ -16,7 +16,6 @@ struct CreditCardSettingsEmptyView: View {
     @State var subTextColor: Color = .clear
     @State var toggleTextColor: Color = .clear
     @State var imageColor: Color = .clear
-    @State var toggleBackgroundOverride: Color = .white
 
     @ObservedObject var toggleModel: ToggleModel
 
@@ -58,7 +57,7 @@ struct CreditCardSettingsEmptyView: View {
             windowUUID: windowUUID,
             textColor: toggleTextColor,
             model: toggleModel)
-        .background(toggleBackgroundOverride)
+        .background(Color.white)
         .padding(.top, 25)
     }
 
@@ -100,7 +99,6 @@ struct CreditCardSettingsEmptyView: View {
         subTextColor = Color(color.textSecondary)
         toggleTextColor = Color(color.textPrimary)
         imageColor = Color(color.iconSecondary)
-        toggleBackgroundOverride = theme.isNova ? .clear : .white
     }
 }
 

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardAutofillToggle.swift
@@ -72,7 +72,7 @@ struct CreditCardAutofillToggle: View {
     func applyTheme(theme: Theme) {
         let color = theme.colors
         textColor = Color(color.textPrimary)
-        backgroundColor = Color(color.layer2)
+        backgroundColor = Color(theme.isNova ? color.layerSurfaceMedium : color.layer2)
         toggleTintColor = Color(color.actionPrimary)
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/ViewComponents/CreditCardInputField.swift
@@ -127,7 +127,7 @@ struct CreditCardInputField: View {
         errorColor = Color(color.textCritical)
         titleColor = Color(color.textSecondary)
         textFieldColor = Color(color.textPrimary)
-        backgroundColor = Color(color.layer2)
+        backgroundColor = Color(theme.isNova ? color.layerSurfaceMedium : color.layer2)
     }
 
     // MARK: Views

--- a/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
@@ -74,7 +74,8 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
         if let detailColor = viewModel?.detailTextColor {
             detailTextLabel?.textColor = detailColor
         }
-        backgroundColor = viewModel?.backgroundColor ?? theme.colors.layer5
+        let defaultBackgroundColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layer5
+        backgroundColor = viewModel?.backgroundColor ?? defaultBackgroundColor
         tintColor = viewModel?.tintColor ?? theme.colors.actionPrimary
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16611)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates background for settings list items, forms since on Nova design all should use `layerSurfaceMedium` token.

<img width="896" height="707" alt="Screenshot 2026-08-19 at 18 33 57" src="https://github.com/user-attachments/assets/2a934cab-4cfc-4dac-ad1b-df8b0625bd17" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

