### PR TITLE
Refactor FXIOS-16670 Clean Up Feature Flag Gating Logic for Native Error Page Features

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -1151,18 +1151,18 @@ extension BrowserViewController: WKNavigationDelegate {
                 let noInternetErrorCode = Int(
                     CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue
                 )
-                let isWaybackCode = WaybackCodes.isWaybackCode(error.code)
+                let featureFlag = NativeErrorPageFeatureFlag()
 
-                let isNoInternetError = NativeErrorPageFeatureFlag().isNICErrorPageEnabled &&
-                    error.code == noInternetErrorCode
-                let isCertificateError = NativeErrorPageHelper.shouldShowNativeBadCertDomainErrorPage(
-                    for: error,
-                    isOtherErrorPagesEnabled: NativeErrorPageFeatureFlag().isBadCertDomainErrorPageEnabled
-                )
-                let isShowWayback = NativeErrorPageFeatureFlag().isWaybackEnabled && isWaybackCode
+                let isWaybackError = WaybackCodes.isWaybackCode(error.code)
+                let isNoInternetError = error.code == noInternetErrorCode
+                let isBadCertError = NativeErrorPageHelper.isBadCertDomainError(error)
 
-                if isNoInternetError || isCertificateError || isShowWayback {
-                    if isCertificateError {
+                let shouldShowNoInternetErrorPage = isNoInternetError && featureFlag.isNICErrorPageEnabled
+                let shouldShowBadCertErrorPage = isBadCertError && featureFlag.isBadCertDomainErrorPageEnabled
+                let shouldShowWaybackErrorPage = isWaybackError && featureFlag.isWaybackEnabled
+
+                if shouldShowNoInternetErrorPage || shouldShowBadCertErrorPage || shouldShowWaybackErrorPage {
+                    if isBadCertError {
                         NativeErrorPageHelper.logCertificateErrorDetails(error: error, logger: logger)
                     }
                     // TODO: FXIOS-15800 Move error type determination to NativeErrorPageMiddleware

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2086,26 +2086,32 @@ class BrowserViewController: UIViewController,
             return
         }
 
-        let isNICErrorCode = url.absoluteString.contains(String(Int(
-            CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue)))
-        let isWaybackErrorCode: Bool = {
+        let featureFlag = NativeErrorPageFeatureFlag()
+
+        let isNoInternetError = url.absoluteString.contains(
+            String(Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue))
+        )
+        let isWaybackError: Bool = {
             guard
                 let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
                 let codeString = components.queryItems?.first(where: { $0.name == "code" })?.value,
                 let code = Int(codeString)
             else { return false }
+
             return WaybackCodes.isWaybackCode(code)
         }()
-        let noInternetConnectionEnabled = isNICErrorCode &&
-            NativeErrorPageFeatureFlag().isNativeErrorPageEnabled
-        let isCertificateError = NativeErrorPageFeatureFlag().isBadCertDomainErrorPageEnabled &&
-            NativeErrorPageHelper.isBadCertDomainErrorURL(url)
-        let isShowWayback = isWaybackErrorCode &&
-            NativeErrorPageFeatureFlag().isWaybackEnabled
+        let isBadCertError = NativeErrorPageHelper.isBadCertDomainErrorURL(url)
+
+        let shouldShowNoInternetErrorPage =
+            isNoInternetError && featureFlag.isNativeErrorPageEnabled
+        let shouldShowBadCertErrorPage =
+            isBadCertError && featureFlag.isBadCertDomainErrorPageEnabled
+        let shouldShowWaybackErrorPage =
+            isWaybackError && featureFlag.isWaybackEnabled
 
         if isAboutHomeURL {
             showEmbeddedHomepage(inline: true, isPrivate: tabManager.selectedTab?.isPrivate ?? false)
-        } else if isErrorURL && (noInternetConnectionEnabled || isCertificateError || isShowWayback) {
+        } else if isErrorURL && (shouldShowNoInternetErrorPage || shouldShowBadCertErrorPage || shouldShowWaybackErrorPage) {
             showEmbeddedNativeErrorPage()
         } else {
             showEmbeddedWebview()

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -200,17 +200,23 @@ final class ErrorPageHandler: InternalSchemeResponse {
             CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue
         )
 
-        let isNoInternetError = NativeErrorPageFeatureFlag().isNICErrorPageEnabled &&
-            (errCode == noInternetErrorCode) && !useOldErrorPage
-        let isCertificateError = NativeErrorPageFeatureFlag().isBadCertDomainErrorPageEnabled &&
-            NativeErrorPageHelper.isBadCertDomainErrorURL(url) && !useOldErrorPage
+        let featureFlag = NativeErrorPageFeatureFlag()
 
-        // Used for checking if current error code is one that should fall back to wayback
-        let isWaybackCode = WaybackCodes.isWaybackCode(errCode)
-        let isWaybackError = NativeErrorPageFeatureFlag().isWaybackEnabled && isWaybackCode && !useOldErrorPage
+        let isNoInternetError = errCode == noInternetErrorCode
+        let isBadCertError = NativeErrorPageHelper.isBadCertDomainErrorURL(url)
+        let isWaybackError = WaybackCodes.isWaybackCode(errCode)
 
-        // Handle No internet access or certificate errors with native error page
-        if isNoInternetError || isCertificateError || isWaybackError {
+        let shouldShowNoInternetErrorPage =
+            featureFlag.isNICErrorPageEnabled && isNoInternetError && !useOldErrorPage
+
+        let shouldShowBadCertErrorPage =
+            featureFlag.isBadCertDomainErrorPageEnabled && isBadCertError && !useOldErrorPage
+
+        let shouldShowWaybackErrorPage =
+            featureFlag.isWaybackEnabled && isWaybackError && !useOldErrorPage
+
+        // Handle no internet access, certificate, and wayback enabled errors with native error page
+        if shouldShowNoInternetErrorPage || shouldShowBadCertErrorPage || shouldShowWaybackErrorPage {
             return responseForNativeErrorPage(request: request)
         } else {
             return responseForErrorWebPage(request: request)

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageFeatureFlag.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageFeatureFlag.swift
@@ -4,24 +4,25 @@
 
 import Foundation
 
+/// Provider for all feature flags related to native error pages. We should only
+/// use this to check if a native error page feature is enabled.
 struct NativeErrorPageFeatureFlag: FeatureFlaggable {
     var isNativeErrorPageEnabled: Bool {
         return featureFlagsProvider.isEnabled(.nativeErrorPage)
     }
 
-    /// Temporary flag for showing no internet connection native error page only.
     var isNICErrorPageEnabled: Bool {
         return featureFlagsProvider.isEnabled(.nativeErrorPage) &&
-            featureFlagsProvider.isEnabled(.noInternetConnectionErrorPage)
+               featureFlagsProvider.isEnabled(.noInternetConnectionErrorPage)
     }
 
-    /// Flag for showing bad certificate domain native error page
     var isBadCertDomainErrorPageEnabled: Bool {
-        return featureFlagsProvider.isEnabled(.badCertDomainErrorPage)
+        return featureFlagsProvider.isEnabled(.nativeErrorPage) &&
+               featureFlagsProvider.isEnabled(.badCertDomainErrorPage)
     }
 
-    /// Flag for showing Wayback entry point
     var isWaybackEnabled: Bool {
-        return featureFlagsProvider.isEnabled(.waybackMachine)
+        return featureFlagsProvider.isEnabled(.nativeErrorPage) &&
+               featureFlagsProvider.isEnabled(.waybackMachine)
     }
 }

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageHelper.swift
@@ -58,7 +58,7 @@ class NativeErrorPageHelper {
     /// Returns true when the error is a certificate error caused by a
     /// hostname mismatch (SSL_ERROR_BAD_CERT_DOMAIN / -9843). Other certificate
     /// failures return false so they fall back to the legacy HTML error page
-    private static func isBadCertDomainError(_ error: NSError) -> Bool {
+    static func isBadCertDomainError(_ error: NSError) -> Bool {
         guard isCertificateErrorCode(error.code) else { return false }
         return certStreamErrorCode(from: error) == NativeGeckoCode.badCertDomain.rawValue
     }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1044,7 +1044,7 @@ final class TabManagerImplementation: NSObject,
 
     private func didSelectTab(_ url: URL?) {
         tabsTelemetry.stopTabSwitchMeasurement()
-        let isNativeErrorPage = featureFlagsProvider.isEnabled(.nativeErrorPage)
+        let isNativeErrorPage = NativeErrorPageFeatureFlag().isNativeErrorPageEnabled
 
         // If app starts with error url, first homepage appears and
         // then error page is loaded. To directly load error page

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageFeatureFlagTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/NativeErrorPage/NativeErrorPageFeatureFlagTests.swift
@@ -23,41 +23,109 @@ class NativeErrorPageFeatureFlagTests: XCTestCase {
     }
 
     func testFeatureFlag_WhenNativeErrorPageEnabled_ThenFeatureIsEnabled() {
-        setupNimbusNativeErrorPageTesting(isEnabled: true,
-                                          noInternetConnectionErrorIsEnabled: true,
-                                          badCertDomainErrorPageIsEnabled: false)
+        setupNimbusNativeErrorPageTesting(isEnabled: true)
+
         XCTAssertTrue(subject.isNativeErrorPageEnabled)
     }
 
     func testFeatureFlag_WhenNativeErrorPageDisabled_ThenFeatureIsDisabled() {
-        setupNimbusNativeErrorPageTesting(isEnabled: false,
-                                          noInternetConnectionErrorIsEnabled: false,
-                                          badCertDomainErrorPageIsEnabled: false)
+        setupNimbusNativeErrorPageTesting(isEnabled: false)
+
         XCTAssertFalse(subject.isNativeErrorPageEnabled)
     }
 
-    func testFeatureFlag_WhenBadCertDomainErrorPageEnabled_ThenFeatureIsEnabled() {
-        setupNimbusNativeErrorPageTesting(isEnabled: true,
-                                          noInternetConnectionErrorIsEnabled: true,
-                                          badCertDomainErrorPageIsEnabled: true)
+    func testFeatureFlag_WhenNICEnabledAndNativeErrorPageEnabled_ThenFeatureIsEnabled() {
+        setupNimbusNativeErrorPageTesting(
+            isEnabled: true,
+            noInternetConnectionErrorIsEnabled: true
+        )
+
+        XCTAssertTrue(subject.isNICErrorPageEnabled)
+    }
+
+    func testFeatureFlag_WhenNICEnabledAndNativeErrorPageDisabled_ThenFeatureIsDisabled() {
+        setupNimbusNativeErrorPageTesting(
+            isEnabled: false,
+            noInternetConnectionErrorIsEnabled: true
+        )
+
+        XCTAssertFalse(subject.isNICErrorPageEnabled)
+    }
+
+    func testFeatureFlag_WhenNICDisabledAndNativeErrorPageEnabled_ThenFeatureIsDisabled() {
+        setupNimbusNativeErrorPageTesting(
+            isEnabled: true,
+            noInternetConnectionErrorIsEnabled: false
+        )
+
+        XCTAssertFalse(subject.isNICErrorPageEnabled)
+    }
+
+    func testFeatureFlag_WhenBadCertDomainErrorPageEnabledAndNativeErrorPageEnabled_ThenFeatureIsEnabled() {
+        setupNimbusNativeErrorPageTesting(
+            isEnabled: true,
+            badCertDomainErrorPageIsEnabled: true
+        )
+
         XCTAssertTrue(subject.isBadCertDomainErrorPageEnabled)
     }
 
-    func testFeatureFlag_WhenBadCertDomainErrorPageDisabled_ThenFeatureIsDisabled() {
-        setupNimbusNativeErrorPageTesting(isEnabled: true,
-                                          noInternetConnectionErrorIsEnabled: true,
-                                          badCertDomainErrorPageIsEnabled: false)
+    func testFeatureFlag_WhenBadCertDomainErrorPageEnabledAndNativeErrorPageDisabled_ThenFeatureIsDisabled() {
+        setupNimbusNativeErrorPageTesting(
+            isEnabled: false,
+            badCertDomainErrorPageIsEnabled: true
+        )
+
         XCTAssertFalse(subject.isBadCertDomainErrorPageEnabled)
     }
 
-    // Helper
-    private func setupNimbusNativeErrorPageTesting(isEnabled: Bool,
-                                                   noInternetConnectionErrorIsEnabled: Bool,
-                                                   badCertDomainErrorPageIsEnabled: Bool = false) {
+    func testFeatureFlag_WhenBadCertDomainErrorPageDisabledAndNativeErrorPageEnabled_ThenFeatureIsDisabled() {
+        setupNimbusNativeErrorPageTesting(
+            isEnabled: true,
+            badCertDomainErrorPageIsEnabled: false
+        )
+
+        XCTAssertFalse(subject.isBadCertDomainErrorPageEnabled)
+    }
+
+    func testFeatureFlag_WhenWaybackEnabledAndNativeErrorPageEnabled_ThenFeatureIsEnabled() {
+        setupNimbusNativeErrorPageTesting(isEnabled: true)
+        setupNimbusWaybackTesting(isEnabled: true)
+
+        XCTAssertTrue(subject.isWaybackEnabled)
+    }
+
+    func testFeatureFlag_WhenWaybackEnabledAndNativeErrorPageDisabled_ThenFeatureIsDisabled() {
+        setupNimbusNativeErrorPageTesting(isEnabled: false)
+        setupNimbusWaybackTesting(isEnabled: true)
+
+        XCTAssertFalse(subject.isWaybackEnabled)
+    }
+
+    func testFeatureFlag_WhenWaybackDisabledAndNativeErrorPageEnabled_ThenFeatureIsDisabled() {
+        setupNimbusNativeErrorPageTesting(isEnabled: true)
+        setupNimbusWaybackTesting(isEnabled: false)
+
+        XCTAssertFalse(subject.isWaybackEnabled)
+    }
+
+    private func setupNimbusNativeErrorPageTesting(
+        isEnabled: Bool,
+        noInternetConnectionErrorIsEnabled: Bool = false,
+        badCertDomainErrorPageIsEnabled: Bool = false
+    ) {
         FxNimbus.shared.features.nativeErrorPageFeature.with { _, _ in
-                return NativeErrorPageFeature(badCertDomainErrorPage: badCertDomainErrorPageIsEnabled,
-                                              enabled: isEnabled,
-                                              noInternetConnectionError: noInternetConnectionErrorIsEnabled)
+            NativeErrorPageFeature(
+                badCertDomainErrorPage: badCertDomainErrorPageIsEnabled,
+                enabled: isEnabled,
+                noInternetConnectionError: noInternetConnectionErrorIsEnabled
+            )
+        }
+    }
+
+    private func setupNimbusWaybackTesting(isEnabled: Bool) {
+        FxNimbus.shared.features.waybackMachineFeature.with { _, _ in
+            WaybackMachineFeature(enabled: isEnabled)
         }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16670)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35363)

## :bulb: Description
Went through all the places where feature flags related to native error pages are being used and cleaned up the code so it is more readable. I also modified the NativeErrorPageFeatureFlag struct which provides the feature flags for all native error page features so that the struct now makes the general Native Error Page Feature Flag a prerequisite for all the other features that depend on it.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

