### PR TITLE
Bugfix FXIOS-15490 [Summarize] Keep the summarize action on iPad in landscape

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -862,7 +862,11 @@ struct AddressBarState: StateType, Sendable, Equatable {
         if isReaderModeWithSummarizerEnabled {
             actions.append(readerModeWithSummarizerAction(isSelected: readerModeState == .active,
                                                           hasAlternativeLocationColor: hasAlternativeLocationColor))
-        } else if isSummarizeFeatureForToolbarOn, canSummarize, readerModeState == .available, !UIWindow.isLandscape {
+        } else if shouldShowSummarizeAction(isToolbarButtonEnabled: isSummarizeFeatureForToolbarOn,
+                                            canSummarize: canSummarize,
+                                            isReaderModeAvailable: readerModeState == .available,
+                                            idiom: UIDevice.current.userInterfaceIdiom,
+                                            isLandscape: UIWindow.isLandscape) {
             actions.append(summaryAction(hasAlternativeLocationColor: hasAlternativeLocationColor))
         } else if readerModeState?.isEnabled == true {
             actions.append(readerModeAction(isSelected: readerModeState == .active,
@@ -1102,6 +1106,18 @@ struct AddressBarState: StateType, Sendable, Equatable {
             a11yLabel: .TabLocationReloadAccessibilityLabel,
             a11yHint: .TabLocationReloadAccessibilityHint,
             a11yId: AccessibilityIdentifiers.Toolbar.reloadButton)
+    }
+
+    /// Whether the address bar shows the summarize entry point instead of the reader-mode button.
+    /// A phone in landscape has no room for it and falls back to reader mode; an iPad has the room
+    /// in either orientation and keeps it.
+    static func shouldShowSummarizeAction(isToolbarButtonEnabled: Bool,
+                                          canSummarize: Bool,
+                                          isReaderModeAvailable: Bool,
+                                          idiom: UIUserInterfaceIdiom,
+                                          isLandscape: Bool) -> Bool {
+        guard isToolbarButtonEnabled, canSummarize, isReaderModeAvailable else { return false }
+        return !(idiom == .phone && isLandscape)
     }
 
     private static func summaryAction(hasAlternativeLocationColor: Bool) -> ToolbarActionConfiguration {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -236,6 +236,38 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.leadingPageActions[0].actionType, .share)
     }
 
+    // MARK: - shouldShowSummarizeAction
+
+    private func shouldShowSummarize(idiom: UIUserInterfaceIdiom,
+                                     isLandscape: Bool,
+                                     isToolbarButtonEnabled: Bool = true,
+                                     canSummarize: Bool = true,
+                                     isReaderModeAvailable: Bool = true) -> Bool {
+        AddressBarState.shouldShowSummarizeAction(
+            isToolbarButtonEnabled: isToolbarButtonEnabled,
+            canSummarize: canSummarize,
+            isReaderModeAvailable: isReaderModeAvailable,
+            idiom: idiom,
+            isLandscape: isLandscape
+        )
+    }
+
+    func test_shouldShowSummarizeAction_onPad_isKeptInBothOrientations() {
+        XCTAssertTrue(shouldShowSummarize(idiom: .pad, isLandscape: false))
+        XCTAssertTrue(shouldShowSummarize(idiom: .pad, isLandscape: true))
+    }
+
+    func test_shouldShowSummarizeAction_onPhone_isDroppedOnlyInLandscape() {
+        XCTAssertTrue(shouldShowSummarize(idiom: .phone, isLandscape: false))
+        XCTAssertFalse(shouldShowSummarize(idiom: .phone, isLandscape: true))
+    }
+
+    func test_shouldShowSummarizeAction_requiresEveryPrecondition() {
+        XCTAssertFalse(shouldShowSummarize(idiom: .pad, isLandscape: false, isToolbarButtonEnabled: false))
+        XCTAssertFalse(shouldShowSummarize(idiom: .pad, isLandscape: false, canSummarize: false))
+        XCTAssertFalse(shouldShowSummarize(idiom: .pad, isLandscape: false, isReaderModeAvailable: false))
+    }
+
     func test_readerModeStateChangedAction_onWebsite_returnsExpectedState_whenSummarizeFeatureOn() {
         setIsHostedSummarizerFeatureEnabled(enabled: true)
         setupStore()


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33237)
[FXIOS-15490](https://mozilla-hub.atlassian.net/browse/FXIOS-15490)

Fixes #33237

## :bulb: Description
The summarize branch in `AddressBarState.pageActions` was gated on `!UIWindow.isLandscape`:

```swift
} else if isSummarizeFeatureForToolbarOn, canSummarize, readerModeState == .available, !UIWindow.isLandscape {
    actions.append(summaryAction(...))
} else if readerModeState?.isEnabled == true {
    actions.append(readerModeAction(...))
}
```

That suppresses it on every device, and control then falls through to the reader-mode branch — which is exactly the reported "the Summarize icon turns into Reading mode". The contextual hint still says "Tap to summarize this page", so the two disagree.

A phone in landscape genuinely has no room for the extra action, which is what the condition was for. This narrows it to that case. `HomepageDimensionImplementation` already draws the same distinction with `device == .phone && isLandscape`, so the shape follows what the codebase does elsewhere.

The decision moves into a pure `shouldShowSummarizeAction(isToolbarButtonEnabled:canSummarize:isReaderModeAvailable:idiom:isLandscape:)`. Both inputs it needs — `UIWindow.isLandscape` and `UIDevice.current.userInterfaceIdiom` — are global reads, so the existing tests around this branch are implicitly tied to whatever the simulator happens to be doing; passing them in makes every combination expressible.

Only the language-expansion path is untouched: `readerModeWithSummarizerAction` has no orientation gate and keeps winning when that flag is on.

## :movie_camera: Demos
Verified on the iPad Pro 11-inch (M5) simulator and iPhone 17, iOS 26.5, on an article with reader mode available. Read from the view hierarchy rather than by eye, since the two icons sit in the same slot:

| Device | Orientation | before | after |
| --- | --- | --- | --- |
| iPad | portrait | `TabLocationView.summarizeButton` | `TabLocationView.summarizeButton` |
| iPad | landscape | `TabLocationView.readerModeButton` | `TabLocationView.summarizeButton` |
| iPhone | portrait | `TabLocationView.summarizeButton` | `TabLocationView.summarizeButton` |
| iPhone | landscape | `TabLocationView.readerModeButton` | `TabLocationView.readerModeButton` |

One cell changes — the one the issue is about — and the deliberate phone-landscape fallback is preserved.

A note on how that was produced: a dev build cannot reach `canSummarize == true`, because it depends on the summarization checker and a hosted summarizer the build has no access to. To exercise the branch I temporarily forced `isSummarizeFeatureForToolbarOn`, `canSummarize` and `isReaderModeWithSummarizerEnabled` locally, took the readings above, then reverted those stubs. Nothing from them is in this diff — the change is the condition plus its tests. If there is a supported way to enable the toolbar entry point in a local build, I would rather use that next time.

## :test_tube: Testing
- `ClientTests/AddressBarStateTests`: 53 tests passed, including 3 new ones covering both idioms in both orientations and each precondition of the new helper.
- `swiftlint lint` clean on both changed files.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — the restored button keeps its existing label and a11y identifier; no new UI
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review — not applicable
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n — not applicable
- [x] If needed, I updated documentation and added comments to complex code

[FXIOS-15490]: https://mozilla-hub.atlassian.net/browse/FXIOS-15490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ