### PR TITLE
Refactor FXIOS-15099 Reader mode navigation uses NavigationBrowserAction

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -740,16 +740,6 @@ final class BrowserCoordinator: BaseCoordinator,
                                                           referringPage: fxaParameters.referringPage)
     }
 
-    func showReaderMode() {
-        // TODO: FXIOS-15099 Refactor showReaderMode with NavigationBrowserAction
-        store.dispatch(
-            GeneralBrowserAction(
-                windowUUID: windowUUID,
-                actionType: GeneralBrowserActionType.showReaderMode
-            )
-        )
-    }
-
     // MARK: - SearchEngineSelectionCoordinatorDelegate
 
     func showSearchEngineSelection(forSourceView sourceView: UIView) {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/GeneralBrowserAction.swift
@@ -78,7 +78,6 @@ enum GeneralBrowserActionType: ActionType {
     case reloadWebsiteNoCache
     case loadWaybackURL
     case showShare
-    case showReaderMode
     case addNewTab
     case showNewTabLongPressActions
     case addToReadingListLongPressAction

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Actions/NavigationBrowserAction.swift
@@ -26,6 +26,7 @@ enum NavigationBrowserActionType: ActionType {
     case tapOnTrackingProtection
     case tapOnShareSheet
     case tapOnSettingsSection
+    case tapOnReaderMode
 
     // link related
     case tapOnLink

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserNavigationType.swift
@@ -24,6 +24,7 @@ enum BrowserNavigationDestination: Equatable {
     case summarizer(config: SummarizerConfig, trigger: SummarizerTrigger)
     case certificatesFromErrorPage
     case nativeErrorPageLearnMore
+    case readerMode
 
     // Webpage views
     case link

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/State/BrowserViewControllerState.swift
@@ -38,7 +38,6 @@ struct BrowserViewControllerState: ScreenState {
         case reloadLongPressAction
         case tabTray
         case share
-        case readerMode
         case newTabLongPressActions
         case readerModeLongPressAction
         case passwordGenerator
@@ -196,7 +195,8 @@ struct BrowserViewControllerState: ScreenState {
             NavigationBrowserActionType.tapOnQuickAnswersButton,
             NavigationBrowserActionType.tapOnPrivacyNoticeLink,
             NavigationBrowserActionType.tapOnShowCertificatesFromErrorPage,
-            NavigationBrowserActionType.tapOnNativeErrorPageLearnMore:
+            NavigationBrowserActionType.tapOnNativeErrorPageLearnMore,
+            NavigationBrowserActionType.tapOnReaderMode:
             return state
                 .resetTransientState()
                 .copy(navigationDestination: action.navigationDestination)
@@ -370,8 +370,6 @@ struct BrowserViewControllerState: ScreenState {
             return handleStopLoadingWebsiteAction(state: state, action: action)
         case GeneralBrowserActionType.showShare:
             return handleShowShareAction(state: state, action: action)
-        case GeneralBrowserActionType.showReaderMode:
-            return handleShowReaderModeAction(state: state, action: action)
         case GeneralBrowserActionType.showNewTabLongPressActions:
             return handleShowNewTabLongPressAction(state: state, action: action)
         case GeneralBrowserActionType.addToReadingListLongPressAction:
@@ -597,17 +595,6 @@ struct BrowserViewControllerState: ScreenState {
             .resetTransientState()
             .copy(displayView: .share)
             .copy(buttonTapped: action.buttonTapped)
-            .copy(microsurveyState: MicrosurveyPromptState.reducer.legacyReducer(state.microsurveyState, action))
-            .copy(autoTranslatePromptState: AutoTranslatePromptState.reducer
-                .legacyReducer(state.autoTranslatePromptState, action))
-    }
-
-    @MainActor
-    private static func handleShowReaderModeAction(state: BrowserViewControllerState,
-                                                   action: GeneralBrowserAction) -> BrowserViewControllerState {
-        return state
-            .resetTransientState()
-            .copy(displayView: .readerMode)
             .copy(microsurveyState: MicrosurveyPromptState.reducer.legacyReducer(state.microsurveyState, action))
             .copy(autoTranslatePromptState: AutoTranslatePromptState.reducer
                 .legacyReducer(state.autoTranslatePromptState, action))

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2354,9 +2354,10 @@ class BrowserViewController: UIViewController,
     }
 
     override func accessibilityPerformMagicTap() -> Bool {
-        let action = GeneralBrowserAction(
+        let action = NavigationBrowserAction(
+            navigationDestination: NavigationDestination(.readerMode),
             windowUUID: windowUUID,
-            actionType: GeneralBrowserActionType.showReaderMode
+            actionType: NavigationBrowserActionType.tapOnReaderMode
         )
         store.dispatch(action)
         return true
@@ -2828,6 +2829,8 @@ class BrowserViewController: UIViewController,
                 return
             }
             navigationHandler?.openLearnMoreFromNativeErrorPage(url: url)
+        case .readerMode:
+            toggleReaderMode()
         }
     }
 
@@ -2862,8 +2865,6 @@ class BrowserViewController: UIViewController,
             // User tapped the Share button in the toolbar
             guard let button = state.buttonTapped else { return }
             shareSelectedTab(fromShareButton: button)
-        case .readerMode:
-            toggleReaderMode()
         case .readerModeLongPressAction:
             _ = toggleReaderModeLongPressAction()
         case .newTabLongPressActions:

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuCoordinator.swift
@@ -41,9 +41,6 @@ protocol MainMenuCoordinatorDelegate: AnyObject {
     @MainActor
     func showPrintSheet()
 
-    @MainActor
-    func showReaderMode()
-
     /// Open the share sheet to share the currently selected `Tab`.
     @MainActor
     func showShareSheetForCurrentlySelectedTab()
@@ -134,8 +131,11 @@ class MainMenuCoordinator: BaseCoordinator {
             navigationHandler?.showSettings(at: .password)
 
         case .readerView:
-            // TODO: FXIOS-15099 Refactor showReaderMode with NavigationBrowserAction
-            navigationHandler?.showReaderMode()
+            store.dispatch(NavigationBrowserAction(
+                navigationDestination: NavigationDestination(.readerMode),
+                windowUUID: windowUUID,
+                actionType: NavigationBrowserActionType.tapOnReaderMode
+            ))
 
         case .settings:
             navigationHandler?.showSettings(at: .general)

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -298,8 +298,9 @@ final class ToolbarMiddleware {
 
         case .readerMode, .readerModeWithSummarizer:
             recordReaderModeTelemetry(state: state, windowUUID: action.windowUUID)
-            let action = GeneralBrowserAction(windowUUID: action.windowUUID,
-                                              actionType: GeneralBrowserActionType.showReaderMode)
+            let action = NavigationBrowserAction(navigationDestination: NavigationDestination(.readerMode),
+                                                 windowUUID: action.windowUUID,
+                                                 actionType: NavigationBrowserActionType.tapOnReaderMode)
             store.dispatch(action)
 
         case .reload:
@@ -401,8 +402,9 @@ final class ToolbarMiddleware {
                                               actionType: GeneralBrowserActionType.addToReadingListLongPressAction)
             store.dispatch(action)
         case .summarizer:
-            let action = GeneralBrowserAction(windowUUID: action.windowUUID,
-                                              actionType: GeneralBrowserActionType.showReaderMode)
+            let action = NavigationBrowserAction(navigationDestination: NavigationDestination(.readerMode),
+                                                 windowUUID: action.windowUUID,
+                                                 actionType: NavigationBrowserActionType.tapOnReaderMode)
             store.dispatch(action)
         case .readerModeWithSummarizer:
             Task {

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
@@ -57,6 +57,8 @@ final class SummarizerMiddleware: SummarizerConfigFactory {
             self.handleGeneralBrowserAction(action: action)
         } else if let action = action as? ToolbarAction {
             self.handleToolbarAction(action: action)
+        } else if let action = action as? NavigationBrowserAction {
+            self.handleNavigationBrowserAction(action: action)
         }
     }
 
@@ -74,13 +76,21 @@ final class SummarizerMiddleware: SummarizerConfigFactory {
             fetchSummarizerConfig(windowUUID: action.windowUUID) {
                 self.handleDidTapReaderModeSummarizerButton(windowUUID: action.windowUUID, summarizerConfig: $0)
             }
-        case GeneralBrowserActionType.showReaderMode:
-            fetchSummarizerConfig(windowUUID: action.windowUUID) {
-                self.handleShowReaderMode(windowUUID: action.windowUUID, summarizerConfig: $0)
-            }
         case GeneralBrowserActionType.shakeMotionEnded:
             fetchSummarizerConfig(windowUUID: action.windowUUID) {
                 self.handleShakeMotionEnded(windowUUID: action.windowUUID, summarizerConfig: $0)
+            }
+        default:
+            break
+        }
+    }
+
+    // MARK: - NavigationBrowserAction
+    private func handleNavigationBrowserAction(action: NavigationBrowserAction) {
+        switch action.actionType {
+        case NavigationBrowserActionType.tapOnReaderMode:
+            fetchSummarizerConfig(windowUUID: action.windowUUID) {
+                self.handleShowReaderMode(windowUUID: action.windowUUID, summarizerConfig: $0)
             }
         default:
             break

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerStateTests.swift
@@ -571,6 +571,20 @@ final class BrowserViewControllerStateTests: XCTestCase, StoreTestUtility {
         )
     }
 
+    // MARK: - Reader Mode
+
+    func test_tapOnReaderMode_navigationBrowserAction_returnsExpectedState() {
+        let initialState = createSubject()
+        let reducer = browserViewControllerReducer()
+
+        XCTAssertNil(initialState.navigationDestination)
+
+        let action = getNavigationBrowserAction(for: .tapOnReaderMode, destination: .readerMode)
+        let newState = reducer.legacyReducer(initialState, action)
+
+        XCTAssertEqual(newState.navigationDestination?.destination, .readerMode)
+    }
+
     func test_navigationDestinationHandled_clearsNavigationDestination() {
         let initialState = createSubject()
         let reducer = browserViewControllerReducer()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1454,18 +1454,6 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertTrue(mockRouter.presentedViewController?.children.first is MainMenuViewController)
     }
 
-    func testShowReaderMode_dispatchesGeneralBrowserAction() throws {
-        let subject = createSubject()
-
-        subject.showReaderMode()
-
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? GeneralBrowserAction)
-        let actionType = try XCTUnwrap(actionCalled.actionType as? GeneralBrowserActionType)
-
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertEqual(actionType, GeneralBrowserActionType.showReaderMode)
-    }
-
     func testMainMenuCoordinatorDelegate_didDidDismiss_removesChild() {
         let subject = createSubject()
         subject.browserHasLoaded()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Summarizer/SummarizerMiddlewareTests.swift
@@ -229,9 +229,10 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let subject = createSubject()
 
-        let action = GeneralBrowserAction(
+        let action = NavigationBrowserAction(
+            navigationDestination: NavigationDestination(.readerMode),
             windowUUID: .XCTestDefaultUUID,
-            actionType: GeneralBrowserActionType.showReaderMode
+            actionType: NavigationBrowserActionType.tapOnReaderMode
         )
         let expectation = XCTestExpectation(description: "Show reader mode action dispatched")
 
@@ -258,9 +259,10 @@ final class SummarizerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let subject = createSubject()
 
-        let action = GeneralBrowserAction(
+        let action = NavigationBrowserAction(
+            navigationDestination: NavigationDestination(.readerMode),
             windowUUID: .XCTestDefaultUUID,
-            actionType: GeneralBrowserActionType.showReaderMode
+            actionType: NavigationBrowserActionType.tapOnReaderMode
         )
         let expectation = XCTestExpectation(description: "Show reader mode not available dispatched")
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuCoordinatorTests.swift
@@ -8,18 +8,35 @@ import XCTest
 @testable import Client
 
 @MainActor
-final class MainMenuCoordinatorTests: XCTestCase {
+final class MainMenuCoordinatorTests: XCTestCase, StoreTestUtility {
     private var mockRouter: MockRouter!
+    private var mockStore: MockStoreForMiddleware<AppState>!
 
     override func setUp() async throws {
         try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         mockRouter = MockRouter(navigationController: MockNavigationController())
+        setupStore()
     }
 
     override func tearDown() async throws {
         DependencyHelperMock().reset()
+        resetStore()
         try await super.tearDown()
+    }
+
+    // MARK: - StoreTestUtility
+    func setupAppState() -> AppState {
+        return AppState()
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
     }
 
     func testInitialState() {
@@ -58,15 +75,17 @@ final class MainMenuCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockRouter.dismissCalled, 1)
     }
 
-    func testHandleNavigation_readerView_callsShowReaderModeOnDelegate() {
+    func testHandleNavigation_readerView_dispatchesNavigationBrowserAction() throws {
         let subject = createSubject()
-        let mockDelegate = MockMainMenuCoordinatorDelegate()
-        subject.navigationHandler = mockDelegate
 
         subject.navigateTo(MenuNavigationDestination(.readerView), animated: false)
         mockRouter.savedCompletion?()
 
-        XCTAssertEqual(mockDelegate.showReaderModeCalled, 1)
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? NavigationBrowserAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? NavigationBrowserActionType)
+
+        XCTAssertEqual(actionType, NavigationBrowserActionType.tapOnReaderMode)
+        XCTAssertEqual(actionCalled.navigationDestination.destination, .readerMode)
         XCTAssertEqual(mockRouter.dismissCalled, 1)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockMainMenuCoordinatorDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockMainMenuCoordinatorDelegate.swift
@@ -18,7 +18,6 @@ class MockMainMenuCoordinatorDelegate: MainMenuCoordinatorDelegate {
     private(set) var presentReportBrokenSiteURL: URL?
     private(set) var presentAdBlockerSettingsCalled = 0
     private(set) var showPrintSheetCalled = 0
-    private(set) var showReaderModeCalled = 0
     private(set) var showShareSheetForCurrentlySelectedTabCalled = 0
     private(set) var showSummarizePanelCalled = 0
     private(set) var showSummarizePanelTrigger: SummarizerTrigger?
@@ -66,10 +65,6 @@ class MockMainMenuCoordinatorDelegate: MainMenuCoordinatorDelegate {
 
     func showPrintSheet() {
         showPrintSheetCalled += 1
-    }
-
-    func showReaderMode() {
-        showReaderModeCalled += 1
     }
 
     func showShareSheetForCurrentlySelectedTab() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -746,7 +746,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     func testDidTapButton_tapOnReaderModeButton_dispatchesShowReaderModes() throws {
-        try didTapButton(buttonType: .readerMode, expectedActionType: GeneralBrowserActionType.showReaderMode)
+        try didTriggerReaderMode(buttonType: .readerMode, gestureType: .tap)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.ReaderModeButtonTappedExtra>
@@ -763,7 +763,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     func testDidTapButton_tapOnReaderModeWithSummarizerButton_dispatchesShowReaderModes() throws {
-        try didTapButton(buttonType: .readerModeWithSummarizer, expectedActionType: .showReaderMode)
+        try didTriggerReaderMode(buttonType: .readerModeWithSummarizer, gestureType: .tap)
 
         let savedMetric = try XCTUnwrap(
             mockGleanWrapper.savedEvents.first as? EventMetricType<GleanMetrics.Toolbar.ReaderModeButtonTappedExtra>
@@ -1004,7 +1004,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
     }
 
     func testDidTapButton_longPressOnSummarizer_dispatchesShowReaderModeAction() throws {
-        try didLongPressButton(buttonType: .summarizer, expectedActionType: .showReaderMode)
+        try didTriggerReaderMode(buttonType: .summarizer, gestureType: .longPress)
     }
 
     func testDidTapButton_longPressOnReaderModeWithSummarizer_dispatchesShowSummarizerAction() throws {
@@ -1310,6 +1310,34 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, expectedActionType)
         assertAction(actionCalled)
+    }
+
+    private func didTriggerReaderMode(buttonType: ToolbarActionConfiguration.ActionType,
+                                      gestureType: ToolbarButtonGesture,
+                                      expectation: XCTestExpectation? = nil) throws {
+        let subject = createSubject(manager: toolbarManager)
+        let action = ToolbarMiddlewareAction(
+            buttonType: buttonType,
+            gestureType: gestureType,
+            windowUUID: windowUUID,
+            actionType: ToolbarMiddlewareActionType.didTapButton)
+
+        mockStore.dispatchCalled = {
+            expectation?.fulfill()
+        }
+
+        subject.toolbarProvider.legacyMiddleware(mockStore.state, action)
+
+        if let expectation {
+            wait(for: [expectation], timeout: 1.0)
+        }
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? NavigationBrowserAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? NavigationBrowserActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, NavigationBrowserActionType.tapOnReaderMode)
+        XCTAssertEqual(actionCalled.navigationDestination.destination, .readerMode)
     }
 
     private func cancelEditMode(dispatchedActionsCount: Int = 2) throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15099)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32508)

## :bulb: Description
Reader mode was still using `GeneralBrowserActionType.showReaderMode`, and the main menu had to bounce through a `MainMenuCoordinatorDelegate` method just to dispatch that action. This moves reader mode's trigger points (toolbar, long press, main menu, accessibility magic tap) over to `NavigationBrowserAction`/`NavigationDestination`, matching the pattern from ADR 0005 that other actions like `tapOnTrackingProtection` already use.

Since `showReaderMode` was shared by four dispatch sites and read by both the state reducer and `SummarizerMiddleware`, this ended up touching more than just the two `TODO: FXIOS-15099` spots — a partial migration would've left two action types doing the same thing. Flagging that up front since the issue itself only points at those two TODOs.

No behavior change intended — same trigger points, same reducer effects, same summarizer side effect, just routed through the newer pattern. Added a reducer test for the new `tapOnReaderMode` case since there wasn't one for the old path either.

## :movie_camera: Demos
No UI change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — N/A, no UI change
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review — N/A, no telemetry change
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n — N/A, no string change
- [x] If needed, I updated documentation and added comments to complex code
