### PR TITLE
Bugfix FXIOS-16641 Update selector pill and segmented control for TabTray

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/DarkTheme.swift
@@ -140,6 +140,7 @@ private struct DarkColourPalette: ThemeColourPalette {
     var layerAccentSubtle: UIColor { NovaMissingToken.color("layerAccentSubtle") }
     var layerInverse: UIColor { NovaMissingToken.color("layerInverse") }
     var layerGlassTintNova: UIColor { NovaMissingToken.color("layerGlassTintNova") }
+    var layerGlassSelectedFill: UIColor { NovaMissingToken.color("layerGlassSelectedFill") }
     var textToast: UIColor { NovaMissingToken.color("textToast") }
     var iconInverted: UIColor { NovaMissingToken.color("iconInverted") }
     var iconOnColorDisabled: UIColor { NovaMissingToken.color("iconOnColorDisabled") }

--- a/BrowserKit/Sources/Common/Theming/LightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/LightTheme.swift
@@ -129,6 +129,7 @@ private struct LightColourPalette: ThemeColourPalette {
     var layerAccentSubtle: UIColor { NovaMissingToken.color("layerAccentSubtle") }
     var layerInverse: UIColor { NovaMissingToken.color("layerInverse") }
     var layerGlassTintNova: UIColor { NovaMissingToken.color("layerGlassTintNova") }
+    var layerGlassSelectedFill: UIColor { NovaMissingToken.color("layerGlassSelectedFill") }
     var textToast: UIColor { NovaMissingToken.color("textToast") }
     var iconInverted: UIColor { NovaMissingToken.color("iconInverted") }
     var iconOnColorDisabled: UIColor { NovaMissingToken.color("iconOnColorDisabled") }

--- a/BrowserKit/Sources/Common/Theming/NovaDarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaDarkTheme.swift
@@ -46,6 +46,7 @@ private struct NovaDarkColourPalette: ThemeColourPalette {
     var layerAutofillText: UIColor = NovaColors.VioletDesaturated30.withAlphaComponent(0.55)
     var layerSelectedText: UIColor = NovaColors.VioletDesaturated30.withAlphaComponent(0.55)
     var layerGlassTintNova: UIColor = NovaColors.Violet90.withAlphaComponent(0.58)
+    var layerGlassSelectedFill: UIColor = NovaColors.Gray65
     var layerAccentPrivateNonOpaque: UIColor { layerAccentSubtle }
 
     // MARK: - Action

--- a/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
@@ -32,7 +32,8 @@ private struct NovaLightColourPalette: ThemeColourPalette {
     var layerSepia: UIColor = NovaColors.Yellow0
     var layerAutofillText: UIColor = NovaColors.VioletDesaturated30
     var layerSelectedText: UIColor = NovaColors.VioletDesaturated30
-    var layerGlassTintNova: UIColor = NovaColors.VioletDesaturated10.withAlphaComponent(0.45)
+    var layerGlassTintNova: UIColor = .clear
+    var layerGlassSelectedFill: UIColor = NovaColors.Gray15
     var layerAccentPrivateNonOpaque: UIColor { layerAccentSubtle }
 
     // MARK: - Action

--- a/BrowserKit/Sources/Common/Theming/NovaPrivateTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaPrivateTheme.swift
@@ -34,6 +34,7 @@ private struct NovaPrivateColourPalette: ThemeColourPalette {
     var layerAutofillText: UIColor = NovaColors.VioletDesaturated30.withAlphaComponent(0.55)
     var layerSelectedText: UIColor = NovaColors.VioletDesaturated30.withAlphaComponent(0.55)
     var layerGlassTintNova: UIColor = .clear
+    var layerGlassSelectedFill: UIColor = NovaColors.VioletDesaturated70
     var layerAccentPrivateNonOpaque: UIColor { layerAccentSubtle }
 
     // MARK: - Action

--- a/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/PrivateModeTheme.swift
@@ -131,6 +131,7 @@ private struct PrivateModeColorPalette: ThemeColourPalette {
     var layerAccentSubtle: UIColor { NovaMissingToken.color("layerAccentSubtle") }
     var layerInverse: UIColor { NovaMissingToken.color("layerInverse") }
     var layerGlassTintNova: UIColor { NovaMissingToken.color("layerGlassTintNova") }
+    var layerGlassSelectedFill: UIColor { NovaMissingToken.color("layerGlassSelectedFill") }
     var textToast: UIColor { NovaMissingToken.color("textToast") }
     var iconInverted: UIColor { NovaMissingToken.color("iconInverted") }
     var iconOnColorDisabled: UIColor { NovaMissingToken.color("iconOnColorDisabled") }

--- a/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
+++ b/BrowserKit/Sources/Common/Theming/ThemeColourPalette.swift
@@ -113,6 +113,7 @@ public protocol ThemeColourPalette {
     var layerAccentSubtle: UIColor { get }
     var layerInverse: UIColor { get }
     var layerGlassTintNova: UIColor { get }
+    var layerGlassSelectedFill: UIColor { get }
     var textToast: UIColor { get }
     var iconInverted: UIColor { get }
     var iconOnColorDisabled: UIColor { get }

--- a/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
+++ b/BrowserKit/Sources/WebCompatReporterKit/WebCompatReportSheetViewController.swift
@@ -430,7 +430,9 @@ public final class WebCompatReportSheetViewController: UIViewController,
         navigationController?.navigationBar.tintColor = theme.colors.actionPrimary
         if theme.isNova {
             previewButton.tintColor = theme.colors.actionPrimary
-            previewButton.setTitleTextAttributes([.foregroundColor: theme.colors.textInverted], for: .normal)
+            if #available(iOS 26.0, *) {
+                previewButton.setTitleTextAttributes([.foregroundColor: theme.colors.textInverted], for: .normal)
+            }
         }
         if hasAppliedThemeOnce {
             reconfigureAllItems()

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabTrayPanelSwipePalette.swift
@@ -184,6 +184,7 @@ struct TabTrayPanelSwipePalette: ThemeColourPalette {
     // MARK: - Nova only tokens
     var layerAccentSubtle: UIColor { base.layerAccentSubtle }
     var layerInverse: UIColor { base.layerInverse }
+    var layerGlassSelectedFill: UIColor { base.layerGlassSelectedFill }
     var textToast: UIColor { base.textToast }
     var iconOnColorDisabled: UIColor { base.iconOnColorDisabled }
     var iconPrivate: UIColor { base.iconPrivate }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/CustomSelectorView/TabTraySelectorView.swift
@@ -384,11 +384,19 @@ class TabTraySelectorView: UIView, ThemeApplicable {
             backgroundColor = trackColor.withAlphaComponent(tabTrayUtils.backgroundAlpha())
         } else if theme.isNova, !DeviceInfo.isRunningLiquidGlassEarlyBeta, !(theme is TabTrayPanelSwipeTheme) {
             let glass = UIGlassEffect(style: .regular)
-            glass.tintColor = theme.type == .light ? UIColor.clear : theme.colors.layerGlassTintNova
+            glass.tintColor = theme.colors.layerGlassTintNova
             visualEffectView.effect = glass
         }
 
-        selectionBackgroundView.backgroundColor = theme.isNova ? theme.colors.layer2 : theme.colors.layerEmphasis
+        if #available(iOS 26, *) {
+            selectionBackgroundView.backgroundColor = theme.isNova
+                ? theme.colors.layerGlassSelectedFill
+                : theme.colors.layerEmphasis
+        } else {
+            selectionBackgroundView.backgroundColor = theme.isNova
+                ? theme.colors.layer2
+                : theme.colors.layerEmphasis
+        }
 
         for button in buttons {
             button.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -201,7 +201,7 @@ final class TabTrayViewController: UIViewController,
     @available(iOS 26.0, *)
     private func applyToolbarGlassButtonTints(theme: Theme) {
         guard isNovaDesignEnabled else { return }
-        let glassTint = theme.type == .light ? UIColor.clear : theme.colors.layerGlassTintNova
+        let glassTint = theme.colors.layerGlassTintNova
         setProminentGlass(deleteButton,
                           StandardImageIdentifiers.Large.delete,
                           background: glassTint,


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16641)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
As per latest design request here [in Figma](https://www.figma.com/design/13nzUgAKwSiWeqvyWnp2KY/iOS-Library--Nova-?node-id=15386-29538&m=dev), the segmented control in Tab Tray on iOS 26 should look like in photo.

This PR adds the new token designed for Nova` layerGlassSelectedFill` used for selected pill, updates the color values for `layerGlassTintNova` for light mode. It also corrects the Preview button text color to be set just for iOS 26 (otherwise text on iOS 18 would not be visible).

<img width="810" height="335" alt="Screenshot 2026-08-27 at 14 54 46" src="https://github.com/user-attachments/assets/9e1c22c8-ac81-4001-8b9e-812fe2ebea7f" />

<img width="849" height="65" alt="Screenshot 2026-08-27 at 14 15 35" src="https://github.com/user-attachments/assets/11ae04c7-ca44-4a69-bd7d-b078f8fe8d59" />

<img width="839" height="85" alt="Screenshot 2026-08-27 at 14 14 30" src="https://github.com/user-attachments/assets/1da10825-d9eb-44eb-aee3-00dc0c2741f8" />


## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

