### PR TITLE
Fix main menu cells blank when theme is nil

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuAccountCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuAccountCell.swift
@@ -84,7 +84,6 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     func configureCellWith(
         model: MenuElement,
-        theme: Theme,
         isFirstCell: Bool,
         isLastCell: Bool,
         mainMenuHelper: MainMenuInterface = MainMenuHelper()
@@ -96,14 +95,7 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
         titleLabel.text = model.title
         descriptionLabel.text = model.description
         contentStackView.spacing = model.description != nil ? UX.contentSpacing : UX.noDescriptionContentSpacing
-        if let needsReAuth = model.needsReAuth, needsReAuth {
-            typealias Icons = StandardImageIdentifiers.Large
-            if theme.type == .light {
-                iconImageView.image = UIImage(named: Icons.avatarWarningCircleFillMulticolorLight)
-            } else {
-                iconImageView.image = UIImage(named: Icons.avatarWarningCircleFillMulticolorDark)
-            }
-        } else if let iconImage = model.iconImage {
+        if let iconImage = model.iconImage {
             iconImageView.image = iconImage
         } else {
             iconImageView.image = UIImage(named: model.iconName)?.withRenderingMode(.alwaysTemplate)
@@ -157,6 +149,10 @@ final class MenuAccountCell: UITableViewCell, ReusableCell, ThemeApplicable {
         guard let model else { return }
         backgroundColor = theme.colors.layerSurfaceMedium.withAlphaComponent(mainMenuHelper?.backgroundAlpha() ?? 1.0)
         if let needsReAuth = model.needsReAuth, needsReAuth {
+            typealias Icons = StandardImageIdentifiers.Large
+            iconImageView.image = UIImage(named: theme.type == .light
+                ? Icons.avatarWarningCircleFillMulticolorLight
+                : Icons.avatarWarningCircleFillMulticolorDark)
             descriptionLabel.textColor = theme.colors.textCritical
         } else if model.iconImage != nil {
             descriptionLabel.textColor = theme.colors.textSecondary

--- a/BrowserKit/Sources/MenuKit/MenuCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuCell.swift
@@ -74,7 +74,6 @@ final class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
 
     func configureCellWith(
         model: MenuElement,
-        theme: Theme,
         isFirstCell: Bool,
         isLastCell: Bool,
         mainMenuHelper: MainMenuInterface = MainMenuHelper()

--- a/BrowserKit/Sources/MenuKit/MenuTableViewHelper.swift
+++ b/BrowserKit/Sources/MenuKit/MenuTableViewHelper.swift
@@ -74,8 +74,10 @@ final class MenuTableViewHelper: NSObject {
                 return UITableViewCell()
             }
             let numberOfRows = tableView.numberOfRows(inSection: indexPath.section)
-            cell.configureCellWith(model: rowOption, isFirstCell: indexPath.row == 0,
-                                   isLastCell: indexPath.row == numberOfRows - 1)
+            cell.configureCellWith(
+                model: rowOption,
+                isFirstCell: indexPath.row == 0,
+                isLastCell: indexPath.row == numberOfRows - 1)
             if let theme { cell.applyTheme(theme: theme) }
             return cell
         }
@@ -99,8 +101,10 @@ final class MenuTableViewHelper: NSObject {
             return UITableViewCell()
         }
         let numberOfRows = tableView.numberOfRows(inSection: indexPath.section)
-        cell.configureCellWith(model: rowOption, isFirstCell: indexPath.row == 0,
-                               isLastCell: indexPath.row == numberOfRows - 1)
+        cell.configureCellWith(
+            model: rowOption,
+            isFirstCell: indexPath.row == 0,
+            isLastCell: indexPath.row == numberOfRows - 1)
         if let theme { cell.applyTheme(theme: theme) }
         return cell
     }

--- a/BrowserKit/Sources/MenuKit/MenuTableViewHelper.swift
+++ b/BrowserKit/Sources/MenuKit/MenuTableViewHelper.swift
@@ -73,13 +73,10 @@ final class MenuTableViewHelper: NSObject {
             ) as? MenuAccountCell else {
                 return UITableViewCell()
             }
-            if let theme {
-                let numberOfRows = tableView.numberOfRows(inSection: indexPath.section)
-                let isFirst = indexPath.row == 0
-                let isLast = indexPath.row == numberOfRows - 1
-                cell.configureCellWith(model: rowOption, theme: theme, isFirstCell: isFirst, isLastCell: isLast)
-                cell.applyTheme(theme: theme)
-            }
+            let numberOfRows = tableView.numberOfRows(inSection: indexPath.section)
+            cell.configureCellWith(model: rowOption, isFirstCell: indexPath.row == 0,
+                                   isLastCell: indexPath.row == numberOfRows - 1)
+            if let theme { cell.applyTheme(theme: theme) }
             return cell
         }
 
@@ -90,10 +87,8 @@ final class MenuTableViewHelper: NSObject {
             ) as? MenuInfoCell else {
                 return UITableViewCell()
             }
-            if let theme {
-                cell.configureCellWith(model: rowOption)
-                cell.applyTheme(theme: theme)
-            }
+            cell.configureCellWith(model: rowOption)
+            if let theme { cell.applyTheme(theme: theme) }
             return cell
         }
 
@@ -103,13 +98,10 @@ final class MenuTableViewHelper: NSObject {
         ) as? MenuCell else {
             return UITableViewCell()
         }
-        if let theme {
-            let numberOfRows = tableView.numberOfRows(inSection: indexPath.section)
-            let isFirst = indexPath.row == 0
-            let isLast = indexPath.row == numberOfRows - 1
-            cell.configureCellWith(model: rowOption, theme: theme, isFirstCell: isFirst, isLastCell: isLast)
-            cell.applyTheme(theme: theme)
-        }
+        let numberOfRows = tableView.numberOfRows(inSection: indexPath.section)
+        cell.configureCellWith(model: rowOption, isFirstCell: indexPath.row == 0,
+                               isLastCell: indexPath.row == numberOfRows - 1)
+        if let theme { cell.applyTheme(theme: theme) }
         return cell
     }
 

--- a/BrowserKit/Tests/MenuKitTests/MenuTableViewHelperTests.swift
+++ b/BrowserKit/Tests/MenuKitTests/MenuTableViewHelperTests.swift
@@ -127,4 +127,48 @@ final class MenuTableViewHelperTests: XCTestCase {
         let cell = helper.cellForRowAt(tableView, IndexPath(row: 0, section: 0))
         XCTAssertTrue(cell is MenuCell)
     }
+
+    func testCellForRow_menuCellIsConfiguredWithNilTheme() {
+        let option = MenuElement(
+            title: "Option 1",
+            iconName: "",
+            isEnabled: true,
+            isActive: false,
+            a11yLabel: "Option 1",
+            a11yHint: "",
+            a11yId: "option1",
+            action: nil
+        )
+
+        tableView.register(MenuCell.self, forCellReuseIdentifier: MenuCell.cellIdentifier)
+        let section = MenuSection(isHorizontalTabsSection: false, isExpanded: true, options: [option])
+        helper.updateData([section], theme: nil, isBannerVisible: false)
+        helper.reload()
+
+        let cell = helper.cellForRowAt(tableView, IndexPath(row: 0, section: 0)) as? MenuCell
+        XCTAssertNotNil(cell?.model, "Cell should be configured even when theme is nil")
+    }
+
+    func testCellForRow_accountCellIsConfiguredWithNilTheme() {
+        let option = MenuElement(
+            title: "Sign In",
+            iconName: "",
+            iconImage: UIImage(),
+            needsReAuth: false,
+            isEnabled: true,
+            isActive: false,
+            a11yLabel: "Sign In",
+            a11yHint: "",
+            a11yId: "signIn",
+            action: nil
+        )
+
+        tableView.register(MenuAccountCell.self, forCellReuseIdentifier: MenuAccountCell.cellIdentifier)
+        let section = MenuSection(isHorizontalTabsSection: false, isExpanded: true, options: [option])
+        helper.updateData([section], theme: nil, isBannerVisible: false)
+        helper.reload()
+
+        let cell = helper.cellForRowAt(tableView, IndexPath(row: 0, section: 0)) as? MenuAccountCell
+        XCTAssertNotNil(cell?.model, "Cell should be configured even when theme is nil")
+    }
 }


### PR DESCRIPTION
Fixes #32205

Menu cells (`MenuCell`, `MenuAccountCell`, `MenuInfoCell`) were returned completely unconfigured — no title, no icon, collapsed height — when `theme` was nil at the time `cellForRowAt` was called.

**Root cause:** `configureCellWith` was gated behind `if let theme` in `MenuTableViewHelper.cellForRowAt`. If `theme` happens to be nil, cells are skipped entirely and returned blank. This is a latent issue that can surface intermittently depending on timing between Redux state delivery and theme application.

**Fix:** Decouple content configuration from theming — `configureCellWith` is now called unconditionally, matching the existing pattern in `MenuSquaresViewContentCell`. `applyTheme` remains guarded on theme availability. The `needsReAuth` light/dark avatar icon selection in `MenuAccountCell` (which requires a theme) is moved into `applyTheme`.

## Changes

- `MenuCell.configureCellWith` — removed `theme` parameter
- `MenuAccountCell.configureCellWith` — removed `theme` parameter; moved `needsReAuth` icon selection to `applyTheme`
- `MenuTableViewHelper.cellForRowAt` — `configureCellWith` called unconditionally for all cell types; `applyTheme` remains theme-guarded
- Added two tests verifying cells are configured (non-nil `model`) even when theme is nil

## Test plan

- [ ] Open the main menu — verify all items (Bookmark Page, Find in Page, Desktop Site, More, Sign In, Settings) render correctly
- [ ] Toggle dark/light mode while menu is open — verify items remain visible
- [ ] Run `MenuTableViewHelperTests` — all tests pass including the two new nil-theme tests