### PR TITLE
Refactor FXIOS-16679 [Sync] Credit card key logic cleanup

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewController.swift
@@ -319,7 +319,7 @@ class CreditCardBottomSheetViewController: UIViewController,
         ) as? HostingTableViewCell<CreditCardItemRow>,
               let creditCard = viewModel.getConvertedCreditCardValues(
                 bottomSheetState: viewModel.state,
-                ccNumberDecrypted: viewModel.decryptCreditCardNumber(card: viewModel.creditCard),
+                ccNumberDecrypted: viewModel.decryptedCardNumber,
                 row: indexPath.row
               )
         else { return UITableViewCell() }
@@ -390,19 +390,22 @@ class CreditCardBottomSheetViewController: UIViewController,
     }
 
     func handleCreditCardSelection(row: Int) {
-        guard let plainTextCreditCard = viewModel.getPlainCreditCardValues(
+        viewModel.getPlainCreditCardValues(
             bottomSheetState: .selectSavedCard,
             row: row
-        ) else {
-            // A nil means the card couldn't be decrypted. The Keychain key is unavailable.
-            logger.log("Credit card autofill selection failed: unable to decrypt selected card.",
-                       level: .warning,
-                       category: .autofill)
-            TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .creditCardAutofillFailed)
-            return
+        ) { [weak self] plainTextCreditCard in
+            guard let self else { return }
+            guard let plainTextCreditCard else {
+                // A nil means the card couldn't be decrypted. The Keychain key is unavailable.
+                self.logger.log("Credit card autofill selection failed: unable to decrypt selected card.",
+                                level: .fatal,
+                                category: .autofill)
+                TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .creditCardAutofillFailed)
+                return
+            }
+            self.didSelectCreditCardToFill?(plainTextCreditCard)
+            self.dismissVC()
         }
-        didSelectCreditCardToFill?(plainTextCreditCard)
-        dismissVC()
     }
 
     // MARK: Themable

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardBottomSheetViewModel.swift
@@ -77,6 +77,13 @@ final class CreditCardBottomSheetViewModel {
     }
 
     var didUpdateCreditCard: (() -> Void)?
+
+    /// The decrypted number of `creditCard`. Cell rendering is synchronous, so the `.update`
+    /// sheet reads it from here instead of decrypting per cell.
+    private(set) var decryptedCardNumber = "" {
+        didSet { didUpdateCreditCard?() }
+    }
+
     var decryptedCreditCard: UnencryptedCreditCardFields?
     var storedCreditCards = [CreditCard]()
     var state: CreditCardBottomSheetState
@@ -102,44 +109,46 @@ final class CreditCardBottomSheetViewModel {
             self.decryptedCreditCard = decryptedCreditCard
             self.creditCard = decryptedCreditCard?.convertToTempCreditCard()
         }
+        loadDecryptedCardNumber()
     }
 
     // MARK: Main Button Action
     public func didTapMainButton(queue: DispatchQueueInterface = DispatchQueue.main,
                                  completion: @escaping @Sendable (Error?) -> Void) {
-        let decryptedCard = getPlainCreditCardValues(bottomSheetState: state)
-        switch state {
-        case .save:
-            saveCreditCard(with: decryptedCard) { [logger] _, error in
-                queue.async {
-                    guard let error = error else {
-                        completion(nil)
-                        return
+        getPlainCreditCardValues(bottomSheetState: state) { [weak self] decryptedCard in
+            guard let self else { return }
+            switch state {
+            case .save:
+                saveCreditCard(with: decryptedCard) { [logger] _, error in
+                    queue.async {
+                        guard let error else {
+                            completion(nil)
+                            return
+                        }
+                        logger.log("Unable to save credit card",
+                                   level: .fatal,
+                                   category: .autofill,
+                                   description: "\(error)")
+                        completion(error)
                     }
-                    logger.log("Unable to save credit card",
-                               level: .fatal,
-                               category: .autofill,
-                               description: "\(error)")
-                    completion(error)
                 }
-            }
-        case .update:
-            updateCreditCard(for: creditCard?.guid,
-                             with: decryptedCard) { [logger] _, error in
-                queue.async {
-                    guard let error = error else {
-                        completion(nil)
-                        return
+            case .update:
+                updateCreditCard(for: creditCard?.guid, with: decryptedCard) { [logger] _, error in
+                    queue.async {
+                        guard let error else {
+                            completion(nil)
+                            return
+                        }
+                        logger.log("Unable to save credit card",
+                                   level: .fatal,
+                                   category: .autofill,
+                                   description: "\(error)")
+                        completion(error)
                     }
-                    logger.log("Unable to save credit card",
-                               level: .fatal,
-                               category: .autofill,
-                               description: "\(error)")
-                    completion(error)
                 }
+            case .selectSavedCard:
+                break
             }
-        case .selectSavedCard:
-            break
         }
     }
 
@@ -179,44 +188,53 @@ final class CreditCardBottomSheetViewModel {
 
     // MARK: Helper Methods
     func getPlainCreditCardValues(bottomSheetState: CreditCardBottomSheetState,
-                                  row: Int? = nil) -> UnencryptedCreditCardFields? {
+                                  row: Int? = nil,
+                                  completion: @escaping @MainActor (UnencryptedCreditCardFields?) -> Void) {
         switch bottomSheetState {
         case .save:
-            guard let plainCard = decryptedCreditCard else { return nil }
-            return plainCard
+            completion(decryptedCreditCard)
         case .update:
-            guard let creditCard = creditCard,
-                  let ccNumberDecrypted = autofill.decryptCreditCardNumber(encryptedCCNum: creditCard.ccNumberEnc)
-            else {
-                return nil
+            guard let creditCard else {
+                completion(nil)
+                return
             }
-            let updatedDecryptedCreditCard = updateDecryptedCreditCard(from: creditCard,
-                                                                       with: ccNumberDecrypted,
-                                                                       fieldValues: decryptedCreditCard)
-            return updatedDecryptedCreditCard
+            autofill.decryptCreditCardNumber(encryptedCCNum: creditCard.ccNumberEnc) { [weak self] ccNumberDecrypted in
+                ensureMainThread {
+                    guard let self, let ccNumberDecrypted else {
+                        completion(nil)
+                        return
+                    }
+                    completion(self.updateDecryptedCreditCard(from: creditCard,
+                                                              with: ccNumberDecrypted,
+                                                              fieldValues: self.decryptedCreditCard))
+                }
+            }
         case .selectSavedCard:
             guard let row = row,
                   let selectedCreditCard = getSavedCreditCard(for: row)
             else {
-                return nil
+                completion(nil)
+                return
             }
 
-            let decryptedCreditCardNum = decryptCreditCardNumber(card: selectedCreditCard)
-
-            guard !decryptedCreditCardNum.isEmpty else {
-                return nil
+            autofill.decryptCreditCardNumber(encryptedCCNum: selectedCreditCard.ccNumberEnc) { ccNumberDecrypted in
+                ensureMainThread {
+                    guard let ccNumberDecrypted, !ccNumberDecrypted.isEmpty else {
+                        completion(nil)
+                        return
+                    }
+                    // We need to show only 2 digits but save full year for sync
+                    let period = Int64(Date.getCurrentPeriod())
+                    let selectedExpYear = selectedCreditCard.ccExpYear
+                    let yearVal = selectedExpYear < 1000 ? selectedExpYear + period : selectedExpYear
+                    completion(UnencryptedCreditCardFields(ccName: selectedCreditCard.ccName,
+                                                           ccNumber: ccNumberDecrypted,
+                                                           ccNumberLast4: selectedCreditCard.ccNumberLast4,
+                                                           ccExpMonth: selectedCreditCard.ccExpMonth,
+                                                           ccExpYear: yearVal,
+                                                           ccType: selectedCreditCard.ccType))
+                }
             }
-            // We need to show only 2 digits but save full year for sync
-            let period = Int64(Date.getCurrentPeriod())
-            let selectedExpYear = selectedCreditCard.ccExpYear
-            let yearVal = selectedExpYear < 1000 ? selectedExpYear + period : selectedExpYear
-            let plainTextCard = UnencryptedCreditCardFields(ccName: selectedCreditCard.ccName,
-                                                            ccNumber: decryptedCreditCardNum,
-                                                            ccNumberLast4: selectedCreditCard.ccNumberLast4,
-                                                            ccExpMonth: selectedCreditCard.ccExpMonth,
-                                                            ccExpYear: yearVal,
-                                                            ccType: selectedCreditCard.ccType)
-            return plainTextCard
         }
     }
 
@@ -294,10 +312,13 @@ final class CreditCardBottomSheetViewModel {
         return decryptedCreditCardVal
     }
 
-    func decryptCreditCardNumber(card: CreditCard?) -> String {
-        guard let card = card else { return "" }
-        let decryptedCardNum = autofill.decryptCreditCardNumber(encryptedCCNum: card.ccNumberEnc)
-        return decryptedCardNum ?? ""
+    private func loadDecryptedCardNumber() {
+        guard state == .update, let creditCard else { return }
+        autofill.decryptCreditCardNumber(encryptedCCNum: creditCard.ccNumberEnc) { [weak self] ccNumber in
+            ensureMainThread {
+                self?.decryptedCardNumber = ccNumber ?? ""
+            }
+        }
     }
 
     private func listStoredCreditCards(completionHandler: @Sendable @escaping ([CreditCard]?) -> Void) {

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardProvider.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardBottomSheet/CreditCardProvider.swift
@@ -11,7 +11,7 @@ protocol CreditCardProvider {
         creditCard: UnencryptedCreditCardFields,
         completion: @escaping @Sendable (CreditCard?, Error?) -> Void
     )
-    func decryptCreditCardNumber(encryptedCCNum: String?) -> String?
+    func decryptCreditCardNumber(encryptedCCNum: String?, completion: @escaping @Sendable (String?) -> Void)
     func deleteCreditCard(id: String, completion: @escaping @Sendable (Bool, Error?) -> Void)
     func listCreditCards(completion: @escaping @Sendable ([CreditCard]?, Error?) -> Void)
     func updateCreditCard(

--- a/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
+++ b/firefox-ios/Client/Frontend/Autofill/CreditCard/CreditCardSettingsView/CreditCardInputViewModel.swift
@@ -292,13 +292,20 @@ final class CreditCardInputViewModel: ObservableObject, @unchecked Sendable {
     public func setupViewValues() {
         guard let creditCard = creditCard else { return }
         nameOnCard = creditCard.ccName
-        cardNumber = autofill.decryptCreditCardNumber(
-            encryptedCCNum: creditCard.ccNumberEnc) ?? ""
         let month = creditCard.ccExpMonth
         isRightBarButtonEnabled = initialStateToEnableTopRightButton()
         let formattedMonth = month < 10 ? String(format: "%02d", month) : String(month)
 
         expirationDate = "\(formattedMonth) / \(creditCard.ccExpYear % 100)"
+
+        autofill.decryptCreditCardNumber(encryptedCCNum: creditCard.ccNumberEnc) { [weak self] ccNumber in
+            ensureMainThread {
+                guard let self else { return }
+                self.cardNumber = ccNumber ?? ""
+                // The button state depends on the card number, so it's recomputed once it lands.
+                self.isRightBarButtonEnabled = self.initialStateToEnableTopRightButton()
+            }
+        }
     }
 
     func initialStateToEnableTopRightButton() -> Bool {

--- a/firefox-ios/Storage/Rust/RustAutofill.swift
+++ b/firefox-ios/Storage/Rust/RustAutofill.swift
@@ -9,6 +9,8 @@ import Glean
 import class MozillaAppServices.Store
 import enum MozillaAppServices.AutofillApiError
 import func MozillaAppServices.encryptString
+import func MozillaAppServices.decryptString
+import func MozillaAppServices.checkCanary
 import struct MozillaAppServices.Address
 import struct MozillaAppServices.CreditCard
 import struct MozillaAppServices.UpdatableAddressFields
@@ -137,14 +139,38 @@ public class RustAutofill: @unchecked Sendable {
 
     /// Decrypts a credit card number using RustKeychain.
     ///
-    /// - Parameter encryptedCCNum: The encrypted credit card number.
-    /// - Returns: The decrypted credit card number or nil if the input is invalid.
+    /// - Parameter
+    ///   - encryptedCCNum: The encrypted credit card number.
+    ///   - completion: A closure called upon completion with the decrypted cc number or nil.
     /// - Note: Uses guard statements and optionals effectively, following Swift best practices.
-    public func decryptCreditCardNumber(encryptedCCNum: String?) -> String? {
-        guard let encryptedCCNum = encryptedCCNum, !encryptedCCNum.isEmpty else {
-            return nil
+    public func decryptCreditCardNumber(encryptedCCNum: String?,
+                                        completion: @escaping @Sendable(String?) -> Void) {
+        queue.async {
+            guard let encryptedCCNum = encryptedCCNum, !encryptedCCNum.isEmpty else {
+                completion(nil)
+                return
+            }
+
+            self.getStoredKey { result in
+                var ccNumber: String
+                switch result {
+                case .success(let key):
+                    do {
+                        ccNumber = try decryptString(key: key, ciphertext: encryptedCCNum)
+                        completion(ccNumber)
+                    } catch let error as NSError {
+                        self.logger.log("Error decrypting credit card number",
+                                        level: .warning,
+                                        category: .storage,
+                                        description: error.localizedDescription)
+                        completion(nil)
+                        return
+                    }
+                case .failure:
+                    completion(nil)
+                }
+            }
         }
-        return rustKeychain.decryptCreditCardNum(encryptedCCNum: encryptedCCNum)
     }
 
     /// Retrieves a credit card from the database by its identifier.
@@ -522,17 +548,18 @@ public class RustAutofill: @unchecked Sendable {
         // We expected the key to be present, and it is.
         var canaryIsValid = false
         do {
-            canaryIsValid = try rustKeychain.checkCanary(
+            canaryIsValid = try checkCanary(
                 canary: encryptedCanaryPhrase!,
                 text: rustKeychain.creditCardCanaryPhrase,
-                key: key!
-            )
+                encryptionKey: key!)
         } catch let error as NSError {
             logger.log("Error validating autofill encryption key",
                        level: .warning,
                        category: .storage,
                        description: error.localizedDescription)
-            completion(.failure(error))
+
+            GleanMetrics.CreditCardKeyRegeneration.corrupt.record()
+            resetCreditCardsAndKey(completion: completion)
             return
         }
         if canaryIsValid {

--- a/firefox-ios/Storage/RustKeychain.swift
+++ b/firefox-ios/Storage/RustKeychain.swift
@@ -6,10 +6,8 @@ import Common
 import Shared
 
 import enum MozillaAppServices.AutofillApiError
-import func MozillaAppServices.checkCanary
 import func MozillaAppServices.createCanary
 import func MozillaAppServices.createKey
-import func MozillaAppServices.decryptString
 
 public enum LoginEncryptionKeyError: Error {
     case noKeyCreated
@@ -56,10 +54,6 @@ public protocol KeychainProtocol: Sendable {
     func createLoginsKeyData() throws -> String
     func queryKeychainForKey(key: String) -> Result<String?, Error>
     func createAndStoreKey(canaryPhrase: String, canaryIdentifier: String, keyIdentifier: String) throws -> String
-    func decryptCreditCardNum(encryptedCCNum: String) -> String?
-    func checkCanary(canary: String,
-                     text: String,
-                     key: String) throws -> Bool
     func createCreditCardsKeyData() throws -> String
 }
 
@@ -243,42 +237,6 @@ public final class RustKeychain: KeychainProtocol {
              addOrUpdateKeychainKey(canaryValue, key: canaryIdentifier)
          }
          return keyValue
-    }
-
-    public func decryptCreditCardNum(encryptedCCNum: String) -> String? {
-        var keyValue: String?
-        (keyValue, _) = getCreditCardKeyData()
-
-        guard let keyValue else {
-            logger.log("Credit card decryption failed: encryption key unavailable from keychain.",
-                       level: .warning,
-                       category: .storage)
-            return nil
-        }
-
-        do {
-            return try decryptString(key: keyValue, ciphertext: encryptedCCNum)
-        } catch let err as NSError {
-            if let autofillStoreError = err as? AutofillApiError {
-                logAutofillStoreError(err: autofillStoreError,
-                                      errorDomain: err.domain,
-                                      errorMessage: "Error while decrypting credit card")
-            } else {
-                logger.log("Unknown error while decrypting credit card",
-                           level: .warning,
-                           category: .storage,
-                           description: err.localizedDescription)
-            }
-            return nil
-        }
-    }
-
-    public func checkCanary(
-        canary: String,
-        text: String,
-        key: String
-    ) throws -> Bool {
-        return try decryptString(key: key, ciphertext: canary) == text
     }
 
     private class func deleteKeychainSecClass(_ secClass: AnyObject) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockCreditCardProvider.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Autofill/Mocks/MockCreditCardProvider.swift
@@ -43,7 +43,10 @@ final class MockCreditCardProvider: CreditCardProvider, @unchecked Sendable {
         addCreditCardCalledCount += 1
         completion(exampleCreditCard, nil)
     }
-    func decryptCreditCardNumber(encryptedCCNum: String?) -> String? { return "testCCNum" }
+    func decryptCreditCardNumber(encryptedCCNum: String?,
+                                 completion: @escaping @Sendable(String?) -> Void) {
+    completion("testCCNum")
+    }
     func deleteCreditCard(id: String, completion: @escaping @Sendable (Bool, (any Error)?) -> Void) {
         deleteCreditCardsCalledCount += 1
         lastDeletedID = id

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CreditCard/CreditCardBottomSheetViewModelTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 @testable import Client
 
-class CreditCardBottomSheetViewModelTests: XCTestCase {
+final class CreditCardBottomSheetViewModelTests: XCTestCase {
     private var autofill: MockCreditCardProvider!
     private var dispatchQueue: MockDispatchQueue!
     private var samplePlainTextCard = UnencryptedCreditCardFields(ccName: "Allen Burges",
@@ -56,7 +56,7 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         let subject = createSubject()
 
         let expectation = expectation(description: "wait for credit card fields to be saved")
-        let decryptedCreditCard = try XCTUnwrap(subject.getPlainCreditCardValues(bottomSheetState: .save))
+        let decryptedCreditCard = try XCTUnwrap(plainCreditCardValues(subject, state: .save))
         // Make sure the year saved is a 4 digit year and not 2 digit
         // 2000 because that is our current period
         XCTAssertTrue(decryptedCreditCard.ccExpYear > 2000)
@@ -122,7 +122,7 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
         let subject = createSubject()
 
         subject.state = .save
-        let value = try XCTUnwrap(subject.getPlainCreditCardValues(bottomSheetState: .save))
+        let value = try XCTUnwrap(plainCreditCardValues(subject, state: .save))
         XCTAssertEqual(value.ccName, samplePlainTextCard.ccName)
         XCTAssertEqual(value.ccExpMonth, samplePlainTextCard.ccExpMonth)
         XCTAssertEqual(value.ccNumberLast4, samplePlainTextCard.ccNumberLast4)
@@ -138,7 +138,7 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
 
         subject.state = .save
         subject.decryptedCreditCard = nil
-        let value = subject.getPlainCreditCardValues(bottomSheetState: .save)
+        let value = plainCreditCardValues(subject, state: .save)
         XCTAssertNil(value)
     }
 
@@ -174,7 +174,7 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
                                                       ccExpYear: 2023,
                                                       ccType: "VISA")
         subject.decryptedCreditCard = invalidCard
-        let value = subject.getPlainCreditCardValues(bottomSheetState: .save)
+        let value = plainCreditCardValues(subject, state: .save)
         XCTAssertNotNil(value)
     }
 
@@ -219,7 +219,7 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
 
         subject.state = .selectSavedCard
         subject.creditCards = [sampleCreditCard]
-        let value = subject.getPlainCreditCardValues(bottomSheetState: .selectSavedCard, row: -1)
+        let value = plainCreditCardValues(subject, state: .selectSavedCard, row: -1)
         XCTAssertNil(value)
     }
 
@@ -464,6 +464,20 @@ class CreditCardBottomSheetViewModelTests: XCTestCase {
     }
 
     // MARK: Helper methods
+
+    @MainActor
+    private func plainCreditCardValues(_ subject: CreditCardBottomSheetViewModel,
+                                       state: CreditCardBottomSheetState,
+                                       row: Int? = nil) -> UnencryptedCreditCardFields? {
+        var result: UnencryptedCreditCardFields?
+        let valuesExpectation = expectation(description: "wait for the plain credit card values.")
+        subject.getPlainCreditCardValues(bottomSheetState: state, row: row) { values in
+            result = values
+            valuesExpectation.fulfill()
+        }
+        wait(for: [valuesExpectation], timeout: 1.0)
+        return result
+    }
 
     @MainActor
     private func createSubject() -> CreditCardBottomSheetViewModel {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16679)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35390)

## :bulb: Description
Addressing some of the cleanup tasks identified in [Orla's claude report](https://omitchell-undecryptable-credit-cards-investigation.quick.mozilla.cloud/undecryptable-credit-cards-investigation.html) to improve the credit card encryption key logic and hopefully reduce the sync decryption errors.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

