### PR TITLE
[MTE-6027] - fixes for search and PDF browsing failures

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -22,6 +22,7 @@ func path(forTestPage page: String) -> String {
 // Extended timeout values for mozWaitForElementToExist and mozWaitForElementToNotExist
 let TIMEOUT: TimeInterval = 10
 let TIMEOUT_LONG: TimeInterval = 20
+let PDF_TIMEOUT: TimeInterval = 60
 // Translation is network-bound and can take up to ~1 min to complete
 let TRANSLATION_TIMEOUT: TimeInterval = 90
 // Probe for optional UI that shows up immediately or not at all

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BrowsingPDFTests.swift
@@ -204,13 +204,13 @@ class BrowsingPDFTests: BaseTestCase {
         // Step 2: Switch to another tab and open another large PDF. All PDF files load properly.
         navigator.openNewURL(urlString: largePDF2["url"]!)
         waitUntilPageLoad(timeout: TIMEOUT_LONG)
-        browser.assertAddressBarContains(value: largePDF2["pdfValue"]!, timeout: TIMEOUT_LONG)
+        browser.assertAddressBarContains(value: largePDF2["pdfValue"]!, timeout: PDF_TIMEOUT)
 
         // Step 3: Return to the first PDF tab. It should be loading or loaded.
         navigator.goto(TabTray)
         tabTrayScreen.tapTabAtIndex(index: 0)
         waitUntilPageLoad(timeout: TIMEOUT_LONG)
-        browser.assertAddressBarContains(value: largePDF1["pdfValue"]!, timeout: TIMEOUT_LONG)
+        browser.assertAddressBarContains(value: largePDF1["pdfValue"]!, timeout: PDF_TIMEOUT)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3168439

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -550,7 +550,7 @@ class SearchTests: FeatureFlaggedTestBase {
         navigator.goto(HomePanelsScreen)
 
         verifySearchSuggestion(searchTerm: "fifa",
-                               expectedMatch: "Wikipedia - FIFA Club World Cup",
+                               expectedMatch: "Wikipedia - FIFA World Cup",
                                hasFirefoxSuggest: true,
                                isSponsored: false)
     }
@@ -560,9 +560,7 @@ class SearchTests: FeatureFlaggedTestBase {
                                         hasFirefoxSuggest: Bool = false,
                                         isSponsored: Bool = false) {
         let siteTable = app.tables["SiteTable"]
-        browserScreen.tapOnAddressBar()
-        browserScreen.tapClearButtonIfExists()
-        browserScreen.typeOnSearchBar(text: searchTerm)
+        typeSearchTerm(searchTerm)
 
         for searchEngine in [
             "Bing search", "DuckDuckGo search", "Perplexity search", "Wikipedia (en) search", "eBay search"
@@ -575,12 +573,17 @@ class SearchTests: FeatureFlaggedTestBase {
         mozWaitForElementToExist(siteTable.staticTexts[searchTerm])
 
         // Firefox Suggest is displayed
-        if XCUIDevice.shared.orientation == UIDeviceOrientation.landscapeLeft {
-            siteTable.cells.firstMatch.swipeUp()
-        }
         if hasFirefoxSuggest {
+            // A suggest query interrupted while the term is still being typed is dropped silently and
+            // never retried, so the term is retyped to trigger a fresh one.
+            let match = app.tables.staticTexts[expectedMatch]
+            var attemptsLeft = 2
+            while attemptsLeft > 0, !mozWaitForElementToExist(match, timeout: 5, failOnTimeout: false) {
+                attemptsLeft -= 1
+                typeSearchTerm(searchTerm)
+            }
             mozWaitForElementToExist(siteTable.otherElements["Firefox Suggest"])
-            mozWaitForElementToExist(app.tables.staticTexts[expectedMatch])
+            mozWaitForElementToExist(match)
         } else {
             mozWaitForElementToNotExist(siteTable.otherElements["Firefox Suggest"])
         }
@@ -589,6 +592,16 @@ class SearchTests: FeatureFlaggedTestBase {
             mozWaitForElementToExist(siteTable.staticTexts["Sponsored"])
         } else {
             mozWaitForElementToNotExist(siteTable.staticTexts["Sponsored"])
+        }
+    }
+
+    /// Clears the address bar before typing, so the term can be retyped without appending to itself.
+    private func typeSearchTerm(_ searchTerm: String) {
+        browserScreen.tapOnAddressBar()
+        browserScreen.tapClearButtonIfExists()
+        browserScreen.typeOnSearchBar(text: searchTerm)
+        if XCUIDevice.shared.orientation == UIDeviceOrientation.landscapeLeft {
+            app.tables["SiteTable"].cells.firstMatch.swipeUp()
         }
     }
 


### PR DESCRIPTION
## :scroll: Tickets


## :bulb: Description
testFirefoxSuggestPartialNonSponsored was failing intermittently because the Firefox Suggest result sometimes never appeared after typing the search term. When a suggestion lookup gets cancelled while the term is still being typed, the app drops it silently and never looks again — so the row never shows up and the test times out waiting for it.

This adds a retry to verifySearchSuggestion: if the expected suggestion isn't there after a short wait, the search term is cleared and retyped (up to twice) to trigger a fresh lookup. The final assertions are unchanged, so a real regression still fails with the same error message, just a bit later.

Also pulled the typing steps into a small typeSearchTerm helper so each retry clears the field first (otherwise the term would be typed on top of itself) and redoes the landscape scroll.
Changed also the staticTexts from "Wikipedia - FIFA Club World Cup" to "Wikipedia - FIFA World Cup", this was actually the initial cause of the test, that led to a more deep fix.

Also added a PDF_TIMEOUT of 60 seconds for testSwitchTabsWhileDownloadingPDF test that keeps failing on CI. The pdf file thats being loaded is a large one and maybe 60 seconds will be enough for it to load. This test will be monitored.
