### PR TITLE
Tech-debt FXIOS-11799 [Search] Decouple ASSearchEngineProvider from Profile

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Redux/SearchEngineSelectionMiddleware.swift
@@ -7,14 +7,11 @@ import Redux
 
 @MainActor
 final class SearchEngineSelectionMiddleware {
-    private let profile: Profile
     private let logger: Logger
     private let searchEnginesManager: SearchEnginesManagerProvider
 
-    init(profile: Profile = AppContainer.shared.resolve(),
-         searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(SearchEnginesManager.self),
+    init(searchEnginesManager: SearchEnginesManagerProvider = AppContainer.shared.resolve(SearchEnginesManager.self),
          logger: Logger = DefaultLogger.shared) {
-        self.profile = profile
         self.logger = logger
         self.searchEnginesManager = searchEnginesManager
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/SearchEngines/SearchEngineSelectionMiddlewareTests.swift
@@ -9,7 +9,6 @@ import XCTest
 
 final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
     var mockStore: MockStoreForMiddleware<AppState>!
-    var mockProfile: MockProfile!
     var mockSearchEnginesManager: SearchEnginesManagerProvider!
     let mockSearchEngines: [OpenSearchEngine] = [
         OpenSearchEngineTests.generateOpenSearchEngine(type: .wikipedia, withImage: UIImage()),
@@ -23,7 +22,6 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
         try await super.setUp()
 
         DependencyHelperMock().bootstrapDependencies()
-        mockProfile = MockProfile()
         mockSearchEnginesManager = MockSearchEnginesManager(searchEngines: mockSearchEngines)
 
         // We must reset the global mock store prior to each test
@@ -66,7 +64,7 @@ final class SearchEngineSelectionMiddlewareTests: XCTestCase, StoreTestUtility {
     // MARK: - Helpers
 
     private func createSubject(mockSearchEnginesManager: SearchEnginesManagerProvider) -> SearchEngineSelectionMiddleware {
-        return SearchEngineSelectionMiddleware(profile: mockProfile, searchEnginesManager: mockSearchEnginesManager)
+        return SearchEngineSelectionMiddleware(searchEnginesManager: mockSearchEnginesManager)
     }
 
     private func getAction(for actionType: SearchEngineSelectionActionType) -> SearchEngineSelectionAction {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11799)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/25731)

## :bulb: Description
Follow-up to #26203, which decoupled `SearchEnginesManager` from `Profile`. Two places nearby were still reaching into `Profile` just to grab `remoteSettingsService`:

- `ASSearchEngineProvider.init` resolved `Profile` from `AppContainer` and drilled into `.remoteSettingsService`.
- `ASSearchEngineIconDataFetcher.init` did the same thing independently.

Both now take an injected `RemoteSettingsService` directly (defaulting to `AppContainer.shared.resolve()`), so neither type needs to know `Profile` exists. `RemoteSettingsService` is registered as its own service in `DependencyHelper`/`DependencyHelperMock`, same pattern as `SearchEnginesManager`'s own registration.

Also removed `SearchEngineSelectionMiddleware`'s `profile` property, which was stored but never read.

Added `ASSearchEngineProviderTests` to cover the new injectable init.

## :movie_camera: Demos
Not applicable — non-UI tech-debt change.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code