### PR TITLE
Add FXIOS-16621 [Nova] Update Edit Bookmarks screen

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -628,6 +628,9 @@ final class BookmarksViewController: SiteTableViewController,
 
             cell.configure(viewModel: viewModel)
             cell.applyTheme(theme: currentTheme())
+            if currentTheme().isNova {
+                cell.editingAccessoryView?.tintColor = currentTheme().colors.textSecondary
+            }
             return cell
         } else {
             if let cell = tableView.dequeueReusableCell(withIdentifier: SeparatorTableViewCell.cellIdentifier,
@@ -706,7 +709,9 @@ final class BookmarksViewController: SiteTableViewController,
              .bookmarks(state: .inFolder):
             bottomRightButton.tintColor = currentTheme().colors.textPrimary
         case .bookmarks(state: .inFolderEditMode):
-            bottomRightButton.tintColor = currentTheme().colors.textAccent
+            bottomRightButton.tintColor = currentTheme().isNova
+                ? currentTheme().colors.textPrimary
+                : currentTheme().colors.textAccent
         case .bookmarks(state: .itemEditMode):
             bottomRightButton.tintColor = currentTheme().colors.textAccent
         case .bookmarks(state: .itemEditModeInvalidField):


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16621)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates Edit bookmarks screen elements that did not follow Nova design. The chevrons should be iconSecondary and the buttons textPrimary to keep them neutral, not purple.

<img width="699" height="510" alt="Screenshot 2026-08-21 at 15 59 04" src="https://github.com/user-attachments/assets/d88d9c30-faa4-4053-8d80-93e33023fe5f" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

