### PR TITLE
Add FXIOS-16663 [Nova] Update selection background color for Site Menu

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuAccountCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuAccountCell.swift
@@ -34,6 +34,8 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     private var iconImageView: UIImageView = .build()
 
+    private lazy var novaSelectedBackgroundView: UIView = .build()
+
     private var horizontalMargin: CGFloat {
         if #available(iOS 26.0, *) {
             return UX.horizontalMargin
@@ -156,6 +158,12 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
     func applyTheme(theme: Theme) {
         guard let model else { return }
         backgroundColor = theme.colors.layerSurfaceMedium.withAlphaComponent(mainMenuHelper?.backgroundAlpha() ?? 1.0)
+        if theme.isNova {
+            novaSelectedBackgroundView.backgroundColor = theme.colors.layer5Hover
+            selectedBackgroundView = novaSelectedBackgroundView
+        } else {
+            selectedBackgroundView = nil
+        }
         if let needsReAuth = model.needsReAuth, needsReAuth {
             descriptionLabel.textColor = theme.colors.textCritical
         } else if model.iconImage != nil {

--- a/BrowserKit/Sources/MenuKit/MenuCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuCell.swift
@@ -34,6 +34,8 @@ final class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     private var iconImageView: UIImageView = .build()
 
+    private lazy var novaSelectedBackgroundView: UIView = .build()
+
     private var horizontalMargin: CGFloat {
         if #available(iOS 26.0, *) {
             return UX.horizontalMargin
@@ -135,6 +137,12 @@ final class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
     func applyTheme(theme: Theme) {
         guard let model else { return }
         backgroundColor = theme.colors.layerSurfaceMedium.withAlphaComponent(mainMenuHelper?.backgroundAlpha() ?? 1.0)
+        if theme.isNova {
+            novaSelectedBackgroundView.backgroundColor = theme.colors.layer5Hover
+            selectedBackgroundView = novaSelectedBackgroundView
+        } else {
+            selectedBackgroundView = nil
+        }
         if model.isActive {
             titleLabel.textColor = theme.colors.textAccent
             descriptionLabel.textColor = theme.colors.textSecondary

--- a/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
@@ -33,6 +33,8 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
         )
     }
 
+    private lazy var novaSelectedBackgroundView: UIView = .build()
+
     private var horizontalMargin: CGFloat {
         if #available(iOS 26.0, *) {
             return UX.horizontalMargin
@@ -115,6 +117,12 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
     func applyTheme(theme: Theme) {
         guard let model else { return }
         backgroundColor = theme.colors.layerSurfaceMedium.withAlphaComponent(mainMenuHelper?.backgroundAlpha() ?? 1.0)
+        if theme.isNova {
+            novaSelectedBackgroundView.backgroundColor = theme.colors.layer5Hover
+            selectedBackgroundView = novaSelectedBackgroundView
+        } else {
+            selectedBackgroundView = nil
+        }
         if model.isActive {
             titleLabel.textColor = theme.colors.textAccent
             infoLabelView.textColor = theme.isNova ? theme.colors.textInverted : theme.colors.textPrimary


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16663)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR adds selection background color for Site Menu, so Private mode will not use dark mode selection background. It uses the same selection token color as in Settings and Library Panel.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

