### PR TITLE
Disable NO-TICKET - testAutofillAddressesByTapingEmailField

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/C_AddressesTests.swift
@@ -325,11 +325,12 @@ class O_AddressesTests: BaseTestCase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2549850
+    // NOTE: Autofill for email hasn't been working. https://github.com/mozilla-mobile/firefox-ios/issues/32817
     func testAutofillAddressesByTapingEmailField() throws {
         if #unavailable(iOS 16) {
             throw XCTSkip("Addresses setting is not available for iOS 15")
         }
-        addAddressAndReachAutofillForm(indexField: 7)
+        throw XCTSkip("Autofill for email is not working: https://github.com/mozilla-mobile/firefox-ios/issues/32817")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2549852


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32817)

## :bulb: Description
`testAutofillAddressesByTapingEmailField` has been consistently failing on iOS 17.5 and 18.6 during a rerun investigation of a failed test report. Video evidence pulled from the .xcresult bundle showed that Firefox's custom keyboard accessory toolbar (which hosts the "Use saved address" autofill button) never attaches to the input at all when tapping the email field — only the bare system keyboard toolbar renders. This matches a real-world user report in [#32817](https://github.com/mozilla-mobile/firefox-ios/issues/32817) of the email field failing to autofill on live sites (e.g. duka.com).

Since email autofill genuinely doesn't work right now, this test would keep failing indefinitely and add noise to CI/regression runs. This PR disables it via `XCTSkip` with a link to the tracking issue, so it can be re-enabled once the underlying autofill bug is fixed. The existing iOS 15 skip check is preserved unchanged for when the test is restored.

## :movie_camera: Demos
N/A — test-only change, no user-facing behavior modified.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code