### PR TITLE
Bugfix FXIOS-16691 [Toolbar] Keep the minimized address bar off an opaque band

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
@@ -47,6 +47,8 @@ public struct AddressToolbarUXConfiguration {
     }
 
     func addressToolbarBackgroundColor(theme: some Theme) -> UIColor {
+        guard !isAddressBarMinimized else { return .clear }
+
         let backgroundColor = isLocationTextCentered ? theme.colors.layerSurfaceLow : theme.colors.layer1
         if shouldBlur {
             return backgroundColor.withAlphaComponent(backgroundAlpha)

--- a/BrowserKit/Tests/ToolbarKitTests/AddressToolbarUXConfigurationTests.swift
+++ b/BrowserKit/Tests/ToolbarKitTests/AddressToolbarUXConfigurationTests.swift
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+@testable import ToolbarKit
+
+final class AddressToolbarUXConfigurationTests: XCTestCase {
+    private let theme = LightTheme()
+
+    func testAddressToolbarBackgroundColorIsClearWhenMinimized() {
+        let subject = AddressToolbarUXConfiguration.default(isAddressBarMinimized: true)
+
+        XCTAssertEqual(subject.addressToolbarBackgroundColor(theme: theme), .clear)
+    }
+
+    func testAddressToolbarBackgroundColorIsClearWhenMinimizedAndBlurring() {
+        let subject = AddressToolbarUXConfiguration.default(backgroundAlpha: 0,
+                                                            isAddressBarMinimized: true,
+                                                            shouldBlur: true)
+
+        XCTAssertEqual(subject.addressToolbarBackgroundColor(theme: theme), .clear)
+    }
+
+    func testAddressToolbarBackgroundColorPaintsChromeWhenExpanded() {
+        let subject = AddressToolbarUXConfiguration.default(isAddressBarMinimized: false)
+
+        XCTAssertEqual(subject.addressToolbarBackgroundColor(theme: theme), theme.colors.layer1)
+    }
+
+    func testAddressToolbarBackgroundColorAppliesBackgroundAlphaWhenExpandedAndBlurring() {
+        let subject = AddressToolbarUXConfiguration.default(backgroundAlpha: 0.5,
+                                                            isAddressBarMinimized: false,
+                                                            shouldBlur: true)
+
+        XCTAssertEqual(subject.addressToolbarBackgroundColor(theme: theme),
+                       theme.colors.layer1.withAlphaComponent(0.5))
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -633,24 +633,30 @@ class BrowserViewController: UIViewController,
     // MARK: - Translucency and blur helpers
 
     func updateBlurViews(scrollOffset: CGFloat? = nil) {
-        guard toolbarHelper.shouldBlur() else {
-            topBlurView.alpha = 0
-            bottomBlurView.isHidden = true
-            header.isClearBackground = false
-            overKeyboardContainer.isClearBackground = false
-            bottomContainer.isClearBackground = false
-            contentContainer.mask = nil
-            return
-        }
-
         let theme = themeManager.getCurrentTheme(for: windowUUID)
-        let isKeyboardShowing = keyboardState != nil
-
         let isToolbarCollapsed = store.state.componentState(
             ToolbarState.self,
             for: .toolbar,
             window: windowUUID
         )?.isAddressBarMinimized == true
+
+        guard toolbarHelper.shouldBlur() else {
+            topBlurView.alpha = 0
+            bottomBlurView.isHidden = true
+            header.isClearBackground = false
+            // Without blur there is no bottom blur view, so this container paints the chrome behind
+            // a bottom address bar — except while the address bar is minimized, where the remaining
+            // pill has to float over the page instead of sitting on an opaque band. Nothing else
+            // re-themes the container while scrolling with blur off, so apply the theme here too or
+            // the flag would not reach the screen until an unrelated theme change.
+            overKeyboardContainer.isClearBackground = isToolbarCollapsed
+            overKeyboardContainer.applyTheme(theme: theme)
+            bottomContainer.isClearBackground = false
+            contentContainer.mask = nil
+            return
+        }
+
+        let isKeyboardShowing = keyboardState != nil
         let isScrollAlphaZero = if #available(iOS 26.0, *) { isToolbarCollapsed } else { false }
 
         // Prevent homepage from showing behind the keyboard when content isn't scrollable.

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -644,12 +644,10 @@ class BrowserViewController: UIViewController,
             topBlurView.alpha = 0
             bottomBlurView.isHidden = true
             header.isClearBackground = false
-            // Without blur there is no bottom blur view, so this container paints the chrome behind
-            // a bottom address bar — except while the address bar is minimized, where the remaining
-            // pill has to float over the page instead of sitting on an opaque band. Nothing else
-            // re-themes the container while scrolling with blur off, so apply the theme here too or
-            // the flag would not reach the screen until an unrelated theme change.
+            // With blur off this container paints the chrome behind a bottom address bar, except while
+            // minimized — the remaining pill has to float over the page, not sit on an opaque band.
             overKeyboardContainer.isClearBackground = isToolbarCollapsed
+            // Nothing else re-themes it while scrolling with blur off.
             overKeyboardContainer.applyTheme(theme: theme)
             bottomContainer.isClearBackground = false
             contentContainer.mask = nil


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35401)
[FXIOS-16691](https://mozilla-hub.atlassian.net/browse/FXIOS-16691)

Fixes #35401

## :bulb: Description
With Reduce Transparency on, minimizing the address bar leaves the remaining pill sitting on a full-width opaque band that cuts off the page, instead of floating over it. Two separate layers paint that band, and the blur path already avoids both.

**1. `overKeyboardContainer`, in `updateBlurViews(scrollOffset:)`.** The method returns early when blurring is off, and that branch set `overKeyboardContainer.isClearBackground = false` unconditionally — while the blur path below it reads the scroll state (`!isKeyboardShowing || shouldClearBackground`). The early return now uses `isToolbarCollapsed`, so with Reduce Transparency the container goes clear only while the address bar is minimized and an expanded address bar keeps its solid chrome. The blur path is untouched.

Two small consequences in the same method:

- The early return applies the theme now. Nothing else re-themes that container while scrolling with blur off, so without it the flag would not reach the screen until an unrelated theme change.
- `isToolbarCollapsed` moved above the guard, and `isKeyboardShowing` / `isScrollAlphaZero` / `shouldClearBackground` moved below it, so the non-blur path no longer computes three values it never reads.

**2. `addressToolbarBackgroundColor()`, in `AddressToolbarUXConfiguration`.** With the container transparent the toolbar itself still painted the same colour. Under blur that call returns the colour with `backgroundAlpha`, which is zero on iOS 26, so it never shows; Reduce Transparency skips that branch and returns an opaque colour, and the method never consulted `isAddressBarMinimized`. The guard added here is the same one `locationContainerBackgroundColor` immediately below it already has.

## :movie_camera: Demos
Verified on iPhone 17 / iOS 26.5, Reduce Transparency on, dark appearance, bottom address bar, scrolled until the bar minimizes.

Measured with the view hierarchy, minimized, before → after:

| View | before | after |
| --- | --- | --- |
| `Browser.overKeyboardContainer` | `rgba(0.169, 0.165, 0.200, 1)` | `rgba(0, 0, 0, 0)` |
| `ToolbarKit.RegularBrowserAddressToolbar` | `rgba(0.169, 0.165, 0.200, 1)` | `rgba(0, 0, 0, 0)` |

On screen the band is gone and page text reads continuously around the pill, matching the recording on the issue.

## :test_tube: Testing
- New `BrowserKit/Tests/ToolbarKitTests/AddressToolbarUXConfigurationTests.swift`: 4 tests on `addressToolbarBackgroundColor` covering `isAddressBarMinimized` × `shouldBlur`. `ToolbarKit` scheme: 53 tests passed.
- `swiftlint lint` clean on all changed files.
- Reproduced the original bug on `main` and confirmed it is gone with this branch, using the same steps.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — this change is itself a Reduce Transparency fix; it leaves the default (blurred) appearance untouched
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review — not applicable
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n — not applicable
- [x] If needed, I updated documentation and added comments to complex code

[FXIOS-16691]: https://mozilla-hub.atlassian.net/browse/FXIOS-16691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
