### PR TITLE
BugFix FXIOS-14918 Fix "Open in Private Tab" missing from context menu

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -230,17 +230,39 @@ extension BrowserViewController: WKUIDelegate {
         for url: URL,
         from contextHelper: ContextMenuHelper?
     ) -> ContextMenuHelper.Elements {
-        if let elements = contextHelper?.elements, elements.link == url {
-            return elements
-        }
-        return ContextMenuHelper.Elements(link: url, image: nil, title: url.normalizedHostWithLRI, alt: nil)
+        matchingContextHelperElements(contextHelper, url)
+            ?? ContextMenuHelper.Elements(link: url, image: nil, title: url.normalizedHostWithLRI, alt: nil)
     }
 
     /// Whether `contextHelper.elements` still belongs to the long press that's being dismissed. WebKit's
     /// dismiss callback for an earlier long press can fire after a later long press has already reported
     /// its own elements over the JS bridge; resetting unconditionally would discard that newer data. See FXIOS-14918.
     static func shouldResetContextMenuElements(afterDismissing url: URL, contextHelper: ContextMenuHelper?) -> Bool {
-        contextHelper?.elements?.link == url
+        matchingContextHelperElements(contextHelper, url) != nil
+    }
+
+    /// The JS bridge builds its link by percent-encoding the raw string it reads from the page, while WebKit
+    /// builds `elementInfo.linkURL` natively; for an internationalized domain the two land on different but
+    /// equivalent encodings (Unicode vs. Punycode host), so a raw `URL` equality check treats them as a mismatch.
+    /// Round-tripping the host through `URLComponents` normalizes both to the same Punycode form before comparing.
+    private static func matchingContextHelperElements(
+        _ contextHelper: ContextMenuHelper?,
+        _ url: URL
+    ) -> ContextMenuHelper.Elements? {
+        guard let elements = contextHelper?.elements,
+              let jsLink = elements.link,
+              normalizedForHostComparison(jsLink) == normalizedForHostComparison(url)
+        else { return nil }
+        return elements
+    }
+
+    private static func normalizedForHostComparison(_ url: URL) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        guard let host = components.host else { return components.url }
+        var hostOnly = URLComponents()
+        hostOnly.host = host
+        components.host = hostOnly.url?.host ?? host
+        return components.url
     }
 
     func webView(

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -211,14 +211,13 @@ extension BrowserViewController: WKUIDelegate {
     }
 
     func webView(_ webView: WKWebView, contextMenuDidEndForElement elementInfo: WKContextMenuElementInfo) {
-        guard let currentTab = tabManager.selectedTab,
-              let contextHelper = currentTab.getContentScript(
-                name: ContextMenuHelper.name()
-              ) as? ContextMenuHelper
-        else { return }
-        let elements = contextHelper.elements
-        ContextMenuTelemetry().dismissed(origin: elements?.image != nil ? .imageLink : .webLink)
-        contextHelper.reset()
+        guard let url = elementInfo.linkURL, let currentTab = tabManager.selectedTab else { return }
+        let contextHelper = currentTab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper
+        let elements = Self.resolveContextMenuElements(for: url, from: contextHelper)
+        ContextMenuTelemetry().dismissed(origin: elements.image != nil ? .imageLink : .webLink)
+        if Self.shouldResetContextMenuElements(afterDismissing: url, contextHelper: contextHelper) {
+            contextHelper?.reset()
+        }
     }
 
     /// WebKit's native long-press gesture that triggers this delegate isn't synchronized with the page's
@@ -234,7 +233,14 @@ extension BrowserViewController: WKUIDelegate {
         if let elements = contextHelper?.elements, elements.link == url {
             return elements
         }
-        return ContextMenuHelper.Elements(link: url, image: nil, title: nil, alt: nil)
+        return ContextMenuHelper.Elements(link: url, image: nil, title: url.normalizedHostWithLRI, alt: nil)
+    }
+
+    /// Whether `contextHelper.elements` still belongs to the long press that's being dismissed. WebKit's
+    /// dismiss callback for an earlier long press can fire after a later long press has already reported
+    /// its own elements over the JS bridge; resetting unconditionally would discard that newer data. See FXIOS-14918.
+    static func shouldResetContextMenuElements(afterDismissing url: URL, contextHelper: ContextMenuHelper?) -> Bool {
+        contextHelper?.elements?.link == url
     }
 
     func webView(
@@ -1262,7 +1268,9 @@ extension BrowserViewController: WKNavigationDelegate {
         let previousURL = tab.url
         tab.url = webView.url
         hideStaleContentOnCrossOriginPopupCommit(for: tab, previousURL: previousURL)
-        (tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper)?.reset()
+        if let contextHelper = tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper {
+            contextHelper.reset()
+        }
         if let handler = tab.onNextCommit {
             tab.onNextCommit = nil
             handler()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -199,16 +199,13 @@ extension BrowserViewController: WKUIDelegate {
         contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
         completionHandler: @escaping @MainActor (UIContextMenuConfiguration?) -> Void
     ) {
-        guard let url = elementInfo.linkURL,
-              let currentTab = tabManager.selectedTab,
-              let contextHelper = currentTab.getContentScript(
-                name: ContextMenuHelper.name()
-              ) as? ContextMenuHelper,
-              let elements = contextHelper.elements
-        else {
+        guard let url = elementInfo.linkURL, let currentTab = tabManager.selectedTab else {
             completionHandler(nil)
             return
         }
+        let contextHelper = currentTab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper
+        let elements = Self.resolveContextMenuElements(for: url, from: contextHelper)
+
         completionHandler(contextMenuConfiguration(for: url, webView: webView, elements: elements))
         ContextMenuTelemetry().shown(origin: elements.image != nil ? .imageLink : .webLink)
     }
@@ -217,10 +214,27 @@ extension BrowserViewController: WKUIDelegate {
         guard let currentTab = tabManager.selectedTab,
               let contextHelper = currentTab.getContentScript(
                 name: ContextMenuHelper.name()
-              ) as? ContextMenuHelper,
-              let elements = contextHelper.elements
+              ) as? ContextMenuHelper
         else { return }
-        ContextMenuTelemetry().dismissed(origin: elements.image != nil ? .imageLink : .webLink)
+        let elements = contextHelper.elements
+        ContextMenuTelemetry().dismissed(origin: elements?.image != nil ? .imageLink : .webLink)
+        contextHelper.reset()
+    }
+
+    /// WebKit's native long-press gesture that triggers this delegate isn't synchronized with the page's
+    /// `touchstart`/`mousedown` listener that reports link/image details across the JS bridge, so that data
+    /// can still be missing, or belong to a previous long press, once WebKit asks for a menu. `elementInfo.linkURL`
+    /// comes straight from WebKit and is always current, so it's used as-is; the JS-sourced data is only trusted
+    /// when its link matches, and otherwise a native-only fallback keeps the custom menu (and its actions like
+    /// "Open in Private Tab") from being replaced with WebKit's default one. See FXIOS-14918.
+    static func resolveContextMenuElements(
+        for url: URL,
+        from contextHelper: ContextMenuHelper?
+    ) -> ContextMenuHelper.Elements {
+        if let elements = contextHelper?.elements, elements.link == url {
+            return elements
+        }
+        return ContextMenuHelper.Elements(link: url, image: nil, title: nil, alt: nil)
     }
 
     func webView(
@@ -1248,6 +1262,7 @@ extension BrowserViewController: WKNavigationDelegate {
         let previousURL = tab.url
         tab.url = webView.url
         hideStaleContentOnCrossOriginPopupCommit(for: tab, previousURL: previousURL)
+        (tab.getContentScript(name: ContextMenuHelper.name()) as? ContextMenuHelper)?.reset()
         if let handler = tab.onNextCommit {
             tab.onNextCommit = nil
             handler()

--- a/firefox-ios/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/ContextMenuHelper.swift
@@ -16,11 +16,17 @@ class ContextMenuHelper: NSObject {
 
     private weak var tab: Tab?
 
-    private(set) var elements: Elements?
+    var elements: Elements?
 
     required init(tab: Tab) {
         super.init()
         self.tab = tab
+    }
+
+    /// Discards any element data collected from the page. Called once a context menu gesture has been
+    /// handled so a stale touch's data can't be attributed to a later, unrelated long press.
+    func reset() {
+        elements = nil
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -630,6 +630,21 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
     }
 
     @MainActor
+    func testResolveContextMenuElements_jsElementsMatchViaDifferentHostEncoding_usesReportedElements() {
+        // WebKit's native `linkURL` for an internationalized domain is Punycode-encoded, while the JS bridge
+        // percent-encodes the raw Unicode string it reads from the page — the two must still be recognized
+        // as the same link.
+        let nativeURL = URL(string: "https://xn--mnchen-3ya.de/stra%C3%9Fe")!
+        let jsReportedURL = URL(string: "https://m%C3%BCnchen.de/stra%C3%9Fe")!
+        let contextHelper = ContextMenuHelper(tab: createTab())
+        contextHelper.elements = ContextMenuHelper.Elements(link: jsReportedURL, image: nil, title: "München", alt: nil)
+
+        let elements = BrowserViewController.resolveContextMenuElements(for: nativeURL, from: contextHelper)
+
+        XCTAssertEqual(elements.title, "München")
+    }
+
+    @MainActor
     func testResolveContextMenuElements_jsElementsAreStale_fallsBackToLinkOnly() {
         let url = URL(string: "https://example.com")!
         let staleURL = URL(string: "https://previous-long-press.example.com")!

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -603,7 +603,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
 
         XCTAssertEqual(elements.link, url)
         XCTAssertNil(elements.image)
-        XCTAssertNil(elements.title)
+        XCTAssertEqual(elements.title, url.normalizedHostWithLRI, "Must not fall back to the raw URL as a title")
         XCTAssertNil(elements.alt)
     }
 
@@ -615,7 +615,7 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         let elements = BrowserViewController.resolveContextMenuElements(for: url, from: contextHelper)
 
         XCTAssertEqual(elements.link, url)
-        XCTAssertNil(elements.title)
+        XCTAssertEqual(elements.title, url.normalizedHostWithLRI, "Must not fall back to the raw URL as a title")
     }
 
     @MainActor
@@ -639,7 +639,11 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         let elements = BrowserViewController.resolveContextMenuElements(for: url, from: contextHelper)
 
         XCTAssertEqual(elements.link, url)
-        XCTAssertNil(elements.title, "Stale JS-reported data for a different link must not be used")
+        XCTAssertEqual(
+            elements.title,
+            url.normalizedHostWithLRI,
+            "Stale JS-reported data for a different link must not be used, and must not fall back to the raw URL"
+        )
     }
 
     @MainActor
@@ -655,5 +659,64 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
         contextHelper.reset()
 
         XCTAssertNil(contextHelper.elements)
+    }
+
+    // MARK: - Context menu dismiss reset guard
+    // See FXIOS-14918 review feedback: a stale dismiss callback for an earlier long press can fire after
+    // a later long press has already reported its own elements over the JS bridge. Resetting unconditionally
+    // in that case would discard the newer data.
+
+    @MainActor
+    func testShouldResetContextMenuElements_matchingLink_returnsTrue() {
+        let url = URL(string: "https://example.com")!
+        let contextHelper = ContextMenuHelper(tab: createTab())
+        contextHelper.elements = ContextMenuHelper.Elements(link: url, image: nil, title: "Example", alt: nil)
+
+        let shouldReset = BrowserViewController.shouldResetContextMenuElements(
+            afterDismissing: url,
+            contextHelper: contextHelper
+        )
+
+        XCTAssertTrue(shouldReset)
+    }
+
+    @MainActor
+    func testShouldResetContextMenuElements_newerLongPressAlreadyOverwroteElements_returnsFalse() {
+        let dismissedURL = URL(string: "https://example.com")!
+        let newerURL = URL(string: "https://newer-long-press.example.com")!
+        let contextHelper = ContextMenuHelper(tab: createTab())
+        contextHelper.elements = ContextMenuHelper.Elements(link: newerURL, image: nil, title: "Newer", alt: nil)
+
+        let shouldReset = BrowserViewController.shouldResetContextMenuElements(
+            afterDismissing: dismissedURL,
+            contextHelper: contextHelper
+        )
+
+        XCTAssertFalse(shouldReset, "Must not discard a newer long press's already-reported elements")
+    }
+
+    @MainActor
+    func testShouldResetContextMenuElements_noElements_returnsFalse() {
+        let url = URL(string: "https://example.com")!
+        let contextHelper = ContextMenuHelper(tab: createTab())
+
+        let shouldReset = BrowserViewController.shouldResetContextMenuElements(
+            afterDismissing: url,
+            contextHelper: contextHelper
+        )
+
+        XCTAssertFalse(shouldReset)
+    }
+
+    @MainActor
+    func testShouldResetContextMenuElements_noContextHelper_returnsFalse() {
+        let url = URL(string: "https://example.com")!
+
+        let shouldReset = BrowserViewController.shouldResetContextMenuElements(
+            afterDismissing: url,
+            contextHelper: nil
+        )
+
+        XCTAssertFalse(shouldReset)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/BrowserViewControllerWebViewDelegateTests.swift
@@ -588,4 +588,72 @@ class BrowserViewControllerWebViewDelegateTests: XCTestCase {
 
         XCTAssertTrue(subject.googleLensSearches.isEmpty)
     }
+
+    // MARK: - Context menu element resolution
+    // See FXIOS-14918: WebKit's native long-press gesture isn't synchronized with the page's
+    // touchstart/mousedown listener, so the JS-reported elements can be missing or stale by the time
+    // WebKit asks for a menu. `resolveContextMenuElements` must fall back to native-only data instead
+    // of letting the custom menu (and actions like "Open in Private Tab") be replaced by WebKit's default one.
+
+    @MainActor
+    func testResolveContextMenuElements_noContextHelper_fallsBackToLinkOnly() {
+        let url = URL(string: "https://example.com")!
+
+        let elements = BrowserViewController.resolveContextMenuElements(for: url, from: nil)
+
+        XCTAssertEqual(elements.link, url)
+        XCTAssertNil(elements.image)
+        XCTAssertNil(elements.title)
+        XCTAssertNil(elements.alt)
+    }
+
+    @MainActor
+    func testResolveContextMenuElements_jsElementsNotYetReported_fallsBackToLinkOnly() {
+        let url = URL(string: "https://example.com")!
+        let contextHelper = ContextMenuHelper(tab: createTab())
+
+        let elements = BrowserViewController.resolveContextMenuElements(for: url, from: contextHelper)
+
+        XCTAssertEqual(elements.link, url)
+        XCTAssertNil(elements.title)
+    }
+
+    @MainActor
+    func testResolveContextMenuElements_jsElementsMatchNativeURL_usesReportedElements() {
+        let url = URL(string: "https://example.com")!
+        let contextHelper = ContextMenuHelper(tab: createTab())
+        contextHelper.elements = ContextMenuHelper.Elements(link: url, image: nil, title: "Example", alt: nil)
+
+        let elements = BrowserViewController.resolveContextMenuElements(for: url, from: contextHelper)
+
+        XCTAssertEqual(elements.title, "Example")
+    }
+
+    @MainActor
+    func testResolveContextMenuElements_jsElementsAreStale_fallsBackToLinkOnly() {
+        let url = URL(string: "https://example.com")!
+        let staleURL = URL(string: "https://previous-long-press.example.com")!
+        let contextHelper = ContextMenuHelper(tab: createTab())
+        contextHelper.elements = ContextMenuHelper.Elements(link: staleURL, image: nil, title: "Stale", alt: nil)
+
+        let elements = BrowserViewController.resolveContextMenuElements(for: url, from: contextHelper)
+
+        XCTAssertEqual(elements.link, url)
+        XCTAssertNil(elements.title, "Stale JS-reported data for a different link must not be used")
+    }
+
+    @MainActor
+    func testContextMenuHelperReset_clearsPreviouslyReportedElements() {
+        let contextHelper = ContextMenuHelper(tab: createTab())
+        contextHelper.elements = ContextMenuHelper.Elements(
+            link: URL(string: "https://example.com"),
+            image: nil,
+            title: "Example",
+            alt: nil
+        )
+
+        contextHelper.reset()
+
+        XCTAssertNil(contextHelper.elements)
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14918)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32148)

## :bulb: Description
On a cold tab (fresh install, or a backgrounded tab you just switched back to), the first long-press on a link sometimes shows WebKit's plain default menu instead of ours — no "Open in Private Tab", nothing custom.

Turns out it's a race: WebKit's native long-press asks us for a menu via `elementInfo.linkURL` (always available immediately), but the link/title/image details we normally attach come from a JS `touchstart` listener posting a message back over the bridge — and that message doesn't always arrive in time. When it hasn't, we were bailing out entirely and letting WebKit fall back to its own menu.

Fix: treat `elementInfo.linkURL` as the source of truth and only use the JS-reported extras when they actually match it. If they don't (missing or stale), we still build our own menu — just without the JS-only bits like the bookmark title. As a bonus this also clears out the cached JS data on dismiss/navigation so it can't get reused for a later, unrelated long-press.

## :movie_camera: Demos
N/A — this is a timing fix for an intermittent race, not a UI change. Menu appearance/actions are unchanged.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code