### PR TITLE
BugFix FXIOS-11197 [Bookmarks] Cap folder row indentation so deep hierarchies stay visible

### DIFF
--- a/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift
@@ -42,6 +42,9 @@ class OneLineTableViewCell: UITableViewCell,
         static let accessoryViewIconSize: CGFloat = 24
         static let accessoryViewSize: CGFloat = 44
         static let accessoryViewTrailingPadding: CGFloat = 6
+        // Caps how far the leading margin can grow so deeply nested rows (e.g. bookmark folder
+        // hierarchies) stay on screen instead of being laid out past the trailing edge.
+        static let maxIndentationLevel = 6
     }
 
     var reorderControlImageView: UIImageView? {
@@ -124,12 +127,13 @@ class OneLineTableViewCell: UITableViewCell,
     private func setMargin() {
         // Sets the indentation so that at each level the folder icon is left
         // aligned with the label of the parent folder above it.
-        if indentationLevel == 0 {
+        let cappedIndentationLevel = min(indentationLevel, UX.maxIndentationLevel)
+        if cappedIndentationLevel == 0 {
             leftImageViewLeadingConstraint?.constant = UX.borderViewMargin
         } else {
             let indentationLevelMargin: CGFloat = UX.borderViewMargin + UX.imageSize + UX.longLeadingMargin
             let indentSize = (UX.imageSize + UX.longLeadingMargin)
-            let indentLevel = indentSize * CGFloat(indentationLevel-1)
+            let indentLevel = indentSize * CGFloat(cappedIndentationLevel - 1)
             leftImageViewLeadingConstraint?.constant = indentationLevelMargin + indentLevel
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Widgets/OneLineTableViewCellTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Widgets/OneLineTableViewCellTests.swift
@@ -75,12 +75,67 @@ final class OneLineTableViewCellTests: XCTestCase {
         XCTAssertNotNil(subject.editingAccessoryView, "editingAccessoryView should be set after configure")
     }
 
+    // MARK: - indentationLevel
+
+    func testIndentationLevel_zero_usesBaseMargin() {
+        let subject = createSubject()
+
+        subject.indentationLevel = 0
+        subject.layoutIfNeeded()
+
+        XCTAssertEqual(subject.leftImageView.frame.origin.x, OneLineTableViewCell.UX.borderViewMargin)
+    }
+
+    func testIndentationLevel_withinCap_scalesLinearlyPerLevel() {
+        let subject = createSubject()
+
+        subject.indentationLevel = 2
+        subject.layoutIfNeeded()
+
+        XCTAssertEqual(subject.leftImageView.frame.origin.x, expectedLeadingMargin(forLevel: 2))
+    }
+
+    func testIndentationLevel_atCap_matchesCappedMargin() {
+        let subject = createSubject()
+
+        subject.indentationLevel = OneLineTableViewCell.UX.maxIndentationLevel
+        subject.layoutIfNeeded()
+
+        XCTAssertEqual(
+            subject.leftImageView.frame.origin.x,
+            expectedLeadingMargin(forLevel: OneLineTableViewCell.UX.maxIndentationLevel)
+        )
+    }
+
+    func testIndentationLevel_beyondCap_doesNotExceedCappedMargin() {
+        let subject = createSubject()
+        let cappedMargin = expectedLeadingMargin(forLevel: OneLineTableViewCell.UX.maxIndentationLevel)
+
+        subject.indentationLevel = 20
+        subject.layoutIfNeeded()
+
+        XCTAssertEqual(
+            subject.leftImageView.frame.origin.x,
+            cappedMargin,
+            "Deeply nested rows (e.g. bookmark folders 9+ levels deep) must stay within the capped margin"
+        )
+    }
+
     // MARK: - Helpers
 
     private func createSubject() -> OneLineTableViewCell {
         let subject = OneLineTableViewCell(style: .default, reuseIdentifier: OneLineTableViewCell.cellIdentifier)
+        subject.frame = CGRect(x: 0, y: 0, width: 375, height: 44)
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    private func expectedLeadingMargin(forLevel level: Int) -> CGFloat {
+        let base = OneLineTableViewCell.UX.borderViewMargin
+            + OneLineTableViewCell.UX.imageSize
+            + OneLineTableViewCell.UX.longLeadingMargin
+        let perLevel = OneLineTableViewCell.UX.imageSize + OneLineTableViewCell.UX.longLeadingMargin
+        return base + perLevel * CGFloat(level - 1)
     }
 
     private func createViewModel(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11197)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/24385)

## :bulb: Description
If you nest bookmark folders more than ~9 levels deep, the "Location" picker (the folder list you get when creating/moving a folder) stops showing the deeper folders at all. They're technically still in the list — you just can't see or tap them.

The cause is in `OneLineTableViewCell`, which is what renders each row in that folder list. Every nesting level adds ~42pt to the row's leading margin with no upper bound, so by level 9 or so that margin alone is wider than the screen. Auto Layout has nowhere left to put the icon and label, so they get squeezed out of the visible/tappable area entirely — it's not a scrolling issue, the row content is just laid out past the edge of the screen.

Fix is a simple clamp: cap the indentation at a fixed max level (6) once building the leading constraint. Past that depth, rows stop indenting further but stay fully visible and tappable, so the deepest folder in a hierarchy can always be reached and selected. It's not a perfect visual solution for extremely deep trees (you lose the ability to tell levels 7+ apart purely from indentation), but it directly fixes the "can't see or select" bug reported in the issue, with minimal risk to the existing behavior for normal (shallow) folder structures.

Added tests covering the base case, a level within the cap, the cap boundary itself, and a level well past the cap (20) to confirm it clamps to the same margin as the cap rather than growing further.

## :movie_camera: Demos
This one's tricky to screenshot meaningfully — the bug only reproduces after manually nesting 9+ folders inside each other, and the "fix" is that previously-invisible rows become visible/tappable rather than a visual change to existing rows. I verified the fix with unit tests asserting the leading-margin math directly (see `OneLineTableViewCellTests.swift`) rather than a screenshot pair.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code