### PR TITLE
Fix #35111: Stop autocomplete after deleting an inline suggestion

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -49,6 +49,7 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
     private var hideCursor = false
     private var isSettingMarkedText = false
     private var lastMarkedText = ""
+    private var shouldApplyAutocompleteSuggestion = true
     var clearButton: UIButton? {
         return value(forKey: "_clearButton") as? UIButton
     }
@@ -143,6 +144,7 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
 
         guard markedTextRange == nil else {
             // If we have an active completion, delete it without deleting any user-typed characters.
+            shouldApplyAutocompleteSuggestion = false
             removeCompletion()
             forceResetCursor()
             return
@@ -172,7 +174,11 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
     func setAutocompleteSuggestion(_ suggestion: String?) {
         let searchText = text ?? ""
 
-        guard let suggestion = suggestion, isEditing && markedTextRange == nil else {
+        guard let suggestion = suggestion,
+              isEditing,
+              markedTextRange == nil,
+              shouldApplyAutocompleteSuggestion
+        else {
             hideCursor = false
             return
         }
@@ -340,6 +346,7 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
 
     // MARK: - UITextFieldDelegate
     public func textFieldDidBeginEditing(_ textField: UITextField) {
+        shouldApplyAutocompleteSuggestion = true
         updateRightView()
         autocompleteDelegate?.locationTextFieldDidBeginEditing(self)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/LocationTextFieldTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/LocationTextFieldTests.swift
@@ -106,6 +106,34 @@ final class LocationTextFieldTests: XCTestCase {
         XCTAssertEqual(textField.text, "youtube.com")
     }
 
+    func testDeleteBackward_withActiveSuggestion_suppressesFurtherSuggestions() {
+        makeTextFieldEditing()
+        textField.text = "pangram"
+        textField.setAutocompleteSuggestion("pangram.com")
+        XCTAssertNotNil(textField.markedTextRange)
+
+        textField.deleteBackward()
+        textField.setAutocompleteSuggestion("pangrampangram.com")
+
+        XCTAssertEqual(textField.text, "pangram")
+        XCTAssertNil(textField.markedTextRange)
+    }
+
+    func testBeginEditing_afterSuppressingSuggestions_allowsSuggestionsAgain() {
+        makeTextFieldEditing()
+        textField.text = "pangram"
+        textField.setAutocompleteSuggestion("pangram.com")
+        XCTAssertNotNil(textField.markedTextRange)
+        textField.deleteBackward()
+        textField.resignFirstResponder()
+
+        makeTextFieldEditing()
+        textField.setAutocompleteSuggestion("pangrampangram.com")
+
+        XCTAssertEqual(textField.text, "pangrampangram.com")
+        XCTAssertNotNil(textField.markedTextRange)
+    }
+
     func testApplyTheme_refreshesMarkedText() {
         textField.text = "github"
         // Move cursor to end of text before setting marked text


### PR DESCRIPTION
## Description

Prevents asynchronous autocomplete results from restoring an inline suggestion after the user has dismissed it with Backspace.

Inline suggestions remain disabled for the rest of the current editing session and are enabled again when a new editing session begins.

## Testing

- Added coverage for suppressing later suggestions after Backspace
- Added coverage for enabling suggestions again in a new editing session
- Ran `LocationTextFieldTests` on an iPhone 17 Pro simulator: 7 passed, 0 failed

Closes #35111