### PR TITLE
Add FXIOS-16671 Github Workflow for Security PR reminder

### DIFF
--- a/.github/workflows/security-pr-reminder.yml
+++ b/.github/workflows/security-pr-reminder.yml
@@ -1,0 +1,56 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: 'Security PR Reminder'
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+permissions: {}
+
+jobs:
+  security-pr-reminder:
+    # Skip bot-authored PRs
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: security-pr-reminder-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      NUMBER: ${{ github.event.pull_request.number }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+
+    steps:
+      - name: Post security reminder if PR references Bugzilla
+        shell: bash
+        env:
+          # Hidden marker used to avoid redundant reminders if the PR is edited
+          MARKER: '<!-- security-bugzilla-reminder -->'
+          BODY: |
+            <!-- security-bugzilla-reminder -->
+            🐞 This PR references Bugzilla. For security fixes, please be sure to assign the current iOS security monitor.
+        run: |
+          set -euo pipefail
+          retry() { n=0; until "$@"; do n=$((n+1)); [ $n -ge 3 ] && return 1; sleep 2; done; }
+
+          # Only act on security PRs that reference Bugzilla in the description.        
+          if ! printf '%s' "$PR_BODY" | grep -qi 'bugzilla'; then
+            echo "No 'bugzilla' reference in PR description; nothing to do."
+            exit 0
+          fi
+
+          existing=$(gh pr view "$NUMBER" -R "$GH_REPO" --json comments --jq '.comments[].body' || true)
+          if printf '%s' "$existing" | grep -qF "$MARKER"; then
+            echo "Reminder already present on PR #$NUMBER; skipping."
+            exit 0
+          fi
+
+          echo "Posting security reminder on PR #$NUMBER."
+          retry gh pr comment "$NUMBER" -R "$GH_REPO" -b "$BODY"

--- a/.github/workflows/security-pr-reminder.yml
+++ b/.github/workflows/security-pr-reminder.yml
@@ -26,6 +26,7 @@ jobs:
       GH_REPO: ${{ github.repository }}
       NUMBER: ${{ github.event.pull_request.number }}
       PR_BODY: ${{ github.event.pull_request.body }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
 
     steps:
       - name: Post security reminder if PR references Bugzilla
@@ -41,8 +42,12 @@ jobs:
           retry() { n=0; until "$@"; do n=$((n+1)); [ $n -ge 3 ] && return 1; sleep 2; done; }
 
           # Only act on security PRs that reference Bugzilla in the description.        
-          if ! printf '%s' "$PR_BODY" | grep -qi 'bugzilla'; then
-            echo "No 'bugzilla' reference in PR description; nothing to do."
+          title_match=false
+          body_link_match=false
+          if printf '%s' "$PR_TITLE" | grep -qi 'bugzilla'; then title_match=true; fi
+          if printf '%s' "$PR_BODY" | grep -Eiq 'https?://[^[:space:]]*bugzilla|bugzilla\.mozilla\.org'; then body_link_match=true; fi
+          if [ "$title_match" = false ] && [ "$body_link_match" = false ]; then
+            echo "No 'bugzilla' in title and no Bugzilla link in description; nothing to do."
             exit 0
           fi
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16671)

## :bulb: Description

Adds a new GH workflow that detects security-related PRs and provides a one-time reminder for assigning the active iOS security monitor. I'm investigating if we can have this workflow auto-assign the monitor (but still working on that).

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

