### PR TITLE
Bugfix FXIOS-16650 Nova [Report broken site] - Preview button is blue no matter the theme

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -428,6 +428,10 @@ public final class WebCompatReportSheetViewController: UIViewController,
         collectionView.backgroundColor = theme.colors.layer1
         collectionView.setCollectionViewLayout(makeLayout(backgroundColor: theme.colors.layer1), animated: false)
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
+        if theme.isNova {
+            previewButton.tintColor = theme.colors.actionPrimary
+            previewButton.setTitleTextAttributes([.foregroundColor: theme.colors.textInverted], for: .normal)
+        }
         if hasAppliedThemeOnce {
             reconfigureAllItems()
         }


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16650)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates Preview button to use Nova action primary token, to implement the purple scheme design.

<img width="1206" height="2622" alt="simulator_screenshot_F03F3F4B-F13E-40E2-8343-167F28416143" src="https://github.com/user-attachments/assets/e1b14a46-1242-4a1a-a569-d2258557c629" />
<img width="1206" height="2622" alt="simulator_screenshot_6588C463-ADEB-4811-A213-2AA42A03FF13" src="https://github.com/user-attachments/assets/99201d08-9589-47ed-b95d-f050e9c276a2" />



<img width="1206" height="2622" alt="simulator_screenshot_59DB10F6-A414-4530-9494-DCC65D9C428F" src="https://github.com/user-attachments/assets/24ec0e0c-9af2-4a20-ab13-853a2169ac66" />

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

