### PR TITLE
Bugfix FXIOS-16647 [Nova] Background is not correct for off pills in Site Menu

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
@@ -123,6 +123,12 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
         } else {
             selectedBackgroundView = nil
         }
+        let offBackground: UIColor
+        if theme.isNova, #unavailable(iOS 26.0) {
+            offBackground = theme.colors.layerSurfaceLow
+        } else {
+            offBackground = theme.colors.layer3
+        }
         if model.isActive {
             titleLabel.textColor = theme.colors.textAccent
             infoLabelView.textColor = theme.isNova ? theme.colors.textInverted : theme.colors.textPrimary
@@ -130,11 +136,11 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
         } else if !model.isEnabled {
             titleLabel.textColor = theme.colors.textDisabled
             infoLabelView.textColor = theme.colors.textDisabled
-            infoLabelView.backgroundColor = theme.colors.layer3
+            infoLabelView.backgroundColor = offBackground
         } else {
             titleLabel.textColor = theme.colors.textPrimary
             infoLabelView.textColor = theme.colors.textPrimary
-            infoLabelView.backgroundColor = theme.colors.layer3
+            infoLabelView.backgroundColor = offBackground
         }
     }
 }


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16647)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates background for Site menu pills off state, to have different color tokens for iOS<26, as requested in Figma for Nova

<img width="283" height="757" alt="Screenshot 2026-08-24 at 17 31 03" src="https://github.com/user-attachments/assets/ab45708f-469c-4725-8f19-da85edef6a88" />
<img width="283" height="754" alt="Screenshot 2026-08-24 at 17 31 21" src="https://github.com/user-attachments/assets/ff3c1f39-2e92-4b96-afa6-d5fe06f20f7f" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

