### PR TITLE
Bugfix FXIOS-16488 [WebCompat] Anchor the category pull-down to the trailing edge

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatCategoryMenuCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatCategoryMenuCell.swift
@@ -7,6 +7,7 @@ import UIKit
 
 /// Category pull-down row: a full-width button opening a `UIMenu` of categories.
 /// Selection is reported through the handler, not stored, so it re-renders on configure.
+/// The title sits on a sibling label so the menu morph has nothing visible to animate.
 final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
     private var selectionHandler: ((String) -> Void)?
     private var chevronSizeConstraints: [NSLayoutConstraint] = []
@@ -21,18 +22,16 @@ final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
         return UIFontMetrics.default.scaledValue(for: WebCompatReporterUX.Chevron.verticalOverlap)
     }
 
-    private lazy var menuButton: UIButton = {
-        var configuration = UIButton.Configuration.plain()
-        // `plain()`'s 12pt leading inset would stack on the cell's own layout margin.
-        configuration.contentInsets.leading = 0
-        let button = UIButton(configuration: configuration)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.contentHorizontalAlignment = .leading
+    private let categoryLabel: UILabel = .build { label in
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+        label.font = FXFontStyles.Regular.body.scaledFont()
+        label.isAccessibilityElement = false
+    }
+
+    private let menuButton: WebCompatTrailingMenuButton = .build { button in
         button.showsMenuAsPrimaryAction = true
-        button.titleLabel?.numberOfLines = 0
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        return button
-    }()
+    }
 
     private lazy var chevronUpView: UIImageView = {
         let image = UIImage(named: StandardImageIdentifiers.Large.chevronUp)?.withRenderingMode(.alwaysTemplate)
@@ -67,11 +66,8 @@ final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
     }
 
     private func setupLayout() {
-        // The button spans the whole row so tapping anywhere — including over the
-        // non-interactive chevrons layered on top — opens the pull-down.
-        contentView.addSubview(menuButton)
-        contentView.addSubview(chevronUpView)
-        contentView.addSubview(chevronDownView)
+        // The button sits beneath the non-interactive title and chevrons, so any tap opens the menu.
+        contentView.addSubviews(menuButton, categoryLabel, chevronUpView, chevronDownView)
         let margins = contentView.layoutMarginsGuide
         chevronSizeConstraints = [
             chevronUpView.widthAnchor.constraint(equalToConstant: scaledChevronSize),
@@ -80,21 +76,28 @@ final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
             chevronDownView.heightAnchor.constraint(equalToConstant: scaledChevronSize)
         ]
         // .defaultHigh (not required) avoids the self-sizing vs. min-height constraint conflict.
-        let topConstraint = menuButton.topAnchor.constraint(equalTo: margins.topAnchor)
-        let bottomConstraint = menuButton.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
-        topConstraint.priority = .defaultHigh
-        bottomConstraint.priority = .defaultHigh
+        let verticalConstraints = [
+            menuButton.topAnchor.constraint(equalTo: margins.topAnchor),
+            menuButton.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+            categoryLabel.topAnchor.constraint(equalTo: margins.topAnchor),
+            categoryLabel.bottomAnchor.constraint(equalTo: margins.bottomAnchor)
+        ]
+        verticalConstraints.forEach { $0.priority = .defaultHigh }
         let chevronUpBottom = chevronUpView.bottomAnchor.constraint(equalTo: contentView.centerYAnchor)
         let chevronDownTop = chevronDownView.topAnchor.constraint(equalTo: contentView.centerYAnchor)
         chevronUpBottomConstraint = chevronUpBottom
         chevronDownTopConstraint = chevronDownTop
-        NSLayoutConstraint.activate(chevronSizeConstraints + [
+        NSLayoutConstraint.activate(chevronSizeConstraints + verticalConstraints + [
             menuButton.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
-            topConstraint,
-            bottomConstraint,
             menuButton.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
             menuButton.heightAnchor.constraint(
                 greaterThanOrEqualToConstant: WebCompatReporterUX.Control.minimumTapTarget
+            ),
+
+            categoryLabel.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+            categoryLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: chevronUpView.leadingAnchor,
+                constant: -WebCompatReporterUX.Spacing.interItem
             ),
 
             chevronUpView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
@@ -115,14 +118,12 @@ final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
         }
     }
 
-    /// Keeps the chevron metrics and the button's reserved trailing space in step with
-    /// the current Dynamic Type size.
+    /// Keeps the chevron metrics in step with the current Dynamic Type size.
     private func applyScaledMetrics() {
         chevronSizeConstraints.forEach { $0.constant = scaledChevronSize }
         let halfOverlap = scaledChevronVerticalOverlap / 2
         chevronUpBottomConstraint?.constant = halfOverlap
         chevronDownTopConstraint?.constant = -halfOverlap
-        menuButton.configuration?.contentInsets.trailing = scaledChevronSize + WebCompatReporterUX.Spacing.interItem
     }
 
     func configure(
@@ -135,17 +136,11 @@ final class WebCompatCategoryMenuCell: UICollectionViewListCell, Notifiable {
     ) {
         selectionHandler = onSelect
         menuButton.accessibilityIdentifier = a11yIdentifier
+        menuButton.accessibilityLabel = title
         backgroundConfiguration = .listGroupedCell()
         backgroundConfiguration?.backgroundColor = theme.colors.layer5
-        var configuration = menuButton.configuration ?? UIButton.Configuration.plain()
-        configuration.title = title
-        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
-            var outgoing = incoming
-            outgoing.font = FXFontStyles.Regular.body.scaledFont()
-            return outgoing
-        }
-        configuration.baseForegroundColor = isPlaceholder ? theme.colors.textSecondary : theme.colors.textPrimary
-        menuButton.configuration = configuration
+        categoryLabel.text = title
+        categoryLabel.textColor = isPlaceholder ? theme.colors.textSecondary : theme.colors.textPrimary
         chevronUpView.tintColor = theme.colors.textSecondary
         chevronDownView.tintColor = theme.colors.textSecondary
         menuButton.menu = UIMenu(children: options.map { option in

--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatTrailingMenuButton.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatTrailingMenuButton.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+
+/// A pull-down button that hangs its menu off its own trailing edge. `UIKit` otherwise lays the
+/// menu out against the source control, which centres it under a button spanning a whole row.
+final class WebCompatTrailingMenuButton: UIButton {
+    override func menuAttachmentPoint(for configuration: UIContextMenuConfiguration) -> CGPoint {
+        let isRightToLeft = effectiveUserInterfaceLayoutDirection == .rightToLeft
+        return CGPoint(x: isRightToLeft ? bounds.minX : bounds.maxX, y: bounds.maxY)
+    }
+}

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatCategoryMenuCellTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatCategoryMenuCellTests.swift
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import TestKit
+import XCTest
+@testable import WebCompatReporterKit
+
+@MainActor
+final class WebCompatCategoryMenuCellTests: XCTestCase {
+    /// A title on the button would animate away as the menu opens, and a title-less button has no
+    /// accessibility label of its own.
+    func testConfigure_keepsTheTitleOffTheButtonAndCarriesItForVoiceOver() throws {
+        let subject = WebCompatCategoryMenuCell(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
+        trackForMemoryLeaks(subject)
+
+        subject.configure(
+            title: "Site is not usable",
+            isPlaceholder: false,
+            options: [],
+            theme: LightTheme(),
+            a11yIdentifier: "WebCompatReporter.CategoryMenu",
+            onSelect: { _ in }
+        )
+
+        let button = try XCTUnwrap(
+            subject.contentView.subviews.compactMap { $0 as? WebCompatTrailingMenuButton }.first
+        )
+        XCTAssertNil(button.currentTitle)
+        XCTAssertEqual(button.accessibilityLabel, "Site is not usable")
+
+        let label = try XCTUnwrap(subject.contentView.subviews.compactMap { $0 as? UILabel }.first)
+        XCTAssertEqual(label.text, "Site is not usable")
+        XCTAssertFalse(label.isAccessibilityElement)
+    }
+}

--- a/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatTrailingMenuButtonTests.swift
+++ b/BrowserKit/Tests/WebCompatReporterKitTests/WebCompatTrailingMenuButtonTests.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import TestKit
+import XCTest
+@testable import WebCompatReporterKit
+
+@MainActor
+final class WebCompatTrailingMenuButtonTests: XCTestCase {
+    func testMenuAttachmentPoint_sitsAtTheTrailingEdge() {
+        let subject = createSubject()
+
+        XCTAssertEqual(subject.menuAttachmentPoint(for: makeConfiguration()), CGPoint(x: 320, y: 44))
+    }
+
+    func testMenuAttachmentPoint_mirrorsForRightToLeft() {
+        let subject = createSubject()
+        subject.semanticContentAttribute = .forceRightToLeft
+
+        XCTAssertEqual(subject.menuAttachmentPoint(for: makeConfiguration()), CGPoint(x: 0, y: 44))
+    }
+
+    private func createSubject() -> WebCompatTrailingMenuButton {
+        let subject = WebCompatTrailingMenuButton(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+
+    private func makeConfiguration() -> UIContextMenuConfiguration {
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: nil)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16488](https://mozilla-hub.atlassian.net/browse/FXIOS-16488)
Github issue: n/a

## :bulb: Description
The category row was a full-width `UIButton` carrying the text as its own title. UIKit morphs a pull-down's source control into the menu and lays the menu out against that control's frame, so the placeholder animated away and the menu centred under the row.

The title moves to a sibling label, leaving the button transparent and title-less, and `menuAttachmentPoint(for:)` returns the trailing edge, mirrored for RTL. The menu now lands at x 111, width 250, trailing edge 361 of 393, matching [Figma](https://www.figma.com/design/BVqEYexibOA2betNVUMrfl?node-id=23608-66616).

Only the alignment half reproduces on iOS 17; the morph is iOS 26+.

## :movie_camera: Demos

<img width="800" height="880" alt="04-before-after-ios27" src="https://github.com/user-attachments/assets/45f53f6c-7c85-4758-9b07-b019a8b24dc9" />
<img width="800" height="880" alt="10-before-after-ios17" src="https://github.com/user-attachments/assets/4f98047d-48eb-42de-b1bc-a884c40f9bbb" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
1. Load a page, then ⋯ → **More** → **Report Broken Site**.
2. Tap the **Choose issue type…** row.
3. The placeholder stays visible, and the menu opens flush with the chevrons instead of centred.
4. Pick a category and reopen the menu: the checkmark is on the selected row.


[FXIOS-16488]: https://mozilla-hub.atlassian.net/browse/FXIOS-16488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ