### PR TITLE
Refactor NO-TICKET - Revert log level to warning for CC failed decryption

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -384,7 +384,7 @@ class CreditCardBottomSheetViewController: UIViewController,
         ) else {
             // A nil means the card couldn't be decrypted. The Keychain key is unavailable.
             logger.log("Credit card autofill selection failed: unable to decrypt selected card.",
-                       level: .fatal,
+                       level: .warning,
                        category: .autofill)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .creditCardAutofillFailed)
             return


### PR DESCRIPTION
## :scroll: Tickets
### NO-TICKET

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
The logs helped us determine the issues related with CC failed decryption so we want to avoid spamming Sentry unnecessary.
This PR is changing the log level from `.fatal` to `.warning`.
## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

