### PR TITLE
Add FXIOS-16610 Enable Native No Internet Connection Error Page

### DIFF
--- a/firefox-ios/nimbus-features/nativeErrorPageFeature.yaml
+++ b/firefox-ios/nimbus-features/nativeErrorPageFeature.yaml
@@ -8,12 +8,12 @@ features:
         description: >
           If true, the feature is active.
         type: Boolean
-        default: false
+        default: true
       no_internet_connection_error:
         description: >
           This feature is for managing the roll out of the no interet connection native error page feature
         type: Boolean
-        default: false
+        default: true
       bad-cert-domain-error-page:
         description: >
           This feature is for managing the roll out of the bad certificate domain native error page
@@ -23,8 +23,8 @@ features:
     defaults:
       - channel: beta
         value:
-          enabled: false
-          no_internet_connection_error: false
+          enabled: true
+          no_internet_connection_error: true
           bad-cert-domain-error-page: false
       - channel: developer
         value:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16610)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35285)

## :bulb: Description
Title

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

