### PR TITLE
Bugfix NO-TICKET - Clear URL bar before typing in LoadURLByTyping

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerUrlBarNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerUrlBarNavigation.swift
@@ -44,6 +44,9 @@ func registerUrlBarNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIAppli
             // Workaround BB iOS13 be sure tap happens on url bar
             searchTextField.waitAndTap()
             searchTextField.waitAndTap()
+            // Tapping doesn't reliably select the existing text (seen on iPad), so typing can insert
+            // into rather than replace it. Clear explicitly before typing.
+            app.buttons["Clear text"].tapIfExists()
             // On CI the field is occasionally focus-less after tapping, which makes typeText abort;
             // wait for keyboard focus (re-tapping if needed) before typing.
             searchTextField.tapAndTypeTextWhenFocused(url)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-TODO)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
`firefox-ios-smoketest-ipad` #868 was failing (reported in `#mobile-alerts-ios`, untriaged). Root cause: `navigator.openURL(...)`'s shared `LoadURLByTyping` gesture (`registerUrlBarNavigation.swift`) taps the address bar and types the new URL directly, relying on the OS to auto-select the existing URL text on focus so typing replaces it. That select-all-on-focus behavior isn't reliable on iPad, so the new URL gets inserted into the existing one instead of replacing it, producing a malformed/incorrect URL and failing the test.

This fixes it by explicitly tapping the standard "Clear text" button before typing, reusing the same pattern already used elsewhere in the suite via `BrowserScreen.tapClearButtonIfExists()`. Since `LoadURLByTyping` is the shared gesture behind every `navigator.openURL(...)` call, this fixes the issue everywhere it's used, not just the one failing smoke test (e.g. `TrackingProtectionTests.swift:117`).

## :movie_camera: Demos
N/A — test-infrastructure-only change, no user-facing behavior modified.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the data stewardship requirements and will request a data review
- [ ] If adding or modifying strings, I read the guidelines and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

## Test plan
- [x] Ran the `Smoketest` plan on iPhone 17 Pro (iOS 26.5) — all pass
- [x] Ran the `Smoketest` plan on iPad mini (A17 Pro, iOS 26.5) — the exact device/OS combo from the failing CI job (#868) — all pass