### PR TITLE
Refactor FXIOS-16690 - [Toolbar] - Skip redundant view rebuilds during address bar state updates

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -410,7 +410,7 @@ public class BrowserAddressToolbar: UIView,
         widthAnchor.priority = .defaultHigh
     }
 
-    private func updateActionStack(stackView: UIStackView, toolbarElements: [ToolbarElement]) {
+    func updateActionStack(stackView: UIStackView, toolbarElements: [ToolbarElement]) {
         let buttons = toolbarElements.map { toolbarElement in
             let hasCachedButton = hasCachedButton(for: toolbarElement)
             let button = getToolbarButton(for: toolbarElement)
@@ -445,6 +445,10 @@ public class BrowserAddressToolbar: UIView,
             }
             return button
         }
+
+        // Buttons are cached and reused, so the stack often ends up with the exact same arrangement.
+        // Tearing it down and rebuilding it in that case only invalidates layout for no visible change.
+        guard !stackView.arrangedSubviews.elementsEqual(buttons, by: { $0 === $1 }) else { return }
 
         stackView.removeAllArrangedViews()
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -89,7 +89,7 @@ final class LocationView: UIView,
     private var lockIconWidthAnchor: NSLayoutConstraint?
 
     // MARK: - Search Engine / Lock Image
-    private lazy var iconContainerStackView: UIStackView = .build { view in
+    lazy var iconContainerStackView: UIStackView = .build { view in
         view.alignment = .center
     }
 
@@ -97,8 +97,8 @@ final class LocationView: UIView,
     // and we can remove `PlainSearchEngineView` from the project.
     private lazy var plainSearchEngineView: PlainSearchEngineView = .build()
     private lazy var dropDownSearchEngineView: DropDownSearchEngineView = .build()
-    private lazy var searchEngineContentView: SearchEngineView = plainSearchEngineView
-    private lazy var lockIconButton: UIButton = .build { button in
+    private(set) lazy var searchEngineContentView: SearchEngineView = plainSearchEngineView
+    private(set) lazy var lockIconButton: UIButton = .build { button in
         button.contentMode = .scaleAspectFit
         button.addTarget(self, action: #selector(self.didTapLockIcon), for: .touchUpInside)
     }
@@ -362,8 +362,12 @@ final class LocationView: UIView,
         urlTextFieldLeadingConstraint?.constant = constant
     }
 
-    private func removeContainerIcons() {
+    /// Rebuilds the icon container only when its arrangement actually changes. `configure` runs on every
+    /// toolbar state update, and tearing the stack down to re-add the same icon just invalidates layout.
+    private func setContainerIcons(_ icons: [UIView]) {
+        guard !iconContainerStackView.arrangedSubviews.elementsEqual(icons, by: { $0 === $1 }) else { return }
         iconContainerStackView.removeAllArrangedViews()
+        icons.forEach { iconContainerStackView.addArrangedSubview($0) }
     }
 
     private func updateIconContainer(isURLTextFieldCentered: Bool,
@@ -397,23 +401,29 @@ final class LocationView: UIView,
             shouldShowLockIcon = true
         }
 
+        let searchEngineAlpha: CGFloat = shouldShowLockIcon ? 0 : 1
+        let lockIconAlpha: CGFloat = shouldShowLockIcon ? 1 : 0
+
+        // Skip the animation when both icons already sit at their target alpha, otherwise every toolbar
+        // state update kicks off an animation block that has nothing to animate.
+        guard searchEngineContentView.alpha != searchEngineAlpha || lockIconButton.alpha != lockIconAlpha
+        else { return }
+
         let isAnimationEnabled = !UIAccessibility.isReduceMotionEnabled
         if isAnimationEnabled {
             UIView.animate(withDuration: UX.iconAnimationTime, delay: UX.iconAnimationDelay) {
-                self.searchEngineContentView.alpha = shouldShowLockIcon ? 0 : 1
-                self.lockIconButton.alpha = shouldShowLockIcon ? 1 : 0
+                self.searchEngineContentView.alpha = searchEngineAlpha
+                self.lockIconButton.alpha = lockIconAlpha
             }
         } else {
-            searchEngineContentView.alpha = shouldShowLockIcon ? 0 : 1
-            lockIconButton.alpha = shouldShowLockIcon ? 1 : 0
+            searchEngineContentView.alpha = searchEngineAlpha
+            lockIconButton.alpha = lockIconAlpha
         }
     }
 
     private func updateUIForSearchEngineDisplay(isURLTextFieldCentered: Bool) {
-        removeContainerIcons()
-        if !isURLTextFieldCentered || isEditing {
-            iconContainerStackView.addArrangedSubview(searchEngineContentView)
-        }
+        let shouldShowSearchEngine = !isURLTextFieldCentered || isEditing
+        setContainerIcons(shouldShowSearchEngine ? [searchEngineContentView] : [])
         updateURLTextFieldLeadingConstraint(constant: UX.horizontalSpace)
         iconContainerStackViewLeadingConstraint?.constant = UX.horizontalSpace
         updateGradient()
@@ -421,8 +431,7 @@ final class LocationView: UIView,
 
     private func updateUIForLockIconDisplay() {
         guard !isEditing else { return }
-        removeContainerIcons()
-        iconContainerStackView.addArrangedSubview(lockIconButton)
+        setContainerIcons([lockIconButton])
 
         updateURLTextFieldLeadingConstraintBasedOnState()
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -89,7 +89,7 @@ final class LocationView: UIView,
     private var lockIconWidthAnchor: NSLayoutConstraint?
 
     // MARK: - Search Engine / Lock Image
-    lazy var iconContainerStackView: UIStackView = .build { view in
+    private(set) lazy var iconContainerStackView: UIStackView = .build { view in
         view.alignment = .center
     }
 

--- a/BrowserKit/Sources/ToolbarKit/NavigationToolbar/BrowserNavigationToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/NavigationToolbar/BrowserNavigationToolbar.swift
@@ -110,6 +110,10 @@ public final class BrowserNavigationToolbar: UIView,
             return button
         }
 
+        // Buttons are cached and reused, so the stack often ends up with the exact same arrangement.
+        // Tearing it down and rebuilding it in that case only invalidates layout for no visible change.
+        guard !actionStack.arrangedSubviews.elementsEqual(buttons, by: { $0 === $1 }) else { return }
+
         actionStack.removeAllArrangedViews()
 
         buttons.forEach { button in

--- a/BrowserKit/Tests/ToolbarKitTests/BrowserAddressToolbarTests.swift
+++ b/BrowserKit/Tests/ToolbarKitTests/BrowserAddressToolbarTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import UIKit
 import XCTest
 import TestKit
 @testable import ToolbarKit
@@ -133,6 +134,60 @@ final class BrowserAddressToolbarTests: XCTestCase {
 
         let button = sut.getToolbarButton(for: tabToolbarElement)
         XCTAssertTrue(button is TabNumberButton, "Should create TabNumberButton when numberOfTabs is provided.")
+    }
+
+    // MARK: - updateActionStack
+    @MainActor
+    func testUpdateActionStack_KeepsSameArrangementWhenElementsUnchanged() {
+        let sut = createSubject()
+        let stackView = UIStackView()
+        guard let toolbarElement, let toolbarElement2 else {
+            XCTFail("Setup failed.")
+            return
+        }
+
+        sut.updateActionStack(stackView: stackView, toolbarElements: [toolbarElement, toolbarElement2])
+        let firstArrangement = stackView.arrangedSubviews
+        sut.updateActionStack(stackView: stackView, toolbarElements: [toolbarElement, toolbarElement2])
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 2, "Stack should still hold both buttons.")
+        XCTAssertTrue(stackView.arrangedSubviews.elementsEqual(firstArrangement) { $0 === $1 },
+                      "Reconfiguring with the same elements should leave the arrangement untouched.")
+    }
+
+    @MainActor
+    func testUpdateActionStack_UpdatesArrangementWhenElementsChange() {
+        let sut = createSubject()
+        let stackView = UIStackView()
+        guard let toolbarElement, let toolbarElement2 else {
+            XCTFail("Setup failed.")
+            return
+        }
+
+        sut.updateActionStack(stackView: stackView, toolbarElements: [toolbarElement])
+        XCTAssertEqual(stackView.arrangedSubviews.count, 1, "Stack should hold the single button.")
+
+        sut.updateActionStack(stackView: stackView, toolbarElements: [toolbarElement, toolbarElement2])
+
+        XCTAssertEqual(stackView.arrangedSubviews.count, 2, "Stack should be rebuilt when the elements change.")
+        XCTAssertTrue(stackView.arrangedSubviews.last === sut.getToolbarButton(for: toolbarElement2),
+                      "The newly added element's button should be last in the stack.")
+    }
+
+    @MainActor
+    func testUpdateActionStack_RebuildsWhenElementOrderChanges() {
+        let sut = createSubject()
+        let stackView = UIStackView()
+        guard let toolbarElement, let toolbarElement2 else {
+            XCTFail("Setup failed")
+            return
+        }
+
+        sut.updateActionStack(stackView: stackView, toolbarElements: [toolbarElement, toolbarElement2])
+        sut.updateActionStack(stackView: stackView, toolbarElements: [toolbarElement2, toolbarElement])
+
+        XCTAssertTrue(stackView.arrangedSubviews.first === sut.getToolbarButton(for: toolbarElement2),
+                      "Reordering the elements should reorder the stack.")
     }
 
     // MARK: Test helper

--- a/BrowserKit/Tests/ToolbarKitTests/LocationViewTests.swift
+++ b/BrowserKit/Tests/ToolbarKitTests/LocationViewTests.swift
@@ -22,7 +22,7 @@ final class LocationViewTests: XCTestCase {
     }
 
     // MARK: - Icon Container Arrangement
-    func testConfigure_WhenNotEditingWithURL_ShowsLockIcon() {
+    func testConfigure_whenNotEditingWithURL_showsLockIcon() {
         let subject = createSubject()
         subject.configure(makeConfig(url: testURL), delegate: delegate)
 
@@ -31,7 +31,7 @@ final class LocationViewTests: XCTestCase {
                       "A loaded page should show the lock icon in the container.")
     }
 
-    func testConfigure_WhenEditing_ShowsSearchEngineView() {
+    func testConfigure_whenEditing_showsSearchEngineView() {
         let subject = createSubject()
         subject.configure(makeConfig(url: nil, isEditing: true), delegate: delegate)
 
@@ -39,7 +39,7 @@ final class LocationViewTests: XCTestCase {
                       "Editing should show the search engine view in the container.")
     }
 
-    func testConfigure_CalledTwiceWithSameState_KeepsIdenticalArrangement() {
+    func testConfigure_walledTwiceWithSameState_seepsIdenticalArrangement() {
         let subject = createSubject()
         let config = makeConfig(url: testURL)
 
@@ -52,7 +52,7 @@ final class LocationViewTests: XCTestCase {
         XCTAssertTrue(isUnchanged, "Reconfiguring with the same state should leave the icon container untouched.")
     }
 
-    func testConfigure_WhenStateChangesFromURLToEditing_RebuildsArrangement() {
+    func testConfigure_whenStateChangesFromURLToEditing_rebuildsArrangement() {
         let subject = createSubject()
 
         subject.configure(makeConfig(url: testURL), delegate: delegate)
@@ -65,36 +65,35 @@ final class LocationViewTests: XCTestCase {
     }
 
     // MARK: - Icon Alphas
-    // `animateIconAppearance` runs inside a delayed `UIView.animate`, so the alpha lands asynchronously.
-    func testConfigure_WhenNotEditingWithURL_SettlesOnLockIconAlphas() async {
+    func testConfigure_whenNotEditingWithURL_showsLockIconAlphas() {
         let subject = createSubject()
+        invalidateIconAlphas(on: subject)
 
         subject.configure(makeConfig(url: testURL), delegate: delegate)
-        await waitForAnimations()
 
         XCTAssertEqual(subject.lockIconButton.alpha, 1, "The lock icon should be visible for a loaded page.")
         XCTAssertEqual(subject.searchEngineContentView.alpha, 0, "The search engine view should be hidden.")
     }
 
-    func testConfigure_WhenEditing_SettlesOnSearchEngineAlphas() async {
+    func testConfigure_whenEditing_showsSearchEngineAlphas() {
         let subject = createSubject()
+        invalidateIconAlphas(on: subject)
 
         subject.configure(makeConfig(url: nil, isEditing: true), delegate: delegate)
-        await waitForAnimations()
 
         XCTAssertEqual(subject.lockIconButton.alpha, 0, "The lock icon should be hidden while editing.")
         XCTAssertEqual(subject.searchEngineContentView.alpha, 1, "The search engine view should be visible.")
     }
 
-    func testConfigure_WhenStateChanges_UpdatesAlphasDespiteSkipGuard() async {
+    func testConfigure_whenStateChanges_updatesAlphasDespiteSkipGuard() {
         let subject = createSubject()
+        invalidateIconAlphas(on: subject)
 
         subject.configure(makeConfig(url: testURL), delegate: delegate)
-        await waitForAnimations()
         XCTAssertEqual(subject.lockIconButton.alpha, 1)
+        XCTAssertEqual(subject.searchEngineContentView.alpha, 0)
 
         subject.configure(makeConfig(url: nil, isEditing: true), delegate: delegate)
-        await waitForAnimations()
 
         let message = "The skip-when-unchanged guard must not block a genuine alpha change."
         XCTAssertEqual(subject.lockIconButton.alpha, 0, message)
@@ -102,6 +101,13 @@ final class LocationViewTests: XCTestCase {
     }
 
     // MARK: - Helpers
+    /// Puts both icons at an alpha no expected value matches, so the assertions fail unless the
+    /// code under test actually writes them.
+    private func invalidateIconAlphas(on subject: LocationView) {
+        subject.lockIconButton.alpha = 0.42
+        subject.searchEngineContentView.alpha = 0.42
+    }
+
     private func createSubject(file: StaticString = #filePath, line: UInt = #line) -> LocationView {
         let subject = LocationView(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
         trackForMemoryLeaks(subject, file: file, line: line)
@@ -128,11 +134,6 @@ final class LocationViewTests: XCTestCase {
             shouldShowKeyboard: false,
             shouldSelectSearchTerm: false
         )
-    }
-
-    // Wait 0.4 seconds
-    private func waitForAnimations() async {
-        try? await Task.sleep(nanoseconds: 400_000_000)
     }
 }
 

--- a/BrowserKit/Tests/ToolbarKitTests/LocationViewTests.swift
+++ b/BrowserKit/Tests/ToolbarKitTests/LocationViewTests.swift
@@ -1,0 +1,159 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import XCTest
+@testable import ToolbarKit
+
+@MainActor
+final class LocationViewTests: XCTestCase {
+    private var delegate: MockLocationViewDelegate!
+    private let testURL = URL(string: "https://mozilla.org")!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        delegate = MockLocationViewDelegate()
+    }
+
+    override func tearDown() async throws {
+        delegate = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Icon Container Arrangement
+    func testConfigure_WhenNotEditingWithURL_ShowsLockIcon() {
+        let subject = createSubject()
+        subject.configure(makeConfig(url: testURL), delegate: delegate)
+
+        XCTAssertEqual(subject.iconContainerStackView.arrangedSubviews.count, 1)
+        XCTAssertTrue(subject.iconContainerStackView.arrangedSubviews.first === subject.lockIconButton,
+                      "A loaded page should show the lock icon in the container.")
+    }
+
+    func testConfigure_WhenEditing_ShowsSearchEngineView() {
+        let subject = createSubject()
+        subject.configure(makeConfig(url: nil, isEditing: true), delegate: delegate)
+
+        XCTAssertTrue(subject.iconContainerStackView.arrangedSubviews.first === subject.searchEngineContentView,
+                      "Editing should show the search engine view in the container.")
+    }
+
+    func testConfigure_CalledTwiceWithSameState_KeepsIdenticalArrangement() {
+        let subject = createSubject()
+        let config = makeConfig(url: testURL)
+
+        subject.configure(config, delegate: delegate)
+        let firstArrangement = subject.iconContainerStackView.arrangedSubviews
+
+        subject.configure(config, delegate: delegate)
+
+        let isUnchanged = subject.iconContainerStackView.arrangedSubviews.elementsEqual(firstArrangement) { $0 === $1 }
+        XCTAssertTrue(isUnchanged, "Reconfiguring with the same state should leave the icon container untouched.")
+    }
+
+    func testConfigure_WhenStateChangesFromURLToEditing_RebuildsArrangement() {
+        let subject = createSubject()
+
+        subject.configure(makeConfig(url: testURL), delegate: delegate)
+        XCTAssertTrue(subject.iconContainerStackView.arrangedSubviews.first === subject.lockIconButton)
+
+        subject.configure(makeConfig(url: nil, isEditing: true), delegate: delegate)
+
+        XCTAssertTrue(subject.iconContainerStackView.arrangedSubviews.first === subject.searchEngineContentView,
+                      "A real state change must still rebuild the icon container.")
+    }
+
+    // MARK: - Icon Alphas
+    // `animateIconAppearance` runs inside a delayed `UIView.animate`, so the alpha lands asynchronously.
+    func testConfigure_WhenNotEditingWithURL_SettlesOnLockIconAlphas() async {
+        let subject = createSubject()
+
+        subject.configure(makeConfig(url: testURL), delegate: delegate)
+        await waitForAnimations()
+
+        XCTAssertEqual(subject.lockIconButton.alpha, 1, "The lock icon should be visible for a loaded page.")
+        XCTAssertEqual(subject.searchEngineContentView.alpha, 0, "The search engine view should be hidden.")
+    }
+
+    func testConfigure_WhenEditing_SettlesOnSearchEngineAlphas() async {
+        let subject = createSubject()
+
+        subject.configure(makeConfig(url: nil, isEditing: true), delegate: delegate)
+        await waitForAnimations()
+
+        XCTAssertEqual(subject.lockIconButton.alpha, 0, "The lock icon should be hidden while editing.")
+        XCTAssertEqual(subject.searchEngineContentView.alpha, 1, "The search engine view should be visible.")
+    }
+
+    func testConfigure_WhenStateChanges_UpdatesAlphasDespiteSkipGuard() async {
+        let subject = createSubject()
+
+        subject.configure(makeConfig(url: testURL), delegate: delegate)
+        await waitForAnimations()
+        XCTAssertEqual(subject.lockIconButton.alpha, 1)
+
+        subject.configure(makeConfig(url: nil, isEditing: true), delegate: delegate)
+        await waitForAnimations()
+
+        let message = "The skip-when-unchanged guard must not block a genuine alpha change."
+        XCTAssertEqual(subject.lockIconButton.alpha, 0, message)
+        XCTAssertEqual(subject.searchEngineContentView.alpha, 1, message)
+    }
+
+    // MARK: - Helpers
+    private func createSubject(file: StaticString = #filePath, line: UInt = #line) -> LocationView {
+        let subject = LocationView(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
+    private func makeConfig(url: URL?, isEditing: Bool = false) -> LocationViewConfiguration {
+        return LocationViewConfiguration(
+            searchEngineImageViewA11yId: "searchEngineA11yId",
+            searchEngineImageViewA11yLabel: "searchEngineA11yLabel",
+            lockIconButtonA11yId: "lockIconA11yId",
+            lockIconButtonA11yLabel: "lockIconA11yLabel",
+            urlTextFieldPlaceholder: "placeholder",
+            urlTextFieldA11yId: "urlTextFieldA11yId",
+            searchEngineImage: UIImage(),
+            lockIconImageName: "lockIcon",
+            lockIconNeedsTheming: false,
+            safeListedURLImageName: nil,
+            url: url,
+            droppableUrl: nil,
+            searchTerm: nil,
+            isEditing: isEditing,
+            didStartTyping: false,
+            shouldShowKeyboard: false,
+            shouldSelectSearchTerm: false
+        )
+    }
+
+    // Wait 0.4 seconds
+    private func waitForAnimations() async {
+        try? await Task.sleep(nanoseconds: 400_000_000)
+    }
+}
+
+private extension LocationView {
+    func configure(_ config: LocationViewConfiguration, delegate: LocationViewDelegate) {
+        configure(config,
+                  delegate: delegate,
+                  isUnifiedSearchEnabled: false,
+                  uxConfig: .default(),
+                  addressBarPosition: .top)
+    }
+}
+
+@MainActor
+private final class MockLocationViewDelegate: LocationViewDelegate {
+    func locationViewDidEnterText(_ text: String) {}
+    func locationViewDidClearText() {}
+    func locationViewDidBeginEditing(_ text: String, shouldShowSuggestions: Bool) {}
+    func locationViewDidSubmitText(_ text: String) {}
+    func locationViewDidTapSearchEngine<T: SearchEngineView>(_ searchEngine: T) {}
+    func locationViewAccessibilityActions() -> [UIAccessibilityCustomAction]? { return nil }
+    func locationTextFieldNeedsSearchReset() {}
+    func locationViewDidDisplayEditingAccessoryButton(_ button: UIButton, contextualHintType: String) {}
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16690)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35398)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

### The Problem
The address and navigation toolbars rebuild their view hierarchies on every Redux state
update, even when nothing visible changed causing layout updates that produce hangs.

`updateActionStack` (both `BrowserAddressToolbar` and `BrowserNavigationToolbar`) calls
`removeAllArrangedViews()` and readds every button unconditionally. The buttons are
cached and reused, so in the common case the same button objects are removed and
readded, invalidating Auto Layout for all four stacks for no visible change. The
address bar's icon container does the same via `removeContainerIcons()`, and
`animateIconAppearance` starts a `UIView.animate` block even when both icons already
sit at their target alpha.

This lands on a hot path. Opening a new tab dispatches a single Redux action that
cascades into 20 actions and 120 subscriber notifications, and `AddressToolbarContainer`
reconfigures the toolbar on most of them.

### The Fix
Skip the rebuild when the resulting arrangement is identical (compared by object
identity, since the buttons are cached), and skip the animation when the alphas already
match their target. No behavior change, a genuine change to the button set, its
order, or the icon state still rebuilds as before.

### Measurements
Instrumented `Store.dispatch` and `LocationView.configure` on an iPhone 13 device,
swiping for a new tab.

| | before | after |
| - | - | - |
| `BrowserNavigationToolbar` per cascade | 18 ms | 9 ms |
| `ToolbarAction.backForwardButtonStateChanged` | 10–20 ms | 2–4 ms |
| Median `LocationView.configure` | 2592 µs | 1661 µs |

I'm confident with these changes we should see an improvement in decreasing Toolbar related hangs.
## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

