### PR TITLE
Bugfix FXIOS-16510 [WebCompat] Announce the report sent toast to VoiceOver

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -639,7 +639,9 @@ final class BrowserCoordinator: BaseCoordinator,
     // MARK: - WebCompatReportCoordinatorNavigationDelegate
 
     func webCompatReportDidSubmit() {
-        browserViewController.showPlainToast(message: .WebCompatReporter.Toast.ReportSent)
+        let message = String.WebCompatReporter.Toast.ReportSent
+        browserViewController.showPlainToast(message: message)
+        UIAccessibility.post(notification: .announcement, argument: message)
     }
 
     func presentAdBlockerSettings() {


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16510](https://mozilla-hub.atlassian.net/browse/FXIOS-16510)

## :bulb: Description
The confirmation toast is only drawn, never announced, so VoiceOver said nothing after a report was sent. Now the message is posted as an announcement too.

## :mag: Testing
With VoiceOver on, send a report and listen for the confirmation.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


[FXIOS-16510]: https://mozilla-hub.atlassian.net/browse/FXIOS-16510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ