### PR TITLE
Add FXIOS-16704 [WebCompat] Send the two remaining broken-site-report parity fields

### DIFF
--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatTechnicalDataViewModel.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatTechnicalDataViewModel.swift
@@ -15,6 +15,7 @@ public struct WebCompatTechnicalDataViewModel: Equatable, Sendable {
         case list([String])
         case bool(Bool)
         case quantity(Int)
+        case objectList([String])
         case null
 
         public var displayText: String {
@@ -27,6 +28,8 @@ public struct WebCompatTechnicalDataViewModel: Equatable, Sendable {
                 return value ? "true" : "false"
             case .quantity(let value):
                 return String(value)
+            case .objectList(let values):
+                return "[" + values.joined(separator: ", ") + "]"
             case .null:
                 return "null"
             }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
@@ -8,6 +8,7 @@ import PDFKit
 import Shared
 import UIKit
 import WebKit
+import struct MozillaAppServices.EnrolledExperiment
 
 /// Device and process values, behind a protocol so tests can fake the
 /// `UIDevice`/`ProcessInfo`/`Locale` statics.
@@ -28,6 +29,20 @@ struct WebCompatDeviceInfoProvider: WebCompatDeviceInfoProviding {
     var displayScale: CGFloat { UITraitCollection.current.displayScale }
 }
 
+protocol WebCompatExperimentsProviding {
+    var activeExperiments: [WebCompatExperiment] { get }
+}
+
+struct WebCompatExperimentsProvider: WebCompatExperimentsProviding {
+    var enrollments: () -> [EnrolledExperiment] = { Experiments.shared.getActiveExperiments() }
+
+    var activeExperiments: [WebCompatExperiment] {
+        return enrollments()
+            .map(WebCompatExperiment.init)
+            .sorted { $0.slug < $1.slug }
+    }
+}
+
 /// Tab inputs as a plain value, so tests don't need a live `Tab`/`WKWebView`. Nil
 /// `blockingStrength` means no content blocker; `blockedOrigins` is nil once the user unchecks Additional Info.
 struct WebCompatTabSnapshot: Equatable {
@@ -36,6 +51,7 @@ struct WebCompatTabSnapshot: Equatable {
     var displayScale: CGFloat?
     var blockingStrength: BlockingStrength?
     var blockedOrigins: [String]?
+    var hasTrackingContentBlocked: Bool?
 }
 
 /// Fills the natively readable `broken-site-report` fields, plus the page screenshot.
@@ -47,21 +63,23 @@ enum WebCompatReportDataCollector {
         tab: Tab,
         includeBlockedList: Bool,
         includeTabSpecificInfo: Bool = true,
-        device: WebCompatDeviceInfoProviding = WebCompatDeviceInfoProvider()
+        device: WebCompatDeviceInfoProviding = WebCompatDeviceInfoProvider(),
+        experiments: WebCompatExperimentsProviding = WebCompatExperimentsProvider()
     ) -> WebCompatReportPayload {
         let snapshot = makeSnapshot(
             from: tab,
             includeBlockedList: includeBlockedList,
             includeTabSpecificInfo: includeTabSpecificInfo
         )
-        return enrich(payload, device: device, tab: snapshot)
+        return enrich(payload, device: device, tab: snapshot, experiments: experiments)
     }
 
     /// Pure mapping: no UIKit, no `Tab`, so tests can drive it with fakes.
     static func enrich(
         _ payload: WebCompatReportPayload,
         device: WebCompatDeviceInfoProviding,
-        tab: WebCompatTabSnapshot
+        tab: WebCompatTabSnapshot,
+        experiments: WebCompatExperimentsProviding
     ) -> WebCompatReportPayload {
         var payload = payload
         // `languages` is the page's navigator.languages; this is the app-level list.
@@ -70,12 +88,14 @@ enum WebCompatReportDataCollector {
         payload.memory = device.physicalMemoryMegabytes
         payload.hasTouchScreen = true
         payload.defaultUserAgentString = device.defaultUserAgent
+        payload.experiments = experiments.activeExperiments
 
         payload.userAgentString = tab.pageUserAgent.flatMap { $0.isEmpty ? nil : $0 }
         // An off-screen web view reports a display scale of 0, not nil.
         let pageScale = tab.displayScale ?? 0
         payload.devicePixelRatio = String(format: "%g", pageScale > 0 ? pageScale : device.displayScale)
         payload.isPrivateBrowsing = tab.isPrivate
+        payload.hasTrackingContentBlocked = tab.hasTrackingContentBlocked
 
         if let blockingStrength = tab.blockingStrength {
             payload.blockList = blockingStrength.rawValue
@@ -103,6 +123,18 @@ enum WebCompatReportDataCollector {
     static func blockedOrigins(from stats: TPPageStats, includeBlockedList: Bool) -> [String]? {
         guard includeBlockedList else { return nil }
         return Set(stats.domains.values.flatMap { $0 }).sorted()
+    }
+
+    /// Cryptomining and fingerprinting carry their own flags in Gecko, so they don't count here.
+    static func hasTrackingContentBlocked(from stats: TPPageStats) -> Bool {
+        return BlocklistCategory.allCases.contains { category in
+            switch category {
+            case .advertising, .analytics, .social:
+                return stats.getTrackersBlockedForCategory(category) > 0
+            case .cryptomining, .fingerprinting:
+                return false
+            }
+        }
     }
 
     /// The page as one tall image, via the same PDF route as Save as PDF. WebKit
@@ -163,7 +195,9 @@ enum WebCompatReportDataCollector {
             pageUserAgent: tab.webView?.customUserAgent,
             displayScale: tab.webView?.traitCollection.displayScale,
             blockingStrength: blocker?.blockingStrengthPref,
-            blockedOrigins: blocker.flatMap { blockedOrigins(from: $0.stats, includeBlockedList: includeBlockedList) }
+            blockedOrigins: blocker.flatMap { blockedOrigins(from: $0.stats, includeBlockedList: includeBlockedList) },
+            // Carries no origins, so it is not gated on the blocked-list opt-in.
+            hasTrackingContentBlocked: blocker.map { hasTrackingContentBlocked(from: $0.stats) }
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -268,9 +268,23 @@ struct WebCompatReportPayload: Equatable {
 
     private func previewValue(_ experiments: [WebCompatExperiment]?) -> WebCompatTechnicalDataViewModel.PreviewValue {
         guard let experiments else { return .null }
-        return .objectList(experiments.map {
-            "{\"branch\": \"\($0.branch)\", \"slug\": \"\($0.slug)\", \"kind\": \"\($0.kind.rawValue)\"}"
+        return .objectList(experiments.map { experiment in
+            let fields = [
+                "\"branch\": \(jsonQuoted(experiment.branch))",
+                "\"slug\": \(jsonQuoted(experiment.slug))",
+                "\"kind\": \(jsonQuoted(experiment.kind.rawValue))"
+            ]
+            return "{\(fields.joined(separator: ", "))}"
         })
+    }
+
+    /// Encoding the object whole reorders its keys, so only the values are encoded.
+    private func jsonQuoted(_ text: String) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .withoutEscapingSlashes
+        guard let data = try? encoder.encode(text),
+              let quoted = String(data: data, encoding: .utf8) else { return "\"\"" }
+        return quoted
     }
 
     private func previewValue(_ flag: Bool?) -> WebCompatTechnicalDataViewModel.PreviewValue {

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -3,8 +3,41 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Glean
 import Shared
 import WebCompatReporterKit
+import struct MozillaAppServices.EnrolledExperiment
+
+struct WebCompatExperiment: Equatable {
+    enum Kind: String {
+        case experiment = "nimbusExperiment"
+        case rollout = "nimbusRollout"
+    }
+
+    let branch: String
+    let slug: String
+    let kind: Kind
+
+    init(_ enrollment: EnrolledExperiment) {
+        branch = enrollment.branchSlug
+        slug = enrollment.slug
+        kind = enrollment.isRollout ? .rollout : .experiment
+    }
+
+    init(branch: String, slug: String, kind: Kind) {
+        self.branch = branch
+        self.slug = slug
+        self.kind = kind
+    }
+
+    var gleanObjectItem: GleanMetrics.BrokenSiteReportBrowserInfo.ExperimentsObjectItem {
+        return GleanMetrics.BrokenSiteReportBrowserInfo.ExperimentsObjectItem(
+            branch: branch,
+            slug: slug,
+            kind: kind.rawValue
+        )
+    }
+}
 
 /// One property per Glean metric in `broken_site_report.yaml`, so the field names
 /// live in one place. The struct is flat; each comment below is the Glean category
@@ -22,10 +55,13 @@ struct WebCompatReportPayload: Equatable {
     var blockedOrigins: [String]?
     var etpCategory: String?
     var isPrivateBrowsing: Bool?
+    var hasTrackingContentBlocked: Bool?
     // broken_site_report.tab_info.frameworks
     var fastclick: Bool?
     var marfeel: Bool?
     var mobify: Bool?
+    // broken_site_report.browser_info
+    var experiments: [WebCompatExperiment]?
     // broken_site_report.browser_info.app
     var defaultLocales: [String]?
     var defaultUserAgentString: String?
@@ -58,9 +94,11 @@ struct WebCompatReportPayload: Equatable {
             case blockedOrigins
             case etpCategory
             case isPrivateBrowsing
+            case hasTrackingContentBlocked
             case fastclick
             case marfeel
             case mobify
+            case experiments
             case defaultLocales
             case defaultUseragentString
             case isTablet
@@ -79,6 +117,7 @@ struct WebCompatReportPayload: Equatable {
             case tabInfo
             case antiTracking
             case frameworks
+            case browserInfo
             case app
             case system
             case graphics
@@ -104,12 +143,16 @@ struct WebCompatReportPayload: Equatable {
                 PreviewField(key: .blockList, value: previewValue(blockList)),
                 PreviewField(key: .blockedOrigins, value: previewValue(blockedOrigins)),
                 PreviewField(key: .etpCategory, value: previewValue(etpCategory)),
-                PreviewField(key: .isPrivateBrowsing, value: previewValue(isPrivateBrowsing))
+                PreviewField(key: .isPrivateBrowsing, value: previewValue(isPrivateBrowsing)),
+                PreviewField(key: .hasTrackingContentBlocked, value: previewValue(hasTrackingContentBlocked))
             ]),
             PreviewGroup(id: .frameworks, fields: [
                 PreviewField(key: .fastclick, value: previewValue(fastclick)),
                 PreviewField(key: .marfeel, value: previewValue(marfeel)),
                 PreviewField(key: .mobify, value: previewValue(mobify))
+            ]),
+            PreviewGroup(id: .browserInfo, fields: [
+                PreviewField(key: .experiments, value: previewValue(experiments))
             ]),
             PreviewGroup(id: .app, fields: [
                 PreviewField(key: .defaultLocales, value: previewValue(defaultLocales)),
@@ -155,7 +198,7 @@ struct WebCompatReportPayload: Equatable {
             (.WebCompatReporter.Preview.Data.IsTablet, [.isTablet]),
             (userAgent, [.useragentString, .defaultUseragentString]),
             (.WebCompatReporter.Preview.Data.TrackingProtectionSetting, [.blockList, .etpCategory]),
-            (.WebCompatReporter.Preview.Data.BlockedTrackers, [.blockedOrigins]),
+            (.WebCompatReporter.Preview.Data.BlockedTrackers, [.blockedOrigins, .hasTrackingContentBlocked]),
             (.WebCompatReporter.Preview.Data.PrivateBrowsingStatus, [.isPrivateBrowsing]),
             (.WebCompatReporter.Preview.Data.AvailableMemory, [.memory]),
             (.WebCompatReporter.Preview.Data.PixelDensity, [.devicePixelRatio]),
@@ -174,7 +217,7 @@ struct WebCompatReportPayload: Equatable {
         switch value {
         case .null:
             return false
-        case .list(let values):
+        case .list(let values), .objectList(let values):
             return !values.isEmpty
         case .string, .bool, .quantity:
             return true
@@ -221,6 +264,13 @@ struct WebCompatReportPayload: Equatable {
     private func previewValue(_ values: [String]?) -> WebCompatTechnicalDataViewModel.PreviewValue {
         guard let values else { return .null }
         return .list(values)
+    }
+
+    private func previewValue(_ experiments: [WebCompatExperiment]?) -> WebCompatTechnicalDataViewModel.PreviewValue {
+        guard let experiments else { return .null }
+        return .objectList(experiments.map {
+            "{\"branch\": \"\($0.branch)\", \"slug\": \"\($0.slug)\", \"kind\": \"\($0.kind.rawValue)\"}"
+        })
     }
 
     private func previewValue(_ flag: Bool?) -> WebCompatTechnicalDataViewModel.PreviewValue {

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportRecorder.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportRecorder.swift
@@ -73,6 +73,10 @@ struct WebCompatReportRecorder {
             gleanWrapper.setBoolean(for: GleanMetrics.BrokenSiteReportTabInfoAntitracking.isPrivateBrowsing,
                                     value: isPrivateBrowsing)
         }
+        if let hasTrackingContentBlocked = payload.hasTrackingContentBlocked {
+            gleanWrapper.setBoolean(for: GleanMetrics.BrokenSiteReportTabInfoAntitracking.hasTrackingContentBlocked,
+                                    value: hasTrackingContentBlocked)
+        }
     }
 
     private func recordFrameworks(_ payload: WebCompatReportPayload) {
@@ -91,6 +95,10 @@ struct WebCompatReportRecorder {
     }
 
     private func recordBrowserInfo(_ payload: WebCompatReportPayload) {
+        if let experiments = payload.experiments {
+            gleanWrapper.recordObject(for: GleanMetrics.BrokenSiteReportBrowserInfo.experiments,
+                                      value: experiments.map { $0.gleanObjectItem })
+        }
         if let defaultLocales = payload.defaultLocales {
             gleanWrapper.recordStringList(for: GleanMetrics.BrokenSiteReportBrowserInfoApp.defaultLocales,
                                           value: defaultLocales)

--- a/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
+++ b/firefox-ios/Client/Frontend/WebCompatReporter/Redux/WebCompatReporterMiddleware.swift
@@ -11,15 +11,18 @@ final class WebCompatReporterMiddleware {
     private let recorder: WebCompatReportRecorder
     private let telemetry: WebCompatReporterTelemetry
     private let pageContextReader: WebCompatPageContextReading
+    private let experiments: WebCompatExperimentsProviding
 
     init(windowManager: WindowManager = AppContainer.shared.resolve(),
          recorder: WebCompatReportRecorder = WebCompatReportRecorder(),
          telemetry: WebCompatReporterTelemetry = WebCompatReporterTelemetry(),
-         pageContextReader: WebCompatPageContextReading = WebCompatPageContextReader()) {
+         pageContextReader: WebCompatPageContextReading = WebCompatPageContextReader(),
+         experiments: WebCompatExperimentsProviding = WebCompatExperimentsProvider()) {
         self.windowManager = windowManager
         self.recorder = recorder
         self.telemetry = telemetry
         self.pageContextReader = pageContextReader
+        self.experiments = experiments
     }
 
     lazy var webCompatReporterProvider: Middleware<AppState> = (legacyProvider, modernProvider)
@@ -102,7 +105,7 @@ final class WebCompatReporterMiddleware {
         ))
     }
 
-    /// The only place a report is assembled, so the preview can't differ from what's sent.
+    /// Preview and submit build the report here, but as separate reads.
     private func makeReport(windowUUID: WindowUUID, state: AppState) -> WebCompatReportPayload {
         let reporterState = WebCompatReporterState(appState: state, uuid: windowUUID)
         let draft = WebCompatReportPayload.make(from: reporterState)
@@ -112,7 +115,8 @@ final class WebCompatReporterMiddleware {
             draft,
             tab: tab,
             includeBlockedList: reporterState.includeBlockedList,
-            includeTabSpecificInfo: includeTabSpecificInfo
+            includeTabSpecificInfo: includeTabSpecificInfo,
+            experiments: experiments
         )
         // Page context is `tab_info`, so it follows the same URL-match gate as that whole group.
         guard includeTabSpecificInfo, let pageContext = reporterState.pageContext else { return payload }

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -27,8 +27,7 @@ $tags:
 # OMITTED (Gecko-only, no WebKit equivalent): browser_info.prefs.*,
 # graphics.{devices,drivers,features,monitors}_json, browser_info.security.*,
 # browser_info.addons, app.fission_enabled, and the Gecko-specific antitracking
-# mixed-content / bounce-tracking flags. browser_info.experiments (Nimbus,
-# object) is deferred — add later if the data team wants it.
+# mixed-content / bounce-tracking flags.
 #
 # SCREENSHOT: the iOS design includes a default-on "Include screenshot" option.
 # The image is intentionally NOT carried by this Glean ping — Glean has no
@@ -36,7 +35,7 @@ $tags:
 # capture/storage is a separate open decision (see the data-review doc); no
 # screenshot field is defined here.
 #
-# `bugs` is the impl ticket (FXIOS-16177); `data_reviews` is the
+# `bugs` is the impl ticket; `data_reviews` is the
 # data-review PR. `url` and `description` carry user-entered data.
 ###############################################################################
 
@@ -201,6 +200,29 @@ broken_site_report.tab_info.antitracking:
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never
+  has_tracking_content_blocked:
+    type: boolean
+    description: |
+      Whether tracking content was blocked on the reported page. True when the
+      content blocker recorded at least one block in the advertising, analytics
+      or social categories, matching how Gecko scopes tracking content;
+      cryptomining and fingerprinting are excluded and carry their own flags
+      there. Narrower than blocked_origins, which lists every blocked origin
+      across all categories, so the two can disagree. Carries no origins, so it
+      is sent independently of the "list of items blocked by tracking
+      protection" opt-in.
+    data_sensitivity:
+      - interaction
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16704
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35402
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
 
 broken_site_report.tab_info.frameworks:
   fastclick:
@@ -251,6 +273,41 @@ broken_site_report.tab_info.frameworks:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16177
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/34309
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+
+broken_site_report.browser_info:
+  experiments:
+    type: object
+    structure:
+      type: array
+      items:
+        type: object
+        properties:
+          branch:
+            type: string
+          slug:
+            type: string
+          kind:
+            type: string
+    description: |
+      Experiments in which the user is actively enrolled, read from Nimbus at
+      report time. List of objects with `branch`, `slug`, and `kind`, sorted by
+      slug. For instance,
+      `[{"branch":"some-branch", "slug":"some-experiment", "kind":"nimbusExperiment"}]`.
+      `kind` is "nimbusExperiment" for experiments and "nimbusRollout" for
+      rollouts, matching how desktop splits the two. Always sent with the ping;
+      an empty list means the client was enrolled in nothing at report time.
+    data_sensitivity:
+      - interaction
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16704
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35402
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Telemetry/GleanWrapper.swift
+++ b/firefox-ios/Client/Telemetry/GleanWrapper.swift
@@ -25,6 +25,8 @@ protocol GleanWrapper: Sendable {
     func recordUrl(for metric: UrlMetricType, value: URL)
     func recordDatetime(for metric: DatetimeMetricType, value: Date)
     func recordUUID(for metric: UuidMetricType, value: UUID)
+    func recordObject<ObjectValue>(for metric: ObjectMetricType<ObjectValue>,
+                                   value: ObjectValue) where ObjectValue: ObjectSerialize
 
     // MARK: Timing Metrics
     /// You should nullify any references to the timer after stopping it
@@ -113,6 +115,13 @@ struct DefaultGleanWrapper: GleanWrapper {
     }
 
     func recordUUID(for metric: UuidMetricType, value: UUID) {
+        metric.set(value)
+    }
+
+    func recordObject<ObjectValue>(
+        for metric: ObjectMetricType<ObjectValue>,
+        value: ObjectValue
+    ) where ObjectValue: ObjectSerialize {
         metric.set(value)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanWrapper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockGleanWrapper.swift
@@ -21,6 +21,7 @@ class MockGleanWrapper: GleanWrapper, @unchecked Sendable {
     var recordUrlCalled = 0
     var recordDatetimeCalled = 0
     var recordUUIDCalled = 0
+    var recordObjectCalled = 0
     var startTimingCalled = 0
     var cancelTimingCalled = 0
     var stopAndAccumulateCalled = 0
@@ -122,6 +123,15 @@ class MockGleanWrapper: GleanWrapper, @unchecked Sendable {
         savedEvents.append(metric)
         savedValues.append(value)
         recordUUIDCalled += 1
+    }
+
+    func recordObject<ObjectValue>(
+        for metric: ObjectMetricType<ObjectValue>,
+        value: ObjectValue
+    ) where ObjectValue: ObjectSerialize {
+        savedEvents.append(metric)
+        savedValues.append(value)
+        recordObjectCalled += 1
     }
 
     func startTiming(for metric: TimingDistributionMetricType) -> GleanTimerId {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
@@ -6,6 +6,7 @@ import Common
 import WebKit
 import XCTest
 
+import struct MozillaAppServices.EnrolledExperiment
 @testable import Client
 
 @MainActor
@@ -26,7 +27,7 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
     func test_enrich_deviceLocales_populateDefaultLocalesButNotLanguages() {
         let device = FakeDeviceInfoProvider(preferredLanguages: ["en-US", "fr-FR"])
 
-        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: makeSnapshot())
+        let payload = enrichedPayload(device: device, tab: makeSnapshot())
 
         XCTAssertEqual(payload.defaultLocales, ["en-US", "fr-FR"])
         XCTAssertNil(payload.languages)
@@ -38,7 +39,7 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
         let snapshot = makeSnapshot(pageUserAgent: "PageUA/2.0")
 
-        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
+        let payload = enrichedPayload(device: device, tab: snapshot)
 
         XCTAssertEqual(payload.userAgentString, "PageUA/2.0")
         XCTAssertEqual(payload.defaultUserAgentString, "DefaultUA/1.0")
@@ -50,7 +51,7 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
         let snapshot = makeSnapshot(pageUserAgent: "")
 
-        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
+        let payload = enrichedPayload(device: device, tab: snapshot)
 
         XCTAssertNil(payload.userAgentString)
         XCTAssertEqual(payload.defaultUserAgentString, "DefaultUA/1.0")
@@ -60,7 +61,7 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         let device = FakeDeviceInfoProvider(defaultUserAgent: "DefaultUA/1.0")
         let snapshot = makeSnapshot(pageUserAgent: nil)
 
-        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
+        let payload = enrichedPayload(device: device, tab: snapshot)
 
         XCTAssertNil(payload.userAgentString)
         XCTAssertEqual(payload.defaultUserAgentString, "DefaultUA/1.0")
@@ -72,7 +73,7 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         let device = FakeDeviceInfoProvider(displayScale: 2.0)
         let snapshot = makeSnapshot(displayScale: 3.0)
 
-        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
+        let payload = enrichedPayload(device: device, tab: snapshot)
 
         XCTAssertEqual(payload.devicePixelRatio, "3")
     }
@@ -81,7 +82,7 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         let device = FakeDeviceInfoProvider(displayScale: 2.0)
         let snapshot = makeSnapshot(displayScale: nil)
 
-        let payload = WebCompatReportDataCollector.enrich(WebCompatReportPayload(), device: device, tab: snapshot)
+        let payload = enrichedPayload(device: device, tab: snapshot)
 
         XCTAssertEqual(payload.devicePixelRatio, "2")
     }
@@ -91,11 +92,7 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
     func test_enrich_strictBlocking_mapsToStrictCategory() {
         let snapshot = makeSnapshot(blockingStrength: .strict)
 
-        let payload = WebCompatReportDataCollector.enrich(
-            WebCompatReportPayload(),
-            device: FakeDeviceInfoProvider(),
-            tab: snapshot
-        )
+        let payload = enrichedPayload(device: FakeDeviceInfoProvider(), tab: snapshot)
 
         XCTAssertEqual(payload.blockList, "strict")
         XCTAssertEqual(payload.etpCategory, "strict")
@@ -104,22 +101,14 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
     func test_enrich_basicBlocking_mapsToStandardCategoryButKeepsBasicBlockList() {
         let snapshot = makeSnapshot(blockingStrength: .basic)
 
-        let payload = WebCompatReportDataCollector.enrich(
-            WebCompatReportPayload(),
-            device: FakeDeviceInfoProvider(),
-            tab: snapshot
-        )
+        let payload = enrichedPayload(device: FakeDeviceInfoProvider(), tab: snapshot)
 
         XCTAssertEqual(payload.blockList, "basic")
         XCTAssertEqual(payload.etpCategory, "standard")
     }
 
     func test_enrich_emptyTabSnapshot_keepsDeviceFieldsButDropsTabFields() {
-        let payload = WebCompatReportDataCollector.enrich(
-            WebCompatReportPayload(),
-            device: FakeDeviceInfoProvider(),
-            tab: WebCompatTabSnapshot()
-        )
+        let payload = enrichedPayload(device: FakeDeviceInfoProvider(), tab: WebCompatTabSnapshot())
 
         XCTAssertNil(payload.isPrivateBrowsing)
         XCTAssertNil(payload.blockList)
@@ -133,11 +122,7 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
     func test_enrich_noBlocker_leavesBlockListAndCategoryNil() {
         let snapshot = makeSnapshot(blockingStrength: nil)
 
-        let payload = WebCompatReportDataCollector.enrich(
-            WebCompatReportPayload(),
-            device: FakeDeviceInfoProvider(),
-            tab: snapshot
-        )
+        let payload = enrichedPayload(device: FakeDeviceInfoProvider(), tab: snapshot)
 
         XCTAssertNil(payload.blockList)
         XCTAssertNil(payload.etpCategory)
@@ -264,13 +249,92 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
     func test_enrich_blockedOriginsWithoutBlockingStrength_areDropped() {
         let snapshot = makeSnapshot(blockingStrength: nil, blockedOrigins: ["a.example"])
 
-        let payload = WebCompatReportDataCollector.enrich(
-            WebCompatReportPayload(),
-            device: FakeDeviceInfoProvider(),
-            tab: snapshot
-        )
+        let payload = enrichedPayload(device: FakeDeviceInfoProvider(), tab: snapshot)
 
         XCTAssertNil(payload.blockedOrigins)
+    }
+
+    // MARK: - hasTrackingContentBlocked
+
+    func test_hasTrackingContentBlocked_withTrackingCategories_isTrue() {
+        XCTAssertTrue(WebCompatReportDataCollector.hasTrackingContentBlocked(from: makeStats()))
+    }
+
+    func test_hasTrackingContentBlocked_withNothingBlocked_isFalse() {
+        XCTAssertFalse(WebCompatReportDataCollector.hasTrackingContentBlocked(from: TPPageStats()))
+    }
+
+    func test_hasTrackingContentBlocked_withOnlyCryptominingAndFingerprinting_isFalse() {
+        var stats = TPPageStats()
+        stats.domains = [
+            .cryptomining: ["miner.example"],
+            .fingerprinting: ["printer.example"]
+        ]
+
+        XCTAssertFalse(WebCompatReportDataCollector.hasTrackingContentBlocked(from: stats))
+    }
+
+    func test_hasTrackingContentBlocked_withSocialAlongsideCryptomining_isTrue() {
+        var stats = TPPageStats()
+        stats.domains = [
+            .social: ["social.example"],
+            .cryptomining: ["miner.example"]
+        ]
+
+        XCTAssertTrue(WebCompatReportDataCollector.hasTrackingContentBlocked(from: stats))
+    }
+
+    func test_enrich_carriesHasTrackingContentBlockedFromTheSnapshot() {
+        let snapshot = makeSnapshot(blockingStrength: .basic, hasTrackingContentBlocked: true)
+
+        let payload = enrichedPayload(device: FakeDeviceInfoProvider(), tab: snapshot)
+
+        XCTAssertEqual(payload.hasTrackingContentBlocked, true)
+    }
+
+    func test_enrich_withoutBlockedOriginsOptIn_stillReportsHasTrackingContentBlocked() {
+        let snapshot = makeSnapshot(
+            blockingStrength: .basic,
+            blockedOrigins: nil,
+            hasTrackingContentBlocked: true
+        )
+
+        let payload = enrichedPayload(device: FakeDeviceInfoProvider(), tab: snapshot)
+
+        XCTAssertNil(payload.blockedOrigins)
+        XCTAssertEqual(payload.hasTrackingContentBlocked, true)
+    }
+
+    // MARK: - experiments
+
+    func test_activeExperiments_sortsBySlugAndTagsRollouts() {
+        let provider = WebCompatExperimentsProvider(enrollments: {
+            [
+                self.makeEnrollment(slug: "z-rollout", branch: "control", isRollout: true),
+                self.makeEnrollment(slug: "a-experiment", branch: "treatment", isRollout: false)
+            ]
+        })
+
+        XCTAssertEqual(provider.activeExperiments, [
+            WebCompatExperiment(branch: "treatment", slug: "a-experiment", kind: .experiment),
+            WebCompatExperiment(branch: "control", slug: "z-rollout", kind: .rollout)
+        ])
+    }
+
+    func test_activeExperiments_withNoEnrollments_isEmptyNotNil() {
+        XCTAssertEqual(WebCompatExperimentsProvider(enrollments: { [] }).activeExperiments, [])
+    }
+
+    func test_enrich_carriesActiveExperiments() {
+        let experiments = FakeExperimentsProvider(activeExperiments: [
+            WebCompatExperiment(branch: "treatment", slug: "a-experiment", kind: .experiment),
+            WebCompatExperiment(branch: "control", slug: "b-rollout", kind: .rollout)
+        ])
+
+        let payload = enrichedPayload(tab: makeSnapshot(), experiments: experiments)
+
+        XCTAssertEqual(payload.experiments?.map { $0.slug }, ["a-experiment", "b-rollout"])
+        XCTAssertEqual(payload.experiments?.map { $0.kind }, [.experiment, .rollout])
     }
 
     // MARK: - Tab-backed collection
@@ -303,19 +367,45 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
 
     private let windowUUID: WindowUUID = .XCTestDefaultUUID
 
+    private func makeEnrollment(slug: String, branch: String, isRollout: Bool) -> EnrolledExperiment {
+        return EnrolledExperiment(
+            featureIds: [],
+            slug: slug,
+            userFacingName: slug,
+            userFacingDescription: slug,
+            branchSlug: branch,
+            isRollout: isRollout
+        )
+    }
+
+    private func enrichedPayload(
+        device: WebCompatDeviceInfoProviding = FakeDeviceInfoProvider(),
+        tab: WebCompatTabSnapshot = WebCompatTabSnapshot(),
+        experiments: WebCompatExperimentsProviding = FakeExperimentsProvider()
+    ) -> WebCompatReportPayload {
+        return WebCompatReportDataCollector.enrich(
+            WebCompatReportPayload(),
+            device: device,
+            tab: tab,
+            experiments: experiments
+        )
+    }
+
     private func makeSnapshot(
         isPrivate: Bool = false,
         pageUserAgent: String? = nil,
         displayScale: CGFloat? = nil,
         blockingStrength: BlockingStrength? = nil,
-        blockedOrigins: [String]? = nil
+        blockedOrigins: [String]? = nil,
+        hasTrackingContentBlocked: Bool? = nil
     ) -> WebCompatTabSnapshot {
         return WebCompatTabSnapshot(
             isPrivate: isPrivate,
             pageUserAgent: pageUserAgent,
             displayScale: displayScale,
             blockingStrength: blockingStrength,
-            blockedOrigins: blockedOrigins
+            blockedOrigins: blockedOrigins,
+            hasTrackingContentBlocked: hasTrackingContentBlocked
         )
     }
 
@@ -334,6 +424,10 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         var physicalMemoryMegabytes = 2048
         var defaultUserAgent = "FakeUA/1.0"
         var displayScale: CGFloat = 2.0
+    }
+
+    private struct FakeExperimentsProvider: WebCompatExperimentsProviding {
+        var activeExperiments: [WebCompatExperiment] = []
     }
 
     private func loadBlankPage(in webView: WKWebView) async {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
@@ -92,6 +92,18 @@ final class WebCompatReportPayloadTests: XCTestCase {
         XCTAssertEqual(rendered["browserInfo.experiments"], expected)
     }
 
+    func testPreviewGroups_experimentWithQuotesInItsSlug_staysValidJSON() {
+        var payload = WebCompatReportPayload()
+        payload.experiments = [
+            WebCompatExperiment(branch: #"a"branch"#, slug: #"a\slug"#, kind: .experiment)
+        ]
+
+        let rendered = renderedFields(of: payload)
+
+        let expected = #"[{"branch": "a\"branch", "slug": "a\\slug", "kind": "nimbusExperiment"}]"#
+        XCTAssertEqual(rendered["browserInfo.experiments"], expected)
+    }
+
     func testPreviewGroups_optedInWithNothingBlocked_showsAnEmptyListNotNull() {
         var payload = WebCompatReportPayload()
         payload.blockedOrigins = []

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
@@ -54,7 +54,7 @@ final class WebCompatReportPayloadTests: XCTestCase {
         // Labelled with the raw schema keys, so a renamed or reordered group misdescribes the ping.
         XCTAssertEqual(
             WebCompatReportPayload().previewGroups.map(\.id.rawValue),
-            ["basic", "tabInfo", "antiTracking", "frameworks", "app", "system", "graphics"]
+            ["basic", "tabInfo", "antiTracking", "frameworks", "browserInfo", "app", "system", "graphics"]
         )
     }
 
@@ -78,6 +78,18 @@ final class WebCompatReportPayloadTests: XCTestCase {
         XCTAssertEqual(rendered["antiTracking.isPrivateBrowsing"], "false")
         XCTAssertEqual(rendered["system.memory"], "4096")
         XCTAssertEqual(rendered["app.defaultLocales"], "[\"en-GB\", \"fr\"]")
+    }
+
+    func testPreviewGroups_renderExperimentsAsTheObjectsThePingCarries() {
+        var payload = WebCompatReportPayload()
+        payload.experiments = [
+            WebCompatExperiment(branch: "treatment", slug: "an-experiment", kind: .rollout)
+        ]
+
+        let rendered = renderedFields(of: payload)
+
+        let expected = #"[{"branch": "treatment", "slug": "an-experiment", "kind": "nimbusRollout"}]"#
+        XCTAssertEqual(rendered["browserInfo.experiments"], expected)
     }
 
     func testPreviewGroups_optedInWithNothingBlocked_showsAnEmptyListNotNull() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportRecorderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportRecorderTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Glean
 import XCTest
 
 @testable import Client
@@ -25,11 +26,41 @@ final class WebCompatReportRecorderTests: XCTestCase {
         XCTAssertEqual(gleanWrapper.recordStringCalled, 4)
         XCTAssertEqual(gleanWrapper.recordTextCalled, 3)
         XCTAssertEqual(gleanWrapper.recordStringListCalled, 3)
-        XCTAssertEqual(gleanWrapper.setBooleanCalled, 6)
+        XCTAssertEqual(gleanWrapper.setBooleanCalled, 7)
         XCTAssertEqual(gleanWrapper.recordQuantityCalled, 1)
         XCTAssertEqual(gleanWrapper.recordUrlCalled, 1)
-        XCTAssertEqual(gleanWrapper.savedEvents.count, 18)
+        XCTAssertEqual(gleanWrapper.recordObjectCalled, 1)
+        XCTAssertEqual(gleanWrapper.savedEvents.count, 20)
         XCTAssertEqual(gleanWrapper.submitPingCalled, 1)
+    }
+
+    func testSubmit_recordsEachExperimentAsAnObjectItem() {
+        var payload = WebCompatReportPayload()
+        payload.experiments = [
+            WebCompatExperiment(branch: "treatment", slug: "an-experiment", kind: .rollout)
+        ]
+
+        createSubject().submit(payload)
+
+        let recorded = gleanWrapper.savedValues.last as? [GleanMetrics.BrokenSiteReportBrowserInfo.ExperimentsObjectItem]
+        XCTAssertEqual(recorded, [
+            GleanMetrics.BrokenSiteReportBrowserInfo.ExperimentsObjectItem(
+                branch: "treatment",
+                slug: "an-experiment",
+                kind: WebCompatExperiment.Kind.rollout.rawValue
+            )
+        ])
+    }
+
+    // `savedEvents` is `[Any]`, so nothing type-checks which boolean went to which metric.
+    func testSubmit_recordsTheAntitrackingBooleansInOrder() {
+        var payload = WebCompatReportPayload()
+        payload.isPrivateBrowsing = false
+        payload.hasTrackingContentBlocked = true
+
+        createSubject().submit(payload)
+
+        XCTAssertEqual(gleanWrapper.savedBooleans, [false, true])
     }
 
     func testSubmit_recordsTheValuesItWasGiven() {
@@ -79,9 +110,13 @@ final class WebCompatReportRecorderTests: XCTestCase {
         payload.blockedOrigins = ["tracker.example"]
         payload.etpCategory = "strict"
         payload.isPrivateBrowsing = false
+        payload.hasTrackingContentBlocked = true
         payload.fastclick = true
         payload.marfeel = false
         payload.mobify = false
+        payload.experiments = [
+            WebCompatExperiment(branch: "treatment", slug: "an-experiment", kind: .experiment)
+        ]
         payload.defaultLocales = ["en-CA"]
         payload.defaultUserAgentString = "app UA"
         payload.devicePixelRatio = "3"


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16704](https://mozilla-hub.atlassian.net/browse/FXIOS-16704)

## :bulb: Description
Desktop sends two fields iOS has no metric for, so QA saw them as not generated: `browser_info.experiments` (Nimbus enrollments as `{branch, slug, kind}`) and `tab_info.antitracking.has_tracking_content_blocked`. Both follow mozilla-central's definitions.

`has_tracking_content_blocked` counts advertising, analytics and social only, so it can read `false` while `blocked_origins` is non-empty. It carries no origins, so it goes out regardless of the blocked-list opt-in.

`data_sensitivity` for it is `interaction`, matching mozilla-central rather than the `technical` used by its iOS siblings. Worth a look in the data review.

## :movie_camera: Demos
Both fields on a tracker-heavy page:

<img height="600" alt="webcompat-both-fields-cnn" src="https://github.com/user-attachments/assets/f93cd588-4710-46c2-9827-e1aa6640a73b" />


Blocked-list option unchecked: `blockedOrigins` is withheld, the boolean still sends:

<img height="600" alt="webcompat-optout-boolean-survives" src="https://github.com/user-attachments/assets/206ac0ce-4def-4efd-930e-2ce6af75161d" />


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Testing
Report a broken site with the Glean debug view on and confirm the two fields reach the ping. Technical Data on the preview screen shows the same payload.



[FXIOS-16704]: https://mozilla-hub.atlassian.net/browse/FXIOS-16704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ