### PR TITLE
Refactor FXIOS-14155 [Swift 6 Migration] Improve Swift Concurrency state for RouteBuilder

### DIFF
--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -8,21 +8,18 @@ import Glean
 import Shared
 import Common
 
-// TODO: FXIOS-14155 - RouteBuilder should not be @unchecked Sendable due to shouldOpenNewTab usage
-final class RouteBuilder: @unchecked Sendable {
+final class RouteBuilder {
     private var isPrivate = false
     private var prefs: Prefs?
-    private var mainQueue: DispatchQueueInterface
     private let actionExtensionTelemetry: ActionExtensionTelemetry
     private let shareExtensionTelemetry: ShareExtensionTelemetry
-    var shouldOpenNewTab = true
+    private var siriOpenTabThrottleIsActive = false
+    private(set) var siriOpenTabThrottleResetTask: Task<Void, Never>?
 
     init(
-        mainQueue: DispatchQueueInterface = DispatchQueue.main,
         actionExtensionTelemetry: ActionExtensionTelemetry = ActionExtensionTelemetry(),
         shareExtensionTelemetry: ShareExtensionTelemetry = ShareExtensionTelemetry()
     ) {
-        self.mainQueue = mainQueue
         self.actionExtensionTelemetry = actionExtensionTelemetry
         self.shareExtensionTelemetry = shareExtensionTelemetry
     }
@@ -177,13 +174,16 @@ final class RouteBuilder: @unchecked Sendable {
         }
     }
 
+    @MainActor
     func makeRoute(userActivity: NSUserActivity) -> Route? {
-        // If the user activity is a Siri shortcut to open the app, show a new search tab.
-        // By using shouldOpenNewTab we avoid duplicated user activities, from Siri, for new tab.
-        if userActivity.activityType == SiriShortcuts.activityType.openURL.rawValue && shouldOpenNewTab {
-            shouldOpenNewTab = false
-            mainQueue.asyncAfter(deadline: .now() + 1) { [weak self] in
-                self?.shouldOpenNewTab = true
+        // A Siri openURL activity opens a new empty tab (no navigation to a URL)
+        // The throttle flag drops additional Siri activities within a time period
+        if userActivity.activityType == SiriShortcuts.activityType.openURL.rawValue {
+            guard !siriOpenTabThrottleIsActive else { return nil }
+            siriOpenTabThrottleIsActive = true
+            siriOpenTabThrottleResetTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
+                self?.siriOpenTabThrottleIsActive = false
             }
             return .search(url: nil, isPrivate: false)
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
@@ -20,7 +20,7 @@ final class RouteBuilderTests: XCTestCase {
     }
 
     func test_makeRoute_HandlesAnyActivityType() {
-        let routeBuilder = createSubject(mainQueue: MockDispatchQueue())
+        let routeBuilder = createSubject()
 
         let route = routeBuilder.makeRoute(
             userActivity: handoffUserActivity
@@ -60,7 +60,7 @@ final class RouteBuilderTests: XCTestCase {
     }
 
     func test_makeRoute_AppIconShortcut_ReturnsAppIconSettingsRoute() {
-        let routeBuilder = createSubject(mainQueue: MockDispatchQueue())
+        let routeBuilder = createSubject()
         let bundleId = Bundle.main.bundleIdentifier ?? ""
         let shortcut = UIApplicationShortcutItem(
             type: "\(bundleId).AppIcon",
@@ -76,18 +76,26 @@ final class RouteBuilderTests: XCTestCase {
         XCTAssertEqual(section, .appIcon)
     }
 
-    func test_makeRoute_ResetsShouldOpenNewTabAfterDelay() {
-        let routeBuilder = createSubject(mainQueue: MockDispatchQueue())
-        routeBuilder.shouldOpenNewTab = true
+    func test_makeRoute_RapidSiriOpenTabActivitiesAreThrottledAndReset() async {
+        let routeBuilder = createSubject()
         let userActivity = NSUserActivity(activityType: SiriShortcuts.activityType.openURL.rawValue)
 
-        _ = routeBuilder.makeRoute(userActivity: userActivity)
+        let firstRoute = routeBuilder.makeRoute(userActivity: userActivity)
+        XCTAssertNotNil(firstRoute)
 
-        XCTAssertTrue(routeBuilder.shouldOpenNewTab)
-     }
+        let duplicateActivityRoute = routeBuilder.makeRoute(userActivity: userActivity)
+        XCTAssertNil(duplicateActivityRoute)
 
-    private func createSubject(mainQueue: MockDispatchQueue) -> RouteBuilder {
-        let subject = RouteBuilder(mainQueue: mainQueue)
+        // Pretend time has passed by cancelling the Task.sleep and waiting for the task to finish
+        routeBuilder.siriOpenTabThrottleResetTask?.cancel()
+        await routeBuilder.siriOpenTabThrottleResetTask?.value
+
+        let routeAfterThrottleReset = routeBuilder.makeRoute(userActivity: userActivity)
+        XCTAssertNotNil(routeAfterThrottleReset)
+    }
+
+    private func createSubject() -> RouteBuilder {
+        let subject = RouteBuilder()
         trackForMemoryLeaks(subject)
         return subject
     }


### PR DESCRIPTION
Remove unchecked sendable and improve the Siri open tab duplicate throttler

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14155)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30687)

## :bulb: Description
Removes @unchecked Sendable from RouteBuilder by getting rid of the unsynchronised state that needed it.

DispatchQueue.asyncAfter was converted to a task with a sleep and the function marked as MainActor to fix the isolation issues, following the existing makeRoute(url:) isolation pattern. 

shouldOpenNewTab was renamed to better show intent. It passes the first activity and drops the rest without extending the window. Behaviour is unchanged but the intent should be more easily interpreted. A second valid Siri invocation inside the 1s window is still dropped, same as before.

Of note: this does not fix the root cause. It is possible that the original cases that caused the issue have been resolved since fully moving to the App Scene Lifecycle.

The testing of the function was also improved.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If needed, I updated documentation and added comments to complex code

