### PR TITLE
Add FXIOS-16656 [FxA Pairflow] v2 FxA pairing routes for external links

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1853,6 +1853,8 @@
 		C8E2E80C23D20FB3005AACE6 /* Avatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E2E80823D20FB3005AACE6 /* Avatar.swift */; };
 		C8E2E80D23D20FB3005AACE6 /* RustFirefoxAccounts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E2E80923D20FB3005AACE6 /* RustFirefoxAccounts.swift */; };
 		C8E2E80E23D20FD2005AACE6 /* FxAWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E2E80723D20FB3005AACE6 /* FxAWebViewController.swift */; };
+		4D5041490000000000000002 /* FxAPairingURLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5041490000000000000001 /* FxAPairingURLParser.swift */; };
+		4D5041490000000000000004 /* FxAPairingURLParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5041490000000000000003 /* FxAPairingURLParserTests.swift */; };
 		C8E531C829E5EB6100E03FEF /* RouteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E531C729E5EB6100E03FEF /* RouteBuilder.swift */; };
 		C8E531CA29E5F7D300E03FEF /* URLScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E531C929E5F7D300E03FEF /* URLScannerTests.swift */; };
 		C8E531CC29E72A2F00E03FEF /* ShortcutRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E531CB29E72A2F00E03FEF /* ShortcutRouteTests.swift */; };
@@ -11038,6 +11040,8 @@
 		C8E2E80723D20FB3005AACE6 /* FxAWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAWebViewController.swift; sourceTree = "<group>"; };
 		C8E2E80823D20FB3005AACE6 /* Avatar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Avatar.swift; sourceTree = "<group>"; };
 		C8E2E80923D20FB3005AACE6 /* RustFirefoxAccounts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustFirefoxAccounts.swift; sourceTree = "<group>"; };
+		4D5041490000000000000001 /* FxAPairingURLParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAPairingURLParser.swift; sourceTree = "<group>"; };
+		4D5041490000000000000003 /* FxAPairingURLParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAPairingURLParserTests.swift; sourceTree = "<group>"; };
 		C8E531C729E5EB6100E03FEF /* RouteBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteBuilder.swift; sourceTree = "<group>"; };
 		C8E531C929E5F7D300E03FEF /* URLScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLScannerTests.swift; sourceTree = "<group>"; };
 		C8E531CB29E72A2F00E03FEF /* ShortcutRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRouteTests.swift; sourceTree = "<group>"; };
@@ -14714,6 +14718,7 @@
 				5AE371802A4DD0CE0092A760 /* Mocks */,
 				5A81C5DC2A4C981A00BE88C2 /* PasswordManagerCoordinatorTests.swift */,
 				C29B64862AD69D0200F3244B /* QRCodeCoordinatorTests.swift */,
+				4D5041490000000000000003 /* FxAPairingURLParserTests.swift */,
 				C8EDDBEF29DD83FC003A4C07 /* RouteTests.swift */,
 				8A7A26E229D4ACF300EA76F1 /* SceneCoordinatorTests.swift */,
 				8A83B7492A265044002FF9AC /* SettingsCoordinatorTests.swift */,
@@ -14741,6 +14746,7 @@
 				8A93F86C29D3A131004159D9 /* DefaultRouter.swift */,
 				C8124BB029D6F55400540B79 /* Route.swift */,
 				C8EDDBF329DF119F003A4C07 /* DeeplinkInput.swift */,
+				4D5041490000000000000001 /* FxAPairingURLParser.swift */,
 				C8EDDBF129DF1159003A4C07 /* URLScanner.swift */,
 				C8E531C729E5EB6100E03FEF /* RouteBuilder.swift */,
 			);
@@ -20215,6 +20221,7 @@
 				0BDDB3412CA6B23300D501DF /* EditFolderCell.swift in Sources */,
 				8A093D7D2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift in Sources */,
 				1DC372022B23C80F000F96C8 /* WindowManager.swift in Sources */,
+				4D5041490000000000000002 /* FxAPairingURLParser.swift in Sources */,
 				C8E531C829E5EB6100E03FEF /* RouteBuilder.swift in Sources */,
 				D3972BF41C22412B00035B87 /* TitleActivityItemProvider.swift in Sources */,
 				D38A1BEE1A9FA2CA00F6A386 /* SiteTableViewController.swift in Sources */,
@@ -20969,6 +20976,7 @@
 				394615602FEC37E3003321D8 /* WebServerUtilTests.swift in Sources */,
 				C2500D7C2ECB4A600071506F /* MockTranslationModelsFetcher.swift in Sources */,
 				8AD8FF172EBB022A00FDFD78 /* MockGleanPlumbMessageManagerProtocol.swift in Sources */,
+				4D5041490000000000000004 /* FxAPairingURLParserTests.swift in Sources */,
 				C8EDDBF029DD83FC003A4C07 /* RouteTests.swift in Sources */,
 				0A7693612C7DD19600103A6D /* CertificatesViewModelTests.swift in Sources */,
 				8A454D372CB86B86009436D9 /* MerinoStateTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -295,7 +295,8 @@ final class BrowserCoordinator: BaseCoordinator,
         guard hasBrowserLoaded else { return false }
 
         switch route {
-        case .searchQuery, .search, .searchURL, .glean, .homepanel, .action, .fxaSignIn, .defaultBrowser, .sharesheet:
+        case .searchQuery, .search, .searchURL, .glean, .homepanel, .action, .fxaSignIn, .fxaPairing,
+                .defaultBrowser, .sharesheet:
             return true
         case let .settings(section):
             return canHandleSettings(with: section)
@@ -338,6 +339,9 @@ final class BrowserCoordinator: BaseCoordinator,
 
         case let .fxaSignIn(params):
             handle(fxaParams: params)
+
+        case let .fxaPairing(url):
+            browserViewController.presentPairingViewController(url)
 
         case let .defaultBrowser(section):
             switch section {

--- a/firefox-ios/Client/Coordinators/Router/FxAPairingURLParser.swift
+++ b/firefox-ios/Client/Coordinators/Router/FxAPairingURLParser.swift
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+enum FxAPairingURLParser {
+    enum ParseResult: Equatable {
+        case notPairing
+        case invalidPairing
+        case pairing(URL)
+    }
+
+    private static let allowedHosts = [
+        "accounts.firefox.com",
+        "accounts.stage.mozaws.net"
+    ]
+
+    static func parse(_ url: URL) -> ParseResult {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let host = components.host?.lowercased(),
+              allowedHosts.contains(host)
+        else { return .notPairing }
+
+        let path = normalized(path: components.path)
+        guard path == "/pair" else { return .notPairing }
+
+        let parameters = pairingParameters(in: components)
+        let pairingVersion = parameters.first(where: { $0.name == "v" })?.value
+        guard pairingVersion == "2" else { return .notPairing }
+
+        guard components.scheme?.lowercased() == "https",
+              components.user == nil,
+              components.password == nil
+        else { return .invalidPairing }
+
+        guard hasChannelCredentials(in: parameters) else { return .invalidPairing }
+        return .pairing(url)
+    }
+
+    private static func normalized(path: String) -> String {
+        guard path.count > 1, path.hasSuffix("/") else { return path }
+        return String(path.dropLast())
+    }
+
+    private static func pairingParameters(in components: URLComponents) -> [URLQueryItem] {
+        let queryItems = components.queryItems ?? []
+        let fragmentItems: [URLQueryItem]
+        if let fragment = components.fragment {
+            var fragmentComponents = URLComponents()
+            fragmentComponents.query = fragment
+            fragmentItems = fragmentComponents.queryItems ?? []
+        } else {
+            fragmentItems = []
+        }
+
+        return queryItems + fragmentItems
+    }
+
+    private static func hasChannelCredentials(in parameters: [URLQueryItem]) -> Bool {
+        let channelID = parameters.first(where: { $0.name == "channel_id" })?.value
+        let channelKey = parameters.first(where: { $0.name == "channel_key" })?.value
+        return channelID?.isEmpty == false && channelKey?.isEmpty == false
+    }
+}

--- a/firefox-ios/Client/Coordinators/Router/Route.swift
+++ b/firefox-ios/Client/Coordinators/Router/Route.swift
@@ -59,6 +59,9 @@ enum Route {
     /// - Parameter params: An instance of `FxALaunchParams` containing the parameters for the sign-in.
     case fxaSignIn(params: FxALaunchParams)
 
+    /// Represents a validated Mozilla Accounts pairing URL opened from outside Firefox.
+    case fxaPairing(url: URL)
+
     /// Represents a default browser route that takes a `DefaultBrowserSection` value indicating
     /// the section to be displayed.
     ///

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -40,6 +40,15 @@ final class RouteBuilder: @unchecked Sendable {
 
     @MainActor
     func makeRoute(url: URL) -> Route? {
+        switch FxAPairingURLParser.parse(url) {
+        case .pairing(let pairingURL):
+            return .fxaPairing(url: pairingURL)
+        case .invalidPairing:
+            return nil
+        case .notPairing:
+            break
+        }
+
         guard let urlScanner = URLScanner(url: url) else { return nil }
 
         if let host = parseURLHost(url) {
@@ -53,23 +62,7 @@ final class RouteBuilder: @unchecked Sendable {
 
             switch host {
             case .deepLink:
-                let deepLinkURL = urlScanner.fullURLQueryItem()?.lowercased()
-                let paths = deepLinkURL?.split(separator: "/") ?? []
-                guard let pathRaw = paths[safe: 0].flatMap(String.init),
-                      let path = DeeplinkInput.Path(rawValue: pathRaw),
-                      let subPath = paths[safe: 1].flatMap(String.init)
-                else { return nil }
-                if path == .settings, let subPath = Route.SettingsSection(rawValue: subPath) {
-                    return .settings(section: subPath)
-                } else if path == .homepanel, let subPath = Route.HomepanelSection(rawValue: subPath) {
-                    return .homepanel(section: subPath)
-                } else if path == .defaultBrowser, let subPath = Route.DefaultBrowserSection(rawValue: subPath) {
-                    return .defaultBrowser(section: subPath)
-                } else if path == .action, let subPath = Route.AppAction(rawValue: subPath) {
-                    return .action(action: subPath)
-                } else {
-                    return nil
-                }
+                return makeDeepLinkRoute(urlScanner: urlScanner)
 
             case .fxaSignIn where urlScanner.value(query: "signin") != nil:
                 return .fxaSignIn(
@@ -83,6 +76,16 @@ final class RouteBuilder: @unchecked Sendable {
                 let isOpeningWithFirefoxExtension = Bool(urlScanner.value(query: "openWithFirefox") ?? "") ?? false
                 if isOpeningWithFirefoxExtension {
                     actionExtensionTelemetry.shareURL()
+                }
+                if let urlQuery {
+                    switch FxAPairingURLParser.parse(urlQuery) {
+                    case .pairing(let pairingURL):
+                        return .fxaPairing(url: pairingURL)
+                    case .invalidPairing:
+                        return nil
+                    case .notPairing:
+                        break
+                    }
                 }
                 return .search(url: urlQuery, isPrivate: isPrivate)
 
@@ -191,7 +194,14 @@ final class RouteBuilder: @unchecked Sendable {
         // If the user activity has a webpageURL, it's a deep link or an old history item.
         // Use the URL to create a new search tab.
         if let url = userActivity.webpageURL {
-            return .search(url: url, isPrivate: false)
+            switch FxAPairingURLParser.parse(url) {
+            case .pairing(let pairingURL):
+                return .fxaPairing(url: pairingURL)
+            case .invalidPairing:
+                return nil
+            case .notPairing:
+                return .search(url: url, isPrivate: false)
+            }
         }
 
         // If the user activity is a CoreSpotlight item, check its activity identifier to determine
@@ -241,6 +251,27 @@ final class RouteBuilder: @unchecked Sendable {
     private func getWidgetRoute(urlQuery: URL?, isPrivate: Bool) -> Route? {
         let isCustomLink = prefs?.stringForKey(NewTabAccessors.NewTabPrefKey) == NewTabPage.homePage.rawValue
         return .search(url: urlQuery, isPrivate: isPrivate, options: isCustomLink ? [] : [.focusLocationField])
+    }
+
+    private func makeDeepLinkRoute(urlScanner: URLScanner) -> Route? {
+        let deepLinkURL = urlScanner.fullURLQueryItem()?.lowercased()
+        let paths = deepLinkURL?.split(separator: "/") ?? []
+        guard let pathRaw = paths[safe: 0].flatMap(String.init),
+              let path = DeeplinkInput.Path(rawValue: pathRaw),
+              let subPath = paths[safe: 1].flatMap(String.init)
+        else { return nil }
+
+        if path == .settings, let subPath = Route.SettingsSection(rawValue: subPath) {
+            return .settings(section: subPath)
+        } else if path == .homepanel, let subPath = Route.HomepanelSection(rawValue: subPath) {
+            return .homepanel(section: subPath)
+        } else if path == .defaultBrowser, let subPath = Route.DefaultBrowserSection(rawValue: subPath) {
+            return .defaultBrowser(section: subPath)
+        } else if path == .action, let subPath = Route.AppAction(rawValue: subPath) {
+            return .action(action: subPath)
+        } else {
+            return nil
+        }
     }
 
     // MARK: - Telemetry

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -25,6 +25,7 @@ import struct MozillaAppServices.Login
 import enum MozillaAppServices.BookmarkRoots
 import struct MozillaAppServices.VisitObservation
 import enum MozillaAppServices.VisitType
+import enum MozillaAppServices.OAuthScope
 
 class BrowserViewController: UIViewController,
                              SearchBarLocationProvider,
@@ -3392,6 +3393,30 @@ class BrowserViewController: UIViewController,
                                     navItemText: .Close,
                                     vcBeingPresented: vcToPresent,
                                     topTabsVisible: UIDevice.current.userInterfaceIdiom == .pad)
+    }
+
+    func presentPairingViewController(_ pairingURL: URL) {
+        guard let accountManager = profile.rustFxA.accountManager else { return }
+
+        accountManager.beginPairingAuthentication(
+            pairingUrl: pairingURL.absoluteString,
+            entrypoint: "pairing_\(FxAEntrypoint.fxaDeepLinkNavigation.rawValue)",
+            scopes: [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session]
+        ) { [weak self] result in
+            guard let self, case .success(let supplicantURL) = result else { return }
+            let viewController = FxAWebViewController(
+                pageType: .qrCode(url: supplicantURL),
+                profile: profile,
+                dismissalStyle: .dismiss,
+                deepLinkParams: FxALaunchParams(entrypoint: .fxaDeepLinkNavigation, query: [:])
+            )
+            presentThemedViewController(
+                navItemLocation: .Left,
+                navItemText: .Close,
+                vcBeingPresented: viewController,
+                topTabsVisible: UIDevice.current.userInterfaceIdiom == .pad
+            )
+        }
     }
 
     // MARK: - Handle Deeplink open URL / query

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1267,6 +1267,21 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertEqual(browserViewController.presentSignInReferringPage, ReferringPage.none)
     }
 
+    func testHandleFxaPairingPresentsPairingFlow() {
+        let subject = createSubject()
+        subject.browserViewController = browserViewController
+        subject.browserHasLoaded()
+        let pairingURL = URL(
+            string: "https://accounts.firefox.com/pair#channel_id=channel&channel_key=key&v=2"
+        )!
+
+        let result = testCanHandleAndHandle(subject, route: .fxaPairing(url: pairingURL))
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(browserViewController.presentPairingCount, 1)
+        XCTAssertEqual(browserViewController.presentPairingURL, pairingURL)
+    }
+
     // MARK: - App action route
 
     func testHandleClosePrivateTabs_returnsTrue() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FxAPairingURLParserTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FxAPairingURLParserTests.swift
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class FxAPairingURLParserTests: XCTestCase {
+    func testPairingURLReturnsProductionPairingURLWithFragmentCredentials() {
+        let url = URL(string: "https://accounts.firefox.com/pair#channel_id=channel&channel_key=key&v=2")!
+
+        XCTAssertEqual(FxAPairingURLParser.parse(url), .pairing(url))
+    }
+
+    func testPairingURLReturnsStagePairingURLWithFragmentCredentials() {
+        let url = URL(
+            string: "https://accounts.stage.mozaws.net/pair#channel_id=channel&channel_key=key&v=2"
+        )!
+
+        XCTAssertEqual(FxAPairingURLParser.parse(url), .pairing(url))
+    }
+
+    func testPairingURLAcceptsTrailingSlash() {
+        let url = URL(string: "https://accounts.firefox.com/pair/#channel_id=channel&channel_key=key&v=2")!
+
+        XCTAssertEqual(FxAPairingURLParser.parse(url), .pairing(url))
+    }
+
+    func testPairingURLRejectsUntrustedHost() {
+        let url = URL(string: "https://example.com/pair#channel_id=channel&channel_key=key&v=2")!
+
+        XCTAssertEqual(FxAPairingURLParser.parse(url), .notPairing)
+    }
+
+    func testPairingURLRejectsHTTP() {
+        let url = URL(string: "http://accounts.firefox.com/pair#channel_id=channel&channel_key=key&v=2")!
+
+        XCTAssertEqual(FxAPairingURLParser.parse(url), .invalidPairing)
+    }
+
+    func testPairingURLRejectsEmbeddedCredentials() {
+        let url = URL(
+            string: "https://user:password@accounts.firefox.com/pair#channel_id=channel&channel_key=key&v=2"
+        )!
+
+        XCTAssertEqual(FxAPairingURLParser.parse(url), .invalidPairing)
+    }
+
+    func testPairingURLRejectsMissingChannelCredentials() {
+        let url = URL(string: "https://accounts.firefox.com/pair#v=2")!
+
+        XCTAssertEqual(FxAPairingURLParser.parse(url), .invalidPairing)
+    }
+
+    func testPairingURLWithoutVersionUsesExistingBehavior() {
+        let url = URL(string: "https://accounts.firefox.com/pair#channel_id=channel&channel_key=key")!
+
+        XCTAssertEqual(FxAPairingURLParser.parse(url), .notPairing)
+    }
+
+    func testPairingURLWithUnsupportedVersionUsesExistingBehavior() {
+        let url = URL(string: "https://accounts.firefox.com/pair#channel_id=channel&channel_key=key&v=1")!
+
+        XCTAssertEqual(FxAPairingURLParser.parse(url), .notPairing)
+    }
+
+    func testPairingURLWithNonEntryPathUsesExistingBehavior() {
+        let paths = ["pair/supp", "poc_pair_init", "poc_pair_start"]
+
+        for path in paths {
+            let url = URL(
+                string: "https://accounts.stage.mozaws.net/\(path)#channel_id=channel&channel_key=key&v=2"
+            )!
+            XCTAssertEqual(FxAPairingURLParser.parse(url), .notPairing)
+        }
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteTests.swift
@@ -72,6 +72,104 @@ class RouteTests: XCTestCase {
         }
     }
 
+    func testPairingRouteFromSystemCameraDeepLink() {
+        let subject = createSubject()
+        let pairingURL = URL(
+            string: "https://accounts.stage.mozaws.net/pair#channel_id=channel&channel_key=key&v=2"
+        )!
+        let url = wrappedDeepLink(for: pairingURL)
+
+        let route = subject.makeRoute(url: url)
+
+        guard case .fxaPairing(let routedURL) = route else {
+            return XCTFail("The route should be an FxA pairing route")
+        }
+        XCTAssertEqual(routedURL, pairingURL)
+    }
+
+    func testPairingRouteFromSystemCameraUserActivity() {
+        let subject = createSubject()
+        let pairingURL = URL(
+            string: "https://accounts.firefox.com/pair#channel_id=channel&channel_key=key&v=2"
+        )!
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = pairingURL
+
+        let route = subject.makeRoute(userActivity: activity)
+
+        guard case .fxaPairing(let routedURL) = route else {
+            return XCTFail("The route should be an FxA pairing route")
+        }
+        XCTAssertEqual(routedURL, pairingURL)
+    }
+
+    func testPairingRouteFromDefaultBrowserURL() {
+        let subject = createSubject()
+        let pairingURL = URL(
+            string: "https://accounts.firefox.com/pair#channel_id=channel&channel_key=key&v=2"
+        )!
+
+        guard case .fxaPairing(let routedURL) = subject.makeRoute(url: pairingURL) else {
+            return XCTFail("The route should be an FxA pairing route")
+        }
+        XCTAssertEqual(routedURL, pairingURL)
+    }
+
+    func testInvalidPairingDeepLinkDoesNotOpenBrowserTab() {
+        let subject = createSubject()
+        let pairingURL = URL(string: "https://accounts.firefox.com/pair#v=2")!
+        let url = wrappedDeepLink(for: pairingURL)
+
+        XCTAssertNil(subject.makeRoute(url: url))
+    }
+
+    func testInvalidPairingUserActivityDoesNotOpenBrowserTab() {
+        let subject = createSubject()
+        let pairingURL = URL(string: "https://accounts.firefox.com/pair#v=2")!
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = pairingURL
+
+        XCTAssertNil(subject.makeRoute(userActivity: activity))
+    }
+
+    func testNonV2PairingUserActivityOpensBrowserTab() {
+        let subject = createSubject()
+        let pairingURL = URL(
+            string: "https://accounts.firefox.com/pair#channel_id=channel&channel_key=key"
+        )!
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = pairingURL
+
+        guard case .search(let routedURL, _, _) = subject.makeRoute(userActivity: activity) else {
+            return XCTFail("A non-v2 pairing URL should use the existing browser route")
+        }
+        XCTAssertEqual(routedURL, pairingURL)
+    }
+
+    func testNonV2DirectPairingURLOpensBrowserTab() {
+        let subject = createSubject()
+        let pairingURL = URL(
+            string: "https://accounts.firefox.com/pair#channel_id=channel&channel_key=key&v=1"
+        )!
+
+        guard case .search(let routedURL, _, _) = subject.makeRoute(url: pairingURL) else {
+            return XCTFail("A non-v2 pairing URL should use the existing browser route")
+        }
+        XCTAssertEqual(routedURL, pairingURL)
+    }
+
+    func testNonV2WrappedPairingDeepLinkOpensBrowserTab() {
+        let subject = createSubject()
+        let pairingURL = URL(
+            string: "https://accounts.firefox.com/pair#channel_id=channel&channel_key=key&v=1"
+        )!
+
+        guard case .search(let routedURL, _, _) = subject.makeRoute(url: wrappedDeepLink(for: pairingURL)) else {
+            return XCTFail("A non-v2 pairing URL should use the existing browser route")
+        }
+        XCTAssertEqual(routedURL, pairingURL)
+    }
+
     func testSettingsRouteWithClearPrivateData() {
         let subject = createSubject()
         let url = URL(string: "firefox://deep-link?url=/settings/clear-private-data")!
@@ -724,5 +822,11 @@ class RouteTests: XCTestCase {
         subject.configure(isPrivate: false, prefs: MockProfile().prefs)
         trackForMemoryLeaks(subject)
         return subject
+    }
+
+    private func wrappedDeepLink(for url: URL) -> URL {
+        var components = URLComponents(string: "firefox://open-url")!
+        components.queryItems = [URLQueryItem(name: "url", value: url.absoluteString)]
+        return components.url!
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockBrowserViewController.swift
@@ -37,6 +37,8 @@ class MockBrowserViewController: BrowserViewController {
     var presentSignInFlowType: FxAPageType?
     var presentSignInReferringPage: ReferringPage?
     var presentSignInCount = 0
+    var presentPairingURL: URL?
+    var presentPairingCount = 0
 
     var closePrivateTabsWidgetAction = 0
 
@@ -134,6 +136,11 @@ class MockBrowserViewController: BrowserViewController {
         presentSignInFlowType = flowType
         presentSignInReferringPage = referringPage
         presentSignInCount += 1
+    }
+
+    override func presentPairingViewController(_ pairingURL: URL) {
+        presentPairingURL = pairingURL
+        presentPairingCount += 1
     }
 
     override func embedContent(_ viewController: ContentContainable) -> Bool {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16656)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
- Routes external Mozilla Accounts `/pair` links with `v=2` into the existing isolated FxA pairing web view. Supports both direct default-browser URLs and wrapped `firefox://open-url` deep links.

### 📝 Technical Details
- Flows
  - Firefox is the default browser:
    - Scan QR code w/ external camera → Firefox receives `/pair?...v=2` → Route to isolated FxA web view and begin pairing
  - Firefox is not the default browser:
    - Scan QR code w/ external camera  → default browser opens `/pair` → tap “Continue with Firefox” → `firefox://open-url` → Firefox validates embedded URL → Route to isolated FxA web view and begin pairing
- Missing HTTPS, `channel_id`, or `channel_key` results in the link being dropped, and no navigation occurs. If path isn't `/pair`, or `v2` is missing, the webpage will open normally in a tab (to maintain backwards compatibility and show "You must pair from within a Firefox app" page)
- Keeps the existing in-app FxA QR scanner unchanged.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

