### PR TITLE
Add FXIOS-16625 [Nova] Update close buttons color tokens

### DIFF
--- a/BrowserKit/Sources/MenuKit/HeaderBanner.swift
+++ b/BrowserKit/Sources/MenuKit/HeaderBanner.swift
@@ -148,7 +148,14 @@ public final class HeaderBanner: UIView, ThemeApplicable {
         headerLabelsContainer.backgroundColor = .clear
         titleLabel.textColor = theme.colors.textPrimary
         subtitleLabel.textColor = theme.colors.textSecondary
-        closeButton.tintColor = theme.colors.iconSecondary
+        closeButton.tintColor = theme.isNova ? theme.colors.textSecondary : theme.colors.iconSecondary
         closeButton.backgroundColor = .clear
+        if theme.isNova, #available(iOS 26.0, *) {
+            var config = UIButton.Configuration.plain()
+            config.image = UIImage(named: UX.crossLarge)?.withRenderingMode(.alwaysTemplate)
+            config.background.backgroundColor = .clear
+            config.background.strokeColor = .clear
+            closeButton.configuration = config
+        }
     }
 }

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputView.swift
@@ -81,7 +81,7 @@ struct CreditCardInputView: ThemeableView {
                     }
                     ToolbarItem(placement: .navigationBarLeading) {
                         leftBarButton()
-                            .foregroundColor(Color(theme.colors.actionPrimary))
+                            .foregroundColor(Color(theme.isNova ? theme.colors.iconPrimary : theme.colors.actionPrimary))
                     }
                 }
                 .padding(.top, 0)

--- a/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
@@ -223,7 +223,7 @@ extension AddCredentialViewController: UITableViewDataSource {
         tableView.separatorColor = theme.colors.borderPrimary
         tableView.backgroundColor = theme.colors.layer1
 
-        cancelButton.tintColor = theme.colors.actionPrimary
+        cancelButton.tintColor = theme.isNova ? theme.colors.iconPrimary : theme.colors.actionPrimary
         saveButton.tintColor = theme.colors.actionPrimary
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16625)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates x button from Add Card and Close button from Add credentials screens to be neutral and to use `iconPrimary` token. Also x button from default browser header should not have a background circle. These changes are only for Nova.

<img width="947" height="740" alt="Screenshot 2026-08-20 at 15 04 29" src="https://github.com/user-attachments/assets/58fa4e2f-06c0-44a2-bcbd-120212aa6c86" />



<img width="459" height="490" alt="Screenshot 2026-08-20 at 15 03 53" src="https://github.com/user-attachments/assets/195e2ebd-8a53-440d-aad9-fd5a3d0dd6e6" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

