### PR TITLE
Add FXIOS-16613 [Google Lens] Interstitial strings

### DIFF
--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4687,6 +4687,26 @@ extension String {
     }
 }
 
+// MARK: - Google Lens
+extension String {
+    public struct GoogleLens {
+        /// The full-screen interstitial shown while a Google Lens image search is loading.
+        public struct Interstitial {
+            public static let LoadingLabel = MZLocalizedString(
+                key: "GoogleLens.Interstitial.LoadingLabel.v156",
+                tableName: "GoogleLens",
+                value: "Looking this up",
+                comment: "Label shown next to a loading spinner on the full screen state that appears while an image is being searched with Google Lens.")
+
+            public static let CancelButtonTitle = MZLocalizedString(
+                key: "GoogleLens.Interstitial.CancelButtonTitle.v156",
+                tableName: "GoogleLens",
+                value: "Cancel",
+                comment: "Title of the button that stops an in-progress Google Lens image search and returns the user to what they were looking at before.")
+        }
+    }
+}
+
 // MARK: - Strings: unorganized & unchecked for use
 // Here we have the original strings. What follows below is unorganized. As
 // the team continues to work on new updates to strings, or to work on a view,

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4695,7 +4695,7 @@ extension String {
             public static let LoadingLabel = MZLocalizedString(
                 key: "GoogleLens.Interstitial.LoadingLabel.v156",
                 tableName: "GoogleLens",
-                value: "Looking this up",
+                value: "Finding Image Results…",
                 comment: "Label shown next to a loading spinner on the full screen state that appears while an image is being searched with Google Lens.")
 
             public static let CancelButtonTitle = MZLocalizedString(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16613)

## :bulb: Description
- Adds the localized loading and cancellation strings for the Google Lens interstitial

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

