### PR TITLE
Fix Bug 1998705 [URLExtension] Simplify about locations presentation

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/URLExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/URLExtension.swift
@@ -125,7 +125,7 @@ extension URL {
     /// ```
     public static func getSubdomainAndHost(from urlString: String) -> (subdomain: String?, normalizedHost: String) {
         guard let url = URL(string: urlString) else { return (nil, urlString) }
-        let normalizedHost = url.normalizedHost ?? urlString
+        let normalizedHost = url.normalizedHost ?? (urlString.hasPrefix("about:") ? "about:blank" : urlString)
 
         guard let publicSuffix = url.publicSuffix else { return (nil, normalizedHost) }
 

--- a/BrowserKit/Sources/Common/Extensions/URLExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/URLExtension.swift
@@ -125,7 +125,7 @@ extension URL {
     /// ```
     public static func getSubdomainAndHost(from urlString: String) -> (subdomain: String?, normalizedHost: String) {
         guard let url = URL(string: urlString) else { return (nil, urlString) }
-        let normalizedHost = url.normalizedHost ?? (urlString.hasPrefix("about:") ? "about:blank" : urlString)
+        let normalizedHost = url.normalizedHost ?? (url.scheme == "about" ? "about:blank" : urlString)
 
         guard let publicSuffix = url.publicSuffix else { return (nil, normalizedHost) }
 


### PR DESCRIPTION
## :scroll: Tickets

[Bug 1998705](https://bugzilla.mozilla.org/show_bug.cgi?id=1998705)

## :bulb: Description

Blank tabs without protocol can be just simpified to _about:blank_ during fixup.

<!-- 
## :movie_camera: Demos

| Before | After |
| - | - |

<details>
<summary>Demo</summary>
</details>
-->

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code