### PR TITLE
Bugfix FXIOS-16694 [Autocomplete] Always append suggestions at the end of the query

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -184,6 +184,7 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
         }
 
         let suggestionText = String(suggestion.dropFirst(normalized.count))
+        selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
         setMarkedText(suggestionText, selectedRange: NSRange())
         hideCursor = true
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/LocationTextFieldTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/LocationTextFieldTests.swift
@@ -9,17 +9,27 @@ import XCTest
 final class LocationTextFieldTests: XCTestCase {
     private var textField: LocationTextField!
     private var themeManager: MockThemeManager!
+    private var window: UIWindow!
 
     override func setUp() async throws {
         try await super.setUp()
         textField = LocationTextField(frame: .zero)
         themeManager = MockThemeManager()
+        window = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 44))
+        window.addSubview(textField)
+        window.makeKeyAndVisible()
     }
 
     override func tearDown() async throws {
+        textField.resignFirstResponder()
         textField = nil
         themeManager = nil
+        window = nil
         try await super.tearDown()
+    }
+
+    private func makeTextFieldEditing() {
+        textField.becomeFirstResponder()
     }
 
     func testHandleInputModeDidChange_withNoLastMarkedText_doesNothing() {
@@ -39,6 +49,60 @@ final class LocationTextFieldTests: XCTestCase {
 
         XCTAssertTrue(textField.text?.contains("www.wiki") ?? false)
         XCTAssertNotNil(textField.markedTextRange)
+    }
+
+    func testAutocompleteSuggestion_whenInsertingAtStartOfText_appendsSuggestionAtEnd() {
+        // Start with "o" already in the text field.
+        makeTextFieldEditing()
+        textField.text = "o"
+
+        // Move the cursor before the "o": |o
+        if let startPosition = textField.position(from: textField.beginningOfDocument, offset: 0) {
+            textField.selectedTextRange = textField.textRange(from: startPosition, to: startPosition)
+        }
+
+        // Simulate the user typing "y" at the start.
+        _ = textField.textField(
+            textField,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "y"
+        )
+
+        textField.text = "yo"
+        if let cursorPosition = textField.position(from: textField.beginningOfDocument, offset: 1) {
+            textField.selectedTextRange = textField.textRange(from: cursorPosition, to: cursorPosition)
+        }
+
+        // Apply the autocomplete suggestion.
+        textField.setAutocompleteSuggestion("youtube.com")
+
+        // It should complete the full text, not insert the suggestion after the cursor.
+        XCTAssertEqual(textField.text, "youtube.com",
+                       "Suggestion should be appended at end of text, not inserted at cursor position")
+    }
+
+    func testAutocompleteSuggestion_whenAppendingAtEnd_stillWorks() {
+        makeTextFieldEditing()
+        textField.text = "yo"
+
+        if let endPosition = textField.position(from: textField.beginningOfDocument, offset: 2) {
+            textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition)
+        }
+
+        _ = textField.textField(
+            textField,
+            shouldChangeCharactersIn: NSRange(location: 2, length: 0),
+            replacementString: "u"
+        )
+
+        textField.text = "you"
+        if let endPosition = textField.position(from: textField.beginningOfDocument, offset: 3) {
+            textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition)
+        }
+
+        textField.setAutocompleteSuggestion("youtube.com")
+
+        XCTAssertEqual(textField.text, "youtube.com")
     }
 
     func testApplyTheme_refreshesMarkedText() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/LocationTextFieldTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/LocationTextFieldTests.swift
@@ -77,7 +77,8 @@ final class LocationTextFieldTests: XCTestCase {
         textField.setAutocompleteSuggestion("youtube.com")
 
         // It should complete the full text, not insert the suggestion after the cursor.
-        XCTAssertEqual(textField.text, "youtube.com",
+        XCTAssertEqual(textField.text,
+                       "youtube.com",
                        "Suggestion should be appended at end of text, not inserted at cursor position")
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16694)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35408)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Autocomplete suggestions were being inserted at the current cursor position instead of always being appended to the end of the text. Since the caret position is irrelevant when applying an autocomplete suggestion, we should always append it at the end.

I also added a regression test that fails with the previous behavior and guards against this happening again.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <video width="200" src="https://github.com/user-attachments/assets/f3c51571-10dc-4eba-bf0a-97bf2d47da06" />  | <video width="200"  src="https://github.com/user-attachments/assets/c9a0df42-2725-4666-96b7-ba0549780714" /> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |



<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

