### PR TITLE
Refactor FXIOS-14968 [Homepage] Move section header configuration out of Redux state

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -797,6 +797,7 @@
 		631A369F2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */; };
 		631A36A32CC0B2470044DFEB /* NativeErrorPageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A36A22CC0B2470044DFEB /* NativeErrorPageHelper.swift */; };
 		635183FB2CF5555C00EDFCE2 /* NativeErrorPageStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635183FA2CF5555C00EDFCE2 /* NativeErrorPageStateTests.swift */; };
+		638201093038D86C003C51C5 /* SectionHeaderConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638201083038D85F003C51C5 /* SectionHeaderConfigurationTests.swift */; };
 		63B213282CCA796D00A466DB /* NativeErrorPageAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B213272CCA796D00A466DB /* NativeErrorPageAction.swift */; };
 		63B2132A2CCA797400A466DB /* NativeErrorPageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B213292CCA797400A466DB /* NativeErrorPageState.swift */; };
 		63F7A9AA2C7529ED005846F5 /* NativeErrorPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F7A9A92C7529ED005846F5 /* NativeErrorPageModel.swift */; };
@@ -1034,8 +1035,8 @@
 		8A5189C92C1B614E00CDB668 /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A87AEE02C1B4D17007428B2 /* SearchViewModelTests.swift */; };
 		8A5435562D53CB6800501214 /* JumpBackInAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5435552D53CB6600501214 /* JumpBackInAction.swift */; };
 		8A552AC72CB43AB400564C98 /* HomepageStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */; };
-		8A552AD22CB43AB400564C98 /* HomepageTelemetryStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AD12CB43AB400564C98 /* HomepageTelemetryStateTests.swift */; };
 		8A552AC82CB43AB400564C98 /* HeaderStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */; };
+		8A552AD22CB43AB400564C98 /* HomepageTelemetryStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A552AD12CB43AB400564C98 /* HomepageTelemetryStateTests.swift */; };
 		8A5564022D23317100028CA7 /* ContextMenuAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5564012D23317100028CA7 /* ContextMenuAction.swift */; };
 		8A55E8042BFBA9BE006DBD85 /* MicrosurveyCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E5F3D2BFBA49400DE052B /* MicrosurveyCoordinatorTests.swift */; };
 		8A5604F629DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */; };
@@ -9315,6 +9316,7 @@
 		631A36A42CC0B2480044DFEB /* CertificateHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateHelper.swift; sourceTree = "<group>"; };
 		634148899F41CAA3BCF71E8B /* or */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = or; path = or.lproj/Localizable.strings; sourceTree = "<group>"; };
 		635183FA2CF5555C00EDFCE2 /* NativeErrorPageStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeErrorPageStateTests.swift; sourceTree = "<group>"; };
+		638201083038D85F003C51C5 /* SectionHeaderConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderConfigurationTests.swift; sourceTree = "<group>"; };
 		63B04BE882C41584580E0E59 /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = "fa.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		63B213272CCA796D00A466DB /* NativeErrorPageAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeErrorPageAction.swift; sourceTree = "<group>"; };
 		63B213292CCA797400A466DB /* NativeErrorPageState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeErrorPageState.swift; sourceTree = "<group>"; };
@@ -9795,8 +9797,8 @@
 		8A5143D6BF179870414566ED /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Search.strings; sourceTree = "<group>"; };
 		8A5435552D53CB6600501214 /* JumpBackInAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInAction.swift; sourceTree = "<group>"; };
 		8A552AC52CB43AB300564C98 /* HomepageStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomepageStateTests.swift; sourceTree = "<group>"; };
-		8A552AD12CB43AB400564C98 /* HomepageTelemetryStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomepageTelemetryStateTests.swift; sourceTree = "<group>"; };
 		8A552AC62CB43AB300564C98 /* HeaderStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderStateTests.swift; sourceTree = "<group>"; };
+		8A552AD12CB43AB400564C98 /* HomepageTelemetryStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomepageTelemetryStateTests.swift; sourceTree = "<group>"; };
 		8A5564012D23317100028CA7 /* ContextMenuAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuAction.swift; sourceTree = "<group>"; };
 		8A5604F529DF09FA00035CA3 /* MockLaunchCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		8A5604F729DF0D2600035CA3 /* BrowserCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -14067,6 +14069,7 @@
 		8A00BD852CAB3FC200680AF9 /* Homepage */ = {
 			isa = PBXGroup;
 			children = (
+				638201083038D85F003C51C5 /* SectionHeaderConfigurationTests.swift */,
 				39CC6FD3301A792500164DCA /* TrackerBlockerModuleCellTests.swift */,
 				8A09BCC12D22F1A500CFDF60 /* ContextMenu */,
 				8AA0A6662CAC745300AC7EB3 /* HomepageDiffableDataSourceTests.swift */,
@@ -21165,6 +21168,7 @@
 				217C6F312F3BD5E00085D9B9 /* BrowserViewControllerConstraintTestsBase.swift in Sources */,
 				8A9D31622D13545A00171502 /* EditFolderViewModelTests.swift in Sources */,
 				ED6C23102DFB4F39005EDE1D /* UserTelemetryTests.swift in Sources */,
+				638201093038D86C003C51C5 /* SectionHeaderConfigurationTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,
 				21FB441A2E7B3AE500A8818D /* MockRecordVisitObservationManager.swift in Sources */,
 				617D8ABD2FC8D27300E1C7A5 /* ConversionDataManagerTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Home/Homepage/Bookmark/BookmarksSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Bookmark/BookmarksSectionState.swift
@@ -14,16 +14,6 @@ struct BookmarksSectionState: StateType, Equatable, Hashable {
     var bookmarks: [BookmarkConfiguration]
     let shouldShowSection: Bool
 
-    struct Constants {
-        static let sectionHeaderConfiguration = SectionHeaderConfiguration(
-            title: .BookmarksSectionTitle,
-            a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.bookmarks,
-            isButtonHidden: false,
-            buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.bookmarks,
-            buttonTitle: .BookmarksSavedShowAllText
-        )
-    }
-
     init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {
         // TODO: FXIOS-11412 - Move profile dependency
         let userPreferences: UserFeaturePreferring = AppContainer.shared.resolve()

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -762,7 +762,7 @@ final class HomepageViewController: UIViewController,
             }
 
             if case .pocket = section,
-               MerinoState.Constants.sectionHeaderConfiguration.style == .newsAffordance {
+               SectionHeaderConfiguration.merino.style == .newsAffordance {
                 guard let newsTransitionHeaderCell = collectionView.dequeueSupplementary(
                     of: kind,
                     cellType: NewsTransitionHeaderCell.self,
@@ -798,7 +798,7 @@ final class HomepageViewController: UIViewController,
     ) -> NewsTransitionHeaderCell {
         let transitionEnabled = isNewsTransitionEnabled()
         newsTransitionHeaderCell.configure(
-            sectionHeaderConfiguration: MerinoState.Constants.sectionHeaderConfiguration,
+            sectionHeaderConfiguration: SectionHeaderConfiguration.merino,
             textColor: homepageState.wallpaperState.wallpaperConfiguration.textColor,
             theme: currentTheme,
             transitionEnabled: transitionEnabled,
@@ -822,7 +822,7 @@ final class HomepageViewController: UIViewController,
         switch section {
         case .topSites(let textColor, _, _):
             sectionLabelCell.configure(
-                sectionHeaderConfiguration: TopSitesSectionState.Constants.sectionHeaderConfiguration,
+                sectionHeaderConfiguration: SectionHeaderConfiguration.topSites,
                 moreButtonAction: { [weak self] _ in
                     self?.navigateToShortcutsLibrary()
                 },
@@ -832,7 +832,7 @@ final class HomepageViewController: UIViewController,
             return sectionLabelCell
         case .jumpBackIn(let textColor, _):
             sectionLabelCell.configure(
-                sectionHeaderConfiguration: JumpBackInSectionState.Constants.sectionHeaderConfiguration,
+                sectionHeaderConfiguration: SectionHeaderConfiguration.jumpBackIn,
                 moreButtonAction: { [weak self] _ in
                     self?.navigateToTabTray(with: .tabs)
                 },
@@ -843,7 +843,7 @@ final class HomepageViewController: UIViewController,
             return sectionLabelCell
         case .bookmarks(let textColor):
             sectionLabelCell.configure(
-                sectionHeaderConfiguration: BookmarksSectionState.Constants.sectionHeaderConfiguration,
+                sectionHeaderConfiguration: SectionHeaderConfiguration.bookmarks,
                 moreButtonAction: { [weak self] _ in
                     self?.navigateToBookmarksPanel()
                 },
@@ -853,7 +853,7 @@ final class HomepageViewController: UIViewController,
             return sectionLabelCell
         case .pocket(let textColor):
             sectionLabelCell.configure(
-                sectionHeaderConfiguration: MerinoState.Constants.sectionHeaderConfiguration,
+                sectionHeaderConfiguration: SectionHeaderConfiguration.merino,
                 textColor: textColor,
                 theme: currentTheme
             )
@@ -878,7 +878,7 @@ final class HomepageViewController: UIViewController,
     /// Returns whether there is enough room at the bottom of the unscrolled homepage for the header to transition.
     /// This is determined by the existence of the spacer with a meaningful height
     private func isNewsTransitionEnabled() -> Bool {
-        guard MerinoState.Constants.sectionHeaderConfiguration.style == .newsAffordance,
+        guard SectionHeaderConfiguration.merino.style == .newsAffordance,
               let collectionView,
               let spacerSectionIndex = dataSource?.snapshot().sectionIdentifiers.firstIndex(where: {
                   if case .spacer = $0 {

--- a/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/JumpBackInSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/JumpBackIn/JumpBackInSectionState.swift
@@ -16,16 +16,6 @@ struct JumpBackInSectionState: StateType, Equatable, Hashable {
     let mostRecentSyncedTab: JumpBackInSyncedTabConfiguration?
     let shouldShowSection: Bool
 
-    struct Constants {
-        static let sectionHeaderConfiguration = SectionHeaderConfiguration(
-            title: .FirefoxHomeJumpBackInSectionTitle,
-            a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.jumpBackIn,
-            isButtonHidden: false,
-            buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn,
-            buttonTitle: .BookmarksSavedShowAllText
-        )
-    }
-
     init(
         profile: Profile = AppContainer.shared.resolve(),
         userPreferences: UserFeaturePreferring = AppContainer.shared.resolve(),

--- a/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Layout/HomepageSectionLayoutProvider.swift
@@ -228,7 +228,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
     ) -> NSCollectionLayoutSection {
         let itemSize: NSCollectionLayoutSize
         let traitCollection = environment.traitCollection
-        let sectionHeaderConfiguration = MerinoState.Constants.sectionHeaderConfiguration
+        let sectionHeaderConfiguration = SectionHeaderConfiguration.merino
 
         let containerWidth = environment.container.effectiveContentSize.width
         let horizontalInset = UX.leadingInset(traitCollection: traitCollection)
@@ -517,7 +517,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
     private func createSpacerSectionLayout(for environment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
         let rawSpacerHeight = getRawSpacerHeight(environment: environment)
 
-        let merinoHeaderConfiguration = MerinoState.Constants.sectionHeaderConfiguration
+        let merinoHeaderConfiguration = SectionHeaderConfiguration.merino
         let headerHeight = getStoriesHeaderHeight(sectionHeaderConfiguration: merinoHeaderConfiguration,
                                                   environment: environment)
 
@@ -608,7 +608,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             topSites: topSitesState.topSitesData,
             numberOfRows: topSitesState.numberOfRows,
             numberOfTilesPerRow: topSitesState.numberOfTilesPerRow,
-            headerState: TopSitesSectionState.Constants.sectionHeaderConfiguration,
+            headerState: SectionHeaderConfiguration.topSites,
             containerWidth: containerWidth,
             isLandscape: UIDevice.current.orientation.isLandscape,
             shouldShowSection: topSitesState.shouldShowSection,
@@ -643,7 +643,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         // Add header height
         if topSitesState.shouldShowSectionHeader {
             totalHeight += getHeaderHeight(
-                sectionHeaderConfiguration: TopSitesSectionState.Constants.sectionHeaderConfiguration,
+                sectionHeaderConfiguration: SectionHeaderConfiguration.topSites,
                 environment: environment
             )
         }
@@ -708,7 +708,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
             syncedTabConfig: jumpBackInState.mostRecentSyncedTab,
             maxNumberOfLocalTabs: jumpBackInConfig.getMaxNumberOfLocalTabsLayout,
             numberOfLocalTabsToShow: numberOfLocalTabsToShow,
-            headerState: JumpBackInSectionState.Constants.sectionHeaderConfiguration,
+            headerState: SectionHeaderConfiguration.jumpBackIn,
             containerWidth: containerWidth,
             shouldShowSection: jumpBackInState.shouldShowSection,
             contentSizeCategory: environment.traitCollection.preferredContentSizeCategory
@@ -753,7 +753,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         // Add header height
         totalHeight += getHeaderHeight(
-            sectionHeaderConfiguration: JumpBackInSectionState.Constants.sectionHeaderConfiguration,
+            sectionHeaderConfiguration: SectionHeaderConfiguration.jumpBackIn,
             environment: environment
         )
 
@@ -903,7 +903,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
         let containerWidth = normalizedDimension(environment.container.contentSize.width)
         let key = HomepageLayoutMeasurementCache.BookmarksMeasurement.Key(
             bookmarks: bookmarkState.bookmarks,
-            headerState: BookmarksSectionState.Constants.sectionHeaderConfiguration,
+            headerState: SectionHeaderConfiguration.bookmarks,
             containerWidth: containerWidth,
             shouldShowSection: bookmarkState.shouldShowSection,
             contentSizeCategory: environment.traitCollection.preferredContentSizeCategory
@@ -940,7 +940,7 @@ final class HomepageSectionLayoutProvider: FeatureFlaggable {
 
         // Get the rest of the section's height and cache and return the results
         let headerHeight = getHeaderHeight(
-            sectionHeaderConfiguration: BookmarksSectionState.Constants.sectionHeaderConfiguration,
+            sectionHeaderConfiguration: SectionHeaderConfiguration.bookmarks,
             environment: environment
         )
         let totalHeight = headerHeight

--- a/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Merino/MerinoState.swift
@@ -17,10 +17,6 @@ struct MerinoState: StateType, Equatable {
     let shouldShowSection: Bool
 
     struct Constants {
-        static var sectionHeaderConfiguration: SectionHeaderConfiguration {
-            // Computed property because feature flag configuration can change after launch
-            MerinoState.initializeSectionHeaderConfiguration()
-        }
         static let footerURL = SupportUtils.URLForPocketLearnMore
     }
 
@@ -121,14 +117,6 @@ struct MerinoState: StateType, Equatable {
             merinoData: state.merinoData,
             hasMerinoResponseContent: state.hasMerinoResponseContent,
             shouldShowSection: state.shouldShowSection
-        )
-    }
-
-    private static func initializeSectionHeaderConfiguration() -> SectionHeaderConfiguration {
-        return SectionHeaderConfiguration(
-            title: .FirefoxHomepage.Pocket.NewsSectionTitle,
-            a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.merino,
-            style: .newsAffordance
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/SectionHeaderConfiguration.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/SectionHeader/SectionHeaderConfiguration.swift
@@ -17,3 +17,37 @@ struct SectionHeaderConfiguration: Equatable, Hashable {
     var buttonTitle: String?
     var style: Style = .sectionTitle
 }
+
+extension SectionHeaderConfiguration {
+    static let bookmarks = SectionHeaderConfiguration(
+        title: .BookmarksSectionTitle,
+        a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.bookmarks,
+        isButtonHidden: false,
+        buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.bookmarks,
+        buttonTitle: .BookmarksSavedShowAllText
+    )
+
+    static let jumpBackIn = SectionHeaderConfiguration(
+        title: .FirefoxHomeJumpBackInSectionTitle,
+        a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.jumpBackIn,
+        isButtonHidden: false,
+        buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.jumpBackIn,
+        buttonTitle: .BookmarksSavedShowAllText
+    )
+
+    static let topSites = SectionHeaderConfiguration(
+        title: .FirefoxHomepage.Shortcuts.SectionTitle,
+        a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.topSites,
+        isButtonHidden: false,
+        buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.shortcuts,
+        buttonTitle: .BookmarksSavedShowAllText
+    )
+
+    static var merino: SectionHeaderConfiguration {
+        SectionHeaderConfiguration(
+            title: .FirefoxHomepage.Pocket.NewsSectionTitle,
+            a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.merino,
+            style: .newsAffordance
+        )
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesSectionState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesSectionState.swift
@@ -21,16 +21,6 @@ struct TopSitesSectionState: StateType, Equatable {
     let shouldShowSectionHeader: Bool
     let shouldShowAddShortcutTile: Bool
 
-    struct Constants {
-        static let sectionHeaderConfiguration = SectionHeaderConfiguration(
-            title: .FirefoxHomepage.Shortcuts.SectionTitle,
-            a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.SectionTitles.topSites,
-            isButtonHidden: false,
-            buttonA11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.MoreButtons.shortcuts,
-            buttonTitle: .BookmarksSavedShowAllText
-        )
-    }
-
     init(profile: Profile = AppContainer.shared.resolve(), windowUUID: WindowUUID) {
         let preferredNumberOfRows = profile.prefs.intForKey(PrefsKeys.NumberOfTopSiteRows)
         let defaultNumberOfRows = TopSitesRowCountSettingsController.defaultNumberOfRows

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
@@ -24,7 +24,7 @@ final class MerinoStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
         XCTAssertEqual(initialState.merinoData.stories, nil)
-        XCTAssertEqual(MerinoState.Constants.sectionHeaderConfiguration.isButtonHidden, true)
+        XCTAssertEqual(SectionHeaderConfiguration.merino.isButtonHidden, true)
     }
 
     @MainActor
@@ -273,8 +273,8 @@ final class MerinoStateTests: XCTestCase {
     }
 
     func test_initialState_returnsExpectedSectionHeaderConfiguration() {
-        XCTAssertEqual(MerinoState.Constants.sectionHeaderConfiguration.style, .newsAffordance)
-        XCTAssertEqual(MerinoState.Constants.sectionHeaderConfiguration.isButtonHidden, true)
+        XCTAssertEqual(SectionHeaderConfiguration.merino.style, .newsAffordance)
+        XCTAssertEqual(SectionHeaderConfiguration.merino.isButtonHidden, true)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/MerinoStateTests.swift
@@ -24,7 +24,6 @@ final class MerinoStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
         XCTAssertEqual(initialState.merinoData.stories, nil)
-        XCTAssertEqual(SectionHeaderConfiguration.merino.isButtonHidden, true)
     }
 
     @MainActor
@@ -270,11 +269,6 @@ final class MerinoStateTests: XCTestCase {
 
         XCTAssertFalse(state.hasMerinoResponseContent)
         XCTAssertFalse(state.shouldShowSection)
-    }
-
-    func test_initialState_returnsExpectedSectionHeaderConfiguration() {
-        XCTAssertEqual(SectionHeaderConfiguration.merino.style, .newsAffordance)
-        XCTAssertEqual(SectionHeaderConfiguration.merino.isButtonHidden, true)
     }
 
     // MARK: - Private

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesSectionStateTests.swift
@@ -24,7 +24,6 @@ final class TopsSitesSectionStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
         XCTAssertEqual(initialState.topSitesData, [])
-        XCTAssertEqual(SectionHeaderConfiguration.topSites.isButtonHidden, false)
         XCTAssertFalse(initialState.shouldShowSectionHeader)
         XCTAssertFalse(initialState.shouldShowAddShortcutTile)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesSectionStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/TopSitesSectionStateTests.swift
@@ -24,7 +24,7 @@ final class TopsSitesSectionStateTests: XCTestCase {
 
         XCTAssertEqual(initialState.windowUUID, .XCTestDefaultUUID)
         XCTAssertEqual(initialState.topSitesData, [])
-        XCTAssertEqual(TopSitesSectionState.Constants.sectionHeaderConfiguration.isButtonHidden, false)
+        XCTAssertEqual(SectionHeaderConfiguration.topSites.isButtonHidden, false)
         XCTAssertFalse(initialState.shouldShowSectionHeader)
         XCTAssertFalse(initialState.shouldShowAddShortcutTile)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/SectionHeaderConfigurationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/SectionHeaderConfigurationTests.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+final class SectionHeaderConfigurationTests: XCTestCase {
+    func test_bookmarks_hasExpectedConfiguration() {
+        XCTAssertFalse(SectionHeaderConfiguration.bookmarks.isButtonHidden)
+        XCTAssertEqual(SectionHeaderConfiguration.bookmarks.style, .sectionTitle)
+    }
+
+    func test_jumpBackIn_hasExpectedConfiguration() {
+        XCTAssertFalse(SectionHeaderConfiguration.jumpBackIn.isButtonHidden)
+        XCTAssertEqual(SectionHeaderConfiguration.jumpBackIn.style, .sectionTitle)
+    }
+
+    func test_topSites_hasExpectedConfiguration() {
+        XCTAssertFalse(SectionHeaderConfiguration.topSites.isButtonHidden)
+        XCTAssertEqual(SectionHeaderConfiguration.topSites.style, .sectionTitle)
+    }
+
+    func test_merino_hasExpectedConfiguration() {
+        XCTAssertTrue(SectionHeaderConfiguration.merino.isButtonHidden)
+        XCTAssertEqual(SectionHeaderConfiguration.merino.style, .newsAffordance)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14968)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32245)

## :bulb: Description
This PR moves the static `SectionHeaderConfiguration` values for `BookmarksSectionState`, `JumpBackInSectionState`, `MerinoState`, and `TopSitesSectionState` out of each state's nested Constants struct and into extensions on `SectionHeaderConfiguration` itself (e.g. `SectionHeaderConfiguration.bookmarks`). 

All call sites in `HomepageViewController` and `HomepageSectionLayoutProvider` were updated to reference the new `SectionHeaderConfiguration` extension properties instead of `State.Constants.sectionHeaderConfiguration.` No reducer logic changed. 

Validated my work by running the `BookmarksSectionState`, `JumpBackInSectionState`, `MerinoState`, and `TopSitesSectionState` unit tests, all passing.


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

