### PR TITLE
Bugfix FXIOS-16495 [WebCompat] Announce the details field as optional

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -184,7 +184,7 @@ final class WebCompatReportViewController: UINavigationController,
             rows: [
                 WebCompatReportViewModel.Row(
                     id: RowID.additionalDetails.rawValue,
-                    title: .WebCompatReporter.Fields.DetailsAccessibilityLabel,
+                    title: .WebCompatReporter.Fields.DetailsPlaceholder,
                     kind: .detailsField(
                         text: state.additionalDetails,
                         placeholder: .WebCompatReporter.Fields.DetailsPlaceholder

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -9367,7 +9367,7 @@ extension String {
                 tableName: "WebCompatReporter",
                 value: "URL",
                 comment: "Placeholder shown in the URL field when no web address has been entered, in the Report a Website Issue form.")
-            public static let WebCompatReporterFieldsDetailsAccessibilityLabel = MZLocalizedString(
+             public static let DetailsAccessibilityLabel = MZLocalizedString(
                 key: "WebCompatReporter.Fields.DetailsAccessibilityLabel.v154",
                 tableName: "WebCompatReporter",
                 value: "Describe the issue in detail",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4513,12 +4513,6 @@ extension String {
                 value: "Describe the issue in detail (optional)",
                 comment: "Placeholder shown in the optional multiline field where the user can describe the website problem in their own words, in the Report a Website Issue form."
             )
-            public static let DetailsAccessibilityLabel = MZLocalizedString(
-                key: "WebCompatReporter.Fields.DetailsAccessibilityLabel.v154",
-                tableName: "WebCompatReporter",
-                value: "Describe the issue in detail",
-                comment: "Accessibility label for the multiline field where the user can describe the website problem in their own words, in the Report a Website Issue form."
-            )
         }
         public struct AdditionalInfo {
             public static let Title = MZLocalizedString(
@@ -9373,6 +9367,11 @@ extension String {
                 tableName: "WebCompatReporter",
                 value: "URL",
                 comment: "Placeholder shown in the URL field when no web address has been entered, in the Report a Website Issue form.")
+            public static let WebCompatReporterFieldsDetailsAccessibilityLabel = MZLocalizedString(
+                key: "WebCompatReporter.Fields.DetailsAccessibilityLabel.v154",
+                tableName: "WebCompatReporter",
+                value: "Describe the issue in detail",
+                comment: "Accessibility label for the multiline field where the user can describe the website problem in their own words, in the Report a Website Issue form.")
         }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/WebCompatReportViewControllerTests.swift
@@ -312,6 +312,17 @@ final class WebCompatReportViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(text, "Broken images")
     }
 
+    func testMakeSections_detailsRowLabelsItselfOptional() {
+        let state = WebCompatReporterState(windowUUID: windowUUID)
+            .copy(url: "https://example.com")
+            .copy(selectedCategory: .siteNotUsable)
+
+        let sections = WebCompatReportViewController.makeSections(from: state)
+
+        let details = sections.first { $0.id == "additionalDetails" }
+        XCTAssertEqual(details?.rows.first?.title, .WebCompatReporter.Fields.DetailsPlaceholder)
+    }
+
     func testMakeSections_attachesLearnMoreFooterWithATappableLink() throws {
         let state = WebCompatReporterState(windowUUID: windowUUID).copy(url: "https://example.com")
 


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16495](https://mozilla-hub.atlassian.net/browse/FXIOS-16495)

## :bulb: Description
The details field had its own shorter accessibility label, so VoiceOver never said "(optional)" while the placeholder showed it. Now the placeholder is the label, and the old string moves to `OldStrings`.

## :mag: Testing
With VoiceOver on, open Report Broken Site, pick a category, and swipe to the description box.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


[FXIOS-16495]: https://mozilla-hub.atlassian.net/browse/FXIOS-16495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ