### PR TITLE
Add FXIOS-16188 [WebCompat] VoiceOver fixes for the report sheet

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatSendButtonCell.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/Cells/WebCompatSendButtonCell.swift
@@ -33,12 +33,19 @@ final class WebCompatSendButtonCell: UICollectionViewListCell, ThemeApplicable {
         ])
     }
 
-    func configure(title: String, isEnabled: Bool, a11yIdentifier: String, onTap: @escaping () -> Void) {
+    func configure(
+        title: String,
+        isEnabled: Bool,
+        a11yIdentifier: String,
+        accessibilityHint: String?,
+        onTap: @escaping () -> Void
+    ) {
         tapHandler = onTap
         button.configure(
             viewModel: PrimaryRoundedButtonViewModel(title: title, a11yIdentifier: a11yIdentifier)
         )
         button.isEnabled = isEnabled
+        button.accessibilityHint = accessibilityHint
     }
 
     // MARK: - ThemeApplicable

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -100,6 +100,7 @@ public final class WebCompatReportSheetViewController: UIViewController,
         closeButton.accessibilityLabel = viewModel.closeButtonAccessibilityLabel
         previewButton.title = viewModel.previewButtonTitle
         previewButton.isEnabled = viewModel.isPreviewEnabled
+        previewButton.accessibilityHint = viewModel.previewAccessibilityHint
         navigationItem.rightBarButtonItem = viewModel.previewButtonTitle == nil ? nil : previewButton
         applySnapshot()
     }
@@ -293,7 +294,12 @@ public final class WebCompatReportSheetViewController: UIViewController,
     -> UICollectionView.CellRegistration<WebCompatSendButtonCell, WebCompatReportViewModel.Row> {
         return UICollectionView.CellRegistration { [weak self] cell, _, row in
             guard let self, case let .sendButton(isEnabled) = row.kind else { return }
-            cell.configure(title: row.title, isEnabled: isEnabled, a11yIdentifier: row.a11yIdentifier) { [weak self] in
+            cell.configure(
+                title: row.title,
+                isEnabled: isEnabled,
+                a11yIdentifier: row.a11yIdentifier,
+                accessibilityHint: row.accessibilityHint
+            ) { [weak self] in
                 // Text fields report on end-editing, so commit the active one before submitting.
                 self?.view.endEditing(true)
                 self?.delegate?.webCompatReportSheetDidTapButton(id: row.id)

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportViewModel.swift
@@ -69,31 +69,44 @@ public struct WebCompatReportViewModel: Equatable, Sendable {
         public let title: String
         public let kind: Kind
         public let a11yIdentifier: String
+        public let accessibilityHint: String?
 
-        public init(id: String, title: String, kind: Kind = .plain, a11yIdentifier: String) {
+        public init(
+            id: String,
+            title: String,
+            kind: Kind = .plain,
+            a11yIdentifier: String,
+            accessibilityHint: String? = nil
+        ) {
             self.id = id
             self.title = title
             self.kind = kind
             self.a11yIdentifier = a11yIdentifier
+            self.accessibilityHint = accessibilityHint
         }
     }
 
     public let navigationTitle: String
     public let closeButtonAccessibilityLabel: String
-    /// Nil hides the Preview bar button entirely. Preview is parked for v1 (FXIOS-16450).
+    /// Nil hides the Preview bar button entirely.
     public let previewButtonTitle: String?
     public let isPreviewEnabled: Bool
+    public let previewAccessibilityHint: String?
     public let sections: [Section]
 
-    public init(navigationTitle: String,
-                closeButtonAccessibilityLabel: String,
-                previewButtonTitle: String? = nil,
-                isPreviewEnabled: Bool = false,
-                sections: [Section] = []) {
+    public init(
+        navigationTitle: String,
+        closeButtonAccessibilityLabel: String,
+        previewButtonTitle: String? = nil,
+        isPreviewEnabled: Bool = false,
+        previewAccessibilityHint: String? = nil,
+        sections: [Section] = []
+    ) {
         self.navigationTitle = navigationTitle
         self.closeButtonAccessibilityLabel = closeButtonAccessibilityLabel
         self.previewButtonTitle = previewButtonTitle
         self.isPreviewEnabled = isPreviewEnabled
+        self.previewAccessibilityHint = previewAccessibilityHint
         self.sections = sections
     }
 }

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatTechnicalDataViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatTechnicalDataViewController.swift
@@ -24,7 +24,7 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
     /// `header` omits `rows` deliberately. Carrying them would mark the header changed on any
     /// value edit, when it only renders the title.
     private enum ItemKind: Equatable {
-        case header(title: String, a11yIdentifier: String)
+        case header(title: String, a11yIdentifier: String, sectionID: String)
         case content(WebCompatTechnicalDataViewModel.PreviewSection)
     }
 
@@ -137,7 +137,7 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
         let headerRegistration = UICollectionView.CellRegistration<
             UICollectionViewListCell, ItemKind
         > { [weak self] cell, _, item in
-            guard let self, case let .header(title, a11yIdentifier) = item else { return }
+            guard let self, case let .header(title, a11yIdentifier, _) = item else { return }
             cell.backgroundConfiguration = UIBackgroundConfiguration.clear()
             var content = cell.defaultContentConfiguration()
             content.text = title
@@ -151,7 +151,11 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
             )
             cell.contentConfiguration = content
             cell.accessibilityIdentifier = a11yIdentifier
+            // One element, otherwise the disclosure accessory repeats the title as a second stop.
+            cell.isAccessibilityElement = true
+            cell.accessibilityLabel = title
             cell.accessibilityTraits.insert(.header)
+            cell.accessibilityTraits.insert(.button)
             let options = UICellAccessory.OutlineDisclosureOptions(
                 style: .header,
                 tintColor: self.theme.colors.actionPrimary
@@ -178,11 +182,11 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
                 )
             }
             switch self.itemsByID[itemID] {
-            case let .header(title, a11yIdentifier):
+            case let .header(title, a11yIdentifier, sectionID):
                 return collectionView.dequeueConfiguredReusableCell(
                     using: headerRegistration,
                     for: indexPath,
-                    item: .header(title: title, a11yIdentifier: a11yIdentifier)
+                    item: .header(title: title, a11yIdentifier: a11yIdentifier, sectionID: sectionID)
                 )
             case let .content(section):
                 return collectionView.dequeueConfiguredReusableCell(
@@ -207,7 +211,8 @@ public final class WebCompatTechnicalDataViewController: UIViewController,
         for section in viewModel.sections {
             itemsByID[Self.headerDataSourceItemID(for: section.id)] = .header(
                 title: section.title,
-                a11yIdentifier: section.a11yIdentifier
+                a11yIdentifier: section.a11yIdentifier,
+                sectionID: section.id
             )
             itemsByID[Self.contentDataSourceItemID(for: section.id)] = .content(section)
             orderedSectionIDs.append(section.id)

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportViewController.swift
@@ -127,8 +127,18 @@ final class WebCompatReportViewController: UINavigationController,
             closeButtonAccessibilityLabel: .WebCompatReporter.Sheet.CloseButtonAccessibilityLabel,
             previewButtonTitle: .WebCompatReporter.Sheet.PreviewButton,
             isPreviewEnabled: state.canPreview,
+            previewAccessibilityHint: categorySelectionHint(for: state),
             sections: makeSections(from: state)
         )
+    }
+
+    /// Omits the URL error, which is already announced under the URL field.
+    private static func categorySelectionHint(for state: WebCompatReporterState) -> String? {
+        guard let selectedCategory = state.selectedCategory else {
+            return .WebCompatReporter.Fields.ChooseIssueTypeAccessibilityHint
+        }
+        guard !selectedCategory.subOptions.isEmpty, state.selectedSubOptionID == nil else { return nil }
+        return .WebCompatReporter.Fields.ChooseSubOptionAccessibilityHint
     }
 
     private enum SectionID: String {
@@ -236,7 +246,8 @@ final class WebCompatReportViewController: UINavigationController,
                     id: RowID.send.rawValue,
                     title: .WebCompatReporter.SendButton.Title,
                     kind: .sendButton(isEnabled: state.canSubmit),
-                    a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.sendButton
+                    a11yIdentifier: AccessibilityIdentifiers.WebCompatReporter.sendButton,
+                    accessibilityHint: categorySelectionHint(for: state)
                 )
             ]
         )

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterState.swift
@@ -24,13 +24,13 @@ struct WebCompatReporterState: ScreenState, Equatable {
     var showsAdditionalDetails: Bool { selectedCategory != nil }
     var isURLValid: Bool { WebCompatURLValidator.isReportable(url) }
 
-    var canPreview: Bool { selectedCategory != nil && isURLValid }
-
     var showsURLError: Bool {
         return !url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isURLValid
     }
 
-    /// Send needs a reportable address and a sub-option, except for "Other", which has none.
+    /// Preview and Send both need a reportable address and a sub-option, except for "Other", which has none.
+    var canPreview: Bool { canSubmit }
+
     var canSubmit: Bool {
         guard let selectedCategory, isURLValid else { return false }
         return selectedCategory.subOptions.isEmpty || selectedSubOptionID != nil

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4523,13 +4523,13 @@ extension String {
                 key: "WebCompatReporter.Fields.ChooseIssueTypeAccessibilityHint.v156",
                 tableName: "WebCompatReporter",
                 value: "Choose an issue type first",
-                comment: "Accessibility hint spoken on the Preview and Send Report buttons while they are unavailable because no issue type has been chosen yet, in the Report a Website Issue form."
+                comment: "Accessibility hint spoken on the Preview and Send Report buttons when they are disabled because no issue type has been selected yet, in the Report a Website Issue form."
             )
             public static let ChooseSubOptionAccessibilityHint = MZLocalizedString(
                 key: "WebCompatReporter.Fields.ChooseSubOptionAccessibilityHint.v156",
                 tableName: "WebCompatReporter",
-                value: "Choose what went wrong first",
-                comment: "Accessibility hint spoken on the Send Report button while it is unavailable because the chosen issue type still needs a specific problem selected, in the Report a Website Issue form."
+                value: "Choose a specific problem for your selected issue type",
+                comment: "Accessibility hint spoken on the Preview and Send Report buttons when they are disabled because no specific problem has been selected yet, in the Report a Website Issue form."
             )
         }
         public struct AdditionalInfo {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -4519,6 +4519,18 @@ extension String {
                 value: "Describe the issue in detail (optional)",
                 comment: "Placeholder shown in the optional multiline field where the user can describe the website problem in their own words, in the Report a Website Issue form."
             )
+            public static let ChooseIssueTypeAccessibilityHint = MZLocalizedString(
+                key: "WebCompatReporter.Fields.ChooseIssueTypeAccessibilityHint.v156",
+                tableName: "WebCompatReporter",
+                value: "Choose an issue type first",
+                comment: "Accessibility hint spoken on the Preview and Send Report buttons while they are unavailable because no issue type has been chosen yet, in the Report a Website Issue form."
+            )
+            public static let ChooseSubOptionAccessibilityHint = MZLocalizedString(
+                key: "WebCompatReporter.Fields.ChooseSubOptionAccessibilityHint.v156",
+                tableName: "WebCompatReporter",
+                value: "Choose what went wrong first",
+                comment: "Accessibility hint spoken on the Send Report button while it is unavailable because the chosen issue type still needs a specific problem selected, in the Report a Website Issue form."
+            )
         }
         public struct AdditionalInfo {
             public static let Title = MZLocalizedString(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterStateTests.swift
@@ -24,13 +24,13 @@ final class WebCompatReporterStateTests: XCTestCase {
         XCTAssertTrue(subject.includeBlockedList)
     }
 
-    func test_canPreview_falseUntilCategorySelected() {
+    func test_canPreview_needsASubOptionUnlessTheCategoryHasNone() {
         XCTAssertFalse(createSubject().canPreview)
-
-        let withCategory = WebCompatReporterState(windowUUID: .XCTestDefaultUUID)
-            .copy(url: "https://example.com")
-            .copy(selectedCategory: .siteNotUsable)
-        XCTAssertTrue(withCategory.canPreview)
+        XCTAssertFalse(makeState(category: .siteNotUsable).canPreview)
+        XCTAssertTrue(
+            makeState(category: .siteNotUsable, subOption: .pageNotLoading).canPreview
+        )
+        XCTAssertTrue(makeState(category: .other).canPreview)
     }
 
     func test_canSubmit_needsASubOptionUnlessTheCategoryHasNone() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16188)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34967)

## :bulb: Description
VoiceOver now says why the Preview/Send buttons are disabled instead of just going quiet. Also fixes the Technical Data headers announcing twice and sometimes the wrong expanded/collapsed state, and makes Preview require the same completion as Send instead of enabling a step early.

## :movie_camera: Demos
Not applicable — VoiceOver behavior, not visual.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code