### PR TITLE
Bugfix FXIOS-16415 [Synced Tabs] Show empty state when no synced tabs are available

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/RemoteTabsPanelState.swift
@@ -48,6 +48,12 @@ enum RemoteTabsPanelEmptyStateReason {
     }
 }
 
+/// Tabs or an empty state, if empty then why.
+enum RemoteTabsPanelContentState: Equatable {
+    case tabs
+    case empty(RemoteTabsPanelEmptyStateReason)
+}
+
 /// State for RemoteTabsPanel. WIP.
 @Copyable
 struct RemoteTabsPanelState: ScreenState, Sendable {
@@ -55,7 +61,7 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
     let refreshState: RemoteTabsPanelRefreshState
     let allowsRefresh: Bool
     let clientAndTabs: [ClientAndTabs]
-    let showingEmptyState: RemoteTabsPanelEmptyStateReason?// If showing empty (or error) state
+    let contentState: RemoteTabsPanelContentState
     let devices: [Device]
 
     init(appState: AppState, uuid: WindowUUID) {
@@ -72,7 +78,7 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
                   refreshState: panelState.refreshState,
                   allowsRefresh: panelState.allowsRefresh,
                   clientAndTabs: panelState.clientAndTabs,
-                  showingEmptyState: panelState.showingEmptyState,
+                  contentState: panelState.contentState,
                   devices: panelState.devices)
     }
 
@@ -81,7 +87,7 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
                   refreshState: .idle,
                   allowsRefresh: false,
                   clientAndTabs: [],
-                  showingEmptyState: .noTabs,
+                  contentState: .empty(.noTabs),
                   devices: [])
     }
 
@@ -89,14 +95,14 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
          refreshState: RemoteTabsPanelRefreshState,
          allowsRefresh: Bool,
          clientAndTabs: [ClientAndTabs],
-         showingEmptyState: RemoteTabsPanelEmptyStateReason?,
+         contentState: RemoteTabsPanelContentState,
          devices: [Device]
     ) {
         self.windowUUID = windowUUID
         self.refreshState = refreshState
         self.allowsRefresh = allowsRefresh
         self.clientAndTabs = clientAndTabs
-        self.showingEmptyState = showingEmptyState
+        self.contentState = contentState
         self.devices = devices
     }
 
@@ -143,7 +149,7 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
         return state
             .copy(refreshState: .idle)
             .copy(allowsRefresh: reason.allowsRefresh)
-            .copy(showingEmptyState: reason)
+            .copy(contentState: .empty(reason))
     }
 
     private static func handleRefreshDidSucceedAction(clientAndTabs: [ClientAndTabs],
@@ -153,8 +159,20 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
             .copy(refreshState: .idle)
             .copy(allowsRefresh: true)
             .copy(clientAndTabs: clientAndTabs)
-            .copy(showingEmptyState: nil)
+            .copy(contentState: contentState(for: clientAndTabs))
             .copy(devices: action.devices ?? state.devices)
+    }
+
+    private static func contentState(for clientAndTabs: [ClientAndTabs]) -> RemoteTabsPanelContentState {
+        if clientAndTabs.isEmpty {
+            return .empty(.noClients)
+        }
+
+        if clientAndTabs.allSatisfy({ $0.tabs.isEmpty }) {
+            return .empty(.noTabs)
+        }
+
+        return .tabs
     }
 
     private static func handleRemoteDevicesChangedAction(devices: [Device],
@@ -175,7 +193,7 @@ struct RemoteTabsPanelState: ScreenState, Sendable {
                                     refreshState: state.refreshState,
                                     allowsRefresh: state.allowsRefresh,
                                     clientAndTabs: state.clientAndTabs,
-                                    showingEmptyState: state.showingEmptyState,
+                                    contentState: state.contentState,
                                     devices: state.devices)
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
@@ -46,7 +46,10 @@ class RemoteTabsViewController: UIViewController,
     private let tabTrayUtils: TabTrayUtils
 
     var tableView: UITableView = .build()
-    private var isShowingEmptyView: Bool { state.showingEmptyState != nil }
+    private var isShowingEmptyView: Bool {
+        guard case .empty = state.contentState else { return false }
+        return true
+    }
     private lazy var emptyView: RemoteTabsEmptyViewProtocol = {
         if isTabTrayUIExperimentsEnabled {
             let view = ExperimentRemoteTabsEmptyView()
@@ -206,7 +209,7 @@ class RemoteTabsViewController: UIViewController,
     }
 
     private func configureEmptyView(isSyncing: Bool = false) {
-        guard let emptyStateReason = state.showingEmptyState else { return }
+        guard case let .empty(emptyStateReason) = state.contentState else { return }
         emptyView.configure(config: emptyStateReason, delegate: remoteTabsPanel, isSyncing: isSyncing)
         emptyView.applyTheme(theme: retrieveTheme())
     }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsViewController.swift
@@ -159,16 +159,13 @@ class RemoteTabsViewController: UIViewController,
     }
 
     func newState(state: RemoteTabsPanelState) {
-        let currentClientAndTabs = self.state.clientAndTabs
         self.state = state
-        reloadUI(currentClientAndTabs: currentClientAndTabs)
+        reloadUI()
     }
 
-    private func reloadUI(currentClientAndTabs: [ClientAndTabs] = []) {
+    private func reloadUI() {
         updateUI()
-        if currentClientAndTabs != self.state.clientAndTabs {
-            tableView.reloadData()
-        }
+        tableView.reloadData()
     }
 
     private func updateUI() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/RemoteTabsPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/RemoteTabsPanelTests.swift
@@ -72,7 +72,7 @@ final class RemoteTabsPanelTests: XCTestCase, StoreTestUtility {
             refreshState: .refreshing,
             allowsRefresh: false,
             clientAndTabs: [],
-            showingEmptyState: nil,
+            contentState: .tabs,
             devices: []
         )
         subject.newState(state: newState)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Redux/RemoteTabPanelStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/Redux/RemoteTabPanelStateTests.swift
@@ -67,6 +67,36 @@ final class RemoteTabPanelStateTests: XCTestCase {
         XCTAssertEqual(newState.clientAndTabs.first!.tabs.count, 2)
         XCTAssertEqual(newState.devices.count, 1)
         XCTAssertEqual(newState.devices[0].id, deviceId)
+        XCTAssertEqual(newState.contentState, RemoteTabsPanelContentState.tabs)
+    }
+
+    @MainActor
+    func testTabsRefreshSuccessWithNoClientsShowsNoClientsEmptyState() {
+        let initialState = createSubject()
+        let reducer = remoteTabsPanelReducer()
+
+        let action = RemoteTabsPanelAction(clientAndTabs: [],
+                                           windowUUID: WindowUUID.XCTestDefaultUUID,
+                                           actionType: RemoteTabsPanelActionType.refreshDidSucceed)
+        let newState = reducer.legacyReducer(initialState, action)
+
+        XCTAssertEqual(newState.contentState, RemoteTabsPanelContentState.empty(.noClients))
+        XCTAssertEqual(newState.refreshState, RemoteTabsPanelRefreshState.idle)
+        XCTAssertTrue(newState.allowsRefresh)
+    }
+
+    @MainActor
+    func testTabsRefreshSuccessWithClientsButNoTabsShowsNoTabsEmptyState() {
+        let initialState = createSubject()
+        let reducer = remoteTabsPanelReducer()
+        let clientAndTabs = generateOneClientNoTabs()
+
+        let action = RemoteTabsPanelAction(clientAndTabs: clientAndTabs,
+                                           windowUUID: WindowUUID.XCTestDefaultUUID,
+                                           actionType: RemoteTabsPanelActionType.refreshDidSucceed)
+        let newState = reducer.legacyReducer(initialState, action)
+
+        XCTAssertEqual(newState.contentState, RemoteTabsPanelContentState.empty(.noTabs))
     }
 
     @MainActor
@@ -92,7 +122,7 @@ final class RemoteTabPanelStateTests: XCTestCase {
         let newState = reducer.legacyReducer(initialState, action)
 
         XCTAssertEqual(newState.refreshState, RemoteTabsPanelRefreshState.idle)
-        XCTAssertNotNil(newState.showingEmptyState)
+        XCTAssertEqual(newState.contentState, RemoteTabsPanelContentState.empty(.failedToSync))
     }
 
     @MainActor
@@ -153,6 +183,18 @@ final class RemoteTabPanelStateTests: XCTestCase {
                                   fxaDeviceId: "12345")
         let fakeData = [ClientAndTabs(client: client, tabs: fakeTabs)]
         return fakeData
+    }
+
+    private func generateOneClientNoTabs() -> [ClientAndTabs] {
+        let client = RemoteClient(guid: "123",
+                                  name: "Client",
+                                  modified: 0,
+                                  type: "Type (Test)",
+                                  formfactor: "Test",
+                                  os: "macOS",
+                                  version: "v1.0",
+                                  fxaDeviceId: "12345")
+        return [ClientAndTabs(client: client, tabs: [])]
     }
 
     private func createSubject() -> RemoteTabsPanelState {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelTests.swift
@@ -71,7 +71,7 @@ final class RemoteTabPanelTests: XCTestCase {
                                     refreshState: .idle,
                                     allowsRefresh: true,
                                     clientAndTabs: fakeData,
-                                    showingEmptyState: nil,
+                                    contentState: .tabs,
                                     devices: [])
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/RemoteTabPanelTests.swift
@@ -38,6 +38,28 @@ final class RemoteTabPanelTests: XCTestCase {
         XCTAssertEqual(tableView.numberOfRows(inSection: 0), 2)
     }
 
+    @MainActor
+    func testNewState_whenOnlyContentStateChanges_reloadsTableView() {
+        let tabsState = generateStateOneClientTwoTabs()
+        let subject = RemoteTabsViewController(state: tabsState, windowUUID: .XCTestDefaultUUID)
+        let tableView = MockRemoteTabsTableView()
+        subject.tableView = tableView
+        trackForMemoryLeaks(subject)
+
+        let emptyState = RemoteTabsPanelState(windowUUID: .XCTestDefaultUUID,
+                                              refreshState: .idle,
+                                              allowsRefresh: true,
+                                              clientAndTabs: tabsState.clientAndTabs,
+                                              contentState: .empty(.failedToSync),
+                                              devices: [])
+
+        subject.newState(state: emptyState)
+        XCTAssertEqual(tableView.reloadDataCallCount, 1)
+
+        subject.newState(state: tabsState)
+        XCTAssertEqual(tableView.reloadDataCallCount, 2)
+    }
+
     // MARK: - Private
 
     private func generateEmptyState() -> RemoteTabsPanelState {
@@ -84,5 +106,13 @@ final class RemoteTabPanelTests: XCTestCase {
 
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
+    }
+}
+
+private final class MockRemoteTabsTableView: UITableView {
+    private(set) var reloadDataCallCount = 0
+
+    override func reloadData() {
+        reloadDataCallCount += 1
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16415)

## :bulb: Description

Display an empty state in the Synced Tabs panel when there are no synced tabs available.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Before" src="https://github.com/user-attachments/assets/e6d4657a-12c1-4d56-89da-60007ea326fd" /> | <img width="1206" height="2622" alt="After" src="https://github.com/user-attachments/assets/18343f38-69ec-441e-881a-d8d79c8ee86a" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

