### PR TITLE
Bugfix FXIOS-16649 [Nova] SIte Menu background is lighter than in Figma

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -23,6 +23,7 @@ class MainMenuViewController: UIViewController,
         static let hintViewMargin: CGFloat = 20
         static let menuHeightTolerance: CGFloat = 20
         static let topMarginCFR: CGFloat = 100
+        static let novaBackgroundAlpha: CGFloat = 0.85
     }
     typealias SubscriberStateType = MainMenuState
 
@@ -471,7 +472,9 @@ class MainMenuViewController: UIViewController,
     func applyTheme() {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         let menuBackground = theme.isNova ? theme.colors.layer1 : theme.colors.layerSurfaceLow
-        view.backgroundColor = menuBackground.withAlphaComponent(mainMenuHelper.backgroundAlpha())
+        let shouldUseNovaAlpha = theme.isNova && !mainMenuHelper.isReduceTransparencyEnabled
+        let alpha = shouldUseNovaAlpha ? UX.novaBackgroundAlpha : mainMenuHelper.backgroundAlpha()
+        view.backgroundColor = menuBackground.withAlphaComponent(alpha)
         menuContent.applyTheme(theme: theme)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16649)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates site menu background alpha, matching Figma's spec for the menu's material, change available for Nova only.

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

