### PR TITLE
Add FXIOS-16665 [Summarizer] Missing telemetry for language and toolbar entry points

### DIFF
--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -91,7 +91,8 @@ public struct PrefsKeys {
         public static let summarizeContentFeature = "summarizeContentFeature"
         public static let shakeGestureEnabled = "shakeGestureEnabledKey"
         public static let selectedLanguage = "summarizer.selectedLanguage"
-        /// Legacy pref name used to store the summarizer selected language, it is only used to migrate to the new pref `selectedLanguage`
+        /// Legacy pref name used to store the summarizer selected language.
+        /// It is only used to migrate to the new pref `selectedLanguage`
         public static let legacySelectedLanguage = "selectedLanguage"
     }
 

--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -90,7 +90,9 @@ public struct PrefsKeys {
         public static let didAgreeTermsOfService = "didAgreeTermOfService"
         public static let summarizeContentFeature = "summarizeContentFeature"
         public static let shakeGestureEnabled = "shakeGestureEnabledKey"
-        public static let selectedLanguage = "selectedLanguage"
+        public static let selectedLanguage = "summarizer.selectedLanguage"
+        /// Legacy pref name used to store the summarizer selected language, it is only used to migrate to the new pref `selectedLanguage`
+        public static let legacySelectedLanguage = "selectedLanguage"
     }
 
     public struct AppVersion {

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerConfig.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerConfig.swift
@@ -17,7 +17,7 @@ public struct SummarizerConfig: LLMConfig, Equatable, Sendable {
     /// Options can include things like temperature, max tokens, and other model-specific settings.
     nonisolated(unsafe) public let options: [String: AnyHashable]
     /// The language the summary is generated in.
-    public let locale: Locale?
+    public let summaryLocale: Locale?
     /// The detected language of the content being summarized.
     public let pageLocale: Locale?
 
@@ -27,12 +27,12 @@ public struct SummarizerConfig: LLMConfig, Equatable, Sendable {
     public init(
         instructions: String,
         options: [String: AnyHashable],
-        locale: Locale? = nil,
+        summaryLocale: Locale? = nil,
         pageLocale: Locale? = nil
     ) {
         self.instructions = instructions
         self.options = options
-        self.locale = locale
+        self.summaryLocale = summaryLocale
         self.pageLocale = pageLocale
     }
 
@@ -44,7 +44,7 @@ public struct SummarizerConfig: LLMConfig, Equatable, Sendable {
         return SummarizerConfig(
             instructions: mergedInstructions,
             options: mergedOptions,
-            locale: self.locale ?? other.locale,
+            summaryLocale: self.summaryLocale ?? other.summaryLocale,
             pageLocale: self.pageLocale ?? other.pageLocale
         )
     }

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerConfig.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerConfig.swift
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Foundation
 import LLMKit
 import FoundationModels
 
@@ -15,12 +16,24 @@ public struct SummarizerConfig: LLMConfig, Equatable, Sendable {
     /// 2. The Apple foundation model is a new API that may introduce additional parameters or change existing ones.
     /// Options can include things like temperature, max tokens, and other model-specific settings.
     nonisolated(unsafe) public let options: [String: AnyHashable]
+    /// The language the summary is generated in.
+    public let locale: Locale?
+    /// The detected language of the content being summarized.
+    public let pageLocale: Locale?
+
     public static let defaultConfig =
         SummarizerConfig(instructions: SummarizerModelInstructions.defaultInstructions, options: [:])
 
-    public init(instructions: String, options: [String: AnyHashable]) {
+    public init(
+        instructions: String,
+        options: [String: AnyHashable],
+        locale: Locale? = nil,
+        pageLocale: Locale? = nil
+    ) {
         self.instructions = instructions
         self.options = options
+        self.locale = locale
+        self.pageLocale = pageLocale
     }
 
     /// Returns a new config by merging the current config with another config.
@@ -28,7 +41,12 @@ public struct SummarizerConfig: LLMConfig, Equatable, Sendable {
     public func merging(with other: SummarizerConfig) -> SummarizerConfig {
         let mergedInstructions = self.instructions.isEmpty ? other.instructions : self.instructions
         let mergedOptions = self.options.merging(other.options) { current, _ in current }
-        return SummarizerConfig(instructions: mergedInstructions, options: mergedOptions)
+        return SummarizerConfig(
+            instructions: mergedInstructions,
+            options: mergedOptions,
+            locale: self.locale ?? other.locale,
+            pageLocale: self.pageLocale ?? other.pageLocale
+        )
     }
 }
 

--- a/BrowserKit/Sources/SummarizeKit/Backend/SummarizerTrigger.swift
+++ b/BrowserKit/Sources/SummarizeKit/Backend/SummarizerTrigger.swift
@@ -7,4 +7,5 @@ public enum SummarizerTrigger: String, Sendable {
     case mainMenu
     case toolbarIcon
     case readerModeBarButton
+    case readerModeWithSummarizerButton
 }

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1565,6 +1565,7 @@
 		BA4BB9A42D7FF754006BD137 /* DarkModeToggleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4BB9A32D7FF74D006BD137 /* DarkModeToggleView.swift */; };
 		BA7A14842C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */; };
 		BA7CB0F12E4174AC0052124B /* SummarizerTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7CB0F02E4174A40052124B /* SummarizerTelemetry.swift */; };
+		FA11B0000000000000000002 /* SummarizerPrefsMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11B0000000000000000001 /* SummarizerPrefsMigration.swift */; };
 		BA8E197F2BF2FB1900590B5F /* AddressFormManager.js in Resources */ = {isa = PBXBuildFile; fileRef = BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */; };
 		BACE70062DC110CA00E6102C /* ASTranslationModelsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE70052DC110C700E6102C /* ASTranslationModelsFetcher.swift */; };
 		BB2F69F8341E538B06F25032 /* XCUIElementHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338510A2D1FFA7548E64224B /* XCUIElementHelpers.swift */; };
@@ -1664,6 +1665,7 @@
 		C28CAABF2E5C8C660049D7C7 /* InsetUpdatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28CAABE2E5C8C620049D7C7 /* InsetUpdatable.swift */; };
 		C28D67832F4491180032D0B2 /* DeleteAppAttestKeySetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28D67822F4491160032D0B2 /* DeleteAppAttestKeySetting.swift */; };
 		C296B6E92F5ECBF4001CD179 /* SummarizerConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C296B6E82F5ECBF4001CD179 /* SummarizerConfigProviderTests.swift */; };
+		FA11B0000000000000000004 /* SummarizerPrefsMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11B0000000000000000003 /* SummarizerPrefsMigrationTests.swift */; };
 		C29B64812AD6959E00F3244B /* QRCodeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64802AD6959E00F3244B /* QRCodeCoordinator.swift */; };
 		C29B64832AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64822AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift */; };
 		C29B64872AD69D0200F3244B /* QRCodeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */; };
@@ -10672,6 +10674,7 @@
 		BA4BB9A32D7FF74D006BD137 /* DarkModeToggleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeToggleView.swift; sourceTree = "<group>"; };
 		BA7A14832C2CCEB3008DF1D9 /* EditAddressWebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAddressWebViewManager.swift; sourceTree = "<group>"; };
 		BA7CB0F02E4174A40052124B /* SummarizerTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerTelemetry.swift; sourceTree = "<group>"; };
+		FA11B0000000000000000001 /* SummarizerPrefsMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerPrefsMigration.swift; sourceTree = "<group>"; };
 		BA8E197E2BF2FB1900590B5F /* AddressFormManager.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AddressFormManager.js; sourceTree = "<group>"; };
 		BA904A3B89BC820A7A802D55 /* es-CL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-CL"; path = "es-CL.lproj/Storage.strings"; sourceTree = "<group>"; };
 		BAA64356B54F1CD258764620 /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/FindInPage.strings; sourceTree = "<group>"; };
@@ -10817,6 +10820,7 @@
 		C28CAABE2E5C8C620049D7C7 /* InsetUpdatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsetUpdatable.swift; sourceTree = "<group>"; };
 		C28D67822F4491160032D0B2 /* DeleteAppAttestKeySetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAppAttestKeySetting.swift; sourceTree = "<group>"; };
 		C296B6E82F5ECBF4001CD179 /* SummarizerConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerConfigProviderTests.swift; sourceTree = "<group>"; };
+		FA11B0000000000000000003 /* SummarizerPrefsMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizerPrefsMigrationTests.swift; sourceTree = "<group>"; };
 		C29B428A81B120AFF0666037 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Menu.strings; sourceTree = "<group>"; };
 		C29B64802AD6959E00F3244B /* QRCodeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeCoordinator.swift; sourceTree = "<group>"; };
 		C29B64822AD69C3E00F3244B /* MockQRCodeParentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockQRCodeParentCoordinator.swift; sourceTree = "<group>"; };
@@ -12556,6 +12560,7 @@
 				BC129A2E2E4558FD004A6875 /* SummarizeAction.swift */,
 				BC129A2C2E45207F004A6875 /* SummarizeMiddleware.swift */,
 				BA7CB0F02E4174A40052124B /* SummarizerTelemetry.swift */,
+				FA11B0000000000000000001 /* SummarizerPrefsMigration.swift */,
 				0B78DC6D2E3C9CE800804872 /* SummarizerNimbusUtils.swift */,
 			);
 			path = Summarizer;
@@ -15625,6 +15630,7 @@
 			children = (
 				61D17EF22FE30B1100BCDD52 /* MockNimbusUtils.swift */,
 				C296B6E82F5ECBF4001CD179 /* SummarizerConfigProviderTests.swift */,
+				FA11B0000000000000000003 /* SummarizerPrefsMigrationTests.swift */,
 				C2126EF92F447A46001C01FE /* SummarizerNimbusUtilsTests.swift */,
 				C27470A12F4C6BB900920313 /* SummarizerLanguageExpansionConfigurationTests.swift */,
 				C21326982F5713F000746393 /* SummarizerLanguageProviderTests.swift */,
@@ -20483,6 +20489,7 @@
 				BC129A2F2E455900004A6875 /* SummarizeAction.swift in Sources */,
 				8CE1E4322B8C76AE0026530B /* LoginStorage.swift in Sources */,
 				BA7CB0F12E4174AC0052124B /* SummarizerTelemetry.swift in Sources */,
+				FA11B0000000000000000002 /* SummarizerPrefsMigration.swift in Sources */,
 				AAD1CD872EAABA8100BEC90A /* TranslationsConfiguration.swift in Sources */,
 				4347B398298D6D7B0045F677 /* CreditCardTableViewModel.swift in Sources */,
 				D3A9949D1A3686BD008AD1AC /* Tab.swift in Sources */,
@@ -20815,6 +20822,7 @@
 				C2E4F4C62F62F959002A8524 /* MockMainMenuCoordinatorDelegate.swift in Sources */,
 				96AF8C1C29FC14F700EC2219 /* CreditCardInputFieldHelperTests.swift in Sources */,
 				C296B6E92F5ECBF4001CD179 /* SummarizerConfigProviderTests.swift in Sources */,
+				FA11B0000000000000000004 /* SummarizerPrefsMigrationTests.swift in Sources */,
 				21FA8FB02AE856590013B815 /* RemoteTabsCoordinatorTests.swift in Sources */,
 				0E6557402D82232B00D7F017 /* DownloadProgressManagerTests.swift in Sources */,
 				AADBD0E42EBBA79B00F35E30 /* MockLanguageDetector.swift in Sources */,

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -39,6 +39,9 @@ final class AppLaunchUtil: FeatureFlaggable, Sendable {
             DefaultBrowserUtility().processUserDefaultState(isFirstRun: introScreenManager.shouldShowIntroScreen)
         }
         DefaultBrowserUtility().migrateDefaultBrowserStatusIfNeeded(isFirstRun: introScreenManager.shouldShowIntroScreen)
+
+        SummarizerPrefsMigration(prefs: profile.prefs).migrateSelectedLanguage()
+
         if #available(iOS 26, *) {
             AppleIntelligenceUtil().processAvailabilityState()
         }

--- a/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
@@ -202,7 +202,7 @@ final class SummarizeCoordinator: BaseCoordinator,
         summarizerTelemetry.summarizationStarted(
             lengthWords: text.numberOfWords,
             lengthChars: Int32(clamping: text.count),
-            language: config?.locale?.identifier,
+            summaryLanguage: config?.summaryLocale?.identifier,
             pageLanguage: config?.pageLocale?.identifier
         )
     }

--- a/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/SummarizeCoordinator.swift
@@ -201,7 +201,9 @@ final class SummarizeCoordinator: BaseCoordinator,
     func summarizerServiceDidStart(_ text: String) {
         summarizerTelemetry.summarizationStarted(
             lengthWords: text.numberOfWords,
-            lengthChars: Int32(clamping: text.count)
+            lengthChars: Int32(clamping: text.count),
+            language: config?.locale?.identifier,
+            pageLanguage: config?.pageLocale?.identifier
         )
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarMiddleware.swift
@@ -297,7 +297,9 @@ final class ToolbarMiddleware {
             cancelEditMode(windowUUID: action.windowUUID)
 
         case .readerMode, .readerModeWithSummarizer:
-            recordReaderModeTelemetry(state: state, windowUUID: action.windowUUID)
+            recordReaderModeTelemetry(state: state,
+                                      windowUUID: action.windowUUID,
+                                      hasSummarizer: action.buttonType == .readerModeWithSummarizer)
             let action = NavigationBrowserAction(navigationDestination: NavigationDestination(.readerMode),
                                                  windowUUID: action.windowUUID,
                                                  actionType: NavigationBrowserActionType.tapOnReaderMode)
@@ -411,7 +413,7 @@ final class ToolbarMiddleware {
                 guard let webView = windowManager.tabManager(for: action.windowUUID)?.selectedTab?.webView else { return }
                 let summarizerConfig = await summarizerConfigFactory.makeConfiguration(from: webView)
                 let action = GeneralBrowserAction(summarizerConfig: summarizerConfig,
-                                                  summarizerTrigger: .toolbarIcon,
+                                                  summarizerTrigger: .readerModeWithSummarizerButton,
                                                   windowUUID: action.windowUUID,
                                                   actionType: GeneralBrowserActionType.showSummarizer)
                 store.dispatch(action)
@@ -566,7 +568,7 @@ final class ToolbarMiddleware {
         return manager.shouldDisplayNavigationBorder(toolbarPosition: toolbarPosition)
     }
 
-    private func recordReaderModeTelemetry(state: AppState, windowUUID: WindowUUID) {
+    private func recordReaderModeTelemetry(state: AppState, windowUUID: WindowUUID, hasSummarizer: Bool) {
         guard let toolbarState = state.componentState(ToolbarState.self, for: .toolbar, window: windowUUID) else { return }
 
         let isReaderModeEnabled = switch toolbarState.addressToolbar.readerModeState {
@@ -574,7 +576,9 @@ final class ToolbarMiddleware {
         default: false
         }
 
-        toolbarTelemetry.readerModeButtonTapped(isPrivate: toolbarState.isPrivateMode, isEnabled: isReaderModeEnabled)
+        toolbarTelemetry.readerModeButtonTapped(isPrivate: toolbarState.isPrivateMode,
+                                                isEnabled: isReaderModeEnabled,
+                                                hasSummarizer: hasSummarizer)
     }
 
     private func tabManager(for uuid: WindowUUID) -> TabManager? {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarTelemetry.swift
@@ -43,9 +43,10 @@ struct ToolbarTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.Toolbar.refreshButtonTapped, extras: isPrivateExtra)
     }
 
-    func readerModeButtonTapped(isPrivate: Bool, isEnabled: Bool) {
-        let readerModeExtra = GleanMetrics.Toolbar.ReaderModeButtonTappedExtra(enabled: isPrivate,
-                                                                               isPrivate: isEnabled)
+    func readerModeButtonTapped(isPrivate: Bool, isEnabled: Bool, hasSummarizer: Bool) {
+        let readerModeExtra = GleanMetrics.Toolbar.ReaderModeButtonTappedExtra(enabled: isEnabled,
+                                                                               hasSummarizer: hasSummarizer,
+                                                                               isPrivate: isPrivate)
         gleanWrapper.recordEvent(for: GleanMetrics.Toolbar.readerModeButtonTapped, extras: readerModeExtra)
     }
 

--- a/firefox-ios/Client/Frontend/Settings/Summarize/SummarizeSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Summarize/SummarizeSettingsViewController.swift
@@ -8,14 +8,17 @@ import Shared
 final class SummarizeSettingsViewController: SettingsTableViewController {
     let prefs: Prefs
     private let nimbusUtils: SummarizerNimbusUtils
+    private let telemetry: SummarizerTelemetry
 
     init(
         prefs: Prefs,
         summarizeNimbusUtils: SummarizerNimbusUtils = DefaultSummarizerNimbusUtils(),
+        telemetry: SummarizerTelemetry = SummarizerTelemetry(),
         windowUUID: WindowUUID
     ) {
         self.prefs = prefs
         self.nimbusUtils = summarizeNimbusUtils
+        self.telemetry = telemetry
         super.init(style: .grouped, windowUUID: windowUUID)
         self.title = .Settings.Summarize.Title
     }
@@ -111,6 +114,7 @@ final class SummarizeSettingsViewController: SettingsTableViewController {
                     onOptionSelected: { [weak self] selectedOption in
                         guard let self else { return }
                         configuration.save(preference: selectedOption, prefs: prefs)
+                        telemetry.summarizationLanguageSettingChanged(language: selectedOption.saveValue)
                         tableView.reloadData()
                     }
                 )

--- a/firefox-ios/Client/Frontend/Settings/Summarize/SummarizeSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Summarize/SummarizeSettingsViewController.swift
@@ -8,17 +8,17 @@ import Shared
 final class SummarizeSettingsViewController: SettingsTableViewController {
     let prefs: Prefs
     private let nimbusUtils: SummarizerNimbusUtils
-    private let telemetry: SummarizerTelemetry
+    private let settingsTelemetry: SettingsTelemetry
 
     init(
         prefs: Prefs,
         summarizeNimbusUtils: SummarizerNimbusUtils = DefaultSummarizerNimbusUtils(),
-        telemetry: SummarizerTelemetry = SummarizerTelemetry(),
+        settingsTelemetry: SettingsTelemetry = SettingsTelemetry(),
         windowUUID: WindowUUID
     ) {
         self.prefs = prefs
         self.nimbusUtils = summarizeNimbusUtils
-        self.telemetry = telemetry
+        self.settingsTelemetry = settingsTelemetry
         super.init(style: .grouped, windowUUID: windowUUID)
         self.title = .Settings.Summarize.Title
     }
@@ -113,8 +113,13 @@ final class SummarizeSettingsViewController: SettingsTableViewController {
                     accessibilityIdentifier: AccessibilityIdentifiers.Settings.Summarize.languageCell,
                     onOptionSelected: { [weak self] selectedOption in
                         guard let self else { return }
+                        let previousOption = configuration.selectedPreference(prefs: prefs)
                         configuration.save(preference: selectedOption, prefs: prefs)
-                        telemetry.summarizationLanguageSettingChanged(language: selectedOption.saveValue)
+                        settingsTelemetry.changedSetting(
+                            PrefsKeys.Summarizer.selectedLanguage,
+                            to: selectedOption.saveValue,
+                            from: previousOption.saveValue
+                        )
                         tableView.reloadData()
                     }
                 )

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizeMiddleware.swift
@@ -189,7 +189,7 @@ final class SummarizerMiddleware: SummarizerConfigFactory {
 
         let preSummarizationCheckResults = await summarizationChecker.check(on: webView, maxWords: maxWords)
         guard preSummarizationCheckResults.canSummarize else { return nil }
-        guard let summarizerLocale = await getSummarizerLocale(for: webView) else { return nil }
+        guard let summarizerLanguages = await getSummarizerLanguages(for: webView) else { return nil }
 
         let contentType = preSummarizationCheckResults.contentType ?? .generic
         let summarizerModel: SummarizerModel =
@@ -198,11 +198,11 @@ final class SummarizerMiddleware: SummarizerConfigFactory {
         return await summarizerConfigProvider.getConfig(
             summarizerModel: summarizerModel,
             contentType: contentType,
-            locale: summarizerLocale
+            languages: summarizerLanguages
         )
     }
 
-    private func getSummarizerLocale(for webView: WKWebView) async -> Locale? {
+    private func getSummarizerLanguages(for webView: WKWebView) async -> SummarizerLanguageResolution? {
         if summarizerNimbusUtils.isLanguageExpansionEnabled {
             let langExpansionConfiguration = summarizerNimbusUtils.languageExpansionConfiguration()
             return await summarizerLanguageProvider.getLanguage(

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerConfigProvider.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerConfigProvider.swift
@@ -9,7 +9,7 @@ protocol SummarizerConfigProvider: Sendable {
     func getConfig(
         summarizerModel: SummarizerModel,
         contentType: SummarizationContentType,
-        locale: Locale
+        languages: SummarizerLanguageResolution
     ) async -> SummarizerConfig
 }
 
@@ -35,7 +35,7 @@ struct DefaultSummarizerConfigProvider: SummarizerConfigProvider {
     func getConfig(
         summarizerModel: SummarizerModel,
         contentType: SummarizationContentType,
-        locale: Locale
+        languages: SummarizerLanguageResolution
     ) async -> SummarizerConfig {
         let initialConfig = SummarizerConfig(instructions: "", options: [:])
         // Merge configs in reverse order (so higher priority overrides lower)
@@ -48,8 +48,15 @@ struct DefaultSummarizerConfigProvider: SummarizerConfigProvider {
         let instructionsWithLocale = config.instructions
             .replacingOccurrences(
                 of: Constants.languageTag,
-                with: Constants.enLocale.localizedString(forIdentifier: locale.identifier) ?? Constants.englishLanguage
+                with: Constants.enLocale.localizedString(
+                    forIdentifier: languages.summaryLocale.identifier
+                ) ?? Constants.englishLanguage
             )
-        return SummarizerConfig(instructions: instructionsWithLocale, options: config.options)
+        return SummarizerConfig(
+            instructions: instructionsWithLocale,
+            options: config.options,
+            locale: languages.summaryLocale,
+            pageLocale: languages.pageLocale
+        )
     }
 }

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerConfigProvider.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerConfigProvider.swift
@@ -55,7 +55,7 @@ struct DefaultSummarizerConfigProvider: SummarizerConfigProvider {
         return SummarizerConfig(
             instructions: instructionsWithLocale,
             options: config.options,
-            locale: languages.summaryLocale,
+            summaryLocale: languages.summaryLocale,
             pageLocale: languages.pageLocale
         )
     }

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerLanguageProvider.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerLanguageProvider.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 
-/// The locales resolved for a summarization, used both to build the prompt and to report telemetry.
 struct SummarizerLanguageResolution: Equatable {
     /// The language the summary is generated in.
     let summaryLocale: Locale

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerLanguageProvider.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerLanguageProvider.swift
@@ -4,6 +4,14 @@
 
 import Foundation
 
+/// The locales resolved for a summarization, used both to build the prompt and to report telemetry.
+struct SummarizerLanguageResolution: Equatable {
+    /// The language the summary is generated in.
+    let summaryLocale: Locale
+    /// The detected language of the page being summarized.
+    let pageLocale: Locale
+}
+
 /// Provides locale selection for summarization based on user preferences and website language detection.
 protocol SummarizerLanguageProvider: Sendable {
     /// Determines the appropriate locale for summarization.
@@ -16,7 +24,7 @@ protocol SummarizerLanguageProvider: Sendable {
         userPreference: SummarizerLanguageExpansionConfiguration.UserPreference,
         supportedLocales: [Locale],
         languageSampleSource: LanguageSampleSource,
-    ) async -> Locale?
+    ) async -> SummarizerLanguageResolution?
 }
 
 struct DefaultSummarizerLanguageProvider: SummarizerLanguageProvider {
@@ -26,7 +34,7 @@ struct DefaultSummarizerLanguageProvider: SummarizerLanguageProvider {
         userPreference: SummarizerLanguageExpansionConfiguration.UserPreference,
         supportedLocales: [Locale],
         languageSampleSource: any LanguageSampleSource
-    ) async -> Locale? {
+    ) async -> SummarizerLanguageResolution? {
         // Always detect website language first.
         // This ensures we only proceed if the website has detectable content in a supported language.
         guard let websiteLanguage = await getWebsiteLocale(from: languageSampleSource) else { return nil }
@@ -34,10 +42,10 @@ struct DefaultSummarizerLanguageProvider: SummarizerLanguageProvider {
 
         switch userPreference {
         case .websiteLanguage:
-            return websiteLanguage
+            return SummarizerLanguageResolution(summaryLocale: websiteLanguage, pageLocale: websiteLanguage)
         case .customLocale(let customLocale):
             guard isLocaleInSupportedLocales(customLocale, supportedLocales: supportedLocales) else { return nil }
-            return customLocale
+            return SummarizerLanguageResolution(summaryLocale: customLocale, pageLocale: websiteLanguage)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerPrefsMigration.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerPrefsMigration.swift
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+
+// TODO: - FXIOS-16678 remove migration struct after enough release cycles (i.e 157.x)
+/// Moves the summarizer language preference onto its namespaced key.
+struct SummarizerPrefsMigration {
+    private let prefs: Prefs
+
+    init(prefs: Prefs) {
+        self.prefs = prefs
+    }
+
+    /// Copies the saved language onto `PrefsKeys.Summarizer.selectedLanguage` and drops the legacy key.
+    /// No-ops once the legacy key is gone, so it is safe to run on every launch.
+    func migrateSelectedLanguage() {
+        guard let savedLanguage = prefs.stringForKey(PrefsKeys.Summarizer.legacySelectedLanguage) else { return }
+
+        if prefs.stringForKey(PrefsKeys.Summarizer.selectedLanguage) == nil {
+            prefs.setString(savedLanguage, forKey: PrefsKeys.Summarizer.selectedLanguage)
+        }
+        prefs.removeObjectForKey(PrefsKeys.Summarizer.legacySelectedLanguage)
+    }
+}

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerTelemetry.swift
@@ -21,10 +21,17 @@ class SummarizerTelemetry {
         gleanWrapper.recordEvent(for: GleanMetrics.AiSummarize.summarizationRequested, extras: summarizationRequestedExtra)
     }
 
-    func summarizationStarted(lengthWords: Int32, lengthChars: Int32) {
+    func summarizationStarted(
+        lengthWords: Int32,
+        lengthChars: Int32,
+        language: String? = nil,
+        pageLanguage: String? = nil
+    ) {
         let summarizationStartedExtra = GleanMetrics.AiSummarize.SummarizationStartedExtra(
+            language: language,
             lengthChars: lengthChars,
-            lengthWords: lengthWords)
+            lengthWords: lengthWords,
+            pageLanguage: pageLanguage)
         summarizationTimerStart()
         gleanWrapper.recordEvent(for: GleanMetrics.AiSummarize.summarizationStarted, extras: summarizationStartedExtra)
     }
@@ -91,5 +98,15 @@ class SummarizerTelemetry {
 
     func summarizationShakeGestureEnabled(_ shakeGestureEnabled: Bool) {
         GleanMetrics.UserAiSummarize.shakeGestureEnabled.set(shakeGestureEnabled)
+    }
+
+    func summarizationSelectedLanguage(_ language: String) {
+        gleanWrapper.recordString(for: GleanMetrics.UserAiSummarize.selectedLanguage, value: language)
+    }
+
+    func summarizationLanguageSettingChanged(language: String) {
+        let languageSettingChangedExtra = GleanMetrics.AiSummarize.LanguageSettingChangedExtra(language: language)
+        gleanWrapper.recordEvent(for: GleanMetrics.AiSummarize.languageSettingChanged,
+                                 extras: languageSettingChangedExtra)
     }
 }

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerTelemetry.swift
@@ -8,6 +8,7 @@ import Common
 import Shared
 import Glean
 
+// TODO: - FXIOS-16664 Add tests to SummarizerTelemetry
 class SummarizerTelemetry {
     private let gleanWrapper: GleanWrapper
     private var summarizationTimerId: GleanTimerId?

--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerTelemetry.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerTelemetry.swift
@@ -25,14 +25,14 @@ class SummarizerTelemetry {
     func summarizationStarted(
         lengthWords: Int32,
         lengthChars: Int32,
-        language: String? = nil,
+        summaryLanguage: String? = nil,
         pageLanguage: String? = nil
     ) {
         let summarizationStartedExtra = GleanMetrics.AiSummarize.SummarizationStartedExtra(
-            language: language,
             lengthChars: lengthChars,
             lengthWords: lengthWords,
-            pageLanguage: pageLanguage)
+            pageLanguage: pageLanguage,
+            summaryLanguage: summaryLanguage)
         summarizationTimerStart()
         gleanWrapper.recordEvent(for: GleanMetrics.AiSummarize.summarizationStarted, extras: summarizationStartedExtra)
     }
@@ -103,11 +103,5 @@ class SummarizerTelemetry {
 
     func summarizationSelectedLanguage(_ language: String) {
         gleanWrapper.recordString(for: GleanMetrics.UserAiSummarize.selectedLanguage, value: language)
-    }
-
-    func summarizationLanguageSettingChanged(language: String) {
-        let languageSettingChangedExtra = GleanMetrics.AiSummarize.LanguageSettingChangedExtra(language: language)
-        gleanWrapper.recordEvent(for: GleanMetrics.AiSummarize.languageSettingChanged,
-                                 extras: languageSettingChangedExtra)
     }
 }

--- a/firefox-ios/Client/Glean/probes/ai.summarizer.yaml
+++ b/firefox-ios/Client/Glean/probes/ai.summarizer.yaml
@@ -210,7 +210,6 @@ ai.summarize:
           identifier from the `supportedLocales` allowlist of the
           `summarizer-language-expansion-feature` Nimbus feature.
     bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/27783
       - https://github.com/mozilla-mobile/firefox-ios/issues/35362
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/35361

--- a/firefox-ios/Client/Glean/probes/ai.summarizer.yaml
+++ b/firefox-ios/Client/Glean/probes/ai.summarizer.yaml
@@ -88,7 +88,7 @@ ai.summarize:
           summary language in settings. Absent when no language could be resolved.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/27783
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-16665
+      - https://github.com/mozilla-mobile/firefox-ios/issues/35362
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/28453
       - https://github.com/mozilla-mobile/firefox-ios/pull/35361
@@ -211,7 +211,7 @@ ai.summarize:
           `summarizer-language-expansion-feature` Nimbus feature.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/27783
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-16665
+      - https://github.com/mozilla-mobile/firefox-ios/issues/35362
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/35361
     notification_emails:
@@ -250,7 +250,7 @@ user.ai.summarize:
       Either `websiteLanguage`, or a locale identifier from the `supportedLocales`
       allowlist of the `summarizer-language-expansion-feature` Nimbus feature.
     bugs:
-    - https://mozilla-hub.atlassian.net/browse/FXIOS-16665
+      - https://github.com/mozilla-mobile/firefox-ios/issues/35362
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/35361
     notification_emails:

--- a/firefox-ios/Client/Glean/probes/ai.summarizer.yaml
+++ b/firefox-ios/Client/Glean/probes/ai.summarizer.yaml
@@ -88,8 +88,10 @@ ai.summarize:
           summary language in settings. Absent when no language could be resolved.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/27783
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16665
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/28453
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35361
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
@@ -209,11 +211,12 @@ ai.summarize:
           `summarizer-language-expansion-feature` Nimbus feature.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/27783
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16665
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/28453
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35361
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: never
+    expires: "2026-12-01"
     no_lint:
       - COMMON_PREFIX
 
@@ -247,9 +250,9 @@ user.ai.summarize:
       Either `websiteLanguage`, or a locale identifier from the `supportedLocales`
       allowlist of the `summarizer-language-expansion-feature` Nimbus feature.
     bugs:
-    - https://github.com/mozilla-mobile/firefox-ios/issues/27783
+    - https://mozilla-hub.atlassian.net/browse/FXIOS-16665
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/28453
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35361
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
-    expires: never
+    expires: "2026-12-01"

--- a/firefox-ios/Client/Glean/probes/ai.summarizer.yaml
+++ b/firefox-ios/Client/Glean/probes/ai.summarizer.yaml
@@ -73,6 +73,19 @@ ai.summarize:
         type: quantity
         description: |
           The length of the text to be summarized, in words.
+      language:
+        type: string
+        description: |
+          The language the summary is generated in, as a locale identifier
+          (e.g. `en`, `de-DE`). Bounded by the `supportedLocales` allowlist of the
+          `summarizer-language-expansion-feature` Nimbus feature.
+          Absent when no language could be resolved.
+      page_language:
+        type: string
+        description: |
+          The detected language of the page being summarized, as a locale identifier
+          (e.g. `en`, `de`). Differs from `language` when the user picked a specific
+          summary language in settings. Absent when no language could be resolved.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/27783
     data_reviews:
@@ -182,6 +195,27 @@ ai.summarize:
     expires: never
     no_lint:
       - COMMON_PREFIX
+  language_setting_changed:
+    type: event
+    description: |
+      Recorded when the user changes the summary language preference in the
+      summarize settings screen.
+    extra_keys:
+      language:
+        type: string
+        description: |
+          The newly selected preference. Either `websiteLanguage`, or a locale
+          identifier from the `supportedLocales` allowlist of the
+          `summarizer-language-expansion-feature` Nimbus feature.
+    bugs:
+      - https://github.com/mozilla-mobile/firefox-ios/issues/27783
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/28453
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+    no_lint:
+      - COMMON_PREFIX
 
 user.ai.summarize:
   summarization_enabled:
@@ -199,6 +233,19 @@ user.ai.summarize:
     type: boolean
     description: |
       Records if the user has shake to summarize option enabled
+    bugs:
+    - https://github.com/mozilla-mobile/firefox-ios/issues/27783
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/28453
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+  selected_language:
+    type: string
+    description: |
+      Records the summary language the user selected in the summarize settings.
+      Either `websiteLanguage`, or a locale identifier from the `supportedLocales`
+      allowlist of the `summarizer-language-expansion-feature` Nimbus feature.
     bugs:
     - https://github.com/mozilla-mobile/firefox-ios/issues/27783
     data_reviews:

--- a/firefox-ios/Client/Glean/probes/ai.summarizer.yaml
+++ b/firefox-ios/Client/Glean/probes/ai.summarizer.yaml
@@ -73,7 +73,7 @@ ai.summarize:
         type: quantity
         description: |
           The length of the text to be summarized, in words.
-      language:
+      summary_language:
         type: string
         description: |
           The language the summary is generated in, as a locale identifier
@@ -84,8 +84,9 @@ ai.summarize:
         type: string
         description: |
           The detected language of the page being summarized, as a locale identifier
-          (e.g. `en`, `de`). Differs from `language` when the user picked a specific
-          summary language in settings. Absent when no language could be resolved.
+          (e.g. `en`, `de`). Differs from `summary_language` when the user picked a
+          specific summary language in settings.
+          Absent when no language could be resolved.
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/27783
       - https://github.com/mozilla-mobile/firefox-ios/issues/35362
@@ -195,27 +196,6 @@ ai.summarize:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
-    no_lint:
-      - COMMON_PREFIX
-  language_setting_changed:
-    type: event
-    description: |
-      Recorded when the user changes the summary language preference in the
-      summarize settings screen.
-    extra_keys:
-      language:
-        type: string
-        description: |
-          The newly selected preference. Either `websiteLanguage`, or a locale
-          identifier from the `supportedLocales` allowlist of the
-          `summarizer-language-expansion-feature` Nimbus feature.
-    bugs:
-      - https://github.com/mozilla-mobile/firefox-ios/issues/35362
-    data_reviews:
-      - https://github.com/mozilla-mobile/firefox-ios/pull/35361
-    notification_emails:
-      - fx-ios-data-stewards@mozilla.com
-    expires: "2026-12-01"
     no_lint:
       - COMMON_PREFIX
 

--- a/firefox-ios/Client/Glean/probes/toolbar.yaml
+++ b/firefox-ios/Client/Glean/probes/toolbar.yaml
@@ -82,10 +82,17 @@ toolbar:
       enabled:
         description: Whether reader mode was opened or closed
         type: boolean
+      has_summarizer:
+        description: |
+            Whether the tapped button was the combined reader mode with summarizer
+            button, which also offers summarization on long press
+        type: boolean
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19327
+      - https://github.com/mozilla-mobile/firefox-ios/issues/27783
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
+      - https://github.com/mozilla-mobile/firefox-ios/pull/28453
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/toolbar.yaml
+++ b/firefox-ios/Client/Glean/probes/toolbar.yaml
@@ -89,7 +89,7 @@ toolbar:
         type: boolean
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19327
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-16665
+      - https://github.com/mozilla-mobile/firefox-ios/issues/35362
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
       - https://github.com/mozilla-mobile/firefox-ios/pull/35361

--- a/firefox-ios/Client/Glean/probes/toolbar.yaml
+++ b/firefox-ios/Client/Glean/probes/toolbar.yaml
@@ -89,10 +89,10 @@ toolbar:
         type: boolean
     bugs:
       - https://github.com/mozilla-mobile/firefox-ios/issues/19327
-      - https://github.com/mozilla-mobile/firefox-ios/issues/27783
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16665
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/22325
-      - https://github.com/mozilla-mobile/firefox-ios/pull/28453
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35361
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -332,6 +332,13 @@ class TelemetryWrapper: TelemetryWrapperProtocol,
             let summarizerTelemetry = SummarizerTelemetry()
             summarizerTelemetry.summarizationEnabled(summarizerNimbusUtils.isSummarizeFeatureToggledOn)
             summarizerTelemetry.summarizationShakeGestureEnabled(summarizerNimbusUtils.isShakeGestureEnabled)
+
+            if summarizerNimbusUtils.isLanguageExpansionEnabled {
+                let languageConfiguration = summarizerNimbusUtils.languageExpansionConfiguration()
+                summarizerTelemetry.summarizationSelectedLanguage(
+                    languageConfiguration.selectedPreference(prefs: prefs).saveValue
+                )
+            }
         }
 
         // Record Google Lens user preference

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SummarizeCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SummarizeCoordinatorTests.swift
@@ -126,7 +126,7 @@ final class SummarizeCoordinatorTests: XCTestCase {
     func test_summarizeServiceDidStart_recordsConfigLanguages() throws {
         let subject = createSubject(config: SummarizerConfig(instructions: "",
                                                              options: [:],
-                                                             locale: Locale(identifier: "it"),
+                                                             summaryLocale: Locale(identifier: "it"),
                                                              pageLocale: Locale(identifier: "de")))
 
         subject.summarizerServiceDidStart("")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SummarizeCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SummarizeCoordinatorTests.swift
@@ -7,6 +7,7 @@ import Common
 import SummarizeKit
 import Shared
 import ComponentLibrary
+import Glean
 @testable import Client
 
 final class MockSummarizer: SummarizerProtocol, @unchecked Sendable {
@@ -122,6 +123,33 @@ final class SummarizeCoordinatorTests: XCTestCase {
         XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
     }
 
+    func test_summarizeServiceDidStart_recordsConfigLanguages() throws {
+        let subject = createSubject(config: SummarizerConfig(instructions: "",
+                                                             options: [:],
+                                                             locale: Locale(identifier: "it"),
+                                                             pageLocale: Locale(identifier: "de")))
+
+        subject.summarizerServiceDidStart("")
+
+        let savedExtras = try XCTUnwrap(
+            gleanWrapper.savedExtras.first as? GleanMetrics.AiSummarize.SummarizationStartedExtra
+        )
+        XCTAssertEqual(savedExtras.language, "it")
+        XCTAssertEqual(savedExtras.pageLanguage, "de")
+    }
+
+    func test_summarizeServiceDidStart_withoutConfig_omitsLanguages() throws {
+        let subject = createSubject()
+
+        subject.summarizerServiceDidStart("")
+
+        let savedExtras = try XCTUnwrap(
+            gleanWrapper.savedExtras.first as? GleanMetrics.AiSummarize.SummarizationStartedExtra
+        )
+        XCTAssertNil(savedExtras.language)
+        XCTAssertNil(savedExtras.pageLanguage)
+    }
+
     func test_summarizeServiceDidComplete_recordsTelemetry() {
         let subject = createSubject()
 
@@ -146,6 +174,7 @@ final class SummarizeCoordinatorTests: XCTestCase {
 
     private func createSubject(
         onRequestOpenURL: ((URL?) -> Void)? = nil,
+        config: SummarizerConfig? = nil,
         trigger: SummarizerTrigger = .mainMenu) -> SummarizeCoordinator {
         let subject = SummarizeCoordinator(browserSnapshot: UIImage(),
                                            browserSnapshotTopOffset: 0.0,
@@ -156,6 +185,7 @@ final class SummarizeCoordinatorTests: XCTestCase {
                                            trigger: trigger,
                                            prefs: prefs,
                                            windowUUID: .XCTestDefaultUUID,
+                                           config: config,
                                            router: router,
                                            gleanWrapper: gleanWrapper,
                                            onRequestOpenURL: onRequestOpenURL)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SummarizeCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SummarizeCoordinatorTests.swift
@@ -134,7 +134,7 @@ final class SummarizeCoordinatorTests: XCTestCase {
         let savedExtras = try XCTUnwrap(
             gleanWrapper.savedExtras.first as? GleanMetrics.AiSummarize.SummarizationStartedExtra
         )
-        XCTAssertEqual(savedExtras.language, "it")
+        XCTAssertEqual(savedExtras.summaryLanguage, "it")
         XCTAssertEqual(savedExtras.pageLanguage, "de")
     }
 
@@ -146,7 +146,7 @@ final class SummarizeCoordinatorTests: XCTestCase {
         let savedExtras = try XCTUnwrap(
             gleanWrapper.savedExtras.first as? GleanMetrics.AiSummarize.SummarizationStartedExtra
         )
-        XCTAssertNil(savedExtras.language)
+        XCTAssertNil(savedExtras.summaryLanguage)
         XCTAssertNil(savedExtras.pageLanguage)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSummarizerConfigProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSummarizerConfigProvider.swift
@@ -12,7 +12,7 @@ final class MockSummarizerConfigProvider: SummarizerConfigProvider, @unchecked S
     func getConfig(
         summarizerModel: SummarizerModel,
         contentType: SummarizationContentType,
-        locale: Locale
+        languages: SummarizerLanguageResolution
     ) async -> SummarizerConfig {
         getConfigCalledCount += 1
         return SummarizerConfig.defaultConfig

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSummarizerLanguageProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSummarizerLanguageProvider.swift
@@ -8,14 +8,16 @@ import Foundation
 final class MockSummarizerLanguageProvider: SummarizerLanguageProvider, @unchecked Sendable {
     var shouldReturnLocale = false
     let returnedLocale = Locale(identifier: "en")
+    var returnedPageLocale = Locale(identifier: "en")
     private(set) var getLanguageCallCount = 0
 
     func getLanguage(
         userPreference: SummarizerLanguageExpansionConfiguration.UserPreference,
         supportedLocales: [Locale],
         languageSampleSource: any LanguageSampleSource
-    ) async -> Locale? {
+    ) async -> SummarizerLanguageResolution? {
         getLanguageCallCount += 1
-        return shouldReturnLocale ? returnedLocale : nil
+        guard shouldReturnLocale else { return nil }
+        return SummarizerLanguageResolution(summaryLocale: returnedLocale, pageLocale: returnedPageLocale)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
+import Glean
 import Shared
 import XCTest
 
@@ -10,16 +12,19 @@ import XCTest
 @MainActor
 final class SummarizeSettingsViewControllerTests: XCTestCase {
     private var profile: Profile!
+    private var gleanWrapper: MockGleanWrapper!
 
     override func setUp() async throws {
         try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
+        gleanWrapper = MockGleanWrapper()
     }
 
     override func tearDown() async throws {
         DependencyHelperMock().reset()
         profile = nil
+        gleanWrapper = nil
         try await super.tearDown()
     }
 
@@ -87,11 +92,38 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
         XCTAssertEqual(sections.last?.children.count, 1)
     }
 
+    @available(iOS 17.4, *)
+    func test_languageSection_whenOptionSelected_recordsTelemetry() throws {
+        let mockSummarizeNimbusUtils = MockSummarizerNimbusUtils()
+        mockSummarizeNimbusUtils.shakeGestureFeatureFlagEnabled = false
+        mockSummarizeNimbusUtils.isLanguageExpansionEnabled = true
+        mockSummarizeNimbusUtils.languageExpansionConfiguration = SummarizerLanguageExpansionConfiguration(
+            supportedLocales: [Locale(identifier: "de")]
+        )
+
+        let subject = createSubject(with: mockSummarizeNimbusUtils)
+        let languageSetting = try XCTUnwrap(subject.generateSettings().last?.children.first)
+        let cell = UITableViewCell()
+        languageSetting.onConfigureCell(cell, theme: LightTheme())
+
+        let pickerButton = try XCTUnwrap(cell.accessoryView as? UIButton)
+        let customLocaleAction = try XCTUnwrap(pickerButton.menu?.children.last as? UIAction)
+        customLocaleAction.performWithSender(nil, target: nil)
+
+        let savedExtras = try XCTUnwrap(
+            gleanWrapper.savedExtras.first as? GleanMetrics.AiSummarize.LanguageSettingChangedExtra
+        )
+        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
+        XCTAssertEqual(savedExtras.language, "de")
+        XCTAssertEqual(profile.prefs.stringForKey(PrefsKeys.Summarizer.selectedLanguage), "de")
+    }
+
     // MARK: - Helper
     private func createSubject(with summarizeNimbusUtils: MockSummarizerNimbusUtils) -> SummarizeSettingsViewController {
         let subject = SummarizeSettingsViewController(
             prefs: profile.prefs,
             summarizeNimbusUtils: summarizeNimbusUtils,
+            telemetry: SummarizerTelemetry(gleanWrapper: gleanWrapper),
             windowUUID: .XCTestDefaultUUID
         )
         trackForMemoryLeaks(subject)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SummarizeSettingsViewControllerTests.swift
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Common
-import Glean
 import Shared
 import XCTest
 
@@ -12,19 +10,16 @@ import XCTest
 @MainActor
 final class SummarizeSettingsViewControllerTests: XCTestCase {
     private var profile: Profile!
-    private var gleanWrapper: MockGleanWrapper!
 
     override func setUp() async throws {
         try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
         profile = MockProfile()
-        gleanWrapper = MockGleanWrapper()
     }
 
     override func tearDown() async throws {
         DependencyHelperMock().reset()
         profile = nil
-        gleanWrapper = nil
         try await super.tearDown()
     }
 
@@ -92,38 +87,11 @@ final class SummarizeSettingsViewControllerTests: XCTestCase {
         XCTAssertEqual(sections.last?.children.count, 1)
     }
 
-    @available(iOS 17.4, *)
-    func test_languageSection_whenOptionSelected_recordsTelemetry() throws {
-        let mockSummarizeNimbusUtils = MockSummarizerNimbusUtils()
-        mockSummarizeNimbusUtils.shakeGestureFeatureFlagEnabled = false
-        mockSummarizeNimbusUtils.isLanguageExpansionEnabled = true
-        mockSummarizeNimbusUtils.languageExpansionConfiguration = SummarizerLanguageExpansionConfiguration(
-            supportedLocales: [Locale(identifier: "de")]
-        )
-
-        let subject = createSubject(with: mockSummarizeNimbusUtils)
-        let languageSetting = try XCTUnwrap(subject.generateSettings().last?.children.first)
-        let cell = UITableViewCell()
-        languageSetting.onConfigureCell(cell, theme: LightTheme())
-
-        let pickerButton = try XCTUnwrap(cell.accessoryView as? UIButton)
-        let customLocaleAction = try XCTUnwrap(pickerButton.menu?.children.last as? UIAction)
-        customLocaleAction.performWithSender(nil, target: nil)
-
-        let savedExtras = try XCTUnwrap(
-            gleanWrapper.savedExtras.first as? GleanMetrics.AiSummarize.LanguageSettingChangedExtra
-        )
-        XCTAssertEqual(gleanWrapper.recordEventCalled, 1)
-        XCTAssertEqual(savedExtras.language, "de")
-        XCTAssertEqual(profile.prefs.stringForKey(PrefsKeys.Summarizer.selectedLanguage), "de")
-    }
-
     // MARK: - Helper
     private func createSubject(with summarizeNimbusUtils: MockSummarizerNimbusUtils) -> SummarizeSettingsViewController {
         let subject = SummarizeSettingsViewController(
             prefs: profile.prefs,
             summarizeNimbusUtils: summarizeNimbusUtils,
-            telemetry: SummarizerTelemetry(gleanWrapper: gleanWrapper),
             windowUUID: .XCTestDefaultUUID
         )
         trackForMemoryLeaks(subject)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Summarizer/SummarizerConfigProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Summarizer/SummarizerConfigProviderTests.swift
@@ -141,7 +141,7 @@ final class SummarizerConfigProviderTests: XCTestCase {
                                              contentType: .generic,
                                              languages: languages)
 
-        XCTAssertEqual(config.locale, languages.summaryLocale)
+        XCTAssertEqual(config.summaryLocale, languages.summaryLocale)
         XCTAssertEqual(config.pageLocale, languages.pageLocale)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Summarizer/SummarizerConfigProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Summarizer/SummarizerConfigProviderTests.swift
@@ -9,10 +9,14 @@ import XCTest
 @MainActor
 final class SummarizerConfigProviderTests: XCTestCase {
     private let locale = Locale(identifier: "en-US")
+    private let languages = SummarizerLanguageResolution(
+        summaryLocale: Locale(identifier: "en-US"),
+        pageLocale: Locale(identifier: "de")
+    )
 
     func testReturnsEmptyConfigWhenNoSourcesProvided() async {
         let subject = createSubject(sources: [])
-        let config = await subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, locale: locale)
+        let config = await subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, languages: languages)
         XCTAssertEqual(config.instructions, "")
         XCTAssertTrue(config.options.isEmpty)
     }
@@ -30,7 +34,7 @@ final class SummarizerConfigProviderTests: XCTestCase {
         ]
 
         let subject = createSubject(sources: mockSources)
-        let config = await subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, locale: locale)
+        let config = await subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, languages: languages)
         XCTAssertEqual(config.instructions, "")
         XCTAssertTrue(config.options.isEmpty)
     }
@@ -48,7 +52,9 @@ final class SummarizerConfigProviderTests: XCTestCase {
         ]
 
         let subject = createSubject(sources: mockSources)
-        let config = await subject.getConfig(summarizerModel: .liteLLMSummarizer, contentType: .recipe, locale: locale)
+        let config = await subject.getConfig(summarizerModel: .liteLLMSummarizer,
+                                             contentType: .recipe,
+                                             languages: languages)
         XCTAssertEqual(config.instructions, "Instructions")
         XCTAssertTrue(config.options.isEmpty)
     }
@@ -70,7 +76,7 @@ final class SummarizerConfigProviderTests: XCTestCase {
         ]
 
         let subject = createSubject(sources: mockSources)
-        let config = await subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, locale: locale)
+        let config = await subject.getConfig(summarizerModel: .appleSummarizer, contentType: .generic, languages: languages)
 
         // Highest priority instructions
         XCTAssertEqual(config.instructions, "Instructions 1")
@@ -95,7 +101,9 @@ final class SummarizerConfigProviderTests: XCTestCase {
         ]
 
         let subject = createSubject(sources: mockSources)
-        let config = await subject.getConfig(summarizerModel: .liteLLMSummarizer, contentType: .recipe, locale: locale)
+        let config = await subject.getConfig(summarizerModel: .liteLLMSummarizer,
+                                             contentType: .recipe,
+                                             languages: languages)
 
         XCTAssertEqual(config.instructions, "Instructions 2")
         XCTAssertEqual(config.options["topP"] as? Int, 2)
@@ -117,13 +125,24 @@ final class SummarizerConfigProviderTests: XCTestCase {
         let config = await subject.getConfig(
             summarizerModel: .appleSummarizer,
             contentType: .recipe,
-            locale: locale
+            languages: languages
         )
 
         XCTAssertEqual(
             config.instructions,
             "Instructions with \(enLocale.localizedString(forIdentifier: locale.identifier) ?? "English")"
         )
+    }
+
+    func testAttachesResolvedLanguagesToConfig() async {
+        let subject = createSubject(sources: [])
+
+        let config = await subject.getConfig(summarizerModel: .appleSummarizer,
+                                             contentType: .generic,
+                                             languages: languages)
+
+        XCTAssertEqual(config.locale, languages.summaryLocale)
+        XCTAssertEqual(config.pageLocale, languages.pageLocale)
     }
 
     private func createSubject(sources: [SummarizerConfigSourceProtocol]) -> DefaultSummarizerConfigProvider {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Summarizer/SummarizerLanguageProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Summarizer/SummarizerLanguageProviderTests.swift
@@ -13,12 +13,12 @@ struct SummarizerLanguageProviderTests {
         websiteLanguageProvider.mockError = NSError(domain: "", code: 0)
         let subject = createSubject()
 
-        let locale = await subject.getLanguage(
+        let languages = await subject.getLanguage(
             userPreference: .websiteLanguage,
             supportedLocales: [],
             languageSampleSource: MockLanguageSampleSource()
         )
-        #expect(locale == nil)
+        #expect(languages == nil)
     }
 
     @Test
@@ -26,12 +26,12 @@ struct SummarizerLanguageProviderTests {
         websiteLanguageProvider.detectedLanguage = "fr"
         let subject = createSubject()
 
-        let locale = await subject.getLanguage(
+        let languages = await subject.getLanguage(
             userPreference: .websiteLanguage,
             supportedLocales: [Locale(identifier: "en-GB")],
             languageSampleSource: MockLanguageSampleSource()
         )
-        #expect(locale == nil)
+        #expect(languages == nil)
     }
 
     @Test
@@ -39,7 +39,7 @@ struct SummarizerLanguageProviderTests {
         websiteLanguageProvider.detectedLanguage = "fr"
         let subject = createSubject()
 
-        let locale = await subject.getLanguage(
+        let languages = await subject.getLanguage(
             userPreference: .websiteLanguage,
             supportedLocales: [
                 Locale(identifier: "fr-FR"),
@@ -48,7 +48,9 @@ struct SummarizerLanguageProviderTests {
             languageSampleSource: MockLanguageSampleSource()
         )
 
-        #expect(locale == Locale(identifier: websiteLanguageProvider.detectedLanguage))
+        let detectedLocale = Locale(identifier: websiteLanguageProvider.detectedLanguage)
+        #expect(languages?.summaryLocale == detectedLocale)
+        #expect(languages?.pageLocale == detectedLocale)
     }
 
     @Test
@@ -56,13 +58,14 @@ struct SummarizerLanguageProviderTests {
         websiteLanguageProvider.detectedLanguage = "de"
         let subject = createSubject()
 
-        let locale = await subject.getLanguage(
+        let languages = await subject.getLanguage(
             userPreference: .customLocale(Locale(identifier: "de")),
             supportedLocales: [Locale(identifier: "de")],
             languageSampleSource: MockLanguageSampleSource()
         )
 
-        #expect(locale == Locale(identifier: "de"))
+        #expect(languages?.summaryLocale == Locale(identifier: "de"))
+        #expect(languages?.pageLocale == Locale(identifier: "de"))
     }
 
     @Test
@@ -70,13 +73,28 @@ struct SummarizerLanguageProviderTests {
         websiteLanguageProvider.detectedLanguage = "it"
         let subject = createSubject()
 
-        let locale = await subject.getLanguage(
+        let languages = await subject.getLanguage(
             userPreference: .customLocale(Locale(identifier: "de")),
             supportedLocales: [Locale(identifier: "it")],
             languageSampleSource: MockLanguageSampleSource()
         )
 
-        #expect(locale == nil)
+        #expect(languages == nil)
+    }
+
+    @Test
+    func test_getLanguage_whenCustomLocaleDiffersFromWebsiteLanguage_reportsBothLocales() async {
+        websiteLanguageProvider.detectedLanguage = "de"
+        let subject = createSubject()
+
+        let languages = await subject.getLanguage(
+            userPreference: .customLocale(Locale(identifier: "it")),
+            supportedLocales: [Locale(identifier: "de"), Locale(identifier: "it")],
+            languageSampleSource: MockLanguageSampleSource()
+        )
+
+        #expect(languages?.summaryLocale == Locale(identifier: "it"))
+        #expect(languages?.pageLocale == Locale(identifier: "de"))
     }
 
     private func createSubject() -> DefaultSummarizerLanguageProvider {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Summarizer/SummarizerPrefsMigrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Summarizer/SummarizerPrefsMigrationTests.swift
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Shared
+@testable import Client
+
+final class SummarizerPrefsMigrationTests: XCTestCase {
+    private var prefs: MockProfilePrefs!
+    private let itTestLanguage = "it-IT"
+    private let deTestLanguage = "de-DE"
+
+    override func setUp() {
+        super.setUp()
+        prefs = MockProfilePrefs()
+    }
+
+    override func tearDown() {
+        prefs = nil
+        super.tearDown()
+    }
+
+    // MARK: - migrateSelectedLanguage
+    func test_migrateSelectedLanguage_whenLegacyKeyIsSet_movesValueAndRemovesLegacyKey() {
+        let subject = createSubject()
+        prefs.setString(itTestLanguage, forKey: PrefsKeys.Summarizer.legacySelectedLanguage)
+
+        subject.migrateSelectedLanguage()
+
+        XCTAssertEqual(prefs.stringForKey(PrefsKeys.Summarizer.selectedLanguage), itTestLanguage)
+        XCTAssertNil(prefs.stringForKey(PrefsKeys.Summarizer.legacySelectedLanguage))
+    }
+
+    func test_migrateSelectedLanguage_whenLegacyKeyIsMissing_writesNothing() {
+        let subject = createSubject()
+
+        subject.migrateSelectedLanguage()
+
+        XCTAssertNil(prefs.stringForKey(PrefsKeys.Summarizer.selectedLanguage))
+        XCTAssertNil(prefs.stringForKey(PrefsKeys.Summarizer.legacySelectedLanguage))
+    }
+
+    func test_migrateSelectedLanguage_whenRunTwice_keepsMigratedValue() {
+        let subject = createSubject()
+        prefs.setString(itTestLanguage, forKey: PrefsKeys.Summarizer.legacySelectedLanguage)
+
+        subject.migrateSelectedLanguage()
+        subject.migrateSelectedLanguage()
+
+        XCTAssertEqual(prefs.stringForKey(PrefsKeys.Summarizer.selectedLanguage), itTestLanguage)
+        XCTAssertNil(prefs.stringForKey(PrefsKeys.Summarizer.legacySelectedLanguage))
+    }
+
+    func test_migrateSelectedLanguage_whenNamespacedKeyIsAlreadySet_doesNotOverwriteIt() {
+        let subject = createSubject()
+        prefs.setString(itTestLanguage, forKey: PrefsKeys.Summarizer.legacySelectedLanguage)
+        prefs.setString(deTestLanguage, forKey: PrefsKeys.Summarizer.selectedLanguage)
+
+        subject.migrateSelectedLanguage()
+
+        XCTAssertEqual(prefs.stringForKey(PrefsKeys.Summarizer.selectedLanguage), deTestLanguage)
+        XCTAssertNil(prefs.stringForKey(PrefsKeys.Summarizer.legacySelectedLanguage))
+    }
+
+    // MARK: - Helpers
+    private func createSubject() -> SummarizerPrefsMigration {
+        return SummarizerPrefsMigration(prefs: prefs)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarMiddlewareTests.swift
@@ -760,6 +760,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
         XCTAssertEqual(savedExtras.isPrivate, false)
         XCTAssertEqual(savedExtras.enabled, false)
+        XCTAssertEqual(savedExtras.hasSummarizer, false)
     }
 
     func testDidTapButton_tapOnReaderModeWithSummarizerButton_dispatchesShowReaderModes() throws {
@@ -777,6 +778,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssert(savedMetric === event, "Received \(savedMetric) instead of \(event)")
         XCTAssertEqual(savedExtras.isPrivate, false)
         XCTAssertEqual(savedExtras.enabled, false)
+        XCTAssertEqual(savedExtras.hasSummarizer, true)
     }
 
     func testDidTapButton_tapOnReloadButton_dispatchesReloadWebsite() throws {
@@ -1016,7 +1018,7 @@ final class ToolbarMiddlewareTests: XCTestCase, StoreTestUtility {
             buttonType: .readerModeWithSummarizer,
             expectedActionType: .showSummarizer,
             expectation: expectation(description: "The show summarizer action should have been dispatched.")) { action in
-                XCTAssertEqual(action.summarizerTrigger, .toolbarIcon)
+                XCTAssertEqual(action.summarizerTrigger, .readerModeWithSummarizerButton)
         }
     }
 

--- a/firefox-ios/nimbus-features/summarizerLanguageExpansionFeature.yaml
+++ b/firefox-ios/nimbus-features/summarizerLanguageExpansionFeature.yaml
@@ -22,10 +22,12 @@ features:
           - "es"
           - "de"
           - "pt"
+          - "ja"
+          - "jp"
     defaults:
       - channel: beta
         value:
-          enabled: false
+          enabled: true
       - channel: developer
         value:
-          enabled: false
+          enabled: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16665)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35362)

## :bulb: Description
Adds the summarizer telemetry that was missing around language expansion and the toolbar entry points:

- New `ai.summarize.language_setting_changed` event and `user.ai.summarize.selected_language` preference metric for the settings language picker.
- `summarization_started` now reports the `language` the summary is generated in and the detected `page_language`.
- The combined reader-mode-with-summarizer toolbar button is now distinguishable: `has_summarizer` extra on `toolbar.reader_mode_button_tapped` for the tap, and a new `readerModeWithSummarizerButton` trigger for the long press.
- Fixes swapped `enabled`/`is_private` arguments in `ToolbarTelemetry.readerModeButtonTapped`.

Also enables the language expansion feature by default on beta and developer channels, and adds `ja`/`jp` to the supported locales.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
