### PR TITLE
Add FXIOS-16622 [Nova] Update save button color token

### DIFF
--- a/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordManagement/AddCredentialViewController.swift
@@ -58,10 +58,15 @@ class AddCredentialViewController: UIViewController, Themeable {
             action: #selector(addCredential)
         )
         button.isEnabled = false
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
         if #available(iOS 26.0, *) {
-            button.tintColor = themeManager.getCurrentTheme(for: windowUUID).colors.textAccent
+            button.tintColor = theme.colors.textAccent
         } else {
-            button.tintColor = themeManager.getCurrentTheme(for: windowUUID).colors.actionPrimary
+            button.tintColor = theme.colors.actionPrimary
+        }
+        if theme.isNova {
+            button.setTitleTextAttributes([.foregroundColor: theme.colors.actionPrimary], for: .normal)
+            button.setTitleTextAttributes([.foregroundColor: theme.colors.textDisabled], for: .disabled)
         }
         return button
     }()
@@ -223,8 +228,12 @@ extension AddCredentialViewController: UITableViewDataSource {
         tableView.separatorColor = theme.colors.borderPrimary
         tableView.backgroundColor = theme.colors.layer1
 
-        cancelButton.tintColor = theme.colors.actionPrimary
+        cancelButton.tintColor = theme.isNova ? theme.colors.iconPrimary : theme.colors.actionPrimary
         saveButton.tintColor = theme.colors.actionPrimary
+        if theme.isNova {
+            saveButton.setTitleTextAttributes([.foregroundColor: theme.colors.actionPrimary], for: .normal)
+            saveButton.setTitleTextAttributes([.foregroundColor: theme.colors.textDisabled], for: .disabled)
+        }
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS_16622)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates Save button token color for Nova depending of enable/disable state. We use `setTitleTextAttributes` instead of tintColor because iOS 26 automatically dims `tintColor` when disabled.

<img width="519" height="543" alt="Screenshot 2026-08-20 at 15 49 39" src="https://github.com/user-attachments/assets/0cad400d-d14c-4434-887f-acac2deaf1df" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

