### PR TITLE
Add FXIOS-16668 [Acorn] Create struct for Acorn illustrations

### DIFF
--- a/BrowserKit/Sources/Common/Constants/StandardIllustrationIdentifiers.swift
+++ b/BrowserKit/Sources/Common/Constants/StandardIllustrationIdentifiers.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// This struct defines all the standard illustration identifiers used in the app.
+/// When adding new identifiers, please respect alphabetical order.
+/// Sing the song if you must.
+public struct StandardIllustrationIdentifiers {
+    // Custom illustrations exported at feature-specific dimensions
+    public struct Exports {
+    }
+
+    // Reusable illustration kits
+    public struct Kit {
+    }
+
+    // Pictogram illustrations
+    public struct Pictograms {
+    }
+}

--- a/BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
+++ b/BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// This struct defines all the standard image identifiers of icons and images used in the app.
+/// This struct defines all the standard image identifiers of icons used in the app.
 /// When adding new identifiers, please respect alphabetical order.
 /// Sing the song if you must.
 public struct StandardImageIdentifiers {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16668)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35380)

## :bulb: Description
Adds a new struct for illustrations from the Acorn repository.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

