### PR TITLE
[MTE-5838] - Re-enable testTyping navigation toolbar Home button

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2027,6 +2027,8 @@
 		DA9FD88624E213CD00168D1E /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9FD88524E213CC00168D1E /* Helpers.swift */; };
 		DA9FD88824E213DD00168D1E /* QuickLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9FD88724E213DC00168D1E /* QuickLink.swift */; };
 		DACDE996225E537900C8F37F /* VersionSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACDE995225E537900C8F37F /* VersionSettingTests.swift */; };
+		DB58110000000000000002 /* GenericSelectableItemCellViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB58110000000000000001 /* GenericSelectableItemCellViewTests.swift */; };
+		DB58110000000000000004 /* NavigationBarMiddleButtonSelectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB58110000000000000003 /* NavigationBarMiddleButtonSelectionViewTests.swift */; };
 		DAE6DF1B29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE6DF1A29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift */; };
 		DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */; };
 		DF8C6DD72A52EED1007FAAF2 /* ClientSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8C6DD62A52EED1007FAAF2 /* ClientSyncManagerTests.swift */; };
@@ -11616,6 +11618,8 @@
 		DAAE4D2BB25BB3FB7F927CBF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		DAC044248882A2485365F9A2 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Menu.strings; sourceTree = "<group>"; };
 		DACDE995225E537900C8F37F /* VersionSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionSettingTests.swift; sourceTree = "<group>"; };
+		DB58110000000000000001 /* GenericSelectableItemCellViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericSelectableItemCellViewTests.swift; sourceTree = "<group>"; };
+		DB58110000000000000003 /* NavigationBarMiddleButtonSelectionViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarMiddleButtonSelectionViewTests.swift; sourceTree = "<group>"; };
 		DAD46F3324A1606C001B3967 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		DAD46F3524A1606C001B3967 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		DAE6DF1A29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+ZoomPage.swift"; sourceTree = "<group>"; };
@@ -14501,6 +14505,8 @@
 				BEEF00012F00000100000001 /* SearchSettingsTableViewControllerTests.swift */,
 				EDADF7832D70DAF800C39295 /* SettingsTelemetryTests.swift */,
 				DACDE995225E537900C8F37F /* VersionSettingTests.swift */,
+				DB58110000000000000001 /* GenericSelectableItemCellViewTests.swift */,
+				DB58110000000000000003 /* NavigationBarMiddleButtonSelectionViewTests.swift */,
 				FBADD1700000000000000001 /* LaunchPairingFromURLSettingTests.swift */,
 				C2FA00322FFF000100AD1FBD /* ResetTipsSettingTests.swift */,
 				C7F5684BA329455783CCB301 /* AdBlockerSettingTests.swift */,
@@ -21037,6 +21043,8 @@
 				434CD57829F6FC4500A0D04B /* MockAppAuthenticator.swift in Sources */,
 				8A94418A2CE3E190007FF4E5 /* MockSearchEngineManager.swift in Sources */,
 				DACDE996225E537900C8F37F /* VersionSettingTests.swift in Sources */,
+				DB58110000000000000002 /* GenericSelectableItemCellViewTests.swift in Sources */,
+				DB58110000000000000004 /* NavigationBarMiddleButtonSelectionViewTests.swift in Sources */,
 				FBADD1700000000000000002 /* LaunchPairingFromURLSettingTests.swift in Sources */,
 				C2FA00332FFF000100AD1FBD /* ResetTipsSettingTests.swift in Sources */,
 				C25017382ECBAE030071506F /* ASTranslationModelsFetcherTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1958,6 +1958,7 @@
 		D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B6923C1B9F9444004B87A4 /* FindInPageBar.swift */; };
 		D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B6923E1B9F9A58004B87A4 /* FindInPageHelper.swift */; };
 		D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */; };
+		DB58110000000000000006 /* SwiftUIViewTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB58110000000000000005 /* SwiftUIViewTestHelpers.swift */; };
 		D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */; };
 		D3BE7B261B054D4400641031 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B251B054D4400641031 /* main.swift */; };
 		D3BE7B461B054F8600641031 /* UITestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B451B054F8600641031 /* UITestAppDelegate.swift */; };
@@ -11233,6 +11234,7 @@
 		D3B6923C1B9F9444004B87A4 /* FindInPageBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageBar.swift; sourceTree = "<group>"; };
 		D3B6923E1B9F9A58004B87A4 /* FindInPageHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageHelper.swift; sourceTree = "<group>"; };
 		D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseExtensions.swift; sourceTree = "<group>"; };
+		DB58110000000000000005 /* SwiftUIViewTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewTestHelpers.swift; sourceTree = "<group>"; };
 		D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextMenuHelper.swift; sourceTree = "<group>"; };
 		D3BE7B251B054D4400641031 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D3BE7B451B054F8600641031 /* UITestAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITestAppDelegate.swift; sourceTree = "<group>"; };
@@ -17562,6 +17564,7 @@
 				2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */,
 				F84B21D71A090F8100AAB793 /* Supporting Files */,
 				C83B7DD129BBAF52005565C2 /* SurveySurface */,
+				DB58110000000000000005 /* SwiftUIViewTestHelpers.swift */,
 				1DDE3DB42AC360EC0039363B /* TabCellTests.swift */,
 				8AED868428CA7B1200351A50 /* TabManagement */,
 				D525DFB225FBE5E000B18763 /* TabTests.swift */,
@@ -21004,6 +21007,7 @@
 				D3FA777B1A43B2990010CD32 /* SearchTests.swift in Sources */,
 				0A80C4242F3CD3F300DB85AE /* AppAuthenticatorTests.swift in Sources */,
 				D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */,
+				DB58110000000000000006 /* SwiftUIViewTestHelpers.swift in Sources */,
 				8A86DAD8277298DE00D7BFFF /* ClosedTabsStoreTests.swift in Sources */,
 				03D9946A2EE821190081D209 /* TermsOfUseLinkTypeTests.swift in Sources */,
 				ED7A08E12CF679CE0035EC8F /* MockShareTab.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSelectableItemCellView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/Generic views/GenericSelectableItemCellView.swift
@@ -14,6 +14,7 @@ struct GenericSelectableItemCellView: View {
     let title: String
     let isSelected: Bool
     let theme: Theme?
+    let a11yIdentifier: String
     private(set) var onTap: () -> Void
 
     var textColor: Color {
@@ -46,7 +47,9 @@ struct GenericSelectableItemCellView: View {
         .padding(.horizontal, UX.horizontalSpacing)
         .background(backgroundColor)
         .accessibilityElement()
+        .accessibilityIdentifier(a11yIdentifier)
         .accessibilityLabel(title)
+        .accessibilityValue(isSelected ? "1" : "0")
         .accessibilityAddTraits(.isButton)
         .onTapGesture {
             onTap()

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/NavigationBarMiddleButtonSelectionView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/NavigationBarMiddleButtonSelectionView.swift
@@ -26,7 +26,8 @@ struct NavigationBarMiddleButtonSelectionView: View {
             GenericSelectableItemCellView(
                 title: NavigationBarMiddleButtonType.newTab.label,
                 isSelected: selectedMiddleButton == NavigationBarMiddleButtonType.newTab,
-                theme: theme
+                theme: theme,
+                a11yIdentifier: identifierName(for: .newTab)
             ) {
                 selectedMiddleButton = NavigationBarMiddleButtonType.newTab
                 onSelected?(selectedMiddleButton)
@@ -38,7 +39,8 @@ struct NavigationBarMiddleButtonSelectionView: View {
             GenericSelectableItemCellView(
                 title: NavigationBarMiddleButtonType.home.label,
                 isSelected: selectedMiddleButton == NavigationBarMiddleButtonType.home,
-                theme: theme
+                theme: theme,
+                a11yIdentifier: identifierName(for: .home)
             ) {
                 selectedMiddleButton = NavigationBarMiddleButtonType.home
                 onSelected?(selectedMiddleButton)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/GenericSelectableItemCellViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/GenericSelectableItemCellViewTests.swift
@@ -49,16 +49,6 @@ final class GenericSelectableItemCellViewTests: XCTestCase {
         XCTAssertNotNil(render(subject))
     }
 
-    /// Lays the view out inside a window so that its body is evaluated.
-    private func render(_ view: some View) -> UIView {
-        let host = UIHostingController(rootView: view)
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
-        window.rootViewController = host
-        window.isHidden = false
-        host.view.layoutIfNeeded()
-        return host.view
-    }
-
     private func createSubject(isSelected: Bool,
                                theme: Theme? = LightTheme(),
                                onTap: @escaping () -> Void = {}) -> GenericSelectableItemCellView {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/GenericSelectableItemCellViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/GenericSelectableItemCellViewTests.swift
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import SwiftUI
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class GenericSelectableItemCellViewTests: XCTestCase {
+    private let theme = LightTheme()
+
+    func testColorsUseTheTheme() {
+        let subject = createSubject(isSelected: true)
+
+        XCTAssertEqual(subject.textColor, Color(theme.colors.textPrimary))
+        XCTAssertEqual(subject.checkmarkTintColor, Color(theme.colors.iconAccent))
+        XCTAssertEqual(subject.backgroundColor, Color(theme.colors.layer5))
+    }
+
+    func testColorsFallBackToClearWithoutATheme() {
+        let subject = createSubject(isSelected: true, theme: nil)
+
+        XCTAssertEqual(subject.textColor, Color(UIColor.clear))
+        XCTAssertEqual(subject.checkmarkTintColor, Color(UIColor.clear))
+        XCTAssertEqual(subject.backgroundColor, Color(UIColor.clear))
+    }
+
+    func testOnTapIsForwarded() {
+        var tapCount = 0
+        let subject = createSubject(isSelected: false) { tapCount += 1 }
+
+        subject.onTap()
+
+        XCTAssertEqual(tapCount, 1)
+    }
+
+    func testRendersWhenSelected() {
+        let subject = createSubject(isSelected: true)
+
+        XCTAssertNotNil(render(subject))
+    }
+
+    func testRendersWhenNotSelected() {
+        let subject = createSubject(isSelected: false)
+
+        XCTAssertNotNil(render(subject))
+    }
+
+    /// Lays the view out inside a window so that its body is evaluated.
+    private func render(_ view: some View) -> UIView {
+        let host = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.layoutIfNeeded()
+        return host.view
+    }
+
+    private func createSubject(isSelected: Bool,
+                               theme: Theme? = LightTheme(),
+                               onTap: @escaping () -> Void = {}) -> GenericSelectableItemCellView {
+        return GenericSelectableItemCellView(title: "Home",
+                                             isSelected: isSelected,
+                                             theme: theme,
+                                             a11yIdentifier: "HomeButton",
+                                             onTap: onTap)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/NavigationBarMiddleButtonSelectionViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/NavigationBarMiddleButtonSelectionViewTests.swift
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import SwiftUI
+import XCTest
+
+@testable import Client
+
+@MainActor
+final class NavigationBarMiddleButtonSelectionViewTests: XCTestCase {
+    func testIdentifierNameMatchesTheSelectedOption() {
+        let subject = createSubject(selectedMiddleButton: .newTab)
+
+        XCTAssertEqual(subject.identifierName(for: .home),
+                       AccessibilityIdentifiers.Settings.NavigationToolbar.homeButton)
+        XCTAssertEqual(subject.identifierName(for: .newTab),
+                       AccessibilityIdentifiers.Settings.NavigationToolbar.newTabButton)
+    }
+
+    func testBackgroundColorFallsBackToClearWithoutATheme() {
+        let subject = createSubject(selectedMiddleButton: .home, theme: nil)
+
+        XCTAssertEqual(subject.backgroundColor, Color(UIColor.clear))
+    }
+
+    func testRendersWithNewTabSelected() {
+        let subject = createSubject(selectedMiddleButton: .newTab)
+
+        XCTAssertNotNil(render(subject))
+    }
+
+    func testRendersWithHomeSelected() {
+        let subject = createSubject(selectedMiddleButton: .home)
+
+        XCTAssertNotNil(render(subject))
+    }
+
+    /// Lays the view out inside a window so that its body is evaluated.
+    private func render(_ view: some View) -> UIView {
+        let host = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.layoutIfNeeded()
+        return host.view
+    }
+
+    private func createSubject(selectedMiddleButton: NavigationBarMiddleButtonType,
+                               theme: Theme? = LightTheme(),
+                               onSelected: ((NavigationBarMiddleButtonType) -> Void)? = nil)
+    -> NavigationBarMiddleButtonSelectionView {
+        return NavigationBarMiddleButtonSelectionView(theme: theme,
+                                                      selectedMiddleButton: selectedMiddleButton,
+                                                      onSelected: onSelected)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/NavigationBarMiddleButtonSelectionViewTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/NavigationBarMiddleButtonSelectionViewTests.swift
@@ -37,16 +37,6 @@ final class NavigationBarMiddleButtonSelectionViewTests: XCTestCase {
         XCTAssertNotNil(render(subject))
     }
 
-    /// Lays the view out inside a window so that its body is evaluated.
-    private func render(_ view: some View) -> UIView {
-        let host = UIHostingController(rootView: view)
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
-        window.rootViewController = host
-        window.isHidden = false
-        host.view.layoutIfNeeded()
-        return host.view
-    }
-
     private func createSubject(selectedMiddleButton: NavigationBarMiddleButtonType,
                                theme: Theme? = LightTheme(),
                                onSelected: ((NavigationBarMiddleButtonType) -> Void)? = nil)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/SwiftUIViewTestHelpers.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/SwiftUIViewTestHelpers.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import XCTest
+
+extension XCTestCase {
+    /// Lays a SwiftUI view out inside a window so that its body is evaluated.
+    /// The host and window stay local so they deallocate as soon as the call returns.
+    @MainActor
+    func render(_ view: some View,
+                size: CGSize = CGSize(width: 390, height: 844)) -> UIView {
+        let host = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.layoutIfNeeded()
+        return host.view
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -150,7 +150,6 @@
         "HistoryTests\/testTabHistory_tabTrayExperimentOn()",
         "HomePageSettingsTest",
         "HomePageSettingsUITests\/testRecentlyVisited()",
-        "HomePageSettingsUITests\/testTyping()",
         "HomePageUITest",
         "IntegrationTests",
         "IntegrationTests\/testFxASyncBookmark()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomeButtonTests.swift
@@ -23,7 +23,7 @@ class HomeButtonTests: BaseTestCase {
     func testGoHome() throws {
         browserScreen.navigateToURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
-        toolbarScreen.tapHomeButton()
+        toolbarScreen.tapOnNewTabButton()
         waitForTabsButton()
         if !iPad() {
             XCTAssertEqual(app.buttons[AccessibilityIdentifiers.Toolbar.searchButton].label, "Search")
@@ -42,8 +42,8 @@ class HomeButtonTests: BaseTestCase {
         browserScreen.navigateToURL("http://localhost:\(serverPort)/test-fixture/\(TestPages.findInPage)")
         waitUntilPageLoad()
 
-        // Switch to Homepage by taping the home button
-        toolbarScreen.tapHomeButton()
+        // Switch to Homepage by taping the new tab button
+        toolbarScreen.tapOnNewTabButton()
 
         validateHomePageAndKeyboardRaisedUp(showKeyboard: true)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -14,10 +14,13 @@ let urlExampleLabel = TestLabels.exampleDomain
 let urlMozillaLabel = "Internet for people, not profit — Mozilla (US)"
 
 class HomePageSettingsUITests: FeatureFlaggedTestBase {
+    private var homepageSettingsScreen: HomepageSettingsScreen!
+    private var settingScreen: SettingScreen!
+    private var toolbarScreen: ToolbarScreen!
+    private var browserScreen: BrowserScreen!
+
     private func enterWebPageAsHomepage(text: String) {
-        app.textFields["HomeAsCustomURLTextField"].tapAndTypeText(text)
-        let value = app.textFields["HomeAsCustomURLTextField"].value
-        XCTAssertEqual(value as? String, text, "The webpage typed does not match with the one saved")
+        homepageSettingsScreen.typeCustomHomepageURL(text)
     }
     let testWithDB = ["testTopSitesCustomNumberOfRows"]
     let prefilledTopSites = "testBookmarksDatabase1000-browser.db"
@@ -37,6 +40,10 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
         }
         launchArguments.append(LaunchArguments.SkipAppleIntelligence)
         try await super.setUp()
+        homepageSettingsScreen = HomepageSettingsScreen(app: app)
+        settingScreen = SettingScreen(app: app)
+        toolbarScreen = ToolbarScreen(app: app)
+        browserScreen = BrowserScreen(app: app)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339256
@@ -68,31 +75,40 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339257
+    // Regression
     func testTyping() throws {
-        let shouldSkipTest = true
-        try XCTSkipIf(shouldSkipTest,
-                      "Skipping test based on https://github.com/mozilla-mobile/firefox-ios/issues/28117.")
+        guard !iPad() else {
+            throw XCTSkip("The navigation toolbar middle button cannot be configured on iPad")
+        }
+        app.launch()
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
         // Enter a webpage
-        enterWebPageAsHomepage(text: "example.com")
+        enterWebPageAsHomepage(text: path(forTestPage: TestPages.exampleHTML))
 
         // Check if it is saved going back and then again to home settings menu
         navigator.goto(SettingsScreen)
         navigator.goto(HomeSettings)
-        mozWaitForValueContains(app.textFields["HomeAsCustomURLTextField"], value: "http://example.com")
+        homepageSettingsScreen.assertCustomHomepageURLContains(TestPages.exampleHTML)
+
+        // The custom homepage is loaded by the Home button only. It replaces the new tab button in
+        // the middle of the navigation toolbar, which follows the New Tab settings instead.
+        navigator.goto(SettingsScreen)
+        settingScreen.navigateToToolbarSettings()
+        settingScreen.selectNavigationToolbarMiddleButton(.home)
+        settingScreen.tapBackToSettings()
+        settingScreen.closeSettingsWithDoneButton()
 
         // Check that it is actually set by opening a different website and going to Home
+        navigator.nowAt(NewTabScreen)
         navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
 
-        // Now check open home page should load the previously saved home page
-        app.buttons[AccessibilityIdentifiers.Toolbar.addNewTabButton].waitAndTap()
+        // Now the home button should load the previously saved home page
+        toolbarScreen.tapHomeButton()
         waitUntilPageLoad()
-        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
-        mozWaitForValueContains(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField],
-                                value: "example.com")
+        browserScreen.assertWebPageText(with: TestLabels.exampleDomain)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339258

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomepageSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomepageSettingsScreen.swift
@@ -29,6 +29,19 @@ final class HomepageSettingsScreen {
         return settingTable.cells.switches[toggle]
     }
 
+    private var customURLTextField: XCUIElement { sel.CUSTOM_URL_TEXT_FIELD.element(in: app) }
+
+    func typeCustomHomepageURL(_ url: String) {
+        customURLTextField.tapAndTypeText(url)
+        XCTAssertEqual(customURLTextField.value as? String,
+                       url,
+                       "The webpage typed does not match with the one saved")
+    }
+
+    func assertCustomHomepageURLContains(_ url: String) {
+        BaseTestCase().mozWaitForValueContains(customURLTextField, value: url)
+    }
+
     func assertBookmarkToggleExists(timeout: TimeInterval = TIMEOUT) {
         BaseTestCase().mozWaitForElementToExist(bookmarkSwitch)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingScreen.swift
@@ -4,6 +4,12 @@
 
 import XCTest
 
+/// The button the user can place in the middle of the navigation toolbar, from Settings → Toolbar.
+enum NavigationToolbarMiddleButton {
+    case home
+    case newTab
+}
+
 @MainActor
 final class SettingScreen {
     private let app: XCUIApplication
@@ -196,6 +202,18 @@ final class SettingScreen {
     func selectBottomToolbar() {
         BaseTestCase().mozWaitForElementToExist(bottomToolbarButton)
         bottomToolbarButton.waitAndTap()
+    }
+
+    /// Picks which button sits in the middle of the navigation toolbar. The Home option is what makes
+    /// the custom homepage URL reachable, as the default New Tab button ignores it.
+    func selectNavigationToolbarMiddleButton(_ button: NavigationToolbarMiddleButton) {
+        let option = switch button {
+        case .home: sel.NAVIGATION_TOOLBAR_HOME_BUTTON.element(in: app)
+        case .newTab: sel.NAVIGATION_TOOLBAR_NEW_TAB_BUTTON.element(in: app)
+        }
+        BaseTestCase().mozWaitForElementToExist(option)
+        option.waitAndTap()
+        BaseTestCase().mozWaitForValueContains(option, value: "1")
     }
 
     func navigateToDisplaySettings() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/HomepageSettingsSelector.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/HomepageSettingsSelector.swift
@@ -8,6 +8,7 @@ protocol HomepageSettingsSelectorSet {
     var BOOKMARK_TOGGLE: Selector { get }
     var JUMP_BACK_IN_TOGGLE: Selector { get }
     var HOMEPAGE_SETTINGS_TABLE: Selector { get }
+    var CUSTOM_URL_TEXT_FIELD: Selector { get }
     var all: [Selector] { get }
 }
 
@@ -15,6 +16,7 @@ struct HomepageSettingsSelectors: HomepageSettingsSelectorSet {
     private enum IDs {
         static let bookmarkToogle = "Bookmarks"
         static let jumpBackInToggle = "Jump Back In"
+        static let customURLTextField = "HomeAsCustomURLTextField"
     }
 
     let HOMEPAGE_SETTINGS_TABLE = Selector.firstTable(
@@ -34,5 +36,11 @@ struct HomepageSettingsSelectors: HomepageSettingsSelectorSet {
         groups: ["homepage_settings"]
     )
 
-    var all: [Selector] { [BOOKMARK_TOGGLE, HOMEPAGE_SETTINGS_TABLE, JUMP_BACK_IN_TOGGLE] }
+    let CUSTOM_URL_TEXT_FIELD = Selector.textFieldId(
+        IDs.customURLTextField,
+        description: "Custom URL text field of the current homepage section",
+        groups: ["homepage_settings"]
+    )
+
+    var all: [Selector] { [BOOKMARK_TOGGLE, HOMEPAGE_SETTINGS_TABLE, JUMP_BACK_IN_TOGGLE, CUSTOM_URL_TEXT_FIELD] }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SettingsSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SettingsSelectors.swift
@@ -43,6 +43,8 @@ protocol SettingsSelectorsSet {
     var BLOCK_POPUPS_SWITCH: Selector { get }
     var TOOLBAR_CELL: Selector { get }
     var BOTTOM_TOOLBAR_BUTTON: Selector { get }
+    var NAVIGATION_TOOLBAR_HOME_BUTTON: Selector { get }
+    var NAVIGATION_TOOLBAR_NEW_TAB_BUTTON: Selector { get }
     var DEFAULT_BROWSER_CELL: Selector { get }
     var SEARCH_CELL: Selector { get }
     var BROWSING_CELL_TITLE: Selector { get }
@@ -81,6 +83,8 @@ struct SettingsSelectors: SettingsSelectorsSet {
         static let settingTitle = "Settings"
         static let toolbarCellSettings = AccessibilityIdentifiers.Settings.SearchBar.searchBarSetting
         static let bottomToolbarButton = AccessibilityIdentifiers.Settings.SearchBar.bottomSetting
+        static let navigationToolbarHomeButton = AccessibilityIdentifiers.Settings.NavigationToolbar.homeButton
+        static let navigationToolbarNewTabButton = AccessibilityIdentifiers.Settings.NavigationToolbar.newTabButton
         static let defaultBrowserSettings = AccessibilityIdentifiers.Settings.DefaultBrowser.defaultBrowser
         static let searchCellTitle = AccessibilityIdentifiers.Settings.Search.title
         static let browsingCellTitle = AccessibilityIdentifiers.Settings.Browsing.title
@@ -261,6 +265,18 @@ struct SettingsSelectors: SettingsSelectorsSet {
         groups: ["settings"]
     )
 
+    let NAVIGATION_TOOLBAR_HOME_BUTTON = Selector.buttonId(
+        IDs.navigationToolbarHomeButton,
+        description: "Home option of the navigation toolbar middle button setting",
+        groups: ["settings"]
+    )
+
+    let NAVIGATION_TOOLBAR_NEW_TAB_BUTTON = Selector.buttonId(
+        IDs.navigationToolbarNewTabButton,
+        description: "New Tab option of the navigation toolbar middle button setting",
+        groups: ["settings"]
+    )
+
     let DEFAULT_BROWSER_CELL = Selector.tableCellById(
         IDs.defaultBrowserSettings,
         description: "Default browser cell in Settings",
@@ -398,7 +414,8 @@ struct SettingsSelectors: SettingsSelectorsSet {
          CLOSE_PRIVATE_TABS_SWITCH, CONTENT_BLOCKER_CELL, NOTIFICATIONS_CELL,
          PRIVACY_POLICY_CELL, LOGINS_CELL, CREDIT_CARDS_CELL, ADDRESS_CELL,
          CLEAR_PRIVATE_DATA_CELL, ALERT_OK_BUTTON, NEW_TAB_CELL, TITLE, TABLE, BROWSING_LINKS_SECTION,
-         NAVIGATIONBAR, CONNECT_SETTING, BLOCK_POPUPS_SWITCH, TOOLBAR_CELL, BOTTOM_TOOLBAR_BUTTON, DEFAULT_BROWSER_CELL,
+         NAVIGATIONBAR, CONNECT_SETTING, BLOCK_POPUPS_SWITCH, TOOLBAR_CELL, BOTTOM_TOOLBAR_BUTTON,
+         NAVIGATION_TOOLBAR_HOME_BUTTON, NAVIGATION_TOOLBAR_NEW_TAB_BUTTON, DEFAULT_BROWSER_CELL,
          SEARCH_CELL, BROWSING_CELL_TITLE, BLOCK_IMAGES_SWITCH_TITLE, NO_IMAGE_MODE_STATUS_SWITCH,
          TRANSLATION_CELL_TITLE, SEND_DATA_CELL, SEND_CRASH_REPORTS_CELL, APPEARANCE_NAVIGATION_BAR]
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/ToolbarSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/ToolbarSelectors.swift
@@ -31,7 +31,7 @@ struct ToolbarSelectors: ToolbarSelectorsSet {
         static let tabToolbar_MenuButton = "TabToolbar.menuButton"
         static let reloadButton = AccessibilityIdentifiers.Toolbar.reloadButton
         static let shareButton = AccessibilityIdentifiers.Toolbar.shareButton
-        static let homeButton = AccessibilityIdentifiers.Toolbar.addNewTabButton
+        static let homeButton = AccessibilityIdentifiers.Toolbar.homeButton
         static let translateButton = AccessibilityIdentifiers.Toolbar.translateButton
         static let translateLoadingButton = AccessibilityIdentifiers.Toolbar.translateLoadingButton
         static let translateActiveButton = AccessibilityIdentifiers.Toolbar.translateActiveButton


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5838

## :bulb: Description
Re-enables `HomePageSettingsUITests/testTyping` (TestRail C2339257 — *Validate Custom URL as Current Homepage*), which has been skipped since #28314.

### Why it was skipped, and why it can come back

The test was not skipped because of a bug. #27993 intentionally changed the navigation-toolbar `+` button so a new tab follows the **New Tab** configuration instead of the **Homepage** custom URL, and product confirmed on #28117 that this is the desired behavior. The test's second half — tap `addNewTabButton`, expect the custom homepage — was asserting behavior that no longer exists.

The feature itself did not go away, it moved. `PrefsKeys.HomeButtonHomepageURL` is still read by `BrowserViewController.didTapOnHome()`, which fires when the `.home` toolbar button is tapped, and the middle button of the navigation toolbar is now user-selectable between **New Tab** (default) and **Home** via Settings → Toolbar. That is a real "press Home" surface and maps 1:1 onto step 2 of the manual case.

### Test changes

`testTyping` keeps step 1 unchanged (type a custom URL, leave and re-enter Homepage settings, assert it persisted) and rewrites step 2 against the Home button:

1. Set the custom homepage to the local `test-example.html` fixture and verify it is saved.
2. Settings → Toolbar → select **Home** as the navigation toolbar middle button.
3. Load the `test-mozilla-org.html` fixture, tap Home, assert *Example Domain* rendered.

Both fixtures are served from `localhost`, so the assertion is on page content rather than the address bar — a "localhost" URL check would pass even if Home did nothing. The test skips on iPad, where `SettingsCoordinator.pressedToolbar()` returns early and the setting is unavailable. It also gained the `app.launch()` that the skipped body was missing. Removed from `FullFunctionalTestPlan` skips; the Smoketest and AccessibilityTestPlan entries are left alone, as those exclusions predate #28117.

### Accessibility identifiers (app change)

`NavigationBarMiddleButtonSelectionView.identifierName(for:)` already existed but was never applied — `GenericSelectableItemCellView` only set an accessibility label, so `AccessibilityIdentifiers.Settings.NavigationToolbar.homeButton/.newTabButton` were dead constants and the options were only reachable by localized string. `GenericSelectableItemCellView` now takes an `a11yIdentifier` and exposes a selected/unselected accessibility value, matching what `GenericImageOption` already does for the address-bar position options right above it in the same screen.

### Drive-by selector fix

`ToolbarSelectors.IDs.homeButton` was mapped to `AccessibilityIdentifiers.Toolbar.addNewTabButton`, so `ToolbarScreen.tapHomeButton()` was actually tapping the `+` button. Its two callers in `HomeButtonTests` now call `tapOnNewTabButton()` — the element they were always hitting, so their behavior is unchanged — and `HOME_BUTTON` now points at the real home button.

### Page-object plumbing

- `SettingScreen.selectNavigationToolbarMiddleButton(_:)` + the two new selectors, taps then waits for the selection to settle.
- `HomepageSettingsScreen.typeCustomHomepageURL(_:)` / `assertCustomHomepageURLContains(_:)` + a `CUSTOM_URL_TEXT_FIELD` selector; the test file's private `enterWebPageAsHomepage` helper now delegates there, so `testChangeHomeSettingsLabel` picks it up as well.

### Verification

Run on iPhone 17 / iOS 26.5 against `FullFunctionalTestPlan`:

- `HomePageSettingsUITests/testTyping` — passed (98s)
- `HomeButtonTests` — 3/3 passed (regression check for the selector fix)

Added unit tests for the two SwiftUI views touched by the accessibility-identifier change; both were previously uncovered.

