### PR TITLE
Add FXIOS-16626 [Nova] Update selected text color

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -184,8 +184,13 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
     private func applyThemeChanges(for window: WindowUUID, using newTheme: ThemeType) {
         // Overwrite the user interface style on the window attached to our scene
         // once we have multiple scenes we need to update all of them
-        let style = self.getCurrentTheme(for: window).type.getInterfaceStyle()
+        let theme = self.getCurrentTheme(for: window)
+        let style = theme.type.getInterfaceStyle()
         self.windows[window]?.overrideUserInterfaceStyle = style
+        // Nova only: highlighted text purple tint.
+        let selectedTextTint = theme.isNova ? theme.colors.layerSelectedText : nil
+        UITextField.appearance().tintColor = selectedTextTint
+        UITextView.appearance().tintColor = selectedTextTint
         notifyCurrentThemeDidChange(for: window)
     }
 

--- a/BrowserKit/Sources/Common/Theming/NovaDarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaDarkTheme.swift
@@ -44,7 +44,7 @@ private struct NovaDarkColourPalette: ThemeColourPalette {
     var layerInformation: UIColor = NovaColors.Blue70
     var layerSepia: UIColor = NovaColors.Yellow0
     var layerAutofillText: UIColor = NovaColors.VioletDesaturated30.withAlphaComponent(0.55)
-    var layerSelectedText: UIColor = NovaColors.Gray45.withAlphaComponent(0.8)
+    var layerSelectedText: UIColor = NovaColors.VioletDesaturated30.withAlphaComponent(0.55)
     var layerGlassTintNova: UIColor = NovaColors.Violet90.withAlphaComponent(0.58)
     var layerAccentPrivateNonOpaque: UIColor { layerAccentSubtle }
 

--- a/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
@@ -31,7 +31,7 @@ private struct NovaLightColourPalette: ThemeColourPalette {
     var layerInformation: UIColor = NovaColors.Blue10
     var layerSepia: UIColor = NovaColors.Yellow0
     var layerAutofillText: UIColor = NovaColors.VioletDesaturated30
-    var layerSelectedText: UIColor = NovaColors.Gray35
+    var layerSelectedText: UIColor = NovaColors.VioletDesaturated30
     var layerGlassTintNova: UIColor = NovaColors.VioletDesaturated10.withAlphaComponent(0.45)
     var layerAccentPrivateNonOpaque: UIColor { layerAccentSubtle }
 

--- a/BrowserKit/Sources/Common/Theming/NovaPrivateTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaPrivateTheme.swift
@@ -32,7 +32,7 @@ private struct NovaPrivateColourPalette: ThemeColourPalette {
     var layerInformation: UIColor = NovaColors.Blue70
     var layerSepia: UIColor = NovaColors.Yellow0
     var layerAutofillText: UIColor = NovaColors.VioletDesaturated30.withAlphaComponent(0.55)
-    var layerSelectedText: UIColor = NovaColors.Gray45.withAlphaComponent(0.81)
+    var layerSelectedText: UIColor = NovaColors.VioletDesaturated30.withAlphaComponent(0.55)
     var layerGlassTintNova: UIColor = .clear
     var layerAccentPrivateNonOpaque: UIColor { layerAccentSubtle }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16626)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates tint for highlighted text on Nova only, we should use purple in all cases, as requested by Figma design:


<img width="428" height="622" alt="Screenshot 2026-08-21 at 15 44 18" src="https://github.com/user-attachments/assets/18564d39-3feb-4ab1-8adb-12bdeabbf447" />

<img width="1206" height="2622" alt="simulator_screenshot_64685899-DA77-49B7-8150-E839E82A9709" src="https://github.com/user-attachments/assets/94c81877-ad8d-47e2-bf60-eac75be25f88" />

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

