### PR TITLE
[MTE-6097] - remove testAddTabFromTabTray from full functional plan

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -235,6 +235,7 @@
         "TabTrayTests",
         "TabTrayTests\/testAccessibility()",
         "TabsPerformanceTest",
+        "TabsTests\/testAddTabFromTabTray()",
         "TabsTests\/testAddTabFromTabTray_tabTrayExperimentOff()",
         "TabsTests\/testAddTabFromTabTray_tabTrayExperimentOn()",
         "TabsTests\/testCloseAllTabsPrivateModeUndo_tabTrayExperimentOff()",


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-6097

## :bulb: Description
https://mozilla.testrail.io/index.php?/cases/view/2307042
testAddTabFromTabTray is marked as a smoke test, removing it from fullfunctionalplan 

