### PR TITLE
Add MTE-5710 Add regression tag to all automated regression tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -364,6 +364,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3168587
+    // Regression
     func testAddNewFolder() {
         app.launch()
         toolbarScreen.tapSettingsMenuButton()
@@ -373,6 +374,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3168596
+    // Regression
     func testDeleteEmptyFolderInEditMode() {
         app.launch()
         toolbarScreen.tapSettingsMenuButton()
@@ -424,6 +426,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3168649
+    // Regression
     func testDeleteBookmarkContextMenu() {
         app.launch()
         toolbarScreen.assertTabsButtonExists()
@@ -489,6 +492,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306911
+    // Regression
     func testRecentlyBookmarked() {
         app.launch()
         navigator.openURL(path(forTestPage: url_2["url"]!))
@@ -549,6 +553,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2445808
+    // Regression
     func testLongTapRecentlySavedLink() {
         addLaunchArgument(jsonFileName: "homepageRedesignOff", featureName: "homepage-redesign-feature")
         app.launch()
@@ -732,6 +737,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3168628
+    // Regression
     func testVerifyFolderSpecialCharacters() {
         app.launch()
         toolbarScreen.tapSettingsMenuButton()
@@ -741,6 +747,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3168627
+    // Regression
     func testCreateFolderWithVeryLongName() {
         app.launch()
         let longFolderName = "A very long folder name used to verify that the title field " +
@@ -753,6 +760,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3168629
+    // Regression
     func testDuplicateFoldersNames() {
         app.launch()
         let folderName = "Sample Folder."
@@ -785,6 +793,7 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3168590
+    // Regression
     func testUserRedirectToMostRecentlyAccessedFolder() {
         app.launch()
         let secondFolder = "Folder2"

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BookmarksTests.swift
@@ -553,7 +553,6 @@ class BookmarksTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2445808
-    // Regression
     func testLongTapRecentlySavedLink() {
         addLaunchArgument(jsonFileName: "homepageRedesignOff", featureName: "homepage-redesign-feature")
         app.launch()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
@@ -65,6 +65,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2618638
+    // Regression
     func testAddNewAddressNameFilled() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -92,6 +93,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2618640
+    // Regression
     func testAddNewAddressStreetAddressFilled() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -106,6 +108,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2618641
+    // Regression
     func testAddNewAddressCityFilled() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -120,6 +123,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2618642
+    // Regression
     func testAddNewAddressPostalCodeFilled() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -134,6 +138,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2618644
+    // Regression
     func testAddNewAddressPhoneFilled() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -148,6 +153,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2618645
+    // Regression
     func testAddNewAddressEmailFilled()  throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -175,6 +181,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2618654
+    // Regression
     func testUpdateAllAddressFields() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -187,6 +194,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2618646
+    // Regression
     func testUpdateAddressFieldName() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -309,6 +317,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2549847
+    // Regression
     func testAutofillAddressesByTapingStateField() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -333,6 +342,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2549852
+    // Regression
     func testAutofillAddressesByTapingPhoneField() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -371,6 +381,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2549846
+    // Regression
     func testAutofillAddressesByTapingCityField() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -379,6 +390,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2549848
+    // Regression
     func testAutofillAddressesByTapingPostalCodeField() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
@@ -387,6 +399,7 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2546298
+    // Regression
     func testToggleAddressOnOff() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ClipBoardTests.swift
@@ -63,6 +63,7 @@ class ClipBoardTests: BaseTestCase {
 
     // This test is disabled in release, but can still run on master
     // https://mozilla.testrail.io/index.php?/cases/view/2325688
+    // Regression
     func testClipboard() {
         navigator.openURL(url)
         waitUntilPageLoad()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -83,6 +83,7 @@ class CreditCardsTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306972
+    // Regression
     func testManageCreditCardsOption() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("addCreditCardAndReachAutofillWebsite() does not work on iOS 15")
@@ -220,6 +221,7 @@ class CreditCardsTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306974
+    // Regression
     func testVerifyThatMultipleCardsCanBeAdded() throws {
         // Add multiple credit cards
         let expectedCards = 3
@@ -366,6 +368,7 @@ class CreditCardsTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306979
+    // Regression
     func testSaveThisCardPrompt() throws {
         if #unavailable(iOS 17) {
             throw XCTSkip("testSaveThisCardPrompt() does not work on iOS 15 and 16")
@@ -430,6 +433,7 @@ class CreditCardsTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306980
+    // Regression
     func testUpdatePrompt() throws {
         if #unavailable(iOS 17) {
             throw XCTSkip("addCreditCardAndReachAutofillWebsite() does not work on iOS 15 and 16")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DataManagementTests.swift
@@ -27,6 +27,7 @@ class DataManagementTests: BaseTestCase {
 
     // Testing the search bar, and clear website data option
     // https://mozilla.testrail.io/index.php?/cases/view/2307015
+    // Regression
     func testWebSiteDataOptions() {
         cleanAllData()
         navigator.nowAt(BrowserTab)
@@ -82,6 +83,7 @@ class DataManagementTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2802088
+    // Regression
     func testFilterWebsiteData() {
         cleanAllData()
         navigator.nowAt(BrowserTab)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DatabaseFixtureTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DatabaseFixtureTest.swift
@@ -54,6 +54,7 @@ class DatabaseFixtureTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2459133
+   // Regression
    func testHistoryDatabaseFixture() throws {
        toolbarScreen.assertTabsButtonExists()
        toolbarScreen.tapSettingsMenuButton()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DesktopModeTests.swift
@@ -96,6 +96,7 @@ class DesktopModeTestsIphone: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306855
+    // Regression
     func testSameHostInMultipleTabs() {
         if skipPlatform { return }
         navigator.openURL(path(forTestPage: "test-user-agent.html"))
@@ -136,6 +137,7 @@ class DesktopModeTestsIphone: BaseTestCase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306854
     // Smoketest
+    // Regression
     func testChangeModeInSameTab() {
         if skipPlatform { return }
         navigator.openURL(path(forTestPage: "test-user-agent.html"))

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
@@ -45,6 +45,7 @@ class DomainAutocompleteTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2334558
+    // Regression
     func test1Autocomplete() {
         // Basic autocompletion cases
         // The autocomplete does not display the history item from the DB. Workaround is to manually visit "mozilla.org".
@@ -73,6 +74,7 @@ class DomainAutocompleteTests: BaseTestCase {
 
     // Test that deleting characters works correctly with autocomplete
     // https://mozilla.testrail.io/index.php?/cases/view/2334647
+    // Regression
     func test3AutocompleteDeletingChars() {
         // The autocomplete does not display the history item from the DB. Workaround is to manually visit "mozilla.org".
         navigator.openURL("mozilla.org")
@@ -132,6 +134,7 @@ class DomainAutocompleteTests: BaseTestCase {
 
     // Non-matches.
     // https://mozilla.testrail.io/index.php?/cases/view/2334650
+    // Regression
     func test5NoMatches() {
         navigator.openURL("https://mozilla.github.io/form-fill-examples/basic.html")
         waitUntilPageLoad()
@@ -180,6 +183,7 @@ class DomainAutocompleteTests: BaseTestCase {
 
     // Test default domains.
     // https://mozilla.testrail.io/index.php?/cases/view/2334651
+    // Regression
     func test2DefaultDomains() {
         navigator.goto(URLBarOpen)
         urlBarAddress.typeText("a")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DownloadsTests.swift
@@ -56,6 +56,7 @@ class DownloadsTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306897
+    // Regression
     func testDownloadFileContextMenu() {
         navigator.openURL(testURL)
         waitUntilPageLoad()
@@ -107,6 +108,7 @@ class DownloadsTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306900
+    // Regression
     func testDeleteDownloadedFile() throws {
         downloadFile(fileName: testFileName, numberOfDownloads: 1)
         navigator.goto(BrowserTabMenu)
@@ -170,6 +172,7 @@ class DownloadsTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306902
+    // Regression
     func testLongPressOnDownloadedFile() {
         downloadFile(fileName: testFileName, numberOfDownloads: 1)
         navigator.goto(BrowserTabMenu)
@@ -248,6 +251,7 @@ class DownloadsTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306904
+    // Regression
     func testRemoveUserDataRemovesDownloadedFiles() {
         navigator.nowAt(NewTabScreen)
         // The option to remove downloaded files from clear private data is off by default

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/EngagementNotificationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/EngagementNotificationTests.swift
@@ -22,6 +22,7 @@ class EngagementNotificationTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307101
+    // Regression
     func testDontAllowNotifications() throws {
         if #unavailable(iOS 17) {
             throw XCTSkip("setUp() fails to remove app intermittently")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FindInPageTests.swift
@@ -39,6 +39,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323463
+    // Regression
     func testFindInLargeDoc() {
         navigator.openURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
         waitUntilPageLoad()
@@ -139,6 +140,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323801
+    // Regression
     func testQueryWithNoMatches() {
         userState.url = path(forTestPage: TestPages.mozillaBook)
         openFindInPageFromMenu(openSite: userState.url!)
@@ -195,6 +197,7 @@ class FindInPageTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2323467
+    // Regression
     func testFindFromLongTap() {
         userState.url = path(forTestPage: TestPages.mozillaBook)
         openFindInPageFromMenu(openSite: userState.url!)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FirefoxSuggestTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FirefoxSuggestTest.swift
@@ -13,6 +13,7 @@ class FirefoxSuggestTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2360075
+    // Regression
     func testFirefoxSuggestExists() {
         // Firefox Suggest only appears once a search has been performed for the same text,
         // so perform the search first and then search again with the same text.

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HistoryTests.swift
@@ -94,6 +94,7 @@ class HistoryTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307487
+    // Regression
     func testClearHistoryFromSettings() throws {
         navigator.nowAt(NewTabScreen)
         // Browse to have an item in history list
@@ -146,6 +147,7 @@ class HistoryTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307357
+    // Regression
     func testRecentlyClosedWebsiteOpen() {
         // Open "Book of Mozilla"
         openBookOfMozilla()
@@ -211,6 +213,7 @@ class HistoryTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307479
+    // Regression
     func testRemoveAllTabsButtonRecentlyClosedHistory() {
         // Open "Book of Mozilla"
         openBookOfMozilla()
@@ -293,6 +296,7 @@ class HistoryTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307484
+    // Regression
     func testOpenInNewTabRecentlyClosedItem() {
         // Open "Book of Mozilla" and close the tab
         openBookOfMozilla()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
@@ -49,6 +49,7 @@ class HomeButtonTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306881
+    // Regression
     func testAppLaunchKeyboardNotRaisedUp() {
         toolbarScreen.assertSettingsButtonExists()
         validateHomePageAndKeyboardRaisedUp()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -68,6 +68,7 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339257
+    // Regression
     func testTyping() throws {
         let shouldSkipTest = true
         try XCTSkipIf(shouldSkipTest,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -68,7 +68,6 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339257
-    // Regression
     func testTyping() throws {
         let shouldSkipTest = true
         try XCTSkipIf(shouldSkipTest,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -432,6 +432,7 @@ class IntegrationTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306822
+    // Regression
     func testFxADisconnectConnect() {
         // Sign into Mozilla Account
         signInFxAccounts()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/IntegrationTests.swift
@@ -432,7 +432,6 @@ class IntegrationTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306822
-    // Regression
     func testFxADisconnectConnect() {
         // Sign into Mozilla Account
         signInFxAccounts()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -88,6 +88,7 @@ class LoginTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306961
+    // Regression
     func testLoginsListFromBrowserTabMenu() {
         closeURLBar()
         // Make sure you can access empty Login List from Browser Tab Menu
@@ -323,6 +324,7 @@ class LoginTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2798587
+    // Regression
     func testVerifyPasswordsSettingMenu() {
         // Go to Settings - Passwords
         openLoginsSettingsFromBrowserTab()
@@ -353,17 +355,20 @@ class LoginTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2798590
+    // Regression
     func testSearchSavedLoginsByURL() {
         validateSearchSavedLoginsByUrlOrUsername(searchText: "localhost")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2798591
+    // Regression
     func testSearchSavedLoginsByUsername() {
         validateSearchSavedLoginsByUrlOrUsername(searchText: "test")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2798597
     // Smoketest
+    // Regression
     func testVerifyUpdatedPasswordIsSaved() throws {
         guard #available(iOS 16, *) else {
             throw XCTSkip("Test not supported on iOS versions prior to iOS 16")
@@ -372,6 +377,7 @@ class LoginTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2798598
+    // Regression
     func testVerifyUpdatedPasswordIsNotSaved() throws {
         guard #available(iOS 16, *) else {
             throw XCTSkip("Test not supported on iOS versions prior to iOS 16")
@@ -380,6 +386,7 @@ class LoginTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3001341
+    // Regression
     func testLoginFreshInstallMessage() throws {
         if #unavailable(iOS 17) {
             throw XCTSkip("setUp() fails to remove app intermittently")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ModernKitOnboardingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ModernKitOnboardingTests.swift
@@ -77,21 +77,25 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4035799
+    // Regression
     func testModernTermsOfUseLinkDisplayAndDismissal() {
         verifyLinkDisplayAndDismissal(for: .termsOfUse)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4035800
+    // Regression
     func testModernPrivacyNoticeLinkDisplayAndDismissal() {
         verifyLinkDisplayAndDismissal(for: .privacyNotice)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4035801
+    // Regression
     func testModernManageBottomSheetDisplayAndDismissal() {
         verifyLinkDisplayAndDismissal(for: .manage)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4035796
+    // Regression
     func testModernManageBottomSheetContent() {
         launchApp()
 
@@ -105,11 +109,13 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4035802
+    // Regression
     func testModernCrashReportsToggle() {
         verifyManageDataToggle(.crashReports)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4035803
+    // Regression
     func testModernTechnicalDataToggle() {
         verifyManageDataToggle(.technicalData)
     }
@@ -182,6 +188,7 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4035645
+    // Regression
     func testModernKitOnboardingToolbarPlacementTop() throws {
         if iPad() {
             throw XCTSkip("Toolbar customization is not available on iPad")
@@ -258,6 +265,7 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4035640
+    // Regression
     func testModernKitOnboardingThemeSelection() throws {
         launchApp()
 
@@ -294,6 +302,7 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3309013
+    // Regression
     func testModernKitOnboardingCardsCopy() throws {
         launchApp()
 
@@ -337,11 +346,13 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4035641
+    // Regression
     func testModernKitOnboardingLightThemeSelection() throws {
         verifyThemeSelection(theme: "Light")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4035642
+    // Regression
     func testModernKitOnboardingDarkThemeSelection() throws {
         verifyThemeSelection(theme: "Dark", restoreLightThemeAfterwards: true)
     }
@@ -513,6 +524,7 @@ class ModernKitOnboardingTests: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/4038427
+    // Regression
     func testModernKitOnboardingDefaultBrowserSkip() {
         launchApp()
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/MultiWindowTests.swift
@@ -35,6 +35,7 @@ class MultiWindowTests: IpadOnlyTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2711015
+    // Regression
     func testMultiWindowSplitView() {
         if skipPlatform { return }
         dismissSurveyPrompt()
@@ -43,6 +44,7 @@ class MultiWindowTests: IpadOnlyTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2711016
+    // Regression
     func testMultiWindowNewTab() {
         if skipPlatform { return }
         splitViewFromHomeScreen()
@@ -68,6 +70,7 @@ class MultiWindowTests: IpadOnlyTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3374336
+    // Regression
     func testOpenWindowFromTabSwitcher() {
         if skipPlatform { return }
         openWindowFromTabSwitcher(windowsNumber: 1)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -223,7 +223,6 @@ class NavigationTest: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441497
-    // Regression
     func testCopyLinkPrivateMode() {
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -208,6 +208,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441496
+    // Regression
     func testCopyLink() {
         longPressLinkOptions(optionSelected: "Copy Link")
         let searchBar = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
@@ -222,6 +223,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441497
+    // Regression
     func testCopyLinkPrivateMode() {
         navigator.nowAt(NewTabScreen)
         navigator.toggleOn(userState.isPrivate, withAction: Action.ToggleExperimentPrivateMode)
@@ -317,6 +319,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441498
+    // Regression
     func testDownloadLink() {
         longPressLinkOptions(optionSelected: "Download Link")
         mozWaitForElementToExist(app.tables["Context Menu"])
@@ -337,6 +340,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441499
+    // Regression
     func testShareLink() {
         longPressLinkOptions(optionSelected: "Share Link")
         if #available(iOS 16, *) {
@@ -514,6 +518,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441772
+    // Regression
     func testOpenInNewTab() {
         // Long-tap on an article link. Choose "Open in New Tab".
         openContextMenuForArticleLink()
@@ -528,6 +533,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441773
+    // Regression
     func testOpenInNewPrivateTab() {
         // Long-tap on an article link. Choose "Open in New Private Tab".
         openContextMenuForArticleLink()
@@ -552,6 +558,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2441774
+    // Regression
     func testBookmarkLink() {
         // Long-tap on an article link. Choose "Bookmark Link".
         openContextMenuForArticleLink()
@@ -615,6 +622,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306833
+    // Regression
     func testLongTapFirefoxIconNewTab() throws {
         guard #available(iOS 18, *) else {
             throw XCTSkip("Test requires iOS 18+ due to app icon springboard behavior after app.terminate()")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PrivateBrowsingTest.swift
@@ -38,6 +38,7 @@ class PrivateBrowsingTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307004
+    // Regression
     func testPrivateTabDoesNotTrackHistory() {
         navigator.openURL(url1)
         waitForTabsButton()
@@ -181,6 +182,7 @@ class PrivateBrowsingTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307007
+    // Regression
     func testPrivateBrowserPanelView() {
         navigator.nowAt(NewTabScreen)
         // If no private tabs are open, there should be a initial screen with label Private Browsing
@@ -444,6 +446,7 @@ class PrivateBrowsingTestIpad: IpadOnlyTestCase {
 
     // This test is only enabled for iPad. Shortcut does not exists on iPhone
     // https://mozilla.testrail.io/index.php?/cases/view/2307008
+    // Regression
     func testClosePrivateTabsOptionClosesPrivateTabsShortCutiPad() {
         if skipPlatform { return }
         waitForTabsButton()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ReadingListTests.swift
@@ -118,6 +118,7 @@ class ReadingListTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306996
+    // Regression
     func testRemoveFromReadingView() {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
@@ -136,6 +137,7 @@ class ReadingListTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306997
+    // Regression
     func testMarkAsReadAndUnreadFromReadingList() throws {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -24,6 +24,7 @@ class SearchSettingsUITests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2435664
+    // Regression
     func testDefaultSearchEngine() {
         // Check the default browser
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)
@@ -66,6 +67,7 @@ class SearchSettingsUITests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353248
+    // Regression
     func testCustomSearchEngineAsDefaultIsNotEditable() {
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
@@ -114,6 +116,7 @@ class SearchSettingsUITests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2353250
+    // Regression
     func testDeletingLastCustomEngineExitsEditing() {
         // Edit is disabled
         XCTAssertFalse(app.buttons["Edit"].isEnabled)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -24,7 +24,6 @@ class SearchSettingsUITests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2435664
-    // Regression
     func testDefaultSearchEngine() {
         // Check the default browser
         let defaultSearchEngine = app.tables.cells.element(boundBy: 0)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -529,7 +529,6 @@ class SearchTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2753076
-    // Regresssion
     // Regression
     func testFirefoxSuggestPartialNonSponsored() {
         launchWithFirefoxSuggestRollout()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -74,6 +74,7 @@ class SearchTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2436093
+    // Regression
     func testPromptPresence() {
         // Suggestion is on by default (starting on Oct 24th 2017), so the prompt should not appear
         app.launch()
@@ -242,6 +243,7 @@ class SearchTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2436091
+    // Regression
     func testSearchWithFirefoxOption() {
         app.launch()
         navigator.openURL(path(forTestPage: TestPages.mozillaBook))
@@ -426,6 +428,7 @@ class SearchTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306942
+    // Regression
     func testSearchSuggestions() throws {
         guard #available(iOS 17.0, *) else { return }
 
@@ -527,6 +530,7 @@ class SearchTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2753076
     // Regresssion
+    // Regression
     func testFirefoxSuggestPartialNonSponsored() {
         launchWithFirefoxSuggestRollout()
         verifySearchSuggestion(searchTerm: "fifa",
@@ -752,6 +756,7 @@ class SearchTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3374353
+    // Regression
     func testPrivateModeSearchSuggestsOnOffAndGeneralSearchSuggestsOff() {
         app.launch()
         // Disable general search suggests

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SettingsTests.swift
@@ -255,6 +255,7 @@ class SettingsTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2951992
+    // Regression
     func testAutofillPasswordSettingsOptionSubtitles() {
         app.launch()
         validateAutofillAndPasswordsUI()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
@@ -22,6 +22,7 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864324
+    // Regression
     func testShareNormalWebsiteSendLinkToDevice() {
         app.launch()
         longPressTopSitesAndReachShareOptions(option: "Send Link to Device")
@@ -54,6 +55,7 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864380
+    // Regression
     func testBookmarksShareNormalWebsiteReminders() {
         app.launch()
         if #available(iOS 17, *) {
@@ -186,6 +188,7 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864482
+    // Regression
     func testShareViaLongPressLinkCopy() {
         app.launch()
         longPressLinkAndSelectShareOption(option: "Copy")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
@@ -56,7 +56,6 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864380
-    // Regression
     func testBookmarksShareNormalWebsiteReminders() {
         app.launch()
         if #available(iOS 17, *) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareLongPressTests.swift
@@ -36,6 +36,7 @@ class ShareLongPressTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864323
+    // Regression
     func testShareNormalWebsiteCopyUrl() {
         app.launch()
         longPressTopSitesAndReachShareOptions(option: "Copy")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareMenuTests.swift
@@ -27,6 +27,7 @@ class ShareMenuTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864049
+    // Regression
     func testShareNormalWebsitePrint() {
         app.launch()
         reachShareMenuLayoutAndSelectOption(option: "Print")
@@ -34,6 +35,7 @@ class ShareMenuTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864047
+    // Regression
     func testShareNormalWebsiteSendLinkToDevice() {
         app.launch()
         reachShareMenuLayoutAndSelectOption(option: "Send Link to Device")
@@ -55,6 +57,7 @@ class ShareMenuTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864046
+    // Regression
     func testShareNormalWebsiteCopyUrl() {
         app.launch()
         reachShareMenuLayoutAndSelectOption(option: "Copy")
@@ -128,6 +131,7 @@ class ShareMenuTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864065
+    // Regression
     func testSharePdfFilePrint() {
         app.launch()
         reachShareMenuLayoutAndSelectOption(option: "Print", url: pdfUrl)
@@ -142,6 +146,7 @@ class ShareMenuTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864066
+    // Regression
     func testSharePdfFileSaveToFile() {
         app.launch()
         if #available(iOS 17, *) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ShareToolbarTests.swift
@@ -26,6 +26,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864279
+    // Regression
     func testShareNormalWebsitePrint() {
         app.launch()
         tapToolbarShareButtonAndSelectOption(option: "Print")
@@ -33,6 +34,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864277
+    // Regression
     func testShareNormalWebsiteSendLinkToDevice() {
         app.launch()
         tapToolbarShareButtonAndSelectOption(option: "Send Link to Device")
@@ -53,6 +55,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864276
+    // Regression
     func testShareNormalWebsiteCopyUrl() {
         app.launch()
         tapToolbarShareButtonAndSelectOption(option: "Copy")
@@ -78,6 +81,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864310
+    // Regression
     func testShareWebsiteReaderModePrint() {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
@@ -88,6 +92,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864307
+    // Regression
     func testShareWebsiteReaderModeCopy() {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
@@ -98,6 +103,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864308
+    // Regression
     func testShareWebsiteReaderModeSendLink() {
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "apple-summarizer-feature")
         addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "hosted-summarizer-feature")
@@ -124,6 +130,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864293
+    // Regression
     func testSharePdfFilePrint() {
         app.launch()
         tapToolbarShareButtonAndSelectOption(option: "Print", url: pdfUrl)
@@ -138,6 +145,7 @@ class ShareToolbarTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2864294
+    // Regression
     func testSharePdfFileSaveToFile() {
         app.launch()
         if #available(iOS 17, *) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -12,6 +12,7 @@ class ThirdPartySearchTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2443998
+    // Regression
     func testCustomSearchEngines() {
         addCustomSearchEngine()
 
@@ -36,6 +37,7 @@ class ThirdPartySearchTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2444328
+    // Regression
     func testCustomSearchEngineAsDefault() {
         addCustomSearchEngine()
 
@@ -62,6 +64,7 @@ class ThirdPartySearchTest: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306941
+    // Regression
     func testCustomSearchEngineDeletion() {
         addCustomSearchEngine()
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift
@@ -392,6 +392,7 @@ class TodayWidgetTests: BaseTestCase {
 
     // TESTS
     // https://mozilla.testrail.io/index.php?/cases/view/2769289
+    // Regression
     func testNewSearchWidget() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("iOS 16 is required")
@@ -438,6 +439,7 @@ class TodayWidgetTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2769297
+    // Regression
     func testNewPrivateSearchWidget() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("iOS 16 is required")
@@ -612,6 +614,7 @@ class TodayWidgetTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2783003
+    // Regression
     func testFxShortcutGoToCopiedLinkWidget() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("iOS 16 is required")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TrackingProtectionTests.swift
@@ -163,6 +163,7 @@ class TrackingProtectionTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2318742
+    // Regression
     func testProtectionLevelMoreInfoMenu() {
         navigator.nowAt(NewTabScreen)
         navigator.goto(TrackingProtectionSettings)
@@ -191,6 +192,7 @@ class TrackingProtectionTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307063
+    // Regression
     func testStrictTrackingProtection() {
         navigator.goto(TrackingProtectionSettings)
         // Enable Strict Protection Level

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ZoomingTests.swift
@@ -100,6 +100,7 @@ final class ZoomingTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306948
+    // Regression
     func testSwitchingZoomedTabs() {
         validateZoomLevelOnSwitchingTabs()
         // Repeat all steps in private browsing


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-5710)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
All automated regression tests should have `// Regression` tags.

I used the daily TestRail backups from testops-tools, asked Claude Code to identify all tests marked with `Regression` and add the `// Regression` tags. I spot check a few tests that suppose to have the tag and not have the tag.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

