### PR TITLE
[MTE-6060] - Fix Firefox Suggest SearchTests on the release channel

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -14,6 +14,11 @@ private let SuggestedSite4 = "foobar buffer length"
 private let SuggestedSite5 = "foobar burn cd"
 private let SuggestedSite6 = "foobar/ b"
 
+private let IngestSuggestionsCell = "Ingest new suggestions now"
+// Nimbus applies fetched recipes on the launch after the fetch, so two attempts is the floor.
+private let SuggestRolloutLaunchAttempts = 5
+private let SuggestRolloutProbeTimeout: TimeInterval = 5
+
 class SearchTests: FeatureFlaggedTestBase {
     var toolbarScreen: ToolbarScreen!
     var browserScreen: BrowserScreen!
@@ -469,15 +474,7 @@ class SearchTests: FeatureFlaggedTestBase {
     // [Config] orientation:portrait, orientation:landscape
     // Smoketest
     func testFirefoxSuggest() {
-        app.launch()
-
-        // Workaround: "Ingest New Suggestions Now" from the
-        // secret settings may force the suggestions to be
-        // loaded.
-        navigator.goto(SettingsScreen)
-        navigator.performAction(Action.OpenSecretSettings)
-        navigator.performAction(Action.IngestNewSuggestionsNow)
-        navigator.goto(HomePanelsScreen)
+        launchWithFirefoxSuggestRollout()
 
         // Create an open Tab
         navigator.openURL("localhost:\(serverPort)/test-fixture/\(TestPages.mozillaOrg)")
@@ -521,14 +518,7 @@ class SearchTests: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2753093
     // Regression
     func testFirefoxSuggestPartialSponsored() {
-        app.launch()
-        // Workaround: Sponsored suggestions do not show up intermittently.
-        // Ingesting the new suggestions forces the app to have the sponsored
-        // results for Firefox Suggest consistently.
-        navigator.goto(SettingsScreen)
-        navigator.performAction(Action.OpenSecretSettings)
-        navigator.performAction(Action.IngestNewSuggestionsNow)
-        navigator.goto(HomePanelsScreen)
+        launchWithFirefoxSuggestRollout()
         verifySearchSuggestion(searchTerm: "amaz",
                                expectedMatch: "Amazon.com - Official Site",
                                hasFirefoxSuggest: true,
@@ -538,17 +528,7 @@ class SearchTests: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2753076
     // Regresssion
     func testFirefoxSuggestPartialNonSponsored() {
-        app.launch()
-        // Precondition: Enable enhanced cross-platform suggest experiment
-        navigator.goto(SettingsScreen)
-        navigator.performAction(Action.OpenSecretSettings)
-        navigator.goto(ExperimentsScreen)
-        navigator.performAction(Action.ListAllExperiments)
-        navigator.userState.experimentToEnroll = "Enhanced Cross-Platform Suggest [iOS] - Phased Roll out 138+"
-        navigator.performAction(Action.EnrollExperiment)
-        navigator.goto(SettingsScreen)
-        navigator.goto(HomePanelsScreen)
-
+        launchWithFirefoxSuggestRollout()
         verifySearchSuggestion(searchTerm: "fifa",
                                expectedMatch: "Wikipedia - FIFA World Cup",
                                hasFirefoxSuggest: true,
@@ -595,6 +575,39 @@ class SearchTests: FeatureFlaggedTestBase {
         }
     }
 
+    /// On release builds Firefox Suggest is enabled by a Nimbus rollout rather than a channel default, and
+    /// Nimbus only applies fetched recipes on the launch that follows the fetch, hence the relaunches.
+    private func launchWithFirefoxSuggestRollout() {
+        app.launch()
+        waitForTabsButtonHittable()
+
+        for _ in 1...SuggestRolloutLaunchAttempts {
+            relaunchKeepingProfile()
+            navigator.goto(SettingsScreen)
+            navigator.performAction(Action.OpenSecretSettings)
+            navigator.goto(FirefoxSuggestSettings)
+            // The ingest row only exists while the feature is enabled, so it doubles as the enrollment probe.
+            guard mozWaitForElementToExist(app.cells[IngestSuggestionsCell],
+                                           timeout: SuggestRolloutProbeTimeout,
+                                           failOnTimeout: false) else { continue }
+            navigator.performAction(Action.IngestNewSuggestionsNow)
+            navigator.goto(HomePanelsScreen)
+            return
+        }
+
+        XCTFail("Firefox Suggest was not enabled after \(SuggestRolloutLaunchAttempts) launches")
+    }
+
+    /// The Nimbus database lives inside the test profile, so clearing it would discard the fetched rollout.
+    private func relaunchKeepingProfile() {
+        app.terminate()
+        _ = app.wait(for: .notRunning, timeout: TIMEOUT)
+        app.launchArguments = app.launchArguments.filter { $0 != LaunchArguments.ClearProfile }
+        app.launch()
+        waitForTabsButtonHittable()
+        navigator.nowAt(NewTabScreen)
+    }
+
     /// Clears the address bar before typing, so the term can be retyped without appending to itself.
     private func typeSearchTerm(_ searchTerm: String) {
         browserScreen.tapOnAddressBar()
@@ -620,14 +633,7 @@ class SearchTests: FeatureFlaggedTestBase {
     // https://mozilla.testrail.io/index.php?/cases/view/2753092
     // Regression
     func testFirefoxSuggestionsLandscapePrivate() {
-        app.launch()
-
-        // Precondition: "Ingest New Suggestions Now" from the
-        // secret settings
-        navigator.goto(SettingsScreen)
-        navigator.performAction(Action.OpenSecretSettings)
-        navigator.performAction(Action.IngestNewSuggestionsNow)
-        navigator.goto(HomePanelsScreen)
+        launchWithFirefoxSuggestRollout()
 
         // Step 1: Type a keyword that trigers a sponsored result
         browserScreen.tapOnAddressBar()


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-6060

## :bulb: Description
Four `SearchTests` cases have been failing on the full-functional CI job:
`testFirefoxSuggest`, `testFirefoxSuggestPartialSponsored`,
`testFirefoxSuggestPartialNonSponsored` and `testFirefoxSuggestionsLandscapePrivate`.

### Root cause

The job builds the **Firefox** configuration, which `bin/nimbus-fml-configuration.sh`
maps to the `release` channel. On that channel `firefoxSuggestFeature.yaml` defaults to
`status: false` — the only override is `channel: developer` — so
`NimbusFeatureFlagLayer.checkFirefoxSuggestFeature()` returns false. Two consequences match
the failures exactly:

* `FirefoxSuggestSettingsViewController` only adds the "Ingest new suggestions now" row when
  the flag is on, so three of the tests time out waiting for it.
* `SearchViewModel.loadFirefoxSuggestions()` early-returns, so no AMP/Wikipedia rows and no
  "Firefox Suggest" section header — which is the fourth failure.

The important detail is that **this is not how the app ships**. Release users in en/US on
138.2.0+ get Firefox Suggest from a 100% Nimbus rollout
(`enhanced-cross-platform-suggest-ios-phased-roll-out-138`, `status: true`, `amp: false`,
`ampMobile: true`, `wikipedia: true`). CI can never receive it: `Experiments.dbPath` places
`nimbus.db` inside the test profile, `FIREFOX_CLEAR_PROFILE` deletes that directory on every
launch, and Nimbus only applies fetched recipes on the *following* launch. So the job tests a
release build that has never enrolled in any rollout.

### Change

`launchWithFirefoxSuggestRollout()` lets the tests enroll the way a real user does, rather than
injecting fabricated Nimbus config:

1. Launch once **with** `FIREFOX_CLEAR_PROFILE` — clean profile, Nimbus fetches.
2. Relaunch with that argument filtered out of `app.launchArguments`, so `nimbus.db` survives
   into the launch that applies the rollout (same pattern as `CookiePersistenceTests`).
3. Probe for the "Ingest new suggestions now" row. It only renders while the feature is enabled,
   so it doubles as the enrollment check, and the visit performs the ingest the tests already
   wanted. Retry the relaunch if it's absent.

Test isolation is preserved: the profile is still wiped on the first launch, only these four
tests skip the wipe on subsequent ones, and XCTest builds a fresh instance per test method.

`testFirefoxSuggestPartialNonSponsored` also drops its manual `Action.EnrollExperiment`
precondition — it selected the `control` branch and never relaunched, so Nimbus never applied
it. The rollout supplies `wikipedia: true` anyway.

### Verification

| Config | Result |
| - | - |
| Fennec (developer) | 4/4 passed |
| Firefox (release) | 4/4 passed, **5 consecutive runs — 20/20** |

Every test needed exactly 2 enrollment attempts (3 launches) in all 20 runs — never 1, never 3.
That's the structural floor of fetch-then-apply-on-next-launch, not a race, which is why it
doesn't vary. The retry budget is 5, leaving headroom for slower CI networks; unused attempts
cost nothing since the loop returns as soon as the row appears.

### Reviewer notes / trade-offs

* These four tests now depend on a live RemoteSettings fetch and on the runner's locale matching
  the rollout's `language in ['en'] && region in ['US']` targeting. The test plan sets `en-US`/`US`.
* If enrollment never lands, the failure is an explicit
  `XCTFail("Firefox Suggest was not enabled after N launches")` rather than an opaque timeout.
One note: on Fennec re-sign step is not needed
