### PR TITLE
Refactor FXIOS-12588 [Swift 6 Migration] Remove nonisolated(unsafe) from SearchViewModel.userAgent

### DIFF
--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -178,6 +178,7 @@ final class AppLaunchUtil: FeatureFlaggable, Sendable {
         AppEventQueue.signal(event: .postLaunchDependenciesComplete)
     }
 
+    @MainActor
     private func setUserAgent() {
         // Record the user agent for use by search suggestion clients.
         SearchViewModel.userAgent = UserAgent.getUserAgent()

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
@@ -36,8 +36,7 @@ class SearchViewModel: FeatureFlaggable,
     var recentSearches = [String]()
     let model: SearchEnginesManager
     var suggestions: [String]? = []
-    // TODO: FXIOS-12588 This global property is not concurrency safe
-    nonisolated(unsafe) static var userAgent: String?
+    static var userAgent: String?
     var searchFeature: FeatureHolder<Search>
     private var searchTelemetry: SearchTelemetry
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-12588)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/27407)

## :bulb: Description

Minor change, no behaviour change.

The `SearchViewModel.userAgent` static is only set by `AppLaunchUtil.setUserAgent()` via `setUpPreLaunchDependencies()` which is already `@MainActor`, so the @MainActor was added to the caller and non isolated(unsafe) was removed.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If needed, I updated documentation and added comments to complex code
