### PR TITLE
Refactor [ToolbarAction refactor] FXIOS-16590 Migrate keyboardStateDidChange to ToolbarModernAction

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -761,7 +761,7 @@ final class BrowserCoordinator: BaseCoordinator,
             navigationController.sheetPresentationController?.detents = [.medium(), .large()]
             navigationController.sheetPresentationController?.prefersGrabberVisible = true
             if isEditing {
-                store.dispatch(ToolbarModernAction.keyboardStateDidChange(shouldShow: false), forWindowUUID: windowUUID)
+                store.dispatch(ToolbarModernAction.didCancelKeyboardRequest, forWindowUUID: windowUUID)
             }
         }
 

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -761,7 +761,7 @@ final class BrowserCoordinator: BaseCoordinator,
             navigationController.sheetPresentationController?.detents = [.medium(), .large()]
             navigationController.sheetPresentationController?.prefersGrabberVisible = true
             if isEditing {
-                store.dispatch(ToolbarModernAction.keyboardStateDidChange(isVisible: false), forWindowUUID: windowUUID)
+                store.dispatch(ToolbarModernAction.keyboardStateDidChange(shouldShow: false), forWindowUUID: windowUUID)
             }
         }
 

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -761,13 +761,7 @@ final class BrowserCoordinator: BaseCoordinator,
             navigationController.sheetPresentationController?.detents = [.medium(), .large()]
             navigationController.sheetPresentationController?.prefersGrabberVisible = true
             if isEditing {
-                store.dispatch(
-                    ToolbarAction(
-                        shouldShowKeyboard: false,
-                        windowUUID: windowUUID,
-                        actionType: ToolbarActionType.keyboardStateDidChange
-                    )
-                )
+                store.dispatch(ToolbarModernAction.keyboardStateDidChange(isVisible: false), forWindowUUID: windowUUID)
             }
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5044,7 +5044,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
         let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: windowUUID)
         let isEditing = toolbarState?.addressToolbar.isEditing == true
         if !isEditing {
-            store.dispatch(ToolbarModernAction.keyboardStateDidChange(shouldShow: false), forWindowUUID: windowUUID)
+            store.dispatch(ToolbarModernAction.didCancelKeyboardRequest, forWindowUUID: windowUUID)
         }
         tabManager.selectedTab?.setFindInPage(isBottomSearchBar: isBottomSearchBar,
                                               doesFindInPageBarExist: iOS15FindInPageBar != nil)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5044,7 +5044,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
         let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: windowUUID)
         let isEditing = toolbarState?.addressToolbar.isEditing == true
         if !isEditing {
-            store.dispatch(ToolbarModernAction.keyboardStateDidChange(isVisible: false), forWindowUUID: windowUUID)
+            store.dispatch(ToolbarModernAction.keyboardStateDidChange(shouldShow: false), forWindowUUID: windowUUID)
         }
         tabManager.selectedTab?.setFindInPage(isBottomSearchBar: isBottomSearchBar,
                                               doesFindInPageBarExist: iOS15FindInPageBar != nil)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5044,13 +5044,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
         let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: windowUUID)
         let isEditing = toolbarState?.addressToolbar.isEditing == true
         if !isEditing {
-            store.dispatch(
-                ToolbarAction(
-                    shouldShowKeyboard: false,
-                    windowUUID: windowUUID,
-                    actionType: ToolbarActionType.keyboardStateDidChange
-                )
-            )
+            store.dispatch(ToolbarModernAction.keyboardStateDidChange(isVisible: false), forWindowUUID: windowUUID)
         }
         tabManager.selectedTab?.setFindInPage(isBottomSearchBar: isBottomSearchBar,
                                               doesFindInPageBarExist: iOS15FindInPageBar != nil)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -362,7 +362,7 @@ final class AddressToolbarContainer: UIView,
 
         guard self.model != newModel else { return }
         updateSkeletonAddressBarsAlpha(forMinimizedAddressBar: newModel.isAddressBarMinimized)
-        if #available(iOS 26.0, *), !newModel.shouldShowKeyboard, !newModel.isAddressBarMinimized {
+        if #available(iOS 26.0, *), !newModel.isAccessoryViewVisible, !newModel.isAddressBarMinimized {
             accessoryViewGradient.opacity = 0
         }
         // in case we are in edit mode but overlay is not active yet we have to activate it

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -221,7 +221,7 @@ final class AddressToolbarContainer: UIView,
         guard #available(iOS 26.0, *), let windowUUID else { return 0 }
 
         let isEditingAddress = state?.addressToolbar.isEditing == true
-        let shouldShowKeyboard = state?.addressToolbar.shouldShowKeyboard
+        let isAccessoryViewVisible = state?.isAccessoryViewVisible ?? false
         let isBottomToolbar = state?.toolbarPosition == .bottom
         let shouldAdjustForAccessory = hasAccessoryView &&
                                        !isEditingAddress &&
@@ -231,21 +231,15 @@ final class AddressToolbarContainer: UIView,
 
         /// We want to check here if the keyboard accessory view state has changed
         /// To avoid spamming redux actions.
-        guard hasAccessoryView != shouldShowKeyboard else { return accessoryViewOffset }
-        store.dispatch(
-            ToolbarAction(
-                shouldShowKeyboard: hasAccessoryView,
-                windowUUID: windowUUID,
-                actionType: ToolbarActionType.keyboardStateDidChange
-            )
-        )
+        guard hasAccessoryView != isAccessoryViewVisible else { return accessoryViewOffset }
+        // Dispatch action to change address bar to minimized state
+        store.dispatch(ToolbarModernAction.accessoryViewVisibilityChanged(isVisible: hasAccessoryView),
+                       forWindowUUID: windowUUID)
 
         if shouldAdjustForAccessory {
             let height = frame.height + UX.accessoryViewGradientOffset
             accessoryViewGradient.frame = CGRect(width: bounds.width, height: height)
             accessoryViewGradient.opacity = 1
-            // Dispatch action to change address bar to minimized state
-            store.dispatch(ToolbarModernAction.accessoryViewDidShow, forWindowUUID: windowUUID)
         }
         return accessoryViewOffset
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -355,7 +355,7 @@ final class AddressToolbarContainer: UIView,
         }
 
         let isMinimizedAddressBar = alpha.isZero
-        updateSkeletonAddressBarsAlpha(isMinimizedAddressBar: isMinimizedAddressBar)
+        updateSkeletonAddressBarsAlpha(forMinimizedAddressBar: isMinimizedAddressBar)
     }
 
     private func updateModel(toolbarState: ToolbarState) {
@@ -367,7 +367,7 @@ final class AddressToolbarContainer: UIView,
         shouldDisplayCompact = newModel.shouldDisplayCompact
 
         guard self.model != newModel else { return }
-        updateSkeletonAddressBarsAlpha(isMinimizedAddressBar: newModel.isAddressBarMinimized)
+        updateSkeletonAddressBarsAlpha(forMinimizedAddressBar: newModel.isAddressBarMinimized)
         if #available(iOS 26.0, *), !newModel.shouldShowKeyboard, !newModel.isAddressBarMinimized {
             accessoryViewGradient.opacity = 0
         }
@@ -419,10 +419,10 @@ final class AddressToolbarContainer: UIView,
         rightSkeletonAddressBar.accessibilityIdentifier = AccessibilityIdentifiers.Browser.AddressToolbar.trailingSkeleton
     }
 
-    private func updateSkeletonAddressBarsAlpha(isMinimizedAddressBar: Bool) {
+    private func updateSkeletonAddressBarsAlpha(forMinimizedAddressBar: Bool) {
         guard toolbarHelper.isSwipingTabsEnabled else { return }
 
-        let alpha: CGFloat = isMinimizedAddressBar ? 0 : 1
+        let alpha: CGFloat = forMinimizedAddressBar ? 0 : 1
         leftSkeletonAddressBar.alpha = alpha
         rightSkeletonAddressBar.alpha = alpha
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -37,6 +37,7 @@ final class AddressToolbarContainerModel: Equatable {
     let shouldAnimate: Bool
     let hasAlternativeLocationColor: Bool
     let isAddressBarMinimized: Bool
+    let isAccessoryViewVisible: Bool
 
     let windowUUID: UUID
 
@@ -251,6 +252,7 @@ final class AddressToolbarContainerModel: Equatable {
         self.canShowNavigationHint = state.canShowNavigationHint
         self.shouldAnimate = state.shouldAnimate
         self.isAddressBarMinimized = state.isAddressBarMinimized
+        self.isAccessoryViewVisible = state.isAccessoryViewVisible
         self.hasAlternativeLocationColor = hasAlternativeLocationColor
         self.toolbarLayoutStyle = state.toolbarLayout
         self.toolbarHelper = toolbarHelper
@@ -386,6 +388,7 @@ final class AddressToolbarContainerModel: Equatable {
         lhs.canShowNavigationHint == rhs.canShowNavigationHint &&
         lhs.shouldAnimate == rhs.shouldAnimate &&
         lhs.isAddressBarMinimized == rhs.isAddressBarMinimized &&
+        lhs.isAccessoryViewVisible == rhs.isAccessoryViewVisible &&
         lhs.hasAlternativeLocationColor == rhs.hasAlternativeLocationColor &&
 
         lhs.windowUUID == rhs.windowUUID

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -163,8 +163,13 @@ struct AddressBarState: StateType, Sendable, Equatable {
     static let reducer: Reducer<Self> = (legacyReducer, modernReducer)
 
     static let modernReducer: ReducerMethod<Self> = { state, action, actionWindowUUID in
-        // Does not handle any modern actions
-        return defaultState(from: state)
+        guard let action = action as? ToolbarModernAction else { return defaultState(from: state) }
+        switch action {
+        case .keyboardStateDidChange(let shouldShow):
+            return state.copy(shouldShowKeyboard: shouldShow)
+        default:
+            return defaultState(from: state)
+        }
     }
 
     // swiftlint:disable:next closure_body_length
@@ -234,9 +239,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
         case ToolbarActionType.didSetTextInLocationView:
             return handleDidSetTextInLocationViewAction(state: state, action: action)
-
-        case ToolbarActionType.keyboardStateDidChange:
-            return handleShouldShowKeyboardAction(state: state, action: action)
 
         case ToolbarActionType.clearSearch:
             return handleClearSearchAction(state: state, action: action)
@@ -553,10 +555,15 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
     @MainActor
     private static func handleCancelEditOnHomepageAction(state: Self, action: Action) -> Self {
+        guard action is ToolbarAction else { return defaultState(from: state) }
+
         if state.url == nil {
             return handleCancelEditAction(state: state, action: action)
         } else {
-            return handleShouldShowKeyboardAction(state: state, action: action)
+            // This case can occur when scrolling on homepage or in search view
+            // and the user is still in isEditing mode (aka Cancel button is shown)
+            // But we don't show the keyboard and the cursor is not active
+            return state.copy(shouldShowKeyboard: false)
         }
     }
 
@@ -604,15 +611,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
             .copy(shouldSelectSearchTerm: false)
             .copy(didStartTyping: false)
             .copy(isEmptySearch: isEmptySearch)
-    }
-
-    /// This case can occur when scrolling on homepage or in search view
-    /// and the user is still in isEditing mode (aka Cancel button is shown)
-    /// But we don't show the keyboard and the cursor is not active
-    private static func handleShouldShowKeyboardAction(state: Self, action: Action) -> Self {
-        guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
-
-        return state.copy(shouldShowKeyboard: toolbarAction.shouldShowKeyboard ?? false)
     }
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -165,8 +165,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
     static let modernReducer: ReducerMethod<Self> = { state, action, actionWindowUUID in
         guard let action = action as? ToolbarModernAction else { return defaultState(from: state) }
         switch action {
-        case .keyboardStateDidChange(let shouldShow):
-            return state.copy(shouldShowKeyboard: shouldShow)
+        case .didCancelKeyboardRequest:
+            return state.copy(shouldShowKeyboard: false)
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -108,9 +108,6 @@ struct ToolbarAction: Action {
 }
 
 enum ToolbarModernAction: ModernAction {
-    // Three distinct user/system triggers drive `ToolbarState.isAddressBarMinimized`
-    // (renders the address bar as its full toolbar vs. its minimized "pill" shape).
-
     /// The user scrolled the page. `true` collapses the toolbar to the pill as the page
     /// scrolls down; `false` restores it when scrolling back up.
     case userDidScroll(minimizeAddressBar: Bool)
@@ -122,6 +119,8 @@ enum ToolbarModernAction: ModernAction {
     /// The keyboard was dismissed. Dispatched to restore the address bar after it was minimized by
     /// `accessoryViewVisibilityChanged`.
     case keyboardDidHide
+
+    case keyboardStateDidChange(isVisible: Bool)
 }
 
 enum ToolbarActionType: ActionType {
@@ -137,7 +136,6 @@ enum ToolbarActionType: ActionType {
     case didStartEditingUrl
     case cancelEditOnHomepage
     case cancelEdit
-//    case keyboardStateDidChange
     case animationStateChanged
     case readerModeStateChanged
     case backForwardButtonStateChanged

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -31,7 +31,6 @@ struct ToolbarAction: Action {
     let lockIconNeedsTheming: Bool?
     let safeListedURLImageName: String?
     let isLoading: Bool?
-    let shouldShowKeyboard: Bool?
     let shouldAnimate: Bool?
     let middleButton: NavigationBarMiddleButtonType?
     let isTranslationsEnabled: Bool?
@@ -95,7 +94,6 @@ struct ToolbarAction: Action {
         self.lockIconNeedsTheming = lockIconNeedsTheming
         self.safeListedURLImageName = safeListedURLImageName
         self.isLoading = isLoading
-        self.shouldShowKeyboard = shouldShowKeyboard
         self.shouldAnimate = shouldAnimate
         self.canSummarize = canSummarize
         self.middleButton = middleButton

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -120,7 +120,7 @@ enum ToolbarModernAction: ModernAction {
     /// `accessoryViewVisibilityChanged`.
     case keyboardDidHide
 
-    case keyboardStateDidChange(shouldShow: Bool)
+    case didCancelKeyboardRequest
 }
 
 enum ToolbarActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -120,7 +120,7 @@ enum ToolbarModernAction: ModernAction {
     /// `accessoryViewVisibilityChanged`.
     case keyboardDidHide
 
-    case keyboardStateDidChange(isVisible: Bool)
+    case keyboardStateDidChange(shouldShow: Bool)
 }
 
 enum ToolbarActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -115,10 +115,12 @@ enum ToolbarModernAction: ModernAction {
     /// scrolls down; `false` restores it when scrolling back up.
     case userDidScroll(minimizeAddressBar: Bool)
 
-    /// A web form's keyboard accessory view appeared. that shrinks the address bar to the pill shape
-    case accessoryViewDidShow
+    /// A web form's keyboard accessory view's visibility changed. Becoming visible also minimizes
+    /// the address bar. Restore address bar remains in `keyboardDidHide` so a scroll-minimized bar isn't force-reopened.
+    case accessoryViewVisibilityChanged(isVisible: Bool)
 
-    /// The keyboard was dismissed. Dispatched to restore the address bar after it was minimized by `accessoryViewDidShow`
+    /// The keyboard was dismissed. Dispatched to restore the address bar after it was minimized by
+    /// `accessoryViewVisibilityChanged`.
     case keyboardDidHide
 }
 
@@ -135,7 +137,7 @@ enum ToolbarActionType: ActionType {
     case didStartEditingUrl
     case cancelEditOnHomepage
     case cancelEdit
-    case keyboardStateDidChange
+//    case keyboardStateDidChange
     case animationStateChanged
     case readerModeStateChanged
     case backForwardButtonStateChanged

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -157,7 +157,10 @@ struct ToolbarState: ScreenState, Sendable {
                 .copy(isAddressBarMinimized: shouldMinimize ? true : state.isAddressBarMinimized)
 
         case .keyboardDidHide:
-            return state.copy(isAddressBarMinimized: false)
+            // The accessory view visible state needs to be reseted when the keyboard hides
+            return state
+                .copy(isAddressBarMinimized: false)
+                .copy(isAccessoryViewVisible: false)
 
         case .didCancelKeyboardRequest:
             // AddressBarState is a nested sub-state, forwards modern call to AddressBarState

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -149,14 +149,21 @@ struct ToolbarState: ScreenState, Sendable {
             return state.copy(isAddressBarMinimized: minimizeAddressBar)
 
         case .accessoryViewVisibilityChanged(let isVisible):
-            let newState = state.copy(isAccessoryViewVisible: isVisible)
             // Don't force-minimize while the user is editing the address bar — editing shows its
             // own overlay UI, and minimizing here would visibly shrink the bar mid-edit.
-            guard isVisible, !state.addressToolbar.isEditing else { return newState }
-            return newState.copy(isAddressBarMinimized: true)
+            let shouldMinimize = isVisible && !state.addressToolbar.isEditing
+            return state
+                .copy(isAccessoryViewVisible: isVisible)
+                .copy(isAddressBarMinimized: shouldMinimize ? true : state.isAddressBarMinimized)
 
         case .keyboardDidHide:
             return state.copy(isAddressBarMinimized: false)
+
+        case .keyboardStateDidChange:
+            // AddressBarState is a nested sub-state, forwards modern call to AddressBarState
+            return state.copy(addressToolbar: AddressBarState.reducer.modernReducer(state.addressToolbar,
+                                                                                    action,
+                                                                                    actionWindowUUID))
         }
     }
 
@@ -180,8 +187,7 @@ struct ToolbarState: ScreenState, Sendable {
             ToolbarActionType.lockIconChanged,
             ToolbarActionType.didSetTextInLocationView, ToolbarActionType.didPasteSearchTerm,
             ToolbarActionType.didStartEditingUrl, ToolbarActionType.cancelEdit,
-            ToolbarActionType.cancelEditOnHomepage,
-            ToolbarActionType.keyboardStateDidChange, ToolbarActionType.websiteLoadingStateDidChange,
+            ToolbarActionType.cancelEditOnHomepage, ToolbarActionType.websiteLoadingStateDidChange,
             ToolbarMiddlewareActionType.googleLensAvailabilityDidChange, ToolbarActionType.clearSearch,
             ToolbarActionType.didDeleteSearchTerm, ToolbarActionType.didEnterSearchTerm,
             ToolbarActionType.didSetSearchTerm, ToolbarActionType.didStartTyping,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -30,6 +30,8 @@ struct ToolbarState: ScreenState, Sendable {
     var nextTabScreenshot: UIImage?
     // Whether the address bar renders as its full toolbar or its minimized "pill" shape
     var isAddressBarMinimized: Bool
+    // When a web form's keyboard accessory view is visible on a bottom-positioned address bar.
+    var isAccessoryViewVisible: Bool
 
     init(appState: AppState, uuid: WindowUUID) {
         guard let toolbarState = appState.componentState(
@@ -60,7 +62,8 @@ struct ToolbarState: ScreenState, Sendable {
                   isTranslationsEnabled: toolbarState.isTranslationsEnabled,
                   previousTabScreenshot: toolbarState.previousTabScreenshot,
                   nextTabScreenshot: toolbarState.nextTabScreenshot,
-                  isAddressBarMinimized: toolbarState.isAddressBarMinimized
+                  isAddressBarMinimized: toolbarState.isAddressBarMinimized,
+                  isAccessoryViewVisible: toolbarState.isAccessoryViewVisible
         )
     }
 
@@ -85,7 +88,8 @@ struct ToolbarState: ScreenState, Sendable {
             isTranslationsEnabled: true,
             previousTabScreenshot: nil,
             nextTabScreenshot: nil,
-            isAddressBarMinimized: false
+            isAddressBarMinimized: false,
+            isAccessoryViewVisible: false
         )
     }
 
@@ -109,7 +113,8 @@ struct ToolbarState: ScreenState, Sendable {
         isTranslationsEnabled: Bool,
         previousTabScreenshot: UIImage?,
         nextTabScreenshot: UIImage?,
-        isAddressBarMinimized: Bool
+        isAddressBarMinimized: Bool,
+        isAccessoryViewVisible: Bool
     ) {
         self.windowUUID = windowUUID
         self.toolbarPosition = toolbarPosition
@@ -131,6 +136,7 @@ struct ToolbarState: ScreenState, Sendable {
         self.previousTabScreenshot = previousTabScreenshot
         self.nextTabScreenshot = nextTabScreenshot
         self.isAddressBarMinimized = isAddressBarMinimized
+        self.isAccessoryViewVisible = isAccessoryViewVisible
     }
 
     static let reducer: Reducer<Self> = (legacyReducer, modernReducer)
@@ -141,8 +147,14 @@ struct ToolbarState: ScreenState, Sendable {
         switch action {
         case .userDidScroll(let minimizeAddressBar):
             return state.copy(isAddressBarMinimized: minimizeAddressBar)
-        case .accessoryViewDidShow:
-            return state.copy(isAddressBarMinimized: true)
+
+        case .accessoryViewVisibilityChanged(let isVisible):
+            let newState = state.copy(isAccessoryViewVisible: isVisible)
+            // Don't force-minimize while the user is editing the address bar — editing shows its
+            // own overlay UI, and minimizing here would visibly shrink the bar mid-edit.
+            guard isVisible, !state.addressToolbar.isEditing else { return newState }
+            return newState.copy(isAddressBarMinimized: true)
+
         case .keyboardDidHide:
             return state.copy(isAddressBarMinimized: false)
         }
@@ -393,6 +405,7 @@ struct ToolbarState: ScreenState, Sendable {
                             isTranslationsEnabled: state.isTranslationsEnabled,
                             previousTabScreenshot: state.previousTabScreenshot,
                             nextTabScreenshot: state.nextTabScreenshot,
-                            isAddressBarMinimized: state.isAddressBarMinimized)
+                            isAddressBarMinimized: state.isAddressBarMinimized,
+                            isAccessoryViewVisible: state.isAccessoryViewVisible)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -159,7 +159,7 @@ struct ToolbarState: ScreenState, Sendable {
         case .keyboardDidHide:
             return state.copy(isAddressBarMinimized: false)
 
-        case .keyboardStateDidChange:
+        case .didCancelKeyboardRequest:
             // AddressBarState is a nested sub-state, forwards modern call to AddressBarState
             return state.copy(addressToolbar: AddressBarState.reducer.modernReducer(state.addressToolbar,
                                                                                     action,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -1138,19 +1138,19 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
 
     func test_keyboardStateDidChangeAction_returnsExpectedState() {
         setupStore()
-        let initialState = createSubject()
+        let initialState = createSubject().copy(shouldShowKeyboard: true)
         let reducer = addressBarReducer()
 
-        XCTAssertFalse(initialState.shouldShowKeyboard)
+        XCTAssertTrue(initialState.shouldShowKeyboard)
 
         let newState = reducer.modernReducer(
             initialState,
-            ToolbarModernAction.keyboardStateDidChange(shouldShow: true),
+            ToolbarModernAction.didCancelKeyboardRequest,
             windowUUID
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertTrue(newState.shouldShowKeyboard)
+        XCTAssertFalse(newState.shouldShowKeyboard)
     }
 
     func test_clearSearchAction_returnsExpectedState() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -992,20 +992,44 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertNotEqual(initialState.isAddressBarMinimized, newState.isAddressBarMinimized)
     }
 
-    func test_accessoryViewDidShowAction_returnsExpectedState() {
+    func test_accessoryViewVisibilityChangedAction_whenVisible_returnsExpectedState() {
         setupStore()
         let initialState = ToolbarState(windowUUID: windowUUID)
         let reducer = ToolbarState.reducer
 
         let newState = reducer.modernReducer(
             initialState,
-            ToolbarModernAction.accessoryViewDidShow,
+            ToolbarModernAction.accessoryViewVisibilityChanged(isVisible: true),
             windowUUID
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
+        XCTAssertEqual(newState.isAccessoryViewVisible, true)
         XCTAssertEqual(newState.isAddressBarMinimized, true)
         XCTAssertNotEqual(initialState.isAddressBarMinimized, newState.isAddressBarMinimized)
+    }
+
+    func test_accessoryViewVisibilityChangedAction_whenNotVisible_doesNotRestoreMinimizedState() {
+        setupStore()
+        var initialState = ToolbarState(windowUUID: windowUUID)
+        let reducer = ToolbarState.reducer
+
+        // Minimize the toolbar first, independently of the accessory view
+        initialState = reducer.modernReducer(
+            initialState,
+            ToolbarModernAction.userDidScroll(minimizeAddressBar: true),
+            windowUUID
+        )
+
+        let newState = reducer.modernReducer(
+            initialState,
+            ToolbarModernAction.accessoryViewVisibilityChanged(isVisible: false),
+            windowUUID
+        )
+
+        XCTAssertEqual(newState.windowUUID, windowUUID)
+        XCTAssertEqual(newState.isAccessoryViewVisible, false)
+        XCTAssertEqual(newState.isAddressBarMinimized, true)
     }
 
     func test_cancelEditOnHomepageAction_withURL_returnsExpectedState() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -1143,17 +1143,14 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
 
         XCTAssertFalse(initialState.shouldShowKeyboard)
 
-        let newState = reducer.legacyReducer(
+        let newState = reducer.modernReducer(
             initialState,
-            ToolbarAction(
-                shouldShowKeyboard: false,
-                windowUUID: windowUUID,
-                actionType: ToolbarActionType.keyboardStateDidChange
-            )
+            ToolbarModernAction.keyboardStateDidChange(isVisible: true),
+            windowUUID
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertFalse(newState.shouldShowKeyboard)
+        XCTAssertTrue(newState.shouldShowKeyboard)
     }
 
     func test_clearSearchAction_returnsExpectedState() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -1343,7 +1343,8 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
             isTranslationsEnabled: toolbarState.isTranslationsEnabled,
             previousTabScreenshot: toolbarState.previousTabScreenshot,
             nextTabScreenshot: toolbarState.nextTabScreenshot,
-            isAddressBarMinimized: toolbarState.isAddressBarMinimized)
+            isAddressBarMinimized: toolbarState.isAddressBarMinimized,
+            isAccessoryViewVisible: toolbarState.isAccessoryViewVisible)
     }
 
     // MARK: StoreTestUtility

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -1145,7 +1145,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
 
         let newState = reducer.modernReducer(
             initialState,
-            ToolbarModernAction.keyboardStateDidChange(isVisible: true),
+            ToolbarModernAction.keyboardStateDidChange(shouldShow: true),
             windowUUID
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -390,7 +390,8 @@ final class AddressToolbarContainerModelTests: XCTestCase {
                             isTranslationsEnabled: true,
                             previousTabScreenshot: nil,
                             nextTabScreenshot: nil,
-                            isAddressBarMinimized: false)
+                            isAddressBarMinimized: false,
+                            isAccessoryViewVisible: false)
     }
 
     private func createToolbarStateWithAlternativeSearchEngine(searchEngine: SearchEngineModel) -> ToolbarState {
@@ -413,7 +414,8 @@ final class AddressToolbarContainerModelTests: XCTestCase {
                             isTranslationsEnabled: true,
                             previousTabScreenshot: nil,
                             nextTabScreenshot: nil,
-                            isAddressBarMinimized: false)
+                            isAddressBarMinimized: false,
+                            isAccessoryViewVisible: false)
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
@@ -208,7 +208,7 @@ final class ToolbarStateTests: XCTestCase, StoreTestUtility {
 
         let newState = reducer.modernReducer(
             initialState,
-            ToolbarModernAction.keyboardStateDidChange(isVisible: true),
+            ToolbarModernAction.keyboardStateDidChange(shouldShow: true),
             windowUUID
         )
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
@@ -206,12 +206,10 @@ final class ToolbarStateTests: XCTestCase, StoreTestUtility {
         let initialState = createSubject()
         let reducer = toolbarReducer()
 
-        let newState = reducer.legacyReducer(
+        let newState = reducer.modernReducer(
             initialState,
-            ToolbarAction(
-                shouldShowKeyboard: true,
-                windowUUID: windowUUID,
-                actionType: ToolbarActionType.keyboardStateDidChange)
+            ToolbarModernAction.keyboardStateDidChange(isVisible: true),
+            windowUUID
         )
 
         XCTAssertNotEqual(newState.addressToolbar, initialState.addressToolbar)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
@@ -203,16 +203,18 @@ final class ToolbarStateTests: XCTestCase, StoreTestUtility {
     }
 
     func test_keyboardStateDidChangeAction_returnsExpectedState() {
-        let initialState = createSubject()
+        let baseState = createSubject()
+        let initialState = baseState.copy(addressToolbar: baseState.addressToolbar.copy(shouldShowKeyboard: true))
         let reducer = toolbarReducer()
 
         let newState = reducer.modernReducer(
             initialState,
-            ToolbarModernAction.keyboardStateDidChange(shouldShow: true),
+            ToolbarModernAction.didCancelKeyboardRequest,
             windowUUID
         )
 
         XCTAssertNotEqual(newState.addressToolbar, initialState.addressToolbar)
+        XCTAssertFalse(newState.addressToolbar.shouldShowKeyboard)
         XCTAssertEqual(newState.navigationToolbar, initialState.navigationToolbar)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -1543,7 +1543,8 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
                             isTranslationsEnabled: true,
                             previousTabScreenshot: nil,
                             nextTabScreenshot: nil,
-                            isAddressBarMinimized: false
+                            isAddressBarMinimized: false,
+                            isAccessoryViewVisible: false
                         )
                     )
                 ]


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16590)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35232)

## :bulb: Description
Continues the ADR-0012 migration by moving `keyboardStateDidChange` from a legacy ToolbarAction to a modern ToolbarModernAction, and along the way fixes the same "one field, two meanings" conflation that motivated the earlier scrollAlpha work, this time on AddressBarState.shouldShowKeyboard, which was carrying both "URL-bar editing wants the keyboard" and "a web form's keyboard accessory view is visible" on one bit.

What changed:
- Split the accessory-view-visibility concern out into its own field, `ToolbarState.isAccessoryViewVisible`, driven by a new `ToolbarModernAction.accessoryViewVisibilityChanged(isVisible:)` case. This lets `AddressToolbarContainer.offsetForKeyboardAccessory` collapse from two dispatches (one legacy, one modern, for a single real event) down to one.
- Migrated `keyboardStateDidChange` to a modern action. Since production code only ever dispatched it with false, dropped the payload it's now `ToolbarModernAction.didCancelKeyboardRequest`.
- Removed `handleShouldShowKeyboardAction` and inlined its one remaining caller's logic directly into `handleCancelEditOnHomepageAction`.
- AddressToolbarContainer.updateModel's gradient-cleanup check now reads isAccessoryViewVisible directly instead of relying on the old conflated field.


## :movie_camera: Demos
- No user interface changes

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

