### PR TITLE
Refactor [ToolbarAction refactor] FXIOS-16630 action states for navigationActions and replace in AddressBarState

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		213046BD2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213046BC2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift */; };
 		213047E62F2153B1007ECEDA /* PageZoomSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213047E52F2153AB007ECEDA /* PageZoomSettingsViewModelTests.swift */; };
 		2132A47130378FC50040B898 /* NavigationActionsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A47030378FC20040B898 /* NavigationActionsState.swift */; };
+		2132A474303894A90040B898 /* NavigationActionsStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A472303894A90040B898 /* NavigationActionsStateTests.swift */; };
 		21365E392F30FD700000C369 /* BrowserViewControllerLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21365E382F30FD580000C369 /* BrowserViewControllerLayoutManager.swift */; };
 		21365E3E2F314D1D0000C369 /* BrowserViewControllerLayoutManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21365E3C2F314D1D0000C369 /* BrowserViewControllerLayoutManagerTests.swift */; };
 		21371FA228A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21371FA128A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift */; };
@@ -3178,6 +3179,7 @@
 		213046BC2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAlertControllerExtensionTests.swift; sourceTree = "<group>"; };
 		213047E52F2153AB007ECEDA /* PageZoomSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageZoomSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		2132A47030378FC20040B898 /* NavigationActionsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationActionsState.swift; sourceTree = "<group>"; };
+		2132A472303894A90040B898 /* NavigationActionsStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationActionsStateTests.swift; sourceTree = "<group>"; };
 		21365E382F30FD580000C369 /* BrowserViewControllerLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerLayoutManager.swift; sourceTree = "<group>"; };
 		21365E3C2F314D1D0000C369 /* BrowserViewControllerLayoutManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerLayoutManagerTests.swift; sourceTree = "<group>"; };
 		21371FA128A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTelemetryUtilityTests.swift; sourceTree = "<group>"; };
@@ -16677,6 +16679,7 @@
 		E16941B22C4E498600FF5F4E /* Toolbar */ = {
 			isa = PBXGroup;
 			children = (
+				2132A472303894A90040B898 /* NavigationActionsStateTests.swift */,
 				EE046A76300A75F4004E3D80 /* SwipeUpTabPreviewGestureHandlerTests.swift */,
 				E14D6D332CCBA9FF0058B910 /* AddressBarStateTests.swift */,
 				E14C78952C105488002AD3C7 /* AddressToolbarContainerModelTests.swift */,
@@ -21035,6 +21038,7 @@
 				39B77FF8300FD65000430F38 /* TrackerBlockerModuleMiddlewareTests.swift in Sources */,
 				39B77FF9300FD65000430F38 /* TrackerBlockerModuleStateTests.swift in Sources */,
 				C71158D32EEA0B19009766B8 /* PrivacyNoticeStateTests.swift in Sources */,
+				2132A474303894A90040B898 /* NavigationActionsStateTests.swift in Sources */,
 				21FB43CB2E7AF25D00A8818D /* MockHistoryHandler.swift in Sources */,
 				E1EAA5EF2D49182700D3039C /* NavigationBarStateTests.swift in Sources */,
 				E14BF33E2950B1230039758D /* MailProvidersTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 		213046BB2F212BCC007ECEDA /* CGRectExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213046BA2F212BCC007ECEDA /* CGRectExtensionsTests.swift */; };
 		213046BD2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213046BC2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift */; };
 		213047E62F2153B1007ECEDA /* PageZoomSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213047E52F2153AB007ECEDA /* PageZoomSettingsViewModelTests.swift */; };
+		2132A47130378FC50040B898 /* NavigationActionsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A47030378FC20040B898 /* NavigationActionsState.swift */; };
 		21365E392F30FD700000C369 /* BrowserViewControllerLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21365E382F30FD580000C369 /* BrowserViewControllerLayoutManager.swift */; };
 		21365E3E2F314D1D0000C369 /* BrowserViewControllerLayoutManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21365E3C2F314D1D0000C369 /* BrowserViewControllerLayoutManagerTests.swift */; };
 		21371FA228A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21371FA128A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift */; };
@@ -3176,6 +3177,7 @@
 		213046BA2F212BCC007ECEDA /* CGRectExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGRectExtensionsTests.swift; sourceTree = "<group>"; };
 		213046BC2F819C9C007ECEDA /* UIAlertControllerExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAlertControllerExtensionTests.swift; sourceTree = "<group>"; };
 		213047E52F2153AB007ECEDA /* PageZoomSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageZoomSettingsViewModelTests.swift; sourceTree = "<group>"; };
+		2132A47030378FC20040B898 /* NavigationActionsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationActionsState.swift; sourceTree = "<group>"; };
 		21365E382F30FD580000C369 /* BrowserViewControllerLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerLayoutManager.swift; sourceTree = "<group>"; };
 		21365E3C2F314D1D0000C369 /* BrowserViewControllerLayoutManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewControllerLayoutManagerTests.swift; sourceTree = "<group>"; };
 		21371FA128A6C4A200BC3F37 /* OnboardingTelemetryUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTelemetryUtilityTests.swift; sourceTree = "<group>"; };
@@ -16817,6 +16819,7 @@
 		E1DE2F812BE394C80054BCDC /* Redux */ = {
 			isa = PBXGroup;
 			children = (
+				2132A47030378FC20040B898 /* NavigationActionsState.swift */,
 				AAD1CD862EAABA7C00BEC90A /* TranslationsConfiguration.swift */,
 				E177989B2BD7D48500F6F0EB /* ToolbarAction.swift */,
 				E177989D2BD7D75A00F6F0EB /* ToolbarMiddleware.swift */,
@@ -19771,6 +19774,7 @@
 				8AAAB0592C1B7240008830B3 /* MockRustFirefoxSuggest.swift in Sources */,
 				0BDDB33F2CA6B1F000D501DF /* EditFolderViewModel.swift in Sources */,
 				8A2F21CB2DEDC2AB00C9F4DE /* StartAtHomeAction.swift in Sources */,
+				2132A47130378FC50040B898 /* NavigationActionsState.swift in Sources */,
 				602B3D6729B0E1DB0066DEF8 /* ConversionValue.swift in Sources */,
 				7AC7E0502C160FF800051D4D /* ReaderPanelEmptyStateView.swift in Sources */,
 				C283EED02E4D4FE7008EB540 /* SummarizerConfigProvider.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -367,8 +367,11 @@ final class AddressToolbarContainer: UIView,
         }
         // in case we are in edit mode but overlay is not active yet we have to activate it
         // so that `inOverlayMode` is set to true so we avoid getting stuck in overlay mode
+        // Redux already has isEditing == true here, so we only sync the local flag/UI to avoid
+        // re-dispatch didStartEditingUrl, which can race with an in-flight cancelEdit.
         if newModel.isEditing, !inOverlayMode {
-            enterOverlayMode(nil, pasted: false, search: true)
+            inOverlayMode = true
+            delegate?.addressToolbarDidEnterOverlayMode(self)
         }
         updateProgressBarPosition(toolbarState.toolbarPosition)
         // When frame is zero it means the toolbar hasn't appeared on screen yet for the first time
@@ -643,6 +646,7 @@ final class AddressToolbarContainer: UIView,
     // MARK: - Overlay Mode
     func enterOverlayMode(_ locationText: String?, pasted: Bool, search: Bool) {
         guard let windowUUID else { return }
+
         inOverlayMode = true
         delegate?.addressToolbarDidEnterOverlayMode(self)
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -209,7 +209,7 @@ final class AddressToolbarContainerModel: Equatable {
         windowUUID: UUID
     ) {
         self.borderPosition = state.addressToolbar.borderPosition
-        self.navigationActions = Self.mapActions(state.addressToolbar.navigationActions,
+        self.navigationActions = Self.mapActions(state.addressToolbar.navigationActionsState.actions,
                                                  isShowingTopTabs: state.isShowingTopTabs,
                                                  windowUUID: windowUUID)
         self.leadingPageActions = Self.mapActions(state.addressToolbar.leadingPageActions,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -11,7 +11,8 @@ import SummarizeKit
 @Copyable
 struct AddressBarState: StateType, Sendable, Equatable {
     var windowUUID: WindowUUID
-    var navigationActions: [ToolbarActionConfiguration]
+    // The address bar's back/forward buttons, shown only when the navigation toolbar is hidden (e.g. compact layout). 
+    var navigationActionsState: NavigationActionsState
     var leadingPageActions: [ToolbarActionConfiguration]
     var trailingPageActions: [ToolbarActionConfiguration]
     var browserActions: [ToolbarActionConfiguration]
@@ -84,7 +85,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
     init(windowUUID: WindowUUID) {
         self.init(
             windowUUID: windowUUID,
-            navigationActions: [],
+            navigationActionsState: NavigationActionsState(windowUUID: windowUUID),
             leadingPageActions: [],
             trailingPageActions: [],
             browserActions: [],
@@ -111,7 +112,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
     }
 
     init(windowUUID: WindowUUID,
-         navigationActions: [ToolbarActionConfiguration],
+         navigationActionsState: NavigationActionsState,
          leadingPageActions: [ToolbarActionConfiguration],
          trailingPageActions: [ToolbarActionConfiguration],
          browserActions: [ToolbarActionConfiguration],
@@ -135,7 +136,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
          alternativeSearchEngine: SearchEngineModel?,
          isNovaDesignEnabled: Bool) {
         self.windowUUID = windowUUID
-        self.navigationActions = navigationActions
+        self.navigationActionsState = navigationActionsState
         self.leadingPageActions = leadingPageActions
         self.trailingPageActions = trailingPageActions
         self.browserActions = browserActions
@@ -276,7 +277,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         }
 
         return state
-            .copy(navigationActions: [])
+            .copy(navigationActionsState: NavigationActionsState(windowUUID: state.windowUUID))
             .copy(leadingPageActions: [])
             .copy(trailingPageActions: [])
             .copy(browserActions: [])
@@ -367,9 +368,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         return state
-            .copy(navigationActions: navigationActions(action: toolbarAction,
-                                                       addressBarState: state,
-                                                       isEditing: state.isEditing))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
                                                          addressBarState: state,
                                                          isEditing: state.isEditing))
@@ -386,9 +385,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let isEmptySearch = toolbarAction.url == nil
 
         return state
-            .copy(navigationActions: navigationActions(action: toolbarAction,
-                                                       addressBarState: state,
-                                                       isEditing: state.isEditing))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
                                                          addressBarState: state,
                                                          isEditing: state.isEditing))
@@ -437,9 +434,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         return state
-            .copy(navigationActions: navigationActions(action: toolbarAction,
-                                                       addressBarState: state,
-                                                       isEditing: state.isEditing))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
                                                          addressBarState: state,
                                                          isEditing: state.isEditing))
@@ -454,9 +449,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         return state
-            .copy(navigationActions: navigationActions(action: toolbarAction,
-                                                       addressBarState: state,
-                                                       isEditing: state.isEditing))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
                                                          addressBarState: state,
                                                          isEditing: state.isEditing))
@@ -473,9 +466,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         return state
-            .copy(navigationActions: navigationActions(action: toolbarAction,
-                                                       addressBarState: state,
-                                                       isEditing: state.isEditing))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
                                                          addressBarState: state,
                                                          isEditing: state.isEditing))
@@ -492,9 +483,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         return state
-            .copy(navigationActions: navigationActions(action: toolbarAction,
-                                                       addressBarState: state,
-                                                       isEditing: state.isEditing))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
                                                          addressBarState: state,
                                                          isEditing: state.isEditing))
@@ -514,7 +503,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
 
         return state
-            .copy(navigationActions: navigationActions(action: toolbarAction, addressBarState: state, isEditing: true))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state, isEditing: true))
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
@@ -538,7 +527,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let isEmptySearch = locationText == nil || locationText?.isEmpty == true
 
         return state
-            .copy(navigationActions: navigationActions(action: toolbarAction, addressBarState: state, isEditing: true))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state, isEditing: true))
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
@@ -575,7 +564,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let isEmptySearch = url == nil
 
         return state
-            .copy(navigationActions: navigationActions(action: toolbarAction, addressBarState: state))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state))
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
@@ -598,7 +587,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
 
         return state
-            .copy(navigationActions: navigationActions(action: toolbarAction, addressBarState: state, isEditing: true))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state, isEditing: true))
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
@@ -699,7 +688,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
     static func defaultState(from state: AddressBarState) -> Self {
         return AddressBarState(
             windowUUID: state.windowUUID,
-            navigationActions: state.navigationActions,
+            navigationActionsState: state.navigationActionsState,
             leadingPageActions: state.leadingPageActions,
             trailingPageActions: state.trailingPageActions,
             browserActions: state.browserActions,
@@ -726,30 +715,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
     }
 
     // MARK: - Address Toolbar Actions
-    @MainActor
-    private static func navigationActions(
-        action: ToolbarAction,
-        addressBarState: AddressBarState,
-        isEditing: Bool = false
-    ) -> [ToolbarActionConfiguration] {
-        var actions = [ToolbarActionConfiguration]()
-
-        guard let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: action.windowUUID)
-        else { return actions }
-
-        let isShowingNavigationToolbar = action.isShowingNavigationToolbar ?? toolbarState.isShowingNavigationToolbar
-
-        if !isShowingNavigationToolbar {
-            // otherwise back/forward and maybe data clearance when navigation toolbar is hidden
-            let canGoBack = action.canGoBack ?? toolbarState.canGoBack
-            let canGoForward = action.canGoForward ?? toolbarState.canGoForward
-            actions.append(backAction(enabled: canGoBack))
-            actions.append(forwardAction(enabled: canGoForward))
-        }
-
-        return actions
-    }
-
     @MainActor
     private static func leadingPageActions(
         action: Action,
@@ -1050,27 +1015,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
             isEnabled: true,
             a11yLabel: .LegacyAppMenu.Toolbar.MenuButtonAccessibilityLabel,
             a11yId: AccessibilityIdentifiers.Toolbar.settingsMenuButton)
-    }
-
-    private static func backAction(enabled: Bool) -> ToolbarActionConfiguration {
-        return ToolbarActionConfiguration(
-            actionType: .back,
-            iconName: StandardImageIdentifiers.Large.chevronLeft,
-            isFlippedForRTL: true,
-            isEnabled: enabled,
-            contextualHintType: ContextualHintType.navigation.rawValue,
-            a11yLabel: .TabToolbarBackAccessibilityLabel,
-            a11yId: AccessibilityIdentifiers.Toolbar.backButton)
-    }
-
-    private static func forwardAction(enabled: Bool) -> ToolbarActionConfiguration {
-        return ToolbarActionConfiguration(
-            actionType: .forward,
-            iconName: StandardImageIdentifiers.Large.chevronRight,
-            isFlippedForRTL: true,
-            isEnabled: enabled,
-            a11yLabel: .TabToolbarForwardAccessibilityLabel,
-            a11yId: AccessibilityIdentifiers.Toolbar.forwardButton)
     }
 
     private static func shareAction(enabled: Bool, hasAlternativeLocationColor: Bool) -> ToolbarActionConfiguration {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -270,6 +270,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         }
     }
 
+    @MainActor
     private static func handleDidLoadToolbarsAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction,
               let borderPosition = toolbarAction.addressBorderPosition else {
@@ -277,7 +278,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         }
 
         return state
-            .copy(navigationActionsState: NavigationActionsState(windowUUID: state.windowUUID))
+            .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: [])
             .copy(trailingPageActions: [])
             .copy(browserActions: [])

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationActionsState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationActionsState.swift
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import ModifiedCopy
+import Redux
+
+@Copyable
+struct NavigationActionsState: StateType, Sendable, Equatable {
+    var windowUUID: WindowUUID
+    var isShowingNavigationToolbar: Bool
+    var canGoBack: Bool
+    var canGoForward: Bool
+
+    var actions: [ToolbarActionConfiguration] {
+        guard !isShowingNavigationToolbar else { return [] }
+        return [
+            Self.backAction(enabled: canGoBack),
+            Self.forwardAction(enabled: canGoForward)
+        ]
+    }
+
+    init(windowUUID: WindowUUID) {
+        self.init(windowUUID: windowUUID,
+                  isShowingNavigationToolbar: true,
+                  canGoBack: false,
+                  canGoForward: false)
+    }
+
+    init(windowUUID: WindowUUID,
+         isShowingNavigationToolbar: Bool,
+         canGoBack: Bool,
+         canGoForward: Bool) {
+        self.windowUUID = windowUUID
+        self.isShowingNavigationToolbar = isShowingNavigationToolbar
+        self.canGoBack = canGoBack
+        self.canGoForward = canGoForward
+    }
+
+    static let reducer: Reducer<Self> = (legacyReducer, modernReducer)
+
+    static let modernReducer: ReducerMethod<Self> = { state, _, _ in
+        // Does not handle any modern actions
+        return defaultState(from: state)
+    }
+
+    static let legacyReducer: LegacyReducerMethod<Self> = { state, action in
+        guard action.windowUUID == .unavailable || action.windowUUID == state.windowUUID
+        else {
+            return defaultState(from: state)
+        }
+
+        switch action.actionType {
+        case ToolbarActionType.didLoadToolbars:
+            return NavigationActionsState(windowUUID: state.windowUUID)
+
+        // None of these set every field below on every dispatch, `handleFieldsChanged` falls back
+        // to the current value for whichever ones a given action doesn't carry.
+        case ToolbarActionType.websiteLoadingStateDidChange, ToolbarActionType.urlDidChange,
+            ToolbarActionType.backForwardButtonStateChanged, ToolbarActionType.traitCollectionDidChange,
+            ToolbarActionType.showMenuWarningBadge, ToolbarActionType.borderPositionChanged,
+            ToolbarActionType.toolbarPositionChanged, ToolbarActionType.didPasteSearchTerm,
+            ToolbarActionType.didStartEditingUrl, ToolbarActionType.cancelEdit,
+            ToolbarActionType.didSetTextInLocationView:
+            return handleFieldsChanged(state: state, action: action)
+
+        default:
+            return defaultState(from: state)
+        }
+    }
+
+    private static func handleFieldsChanged(state: Self, action: Action) -> Self {
+        guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
+
+        return state
+            .copy(isShowingNavigationToolbar: toolbarAction.isShowingNavigationToolbar ?? state.isShowingNavigationToolbar)
+            .copy(canGoBack: toolbarAction.canGoBack ?? state.canGoBack)
+            .copy(canGoForward: toolbarAction.canGoForward ?? state.canGoForward)
+    }
+
+    static func defaultState(from state: NavigationActionsState) -> NavigationActionsState {
+        return NavigationActionsState(
+            windowUUID: state.windowUUID,
+            isShowingNavigationToolbar: state.isShowingNavigationToolbar,
+            canGoBack: state.canGoBack,
+            canGoForward: state.canGoForward
+        )
+    }
+
+    // MARK: - Helper
+    static func backAction(enabled: Bool) -> ToolbarActionConfiguration {
+        return ToolbarActionConfiguration(
+            actionType: .back,
+            iconName: StandardImageIdentifiers.Large.chevronLeft,
+            isFlippedForRTL: true,
+            isEnabled: enabled,
+            contextualHintType: ContextualHintType.navigation.rawValue,
+            a11yLabel: .TabToolbarBackAccessibilityLabel,
+            a11yId: AccessibilityIdentifiers.Toolbar.backButton)
+    }
+
+    static func forwardAction(enabled: Bool) -> ToolbarActionConfiguration {
+        return ToolbarActionConfiguration(
+            actionType: .forward,
+            iconName: StandardImageIdentifiers.Large.chevronRight,
+            isFlippedForRTL: true,
+            isEnabled: enabled,
+            a11yLabel: .TabToolbarForwardAccessibilityLabel,
+            a11yId: AccessibilityIdentifiers.Toolbar.forwardButton)
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/NavigationBarState.swift
@@ -242,8 +242,8 @@ struct NavigationBarState: StateType, Equatable {
         let nextTabScreenshot = isTabScreenshotAction ? action.nextTabScreenshot : toolbarState.nextTabScreenshot
 
         actions = [
-            backAction(enabled: canGoBack),
-            forwardAction(enabled: canGoForward)
+            NavigationActionsState.backAction(enabled: canGoBack),
+            NavigationActionsState.forwardAction(enabled: canGoForward)
         ]
 
         let iconName: String? = switch tabTrayButtonStyle {
@@ -295,27 +295,6 @@ struct NavigationBarState: StateType, Equatable {
     }
 
     // MARK: - Helper
-    private static func backAction(enabled: Bool) -> ToolbarActionConfiguration {
-        return ToolbarActionConfiguration(
-            actionType: .back,
-            iconName: StandardImageIdentifiers.Large.chevronLeft,
-            isFlippedForRTL: true,
-            isEnabled: enabled,
-            contextualHintType: ContextualHintType.navigation.rawValue,
-            a11yLabel: .TabToolbarBackAccessibilityLabel,
-            a11yId: AccessibilityIdentifiers.Toolbar.backButton)
-    }
-
-    private static func forwardAction(enabled: Bool) -> ToolbarActionConfiguration {
-        return ToolbarActionConfiguration(
-            actionType: .forward,
-            iconName: StandardImageIdentifiers.Large.chevronRight,
-            isFlippedForRTL: true,
-            isEnabled: enabled,
-            a11yLabel: .TabToolbarForwardAccessibilityLabel,
-            a11yId: AccessibilityIdentifiers.Toolbar.forwardButton)
-    }
-
     private static func tabsAction(iconName: String?,
                                    numberOfTabs: Int = 1,
                                    isPrivateMode: Bool = false,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -118,6 +118,7 @@ enum ToolbarModernAction: ModernAction {
     /// `accessoryViewVisibilityChanged`.
     case keyboardDidHide
 
+    // When the keyboard hides, or a search engine is selected while isEditing, update shouldShowKeyboard
     case didCancelKeyboardRequest
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -35,7 +35,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         let initialState = createSubject()
 
         XCTAssertEqual(initialState.windowUUID, windowUUID)
-        XCTAssertEqual(initialState.navigationActions, [])
+        XCTAssertEqual(initialState.navigationActionsState, NavigationActionsState(windowUUID: windowUUID))
         XCTAssertEqual(initialState.trailingPageActions, [])
         XCTAssertEqual(initialState.leadingPageActions, [])
         XCTAssertEqual(initialState.browserActions, [])
@@ -69,7 +69,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions, [])
+        XCTAssertEqual(newState.navigationActionsState, NavigationActionsState(windowUUID: windowUUID))
 
         XCTAssertEqual(newState.leadingPageActions.count, 0)
         XCTAssertEqual(newState.trailingPageActions.count, 0)
@@ -371,7 +371,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.windowUUID, windowUUID)
         XCTAssertEqual(newState.trailingPageActions.count, 1)
         XCTAssertEqual(newState.trailingPageActions[0].actionType, .stopLoading)
-        XCTAssertEqual(newState.navigationActions.count, 0)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 0)
         XCTAssertEqual(newState.leadingPageActions.count, 0)
     }
 
@@ -393,7 +393,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.windowUUID, windowUUID)
         XCTAssertEqual(newState.trailingPageActions.count, 1)
         XCTAssertEqual(newState.trailingPageActions[0].actionType, .reload)
-        XCTAssertEqual(newState.navigationActions.count, 0)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 0)
         XCTAssertEqual(newState.leadingPageActions.count, 0)
     }
 
@@ -420,9 +420,9 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.trailingPageActions[0].actionType, .stopLoading)
         XCTAssertEqual(newState.leadingPageActions.count, 0)
 
-        XCTAssertEqual(newState.navigationActions.count, 2)
-        XCTAssertEqual(newState.navigationActions[0].actionType, .back)
-        XCTAssertEqual(newState.navigationActions[1].actionType, .forward)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 2)
+        XCTAssertEqual(newState.navigationActionsState.actions[0].actionType, .back)
+        XCTAssertEqual(newState.navigationActionsState.actions[1].actionType, .forward)
     }
 
     func test_urlDidChangeAction_withNavigationToolbar_returnsExpectedState() {
@@ -477,7 +477,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions.count, 0)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 0)
     }
 
     func test_backForwardButtonStateChangedAction_withoutNavigationToolbar_returnsExpectedState() {
@@ -485,7 +485,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         let initialState = createSubject()
         let reducer = addressBarReducer()
 
-        let urlDidChangeState = loadWebsiteAction(state: initialState, reducer: reducer)
+        let urlDidChangeState = loadWebsiteAction(state: initialState, isShowingNavigationToolbar: false, reducer: reducer)
         let newState = reducer.legacyReducer(
             urlDidChangeState,
             ToolbarAction(
@@ -497,11 +497,11 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions.count, 2)
-        XCTAssertEqual(newState.navigationActions[0].actionType, .back)
-        XCTAssertEqual(newState.navigationActions[0].isEnabled, true)
-        XCTAssertEqual(newState.navigationActions[1].actionType, .forward)
-        XCTAssertEqual(newState.navigationActions[1].isEnabled, false)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 2)
+        XCTAssertEqual(newState.navigationActionsState.actions[0].actionType, .back)
+        XCTAssertEqual(newState.navigationActionsState.actions[0].isEnabled, true)
+        XCTAssertEqual(newState.navigationActionsState.actions[1].actionType, .forward)
+        XCTAssertEqual(newState.navigationActionsState.actions[1].isEnabled, false)
     }
 
     // MARK: - Translation Configuration
@@ -757,9 +757,9 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions.count, 2)
-        XCTAssertEqual(newState.navigationActions[0].actionType, .back)
-        XCTAssertEqual(newState.navigationActions[1].actionType, .forward)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 2)
+        XCTAssertEqual(newState.navigationActionsState.actions[0].actionType, .back)
+        XCTAssertEqual(newState.navigationActionsState.actions[1].actionType, .forward)
 
         XCTAssertEqual(newState.trailingPageActions.count, 0)
         XCTAssertEqual(newState.leadingPageActions.count, 0)
@@ -780,15 +780,16 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
             initialState,
             ToolbarAction(
                 showMenuWarningBadge: true,
+                isShowingNavigationToolbar: false,
                 windowUUID: windowUUID,
                 actionType: ToolbarActionType.showMenuWarningBadge
             )
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions.count, 2)
-        XCTAssertEqual(newState.navigationActions[0].actionType, .back)
-        XCTAssertEqual(newState.navigationActions[1].actionType, .forward)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 2)
+        XCTAssertEqual(newState.navigationActionsState.actions[0].actionType, .back)
+        XCTAssertEqual(newState.navigationActionsState.actions[1].actionType, .forward)
 
         XCTAssertEqual(newState.trailingPageActions.count, 0)
 
@@ -855,7 +856,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions.count, 0)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 0)
 
         XCTAssertEqual(newState.leadingPageActions.count, 0)
         XCTAssertEqual(newState.trailingPageActions.count, 0)
@@ -884,7 +885,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions.count, 0)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 0)
 
         XCTAssertEqual(newState.leadingPageActions.count, 0)
         XCTAssertEqual(newState.trailingPageActions.count, 0)
@@ -915,7 +916,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions.count, 0)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 0)
 
         XCTAssertEqual(newState.leadingPageActions.count, 0)
         XCTAssertEqual(newState.trailingPageActions.count, 0)
@@ -1090,7 +1091,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions.count, 0)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 0)
 
         XCTAssertEqual(newState.trailingPageActions.count, 1)
         XCTAssertEqual(newState.trailingPageActions[0].actionType, .reload)
@@ -1122,7 +1123,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.navigationActions.count, 0)
+        XCTAssertEqual(newState.navigationActionsState.actions.count, 0)
         XCTAssertEqual(newState.leadingPageActions.count, 0)
         XCTAssertEqual(newState.trailingPageActions.count, 0)
         XCTAssertEqual(newState.browserActions.count, 1)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressToolbarContainerModelTests.swift
@@ -303,7 +303,7 @@ final class AddressToolbarContainerModelTests: XCTestCase {
         isGoogleLensEnabled: Bool = false
     ) -> AddressBarState {
         return AddressBarState(windowUUID: windowUUID,
-                               navigationActions: [],
+                               navigationActionsState: NavigationActionsState(windowUUID: windowUUID),
                                leadingPageActions: [],
                                trailingPageActions: [],
                                browserActions: [],

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/NavigationActionsStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/NavigationActionsStateTests.swift
@@ -1,0 +1,176 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Redux
+import XCTest
+import Common
+
+@testable import Client
+
+@MainActor
+final class NavigationActionsStateTests: XCTestCase {
+    let windowUUID: WindowUUID = .XCTestDefaultUUID
+
+    func test_initialState_returnsExpectedState() {
+        let initialState = createSubject()
+
+        XCTAssertEqual(initialState.windowUUID, windowUUID)
+        XCTAssertTrue(initialState.isShowingNavigationToolbar)
+        XCTAssertFalse(initialState.canGoBack)
+        XCTAssertFalse(initialState.canGoForward)
+        XCTAssertEqual(initialState.actions, [])
+    }
+
+    func test_didLoadToolbarsAction_resetsToInitialState() {
+        let initialState = NavigationActionsState(
+            windowUUID: windowUUID,
+            isShowingNavigationToolbar: false,
+            canGoBack: true,
+            canGoForward: true
+        )
+        let reducer = navigationActionsReducer()
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.didLoadToolbars)
+        )
+
+        XCTAssertEqual(newState.windowUUID, windowUUID)
+        XCTAssertTrue(newState.isShowingNavigationToolbar)
+        XCTAssertFalse(newState.canGoBack)
+        XCTAssertFalse(newState.canGoForward)
+        XCTAssertEqual(newState.actions, [])
+    }
+
+    func test_backForwardButtonStateChangedAction_updatesCanGoBackAndCanGoForward() {
+        let initialState = createSubject()
+        let reducer = navigationActionsReducer()
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            ToolbarAction(
+                canGoBack: true,
+                canGoForward: true,
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.backForwardButtonStateChanged
+            )
+        )
+
+        XCTAssertTrue(newState.canGoBack)
+        XCTAssertTrue(newState.canGoForward)
+    }
+
+    func test_backForwardButtonStateChangedAction_withOnlyCanGoBack_preservesCanGoForward() {
+        let initialState = createSubject().copy(canGoForward: true)
+        let reducer = navigationActionsReducer()
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            ToolbarAction(
+                canGoBack: true,
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.backForwardButtonStateChanged
+            )
+        )
+
+        XCTAssertTrue(newState.canGoBack)
+        XCTAssertTrue(newState.canGoForward)
+    }
+
+    func test_traitCollectionDidChangeAction_updatesIsShowingNavigationToolbar() {
+        let initialState = createSubject()
+        let reducer = navigationActionsReducer()
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            ToolbarAction(
+                isShowingNavigationToolbar: false,
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.traitCollectionDidChange
+            )
+        )
+
+        XCTAssertFalse(newState.isShowingNavigationToolbar)
+    }
+
+    func test_urlDidChangeAction_updatesAllThreeFields() {
+        let initialState = createSubject()
+        let reducer = navigationActionsReducer()
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            ToolbarAction(
+                isShowingNavigationToolbar: false,
+                canGoBack: true,
+                canGoForward: true,
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.urlDidChange
+            )
+        )
+
+        XCTAssertFalse(newState.isShowingNavigationToolbar)
+        XCTAssertTrue(newState.canGoBack)
+        XCTAssertTrue(newState.canGoForward)
+    }
+
+    func test_unrelatedAction_returnsUnchangedState() {
+        let initialState = createSubject().copy(canGoBack: true)
+        let reducer = navigationActionsReducer()
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            ToolbarAction(windowUUID: windowUUID, actionType: ToolbarActionType.didSetSearchTerm)
+        )
+
+        XCTAssertEqual(newState, initialState)
+    }
+
+    func test_actions_whenShowingNavigationToolbar_isEmpty() {
+        let initialState = createSubject()
+        let reducer = navigationActionsReducer()
+
+        let state = reducer.legacyReducer(
+            initialState,
+            ToolbarAction(
+                canGoBack: true,
+                canGoForward: true,
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.backForwardButtonStateChanged
+            )
+        )
+
+        XCTAssertEqual(state.actions, [])
+    }
+
+    func test_actions_whenNotShowingNavigationToolbar_returnsBackAndForward() {
+        let initialState = createSubject()
+        let reducer = navigationActionsReducer()
+
+        let state = reducer.legacyReducer(
+            initialState,
+            ToolbarAction(
+                isShowingNavigationToolbar: false,
+                canGoBack: true,
+                canGoForward: false,
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.urlDidChange
+            )
+        )
+
+        XCTAssertEqual(state.actions.count, 2)
+        XCTAssertEqual(state.actions[0].actionType, .back)
+        XCTAssertEqual(state.actions[0].isEnabled, true)
+        XCTAssertEqual(state.actions[1].actionType, .forward)
+        XCTAssertEqual(state.actions[1].isEnabled, false)
+    }
+
+    // MARK: - Helper
+    private func createSubject() -> NavigationActionsState {
+        return NavigationActionsState(windowUUID: windowUUID)
+    }
+
+    private func navigationActionsReducer() -> Reducer<NavigationActionsState> {
+        return NavigationActionsState.reducer
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -1490,7 +1490,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         }
         let addressToolbar = AddressBarState(
             windowUUID: .XCTestDefaultUUID,
-            navigationActions: [],
+            navigationActionsState: NavigationActionsState(windowUUID: .XCTestDefaultUUID),
             leadingPageActions: [],
             trailingPageActions: [],
             browserActions: [],


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16630)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35329)

## :bulb: Description
- Related to ToolbarAction refactor and AddressBarState refactor
- Opening the PR for this first state only to double-check this is the right direction 
- Create `NavigationActionsState` and replace in AddressBarState only since the logic in `NavigationBarState` is more complex so I can create a ticket afterwards to migrate `NavigationBarState` to use `NavigationActionsState`. Also for now we are using legacyReducer once more actions are migrated we will move them to modernReducer

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
No user interface changes

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

