### PR TITLE
BugFix FXIOS-16667 [Acorn] Support ExtraExtraExtraLarge icon size in the Acorn updater

### DIFF
--- a/sync_acorn_icons.py
+++ b/sync_acorn_icons.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import os
+import re
 import shutil
 import subprocess
 
@@ -36,7 +37,8 @@ TARGET_SIZES = [
     ("16", "Small"),
     ("20", "Medium"),
     ("24", "Large"),
-    ("30", "ExtraLarge")
+    ("30", "ExtraLarge"),
+    ("72", "ExtraExtraExtraLarge")
 ]
 
 # Asset catalogs kept in sync with Acorn.
@@ -122,7 +124,8 @@ def download_icons_and_save_in_assets():
 
 def sort_icons_by_size() -> dict:
     '''
-    Sort all the Acorns icons in firefox-ios/Client/Assets/Images.xcassets/ by their respective size
+    Sort all the Acorns icons found in ASSET_FOLDER_PATHS by their respective size.
+    Icons shared between several asset catalogs are only listed once.
 
     Returns:
         dict: A dictionary with the title sizes as key and as value the list of acorn folders with the respective size
@@ -132,25 +135,37 @@ def sort_icons_by_size() -> dict:
             ...
         }
     '''
+    # regular expression to check for camel case format starting with lowercase char i.e crossCircleFill
+    lower_camel_case_pattern = re.compile(r"^[a-z][a-zA-Z0-9]*$")
+
     icons_by_size = {}
     for _, titleSize in TARGET_SIZES:
         icons_by_size[titleSize] = []
 
-    asset_folder_path = "firefox-ios/Client/Assets/Images.xcassets/"
-    for folder in os.listdir(asset_folder_path):
-        if folder.endswith(".imageset"):
-            file_name = folder.split(".")[0]
+    seen_icons = set()
+    for asset_folder_path in ASSET_FOLDER_PATHS:
+        for folder in sorted(os.listdir(asset_folder_path)):
+            if not folder.endswith(".imageset"):
+                continue
 
-            size_key = next((key for key in icons_by_size if key in file_name), None)
-            
-            if size_key:
-                # Check whether Extra not in the size_key while the file name has Extra size
-                # this means the next method pulled the wrong size_key
-                if "Extra" not in size_key and "Extra" in file_name:
-                    size_key = f"Extra{size_key}"
-                
-                icon_name = file_name.replace(size_key, "")
-                icons_by_size[size_key].append((icon_name, file_name))
+            file_name = folder.split(".")[0]
+            if file_name in seen_icons:
+                continue
+            seen_icons.add(file_name)
+
+            # Longest match wins so that sizes sharing a suffix (Large, ExtraLarge,
+            # ExtraExtraExtraLarge) resolve to the most specific one
+            size_key = max((key for key in icons_by_size if key in file_name), key=len, default=None)
+            if not size_key:
+                continue
+
+            icon_name = file_name.replace(size_key, "")
+            # Check wheter the icon_name is in lower camel case format otherwise the name is not a valid swift name for an acorn icon.
+            if not lower_camel_case_pattern.match(icon_name):
+                print(f"Skipping {folder}, \"{icon_name}\" is not lowerCamelCase")
+                continue
+
+            icons_by_size[size_key].append((icon_name, file_name))
 
     return icons_by_size
 
@@ -170,19 +185,20 @@ public struct StandardImageIdentifiers {
     for image_size, image_size_title in TARGET_SIZES:
         size_struct_map[image_size_title] = f"{image_size}x{image_size}"
 
+    struct_blocks = []
     for size, struct_name in size_struct_map.items():
         if sorted_icons[size]:
-            swift_file_content += f"    // Icon size {struct_name}\n"
-            swift_file_content += f"    public struct {size} {{\n"
-            
+            block = f"    // Icon size {struct_name}\n"
+            block += f"    public struct {size} {{\n"
+
             # Sort icons alphabetically and add them to the struct
             for icon_info in sorted(sorted_icons[size], key=lambda x: x[0].lower()):
-                swift_file_content += f"        public static let {icon_info[0]} = \"{icon_info[1]}\"\n"
-            
-            if size == "ExtraLarge":
-                swift_file_content += "    }\n"
-            else:
-                swift_file_content += "    }\n\n"
+                block += f"        public static let {icon_info[0]} = \"{icon_info[1]}\"\n"
+
+            block += "    }\n"
+            struct_blocks.append(block)
+
+    swift_file_content += "\n".join(struct_blocks)
     swift_file_content += "}\n"
 
     standard_image_file_path = "BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16667)

## :bulb: Description
Adds the `72x72` `ExtraExtraExtraLarge` size to the Acorn sync script and fixes size resolution so those icons are no longer mislabelled as `ExtraLarge`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
