### PR TITLE
Bugfix FXIOS-15893 Report translation state from the page on pageshow

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1350,6 +1350,7 @@
 		8C2937702BF79F0300146613 /* EditAddressLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C29376D2BF79F0200146613 /* EditAddressLocalization.swift */; };
 		8C2937712BF79F0300146613 /* EditAddressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C29376E2BF79F0300146613 /* EditAddressViewController.swift */; };
 		8C2937722BF79F0300146613 /* Address+Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C29376F2BF79F0300146613 /* Address+Encodable.swift */; };
+		8C295C4F303DC5D10061EB3C /* TranslationsPageStateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C295C4E303DC5D10061EB3C /* TranslationsPageStateHelper.swift */; };
 		8C2FB1E22FF3D65C00C9A803 /* WebCompatIssueCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1E12FF3D65C00C9A803 /* WebCompatIssueCategory.swift */; };
 		8C2FB1E42FF3D66500C9A803 /* WebCompatReporterAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1E32FF3D66500C9A803 /* WebCompatReporterAction.swift */; };
 		8C2FB1E62FF3D67900C9A803 /* WebCompatReporterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FB1E52FF3D67900C9A803 /* WebCompatReporterState.swift */; };
@@ -10210,6 +10211,7 @@
 		8C29376D2BF79F0200146613 /* EditAddressLocalization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditAddressLocalization.swift; sourceTree = "<group>"; };
 		8C29376E2BF79F0300146613 /* EditAddressViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditAddressViewController.swift; sourceTree = "<group>"; };
 		8C29376F2BF79F0300146613 /* Address+Encodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Address+Encodable.swift"; sourceTree = "<group>"; };
+		8C295C4E303DC5D10061EB3C /* TranslationsPageStateHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsPageStateHelper.swift; sourceTree = "<group>"; };
 		8C2FB1E12FF3D65C00C9A803 /* WebCompatIssueCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatIssueCategory.swift; sourceTree = "<group>"; };
 		8C2FB1E32FF3D66500C9A803 /* WebCompatReporterAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReporterAction.swift; sourceTree = "<group>"; };
 		8C2FB1E52FF3D67900C9A803 /* WebCompatReporterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCompatReporterState.swift; sourceTree = "<group>"; };
@@ -15488,6 +15490,7 @@
 				AA02D5EA2EB3D82F00814F4C /* TranslationsAction.swift */,
 				AA5E81462EB12BD800919E60 /* TranslationsMiddleware.swift */,
 				AA5E81492EF5000000000001 /* PreferredTranslationLanguagesManager.swift */,
+				8C295C4E303DC5D10061EB3C /* TranslationsPageStateHelper.swift */,
 			);
 			path = Translations;
 			sourceTree = "<group>";
@@ -20300,6 +20303,7 @@
 				CA520E7A24913C1B00CCAB48 /* PasswordManagerViewModel.swift in Sources */,
 				C283EECC2E4D2C02008EB540 /* ASAIRemoteConfig.swift in Sources */,
 				8AE1E1CD27B191110024C45E /* SearchBarSettingsViewModel.swift in Sources */,
+				8C295C4F303DC5D10061EB3C /* TranslationsPageStateHelper.swift in Sources */,
 				43D16B8529831EA5009F8279 /* Style.swift in Sources */,
 				8A5564022D23317100028CA7 /* ContextMenuAction.swift in Sources */,
 				219588942D6E519F00B8715E /* AutofillPasswordSetting.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4430,6 +4430,9 @@ extension BrowserViewController: LegacyTabDelegate {
         let adsHelper = AdsTelemetryHelper(tab: tab)
         tab.addContentScript(adsHelper, name: AdsTelemetryHelper.name())
 
+        let translationsPageStateHelper = TranslationsPageStateHelper(tab: tab)
+        tab.addContentScript(translationsPageStateHelper, name: TranslationsPageStateHelper.name())
+
         let noImageModeHelper = NoImageModeHelper(tab: tab)
         tab.addContentScript(noImageModeHelper, name: NoImageModeHelper.name())
 

--- a/firefox-ios/Client/Frontend/Translations/TranslationsAction.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsAction.swift
@@ -24,6 +24,31 @@ struct TranslationsAction: Action {
     }
 }
 
+enum PageTranslationState: Equatable, Sendable {
+    case notTranslated
+    case translated(from: String, to: String)
+}
+
+struct TranslationsPageStateAction: Action {
+    let windowUUID: WindowUUID
+    let actionType: ActionType
+    let pageState: PageTranslationState
+    /// Reports arrive from background tabs too, so state must not go to the selected tab.
+    let tabUUID: TabUUID
+
+    init(
+        windowUUID: WindowUUID,
+        pageState: PageTranslationState,
+        tabUUID: TabUUID,
+        actionType: any ActionType
+    ) {
+        self.windowUUID = windowUUID
+        self.pageState = pageState
+        self.tabUUID = tabUUID
+        self.actionType = actionType
+    }
+}
+
 /// Carries the user-selected target language from the UIMenu picker.
 /// `targetLanguage` is always known — the user just picked it from the menu.
 struct TranslationLanguageSelectedAction: Action {
@@ -53,4 +78,5 @@ enum TranslationsActionType: ActionType {
     case receivedTranslationLanguage
     case didReceiveErrorTranslating
     case didTranslationSettingsChange
+    case pageDidReportTranslationState
 }

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -97,6 +97,7 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
             guard let action = action as? ToolbarAction, action.url?.isWebPage() == true else { return }
             // Fires before the new document is presented, so it must not touch the icon.
             self.clearFlowId(for: action)
+            self.cancelInFlightTranslation(for: windowUUID)
 
         case ToolbarMiddlewareActionType.didTapButton:
             guard let action = (action as? ToolbarMiddlewareAction) else { return }
@@ -158,9 +159,7 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
               reportingTab.tabUUID == action.tabUUID else { return }
 
         // Any translation still running belongs to the page we left.
-        translationTasks[windowUUID]?.cancel()
-        translationTasks[windowUUID] = nil
-        translationTaskTokens[windowUUID] = nil
+        cancelInFlightTranslation(for: windowUUID)
 
         let translationsEnabled = store.state.componentState(
             ToolbarState.self,
@@ -676,6 +675,12 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
         store.dispatch(reloadAction)
         translationsTelemetry.webpageRestored(translationFlowId: flowId(for: action.windowUUID))
         clearFlowId(for: action)
+    }
+
+    private func cancelInFlightTranslation(for windowUUID: WindowUUID) {
+        translationTasks[windowUUID]?.cancel()
+        translationTasks[windowUUID] = nil
+        translationTaskTokens[windowUUID] = nil
     }
 
     private func cancelInFlightTranslations() {

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -27,8 +27,8 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
     private var selectedTargetLanguages: [WindowUUID: String] = [:]
 
     /// Tracks windows where the user explicitly restored the original (untranslated) page.
-    /// Without this flag, the restore-triggered reload would fire urlDidChange and cause
-    /// auto-translate to immediately re-translate the page the user just opted out of.
+    /// Without this flag, the restored page would report itself on `pageshow` and auto-translate
+    /// would immediately re-translate the page the user just opted out of.
     /// Each entry is a one-shot flag: auto-translate is skipped for the immediately following
     /// page load for that window, then the entry is removed. On iPhone only one window exists.
     private var restoringWindows: Set<WindowUUID> = []
@@ -37,6 +37,8 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
     /// requested language instead of the user's top preferred language.
     private var pendingLanguageSwitchTargets: [WindowUUID: String] = [:]
     private var translationTasks: [WindowUUID: Task<Void, Never>] = [:]
+    /// Lets a finishing task tell whether it still owns its `translationTasks` slot.
+    private var translationTaskTokens: [WindowUUID: UUID] = [:]
     var backgroundTimestamp: Date?
     private static let backgroundRecoveryThreshold: TimeInterval = 3
 
@@ -92,19 +94,9 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
         let windowUUID = action.windowUUID
         switch action.actionType {
         case ToolbarActionType.urlDidChange:
-            guard let action = (action as? ToolbarAction) else { return }
-
-            guard action.url?.isWebPage() == true else { return }
-            // Tab-tray round-trip OR mid-translation tab switch: the action carries the tab's
-            // persisted state. Skipping eligibility keeps Redux in sync with the WKWebView —
-            // re-running would dispatch `.inactive`/`nil` and clobber `.active` (translated DOM
-            // still on screen) or `.loading` (in-flight translation we'd otherwise race against).
-            // `.inactive`/restore-flow paths still run so `restoringWindows` is consumed and
-            // auto-translate behaves correctly.
-            let persistedState = action.translationConfiguration?.state
-            if persistedState == .active || persistedState == .loading { return }
+            guard let action = action as? ToolbarAction, action.url?.isWebPage() == true else { return }
+            // Fires before the new document is presented, so it must not touch the icon.
             self.clearFlowId(for: action)
-            self.checkTranslationsAreEligible(for: action)
 
         case ToolbarMiddlewareActionType.didTapButton:
             guard let action = (action as? ToolbarMiddlewareAction) else { return }
@@ -124,6 +116,10 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
         case TranslationsActionType.didTranslationSettingsChange:
             guard let action = (action as? TranslationsAction) else { return }
             self.handleTranslationSettingsChange(action: action, windowUUID: windowUUID)
+
+        case TranslationsActionType.pageDidReportTranslationState:
+            guard let action = (action as? TranslationsPageStateAction) else { return }
+            self.handlePageDidReportTranslationState(action: action, windowUUID: windowUUID)
 
         default:
            break
@@ -153,6 +149,44 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
         guard featureFlagsProvider.isEnabled(.translation),
               action.isTranslationsEnabled ?? true else { return }
         checkTranslationsAreEligible(for: action)
+    }
+
+    private func handlePageDidReportTranslationState(action: TranslationsPageStateAction, windowUUID: WindowUUID) {
+        guard featureFlagsProvider.isEnabled(.translation) else { return }
+
+        guard let reportingTab = selectedTab(for: windowUUID),
+              reportingTab.tabUUID == action.tabUUID else { return }
+
+        // Any translation still running belongs to the page we left.
+        translationTasks[windowUUID]?.cancel()
+        translationTasks[windowUUID] = nil
+        translationTaskTokens[windowUUID] = nil
+
+        let translationsEnabled = store.state.componentState(
+            ToolbarState.self,
+            for: .toolbar,
+            window: windowUUID
+        )?.isTranslationsEnabled ?? true
+
+        switch action.pageState {
+        case .translated(let from, let to) where translationsEnabled:
+            selectedTargetLanguages[windowUUID] = to
+            dispatchAction(
+                for: TranslationsActionType.translationCompleted,
+                with: .active,
+                translatedToLanguage: to,
+                sourceLanguage: from,
+                and: windowUUID,
+                on: reportingTab
+            )
+
+        case .translated:
+            dispatchClearTranslationIcon(windowUUID: windowUUID, on: reportingTab)
+
+        case .notTranslated:
+            persistTranslationConfig(nil, on: reportingTab)
+            checkTranslationsAreEligible(for: action, on: reportingTab)
+        }
     }
 
     private func handleTappingOnTranslateButton(for action: ToolbarMiddlewareAction, and state: AppState) {
@@ -474,12 +508,12 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
 
     /// Checks whether the current page in the active tab is eligible for translation,
     /// and if so, dispatches a translation action to update the translation state.
-    private func checkTranslationsAreEligible(for action: Action) {
+    private func checkTranslationsAreEligible(for action: Action, on tab: Tab? = nil) {
         // Pre-capture the tab so a tab switch mid-flight doesn't stomp the new active tab's state.
-        let originatingTab = selectedTab(for: action.windowUUID)
+        let originatingTab = tab ?? selectedTab(for: action.windowUUID)
         // The action's `isTranslationsEnabled` carries the explicit new value for settings-change
-        // actions (where store.state hasn't been updated yet). For `urlDidChange` it is nil, so we
-        // fall back to ToolbarState which is always up-to-date by the time `urlDidChange` fires.
+        // actions (where store.state hasn't been updated yet). A page report does not carry it, so
+        // fall back to ToolbarState, which is up to date by the time the document reports.
         let translationsEnabled = isTranslationsEnabled(from: action) ?? (store.state.componentState(
             ToolbarState.self,
             for: .toolbar,
@@ -561,6 +595,9 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
         on tab: Tab? = nil
     ) {
         translationTasks[windowUUID]?.cancel()
+        // A cancelled task keeps running, so it can outlive the one that replaced it.
+        let token = UUID()
+        translationTaskTokens[windowUUID] = token
         translationTasks[windowUUID] = Task {
             await self.performTranslation(
                 windowUUID: windowUUID,
@@ -569,7 +606,9 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
                 autoTranslate: autoTranslate,
                 on: tab
             )
+            guard self.translationTaskTokens[windowUUID] == token else { return }
             self.translationTasks[windowUUID] = nil
+            self.translationTaskTokens[windowUUID] = nil
         }
     }
 
@@ -643,6 +682,7 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
         for (windowUUID, task) in translationTasks {
             task.cancel()
             translationTasks[windowUUID] = nil
+            translationTaskTokens[windowUUID] = nil
             guard let targetLanguage = selectedTargetLanguages[windowUUID] else { continue }
             let tab = selectedTab(for: windowUUID)
             pendingLanguageSwitchTargets[windowUUID] = targetLanguage

--- a/firefox-ios/Client/Frontend/Translations/TranslationsPageStateHelper.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsPageStateHelper.swift
@@ -22,7 +22,8 @@ class TranslationsPageStateHelper: TabContentScript {
         _ userContentController: WKUserContentController,
         didReceiveScriptMessage message: WKScriptMessage
     ) {
-        guard let tab,
+        guard message.frameInfo.isMainFrame,
+              let tab,
               let body = message.body as? [String: Any] else { return }
 
         store.dispatch(TranslationsPageStateAction(

--- a/firefox-ios/Client/Frontend/Translations/TranslationsPageStateHelper.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsPageStateHelper.swift
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Redux
+import WebKit
+
+/// `pageshow` is the earliest point at which a document can be asked whether it is translated.
+class TranslationsPageStateHelper: TabContentScript {
+    private weak var tab: Tab?
+
+    class func name() -> String { return "TranslationsPageStateHelper" }
+
+    required init(tab: Tab) {
+        self.tab = tab
+    }
+
+    func scriptMessageHandlerNames() -> [String]? { return ["translationsPageState"] }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceiveScriptMessage message: WKScriptMessage
+    ) {
+        guard let tab,
+              let body = message.body as? [String: Any] else { return }
+
+        store.dispatch(TranslationsPageStateAction(
+            windowUUID: tab.windowUUID,
+            pageState: Self.pageState(from: body),
+            tabUUID: tab.tabUUID,
+            actionType: TranslationsActionType.pageDidReportTranslationState
+        ))
+    }
+
+    static func pageState(from body: [String: Any]) -> PageTranslationState {
+        guard body["translated"] as? Bool == true,
+              let from = body["from"] as? String,
+              let to = body["to"] as? String,
+              !from.isEmpty,
+              !to.isEmpty
+        else { return .notTranslated }
+
+        return .translated(from: from, to: to)
+    }
+}

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
@@ -12,6 +12,10 @@ let isDoneResolve;
 let isDoneReject;
 let isDonePromise;
 
+/// Lives in the page, so it rides the back/forward cache alongside the translated DOM.
+let currentTranslation = null;
+let pendingTranslation = null;
+
 const resetIsDone = () => {
     isDonePromise = new Promise((resolve, reject) => {
         isDoneResolve = resolve;
@@ -33,6 +37,8 @@ const sendToEngine = (message) => {
 /// For "done" messages, it resolves the isDone promise.
 window.receive = (message) => {
     if (message.type === "TranslationsPort:TranslationResponse" && isDoneResolve) {
+        // A requested but never rendered translation must not count as translated.
+        currentTranslation = pendingTranslation;
         isDoneResolve(true);
         isDoneResolve = null;
         isDoneReject = null;
@@ -56,9 +62,20 @@ port1.onmessage = (message) => {
 };
 
 
+const reportPageState = () => {
+    window.webkit.messageHandlers.translationsPageState.postMessage({
+        translated: currentTranslation !== null,
+        from: currentTranslation ? currentTranslation.from : null,
+        to: currentTranslation ? currentTranslation.to : null
+    });
+};
+
+window.addEventListener("pageshow", reportPageState);
+
 /// NOTE: This should be called to start the translation process for this document.
 /// This creates the TranslationsDocument instance that manages the translation lifecycle.
 const startTranslations = ({from, to}) => {
+    pendingTranslation = { from, to };
     resetIsDone();
     const languagePair = {sourceLanguage: from, targetLanguage: to}
     const translationsCache = new LRUCache(languagePair);
@@ -85,6 +102,8 @@ const startTranslations = ({from, to}) => {
 
 /// NOTE: This should be called when we teardown the translations for this document.
 const discardTranslations = ({from, to}) => {
+    currentTranslation = null;
+    pendingTranslation = null;
     resetIsDone();
     sendToEngine({ type: "DiscardTranslations", innerWindowId })
 };

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
@@ -14,6 +14,9 @@ final class MockTranslationsService: TranslationsServiceProtocol {
     private let firstResponseReceivedResult: Result<Void, Error>
     private let detectPageLanguageResult: Result<String, Error>
 
+    // MARK: - Call records
+    var shouldOfferTranslationCallCount = 0
+
     // MARK: - Init
     init(
         shouldOfferTranslationResult: Result<Bool, Error> = .success(false),
@@ -29,6 +32,7 @@ final class MockTranslationsService: TranslationsServiceProtocol {
 
     // MARK: - TranslationsServiceProtocol
     func shouldOfferTranslation(for windowUUID: WindowUUID, using preferredLanguages: [String]) async throws -> Bool {
+        shouldOfferTranslationCallCount += 1
         return try shouldOfferTranslationResult.get()
     }
 
@@ -38,8 +42,10 @@ final class MockTranslationsService: TranslationsServiceProtocol {
         to targetLanguage: String,
         onLanguageIdentified: ((String, String) -> Void)?
     ) async throws {
-        try translateResult.get()
+        // Production identifies the language before it can fail, so a thrown error must not
+        // swallow the callback — that is what emits `translationRequested` telemetry.
         onLanguageIdentified?(sourceLanguage ?? "en", targetLanguage)
+        try translateResult.get()
     }
 
     func firstResponseReceived(for windowUUID: WindowUUID) async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/MockTranslationsService.swift
@@ -17,17 +17,28 @@ final class MockTranslationsService: TranslationsServiceProtocol {
     // MARK: - Call records
     var shouldOfferTranslationCallCount = 0
 
+    /// Parks `firstResponseReceived` until `releaseFirstResponse()` is called.
+    private var firstResponseGate: CheckedContinuation<Void, Never>?
+    private let gatesFirstResponse: Bool
+
     // MARK: - Init
     init(
         shouldOfferTranslationResult: Result<Bool, Error> = .success(false),
         translateResult: Result<Void, Error> = .success(()),
         firstResponseReceivedResult: Result<Void, Error> = .success(()),
-        detectPageLanguageResult: Result<String, Error> = .success("en")
+        detectPageLanguageResult: Result<String, Error> = .success("en"),
+        gatesFirstResponse: Bool = false
     ) {
         self.shouldOfferTranslationResult = shouldOfferTranslationResult
         self.translateResult = translateResult
         self.firstResponseReceivedResult = firstResponseReceivedResult
         self.detectPageLanguageResult = detectPageLanguageResult
+        self.gatesFirstResponse = gatesFirstResponse
+    }
+
+    func releaseFirstResponse() {
+        firstResponseGate?.resume()
+        firstResponseGate = nil
     }
 
     // MARK: - TranslationsServiceProtocol
@@ -49,6 +60,11 @@ final class MockTranslationsService: TranslationsServiceProtocol {
     }
 
     func firstResponseReceived(for windowUUID: WindowUUID) async throws {
+        if gatesFirstResponse {
+            await withCheckedContinuation { continuation in
+                firstResponseGate = continuation
+            }
+        }
         try firstResponseReceivedResult.get()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -110,6 +110,42 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
     }
 
+    /// Regression guard: a translation still in flight on navigation must not complete onto
+    /// the page being navigated to.
+    func test_urlDidChangeAction_withTranslationInFlight_cancelsIt() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let mockTranslationService = MockTranslationsService(gatesFirstResponse: true)
+        let subject = createSubject(translationsService: mockTranslationService)
+
+        let startAction = TranslationLanguageSelectedAction(
+            windowUUID: .XCTestDefaultUUID,
+            targetLanguage: "de",
+            actionType: TranslationsActionType.didSelectTargetLanguage
+        )
+
+        let startExpectation = XCTestExpectation(description: "didStartTranslatingPage dispatched")
+        mockStore.dispatchCalled = { startExpectation.fulfill() }
+        subject.translationsProvider.legacyMiddleware(mockStore.state, startAction)
+        wait(for: [startExpectation], timeout: 1.0)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+
+        let urlDidChangeAction = ToolbarAction(
+            url: URL(string: "https://www.example.com"),
+            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
+            windowUUID: .XCTestDefaultUUID,
+            actionType: ToolbarActionType.urlDidChange
+        )
+        subject.translationsProvider.legacyMiddleware(mockStore.state, urlDidChangeAction)
+
+        let noFurtherDispatch = XCTestExpectation(description: "no dispatch once the cancelled task resolves")
+        noFurtherDispatch.isInverted = true
+        mockStore.dispatchCalled = { noFurtherDispatch.fulfill() }
+        mockTranslationService.releaseFirstResponse()
+
+        wait(for: [noFurtherDispatch], timeout: 0.5)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+    }
+
     // MARK: - pageDidReportTranslationState tests (translated)
 
     func test_pageDidReportTranslationState_whenTranslated_dispatchesActiveStateWithLanguages() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -36,6 +36,9 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             injectedWindowManager: mockWindowManager,
             injectedTabManager: mockTabManager
         )
+        let tab = MockTab(profile: mockProfile, windowUUID: .XCTestDefaultUUID)
+        tab.webView = MockTabWebView(tab: tab)
+        mockTabManager.selectedTab = tab
         setupStore()
     }
 
@@ -51,52 +54,11 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         try await super.tearDown()
     }
 
-    // MARK: - urlDidChangeAction tests
+    // MARK: - urlDidChange tests
 
-    func test_urlDidChangeAction_withoutTranslationConfiguration_doesNotDispatchAction() throws {
-        setTranslationsFeatureEnabled(enabled: true)
-        let subject = createSubject()
-        let action = ToolbarAction(
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
-    }
-
-    func test_urlDidChangeAction_withoutFF_doesNotDispatchAction() throws {
-        setTranslationsFeatureEnabled(enabled: false)
-        let subject = createSubject()
-        let action = ToolbarAction(
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
-    }
-
-    func test_urlDidChangeAction_withoutWebView_doesDispatchAction() throws {
-        setTranslationsFeatureEnabled(enabled: true)
-        let subject = createSubject()
-        let action = ToolbarAction(
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
-    }
-
-    func test_urlDidChangeAction_withTranslationConfiguration_doesDispatchAction() throws {
+    /// FXIOS-15893 regression guard. `urlDidChange` fires before the incoming document is on
+    /// screen, so it must never write translation state — even for a page that would be eligible.
+    func test_urlDidChangeAction_withEligiblePage_doesNotDispatchTranslationState() throws {
         setTranslationsFeatureEnabled(enabled: true)
         let mockTranslationService = MockTranslationsService(
             shouldOfferTranslationResult: .success(true)
@@ -109,152 +71,24 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarActionType.urlDidChange
         )
 
-        let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage action to be fired")
-
-        mockStore.dispatchCalled = {
-            expectation.fulfill()
-        }
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        wait(for: [expectation], timeout: 1.0)
-
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
-        let actionType = try XCTUnwrap(actionCalled.actionType as? TranslationsActionType)
-
-        XCTAssertEqual(actionCalled.translationConfiguration?.state, .inactive)
-        XCTAssertEqual(actionType, TranslationsActionType.receivedTranslationLanguage)
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-        XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
-        XCTAssertEqual(mockTranslationsTelemetry.pageLanguageIdentificationFailedCalledCount, 0)
-    }
-
-    func test_urlDidChangeAction_withLanguagePickerEnabled_andEligiblePage_doesDispatchAction() throws {
-        setTranslationsFeatureEnabled(enabled: true, languagePickerEnabled: true)
-        let mockTranslationService = MockTranslationsService(
-            shouldOfferTranslationResult: .success(true)
-        )
-        let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
-
-        let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage action to be fired")
+        let expectation = XCTestExpectation(description: "urlDidChange must not dispatch")
+        expectation.isInverted = true
         mockStore.dispatchCalled = { expectation.fulfill() }
 
         subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
-        wait(for: [expectation], timeout: 1.0)
-
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
-        let actionType = try XCTUnwrap(actionCalled.actionType as? TranslationsActionType)
-
-        XCTAssertEqual(actionCalled.translationConfiguration?.state, .inactive)
-        XCTAssertEqual(actionType, TranslationsActionType.receivedTranslationLanguage)
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-    }
-
-    func test_urlDidChangeAction_withError_doesNotDispatchActionAndLogsError() throws {
-        setTranslationsFeatureEnabled(enabled: true)
-        enum TestError: Error { case example }
-        let mockTranslationService = MockTranslationsService(
-            shouldOfferTranslationResult: .failure(TestError.example)
-        )
-        let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
-
-        let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage action to be fired")
-        expectation.isInverted = true
-
-        mockStore.dispatchCalled = {
-            expectation.fulfill()
-        }
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        wait(for: [expectation], timeout: 1.0)
-
+        wait(for: [expectation], timeout: 0.5)
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-        XCTAssertEqual(mockLogger.savedLevel, .warning)
-        XCTAssertEqual(
-            mockLogger.savedMessage,
-            "Unable to detect language from page to determine if eligible for translations."
-            + " LanguageDetector error: \(TestError.example.localizedDescription)"
-        )
-        XCTAssertNil(mockTranslationsTelemetry.lastTranslationFlowId)
-        XCTAssertEqual(mockTranslationsTelemetry.pageLanguageIdentificationFailedCalledCount, 1)
-        XCTAssertNotNil(mockTranslationsTelemetry.lastErrorType)
+        XCTAssertEqual(mockTranslationService.shouldOfferTranslationCallCount, 0)
     }
 
-    func test_urlDidChangeAction_withSamePageLanguage_doesNotDispatchAction() throws {
+    /// The previous implementation relied on an `.active`/`.loading` early return here to avoid
+    /// clobbering a translated page. That guard is gone; nothing is dispatched either way.
+    func test_urlDidChangeAction_withActivePersistedState_doesNotDispatchTranslationState() throws {
         setTranslationsFeatureEnabled(enabled: true)
-        let mockTranslationService = MockTranslationsService(
-            shouldOfferTranslationResult: .success(false)
+        let subject = createSubject(
+            translationsService: MockTranslationsService(shouldOfferTranslationResult: .success(true))
         )
-        let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
-
-        let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage action to be fired")
-        expectation.isInverted = true
-
-        mockStore.dispatchCalled = {
-            expectation.fulfill()
-        }
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        wait(for: [expectation], timeout: 1.0)
-
-        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-    }
-
-    func test_urlDidChangeAction_withNotEligiblePage_dispatchesClearAction() throws {
-        setTranslationsFeatureEnabled(enabled: true)
-        let mockTranslationService = MockTranslationsService(
-            shouldOfferTranslationResult: .success(false)
-        )
-        let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
-
-        let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage clear action to be fired")
-        mockStore.dispatchCalled = { expectation.fulfill() }
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        wait(for: [expectation], timeout: 1.0)
-
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
-        let actionType = try XCTUnwrap(actionCalled.actionType as? TranslationsActionType)
-
-        XCTAssertNil(actionCalled.translationConfiguration)
-        XCTAssertEqual(actionType, TranslationsActionType.receivedTranslationLanguage)
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
-    }
-
-    /// urlDidChange with `.active` skips eligibility re-check.
-    func test_urlDidChangeAction_withActiveState_skipsEligibilityRecheck() throws {
-        setTranslationsFeatureEnabled(enabled: true)
-        let mockTranslationService = MockTranslationsService(
-            shouldOfferTranslationResult: .success(true)
-        )
-        let subject = createSubject(translationsService: mockTranslationService)
         let action = ToolbarAction(
             url: URL(string: "https://www.example.com"),
             translationConfiguration: TranslationConfiguration(
@@ -266,210 +100,119 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             actionType: ToolbarActionType.urlDidChange
         )
 
-        let expectation = XCTestExpectation(description: "no dispatch should occur for tab-switch round-trip")
+        let expectation = XCTestExpectation(description: "urlDidChange must not dispatch")
         expectation.isInverted = true
         mockStore.dispatchCalled = { expectation.fulfill() }
 
         subject.translationsProvider.legacyMiddleware(mockStore.state, action)
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 0.5)
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
     }
 
-    /// urlDidChange with `.loading` skips eligibility re-check.
-    func test_urlDidChangeAction_withLoadingState_skipsEligibilityRecheck() throws {
-        setTranslationsFeatureEnabled(enabled: true)
-        let mockTranslationService = MockTranslationsService(
-            shouldOfferTranslationResult: .success(true)
-        )
-        let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(
-                prefs: mockProfile.prefs,
-                state: .loading
-            ),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
+    // MARK: - pageDidReportTranslationState tests (translated)
 
-        let expectation = XCTestExpectation(description: "no dispatch should occur for in-flight round-trip")
-        expectation.isInverted = true
+    func test_pageDidReportTranslationState_whenTranslated_dispatchesActiveStateWithLanguages() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let subject = createSubject()
+
+        let expectation = XCTestExpectation(description: "translationCompleted dispatched")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
-    }
-
-    /// urlDidChange with `.inactive` falls through and runs eligibility (restore-flow contract).
-    func test_urlDidChangeAction_withInactiveState_runsEligibility() throws {
-        setTranslationsFeatureEnabled(enabled: true)
-        let mockTranslationService = MockTranslationsService(
-            shouldOfferTranslationResult: .success(true)
-        )
-        let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(
-                prefs: mockProfile.prefs,
-                state: .inactive
-            ),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
+        subject.translationsProvider.legacyMiddleware(
+            mockStore.state,
+            pageStateAction(.translated(from: "ja", to: "en"))
         )
 
-        let expectation = XCTestExpectation(description: "receivedTranslationLanguage dispatched")
-        mockStore.dispatchCalled = { expectation.fulfill() }
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
-        XCTAssertEqual(dispatched.actionType as? TranslationsActionType, .receivedTranslationLanguage)
+        XCTAssertEqual(dispatched.actionType as? TranslationsActionType, .translationCompleted)
+        XCTAssertEqual(dispatched.translationConfiguration?.state, .active)
+        XCTAssertEqual(dispatched.translationConfiguration?.sourceLanguage, "ja")
+        XCTAssertEqual(dispatched.translationConfiguration?.translatedToLanguage, "en")
     }
 
-    /// Eligible page persists `.inactive` to the tab's store entry.
-    func test_urlDidChangeAction_withEligiblePage_persistsInactiveStateOnTab() throws {
+    /// The FXIOS-15893 case: a bfcache restore reports the translated DOM, so the icon must come
+    /// back active rather than falling through to the offer path and being cleared.
+    func test_pageDidReportTranslationState_whenTranslated_doesNotReRunEligibility() throws {
         setTranslationsFeatureEnabled(enabled: true)
         let mockTranslationService = MockTranslationsService(
             shouldOfferTranslationResult: .success(true)
         )
+        let subject = createSubject(translationsService: mockTranslationService)
+
+        let expectation = XCTestExpectation(description: "translationCompleted dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(
+            mockStore.state,
+            pageStateAction(.translated(from: "ja", to: "en"))
+        )
+
+        wait(for: [expectation], timeout: 1.0)
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
+        XCTAssertEqual(dispatched.translationConfiguration?.state, .active)
+        // Eligibility would report the restored page as English and clear the icon.
+        XCTAssertEqual(mockTranslationService.shouldOfferTranslationCallCount, 0)
+    }
+
+    func test_pageDidReportTranslationState_whenTranslated_persistsActiveStateOnTab() throws {
+        setTranslationsFeatureEnabled(enabled: true)
         let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
         tab.webView = MockTabWebView(tab: tab)
         mockTabManager.selectedTab = tab
+        let subject = createSubject()
 
-        let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
-
-        let expectation = XCTestExpectation(description: "receivedTranslationLanguage dispatched")
+        let expectation = XCTestExpectation(description: "translationCompleted dispatched")
         mockStore.dispatchCalled = { expectation.fulfill() }
 
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        wait(for: [expectation], timeout: 1.0)
-        XCTAssertEqual(tab.translationConfiguration?.state, .inactive)
-    }
-
-    /// Ineligible page clears the tab's stored translation config.
-    func test_urlDidChangeAction_withIneligiblePage_clearsTabState() throws {
-        setTranslationsFeatureEnabled(enabled: true)
-        let mockTranslationService = MockTranslationsService(
-            shouldOfferTranslationResult: .success(false)
-        )
-        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
-        tab.webView = MockTabWebView(tab: tab)
-        // Pre-seed a stale state to verify the middleware actively clears it.
-        tab.translationConfiguration = TranslationConfiguration(prefs: mockProfile.prefs, state: .inactive)
-        mockTabManager.selectedTab = tab
-
-        let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
+        subject.translationsProvider.legacyMiddleware(
+            mockStore.state,
+            pageStateAction(.translated(from: "ja", to: "en"))
         )
 
-        let expectation = XCTestExpectation(description: "receivedTranslationLanguage clear dispatched")
-        mockStore.dispatchCalled = { expectation.fulfill() }
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
         wait(for: [expectation], timeout: 1.0)
-        XCTAssertNil(tab.translationConfiguration)
+        XCTAssertEqual(tab.translationConfiguration?.state, .active)
+        XCTAssertEqual(tab.translationConfiguration?.translatedToLanguage, "en")
     }
 
-    /// PDF MIME type suppresses the translate icon without calling language detection.
-    func test_urlDidChangeAction_withPDFMimeType_dispatchesClearAction() throws {
+    /// The script runs in every tab, so a background tab finishing a load also reports. Its state
+    /// must not be written onto the tab the user is actually looking at.
+    func test_pageDidReportTranslationState_fromBackgroundTab_leavesSelectedTabUntouched() throws {
         setTranslationsFeatureEnabled(enabled: true)
         let mockTranslationService = MockTranslationsService(
             shouldOfferTranslationResult: .success(true)
         )
-        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
-        tab.mimeType = MIMEType.PDF
-        tab.translationConfiguration = TranslationConfiguration(prefs: mockProfile.prefs, state: .inactive)
-        mockTabManager.selectedTab = tab
-
+        let selectedTab = try XCTUnwrap(mockTabManager.selectedTab)
+        let backgroundTab = MockTab(profile: mockProfile, windowUUID: .XCTestDefaultUUID)
         let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com/document.pdf"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
+
+        let noDispatch = XCTestExpectation(description: "no action dispatched for a background tab")
+        noDispatch.isInverted = true
+        mockStore.dispatchCalled = { noDispatch.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(
+            mockStore.state,
+            pageStateAction(.translated(from: "ja", to: "en"), tabUUID: backgroundTab.tabUUID)
         )
 
-        let expectation = XCTestExpectation(description: "receivedTranslationLanguage clear dispatched for PDF")
-        mockStore.dispatchCalled = { expectation.fulfill() }
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        wait(for: [expectation], timeout: 1.0)
-
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
-        XCTAssertNil(actionCalled.translationConfiguration)
-        XCTAssertEqual(actionCalled.actionType as? TranslationsActionType, .receivedTranslationLanguage)
-        XCTAssertNil(tab.translationConfiguration)
+        wait(for: [noDispatch], timeout: 0.2)
+        XCTAssertTrue(mockStore.dispatchedActions.isEmpty)
+        XCTAssertNil(selectedTab.translationConfiguration)
+        XCTAssertEqual(mockTranslationService.shouldOfferTranslationCallCount, 0)
     }
 
-    /// Image MIME type suppresses the translate icon without calling language detection.
-    func test_urlDidChangeAction_withImageMimeType_dispatchesClearAction() throws {
+    /// The page report pins the reporting tab, so changing tabs while eligibility is still in
+    /// flight must not write that page's state onto the newly selected tab.
+    func test_pageDidReportTranslationState_tabChangeMidEligibility_persistsOnOriginatingTab() throws {
         setTranslationsFeatureEnabled(enabled: true)
         let mockTranslationService = MockTranslationsService(
             shouldOfferTranslationResult: .success(true)
         )
-        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
-        tab.mimeType = MIMEType.JPEG
-        tab.translationConfiguration = TranslationConfiguration(prefs: mockProfile.prefs, state: .inactive)
-        mockTabManager.selectedTab = tab
-
-        let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com/photo.jpg"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
-
-        let expectation = XCTestExpectation(description: "receivedTranslationLanguage clear dispatched for image")
-        mockStore.dispatchCalled = { expectation.fulfill() }
-
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-
-        wait(for: [expectation], timeout: 1.0)
-
-        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
-        XCTAssertNil(actionCalled.translationConfiguration)
-        XCTAssertEqual(actionCalled.actionType as? TranslationsActionType, .receivedTranslationLanguage)
-        XCTAssertNil(tab.translationConfiguration)
-    }
-
-    /// Mid-eligibility tab switch: result lands on the originating tab, not the new active tab.
-    func test_urlDidChangeAction_tabSwitchMidEligibility_persistsOnOriginatingTab() throws {
-        setTranslationsFeatureEnabled(enabled: true)
-        let mockTranslationService = MockTranslationsService(
-            shouldOfferTranslationResult: .success(true)
-        )
-        let tabA = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
-        tabA.webView = MockTabWebView(tab: tabA)
-        let tabB = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        let tabA = try XCTUnwrap(mockTabManager.selectedTab)
+        let tabB = MockTab(profile: mockProfile, windowUUID: .XCTestDefaultUUID)
         tabB.webView = MockTabWebView(tab: tabB)
-        mockTabManager.selectedTab = tabA
-
         let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
 
         let expectation = XCTestExpectation(description: "receivedTranslationLanguage dispatched")
         mockStore.dispatchCalled = { [weak mockStore] in
@@ -478,8 +221,8 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             }
         }
 
-        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
-        // Simulate a tab switch while the eligibility Task is in flight.
+        subject.translationsProvider.legacyMiddleware(mockStore.state, pageStateAction(.notTranslated))
+        // The user moves to another tab while the eligibility Task is in flight.
         mockTabManager.selectedTab = tabB
 
         wait(for: [expectation], timeout: 1.0)
@@ -487,7 +230,240 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertNil(tabB.translationConfiguration)
     }
 
-    /// Translation completion persists `.active` to the tab's store entry.
+    // MARK: - pageDidReportTranslationState tests (not translated)
+
+    func test_pageDidReportTranslationState_whenNotTranslatedAndEligible_dispatchesInactiveOffer() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let mockTranslationService = MockTranslationsService(
+            shouldOfferTranslationResult: .success(true)
+        )
+        let subject = createSubject(translationsService: mockTranslationService)
+
+        let expectation = XCTestExpectation(description: "receivedTranslationLanguage dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(mockStore.state, pageStateAction(.notTranslated))
+
+        wait(for: [expectation], timeout: 1.0)
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
+        XCTAssertEqual(dispatched.actionType as? TranslationsActionType, .receivedTranslationLanguage)
+        XCTAssertEqual(dispatched.translationConfiguration?.state, .inactive)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+    }
+
+    func test_pageDidReportTranslationState_withLanguagePickerEnabled_andEligiblePage_dispatchesInactiveOffer() throws {
+        setTranslationsFeatureEnabled(enabled: true, languagePickerEnabled: true)
+        let subject = createSubject(
+            translationsService: MockTranslationsService(shouldOfferTranslationResult: .success(true))
+        )
+
+        let expectation = XCTestExpectation(description: "receivedTranslationLanguage dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(mockStore.state, pageStateAction(.notTranslated))
+
+        wait(for: [expectation], timeout: 1.0)
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
+        XCTAssertEqual(dispatched.translationConfiguration?.state, .inactive)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+    }
+
+    func test_pageDidReportTranslationState_whenNotTranslatedAndNotEligible_dispatchesClearAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let subject = createSubject(
+            translationsService: MockTranslationsService(shouldOfferTranslationResult: .success(false))
+        )
+
+        let expectation = XCTestExpectation(description: "clear action dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(mockStore.state, pageStateAction(.notTranslated))
+
+        wait(for: [expectation], timeout: 1.0)
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
+        XCTAssertNil(dispatched.translationConfiguration)
+        XCTAssertEqual(dispatched.actionType as? TranslationsActionType, .receivedTranslationLanguage)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+    }
+
+    /// A document reporting itself untranslated must drop any `.active` carried over from the
+    /// page we navigated away from, otherwise the icon stays blue over untranslated content.
+    func test_pageDidReportTranslationState_whenNotTranslated_clearsStaleActiveStateOnTab() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.webView = MockTabWebView(tab: tab)
+        tab.translationConfiguration = TranslationConfiguration(
+            prefs: mockProfile.prefs,
+            state: .active,
+            translatedToLanguage: "en"
+        )
+        mockTabManager.selectedTab = tab
+        let subject = createSubject(
+            translationsService: MockTranslationsService(shouldOfferTranslationResult: .success(false))
+        )
+
+        let expectation = XCTestExpectation(description: "clear action dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(mockStore.state, pageStateAction(.notTranslated))
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertNil(tab.translationConfiguration)
+    }
+
+    func test_pageDidReportTranslationState_whenNotTranslatedAndEligible_persistsInactiveStateOnTab() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.webView = MockTabWebView(tab: tab)
+        mockTabManager.selectedTab = tab
+        let subject = createSubject(
+            translationsService: MockTranslationsService(shouldOfferTranslationResult: .success(true))
+        )
+
+        let expectation = XCTestExpectation(description: "receivedTranslationLanguage dispatched")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(mockStore.state, pageStateAction(.notTranslated))
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(tab.translationConfiguration?.state, .inactive)
+    }
+
+    func test_pageDidReportTranslationState_withoutFF_doesNotDispatchAction() throws {
+        setTranslationsFeatureEnabled(enabled: false)
+        let mockTranslationService = MockTranslationsService(
+            shouldOfferTranslationResult: .success(true)
+        )
+        let subject = createSubject(translationsService: mockTranslationService)
+
+        let expectation = XCTestExpectation(description: "no dispatch without the feature flag")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(
+            mockStore.state,
+            pageStateAction(.translated(from: "ja", to: "en"))
+        )
+
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertEqual(mockTranslationService.shouldOfferTranslationCallCount, 0)
+    }
+
+    func test_pageDidReportTranslationState_withError_doesNotDispatchActionAndLogsError() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        enum TestError: Error { case example }
+        let subject = createSubject(
+            translationsService: MockTranslationsService(
+                shouldOfferTranslationResult: .failure(TestError.example)
+            )
+        )
+
+        let expectation = XCTestExpectation(description: "no dispatch on detection failure")
+        expectation.isInverted = true
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(mockStore.state, pageStateAction(.notTranslated))
+
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(mockStore.dispatchedActions.count, 0)
+        XCTAssertEqual(mockLogger.savedLevel, .warning)
+        XCTAssertEqual(
+            mockLogger.savedMessage,
+            "Unable to detect language from page to determine if eligible for translations."
+            + " LanguageDetector error: \(TestError.example.localizedDescription)"
+        )
+        XCTAssertEqual(mockTranslationsTelemetry.pageLanguageIdentificationFailedCalledCount, 1)
+        XCTAssertNotNil(mockTranslationsTelemetry.lastErrorType)
+    }
+
+    /// PDF MIME type suppresses the translate icon without calling language detection.
+    func test_pageDidReportTranslationState_withPDFMimeType_dispatchesClearAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let mockTranslationService = MockTranslationsService(
+            shouldOfferTranslationResult: .success(true)
+        )
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.mimeType = MIMEType.PDF
+        tab.translationConfiguration = TranslationConfiguration(prefs: mockProfile.prefs, state: .inactive)
+        mockTabManager.selectedTab = tab
+        let subject = createSubject(translationsService: mockTranslationService)
+
+        let expectation = XCTestExpectation(description: "clear action dispatched for PDF")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(mockStore.state, pageStateAction(.notTranslated))
+
+        wait(for: [expectation], timeout: 1.0)
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
+        XCTAssertNil(dispatched.translationConfiguration)
+        XCTAssertNil(tab.translationConfiguration)
+        XCTAssertEqual(mockTranslationService.shouldOfferTranslationCallCount, 0)
+    }
+
+    /// Image MIME type suppresses the translate icon without calling language detection.
+    func test_pageDidReportTranslationState_withImageMimeType_dispatchesClearAction() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let mockTranslationService = MockTranslationsService(
+            shouldOfferTranslationResult: .success(true)
+        )
+        let tab = MockTab(profile: MockProfile(), windowUUID: .XCTestDefaultUUID)
+        tab.mimeType = MIMEType.JPEG
+        tab.translationConfiguration = TranslationConfiguration(prefs: mockProfile.prefs, state: .inactive)
+        mockTabManager.selectedTab = tab
+        let subject = createSubject(translationsService: mockTranslationService)
+
+        let expectation = XCTestExpectation(description: "clear action dispatched for image")
+        mockStore.dispatchCalled = { expectation.fulfill() }
+
+        subject.translationsProvider.legacyMiddleware(mockStore.state, pageStateAction(.notTranslated))
+
+        wait(for: [expectation], timeout: 1.0)
+        let dispatched = try XCTUnwrap(mockStore.dispatchedActions.first as? TranslationsAction)
+        XCTAssertNil(dispatched.translationConfiguration)
+        XCTAssertNil(tab.translationConfiguration)
+        XCTAssertEqual(mockTranslationService.shouldOfferTranslationCallCount, 0)
+    }
+
+    // MARK: - Page state payload parsing
+
+    func test_pageStateParsing_withTranslatedPayload_returnsTranslated() {
+        let state = TranslationsPageStateHelper.pageState(
+            from: ["translated": true, "from": "ja", "to": "en"]
+        )
+
+        XCTAssertEqual(state, .translated(from: "ja", to: "en"))
+    }
+
+    func test_pageStateParsing_withNotTranslatedPayload_returnsNotTranslated() {
+        let state = TranslationsPageStateHelper.pageState(
+            from: ["translated": false, "from": NSNull(), "to": NSNull()]
+        )
+
+        XCTAssertEqual(state, .notTranslated)
+    }
+
+    /// A translated claim without usable language codes cannot describe a translation, so it is
+    /// treated as untranslated rather than producing an `.active` icon with no languages.
+    func test_pageStateParsing_withTranslatedButMissingLanguages_returnsNotTranslated() {
+        XCTAssertEqual(
+            TranslationsPageStateHelper.pageState(from: ["translated": true]),
+            .notTranslated
+        )
+        XCTAssertEqual(
+            TranslationsPageStateHelper.pageState(from: ["translated": true, "from": "ja"]),
+            .notTranslated
+        )
+        XCTAssertEqual(
+            TranslationsPageStateHelper.pageState(from: ["translated": true, "from": "", "to": "en"]),
+            .notTranslated
+        )
+    }
+
+    func test_pageStateParsing_withEmptyPayload_returnsNotTranslated() {
+        XCTAssertEqual(TranslationsPageStateHelper.pageState(from: [:]), .notTranslated)
+    }
+
     func test_didSelectTargetLanguage_persistsActiveStateOnTab() throws {
         setTranslationsFeatureEnabled(enabled: true)
         mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslatePromptShown)
@@ -987,7 +963,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
 
     // MARK: - Auto-translate tests
 
-    func test_urlDidChangeAction_withAutoTranslateEnabled_andPreferredLanguages_translatesAutomatically() throws {
+    func test_pageReport_withAutoTranslateEnabled_andPreferredLanguages_translatesAutomatically() throws {
         setTranslationsFeatureEnabled(enabled: true)
         mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslate)
         mockProfile.prefs.setString("de", forKey: PrefsKeys.Settings.translationPreferredLanguages)
@@ -995,12 +971,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             shouldOfferTranslationResult: .success(true)
         )
         let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
+        let action = pageStateAction(.notTranslated)
 
         let expectation = XCTestExpectation(
             description: "expect didStartTranslatingPage and translationCompleted to be fired"
@@ -1026,19 +997,14 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(secondActionType, TranslationsActionType.translationCompleted)
     }
 
-    func test_urlDidChangeAction_withAutoTranslateEnabled_andNoPreferredLanguages_offersManualTranslation() throws {
+    func test_pageReport_withAutoTranslateEnabled_andNoPreferredLanguages_offersManualTranslation() throws {
         setTranslationsFeatureEnabled(enabled: true)
         mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslate)
         let mockTranslationService = MockTranslationsService(
             shouldOfferTranslationResult: .success(true)
         )
         let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
+        let action = pageStateAction(.notTranslated)
 
         let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage to be fired")
         expectation.expectedFulfillmentCount = 1
@@ -1057,7 +1023,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(dispatchedActionType, TranslationsActionType.receivedTranslationLanguage)
     }
 
-    func test_urlDidChangeAction_withAutoTranslateEnabled_afterRestore_skipsAutoTranslateOnce() throws {
+    func test_pageReport_withAutoTranslateEnabled_afterRestore_skipsAutoTranslateOnce() throws {
         setTranslationsFeatureEnabled(enabled: true)
         mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslate)
         mockProfile.prefs.setString("de", forKey: PrefsKeys.Settings.translationPreferredLanguages)
@@ -1080,13 +1046,8 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         wait(for: [restoreExpectation], timeout: 1.0)
         mockStore.dispatchedActions.removeAll()
 
-        // Dispatch urlDidChange — auto-translate is skipped for this cycle.
-        let urlAction = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
+        // The reloaded page reports itself untranslated — auto-translate is skipped this cycle.
+        let urlAction = pageStateAction(.notTranslated)
         let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage to be fired")
         expectation.expectedFulfillmentCount = 1
         mockStore.dispatchCalled = { expectation.fulfill() }
@@ -1104,7 +1065,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(dispatchedActionType, TranslationsActionType.receivedTranslationLanguage)
     }
 
-    func test_urlDidChangeAction_withAutoTranslateEnabled_andPageInPreferredLanguages_skipsAutoTranslate() throws {
+    func test_pageReport_withAutoTranslateEnabled_andPageInPreferredLanguages_skipsAutoTranslate() throws {
         setTranslationsFeatureEnabled(enabled: true)
         mockProfile.prefs.setBool(true, forKey: PrefsKeys.Settings.translationAutoTranslate)
         // Two preferred languages: "en" first, "de" second.
@@ -1115,12 +1076,7 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
             detectPageLanguageResult: .success("en")
         )
         let subject = createSubject(translationsService: mockTranslationService)
-        let action = ToolbarAction(
-            url: URL(string: "https://www.example.com"),
-            translationConfiguration: TranslationConfiguration(prefs: mockProfile.prefs),
-            windowUUID: .XCTestDefaultUUID,
-            actionType: ToolbarActionType.urlDidChange
-        )
+        let action = pageStateAction(.notTranslated)
 
         let expectation = XCTestExpectation(description: "expect receivedTranslationLanguage to be fired")
         expectation.expectedFulfillmentCount = 1
@@ -1426,6 +1382,18 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
     }
 
     // MARK: - Helpers
+
+    private func pageStateAction(
+        _ pageState: PageTranslationState,
+        tabUUID: TabUUID? = nil
+    ) -> TranslationsPageStateAction {
+        return TranslationsPageStateAction(
+            windowUUID: .XCTestDefaultUUID,
+            pageState: pageState,
+            tabUUID: tabUUID ?? mockTabManager.selectedTab?.tabUUID ?? "",
+            actionType: TranslationsActionType.pageDidReportTranslationState
+        )
+    }
 
     /// Seeds `selectedTargetLanguages` in the middleware by dispatching a `TranslationLanguageSelectedAction`
     /// and waiting for `successDispatchCount` actions to be dispatched (then clears them).


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15893)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33973)

## :bulb: Description
Translate a page, follow a link, tap Back. The page is still translated but the icon is grey.

`urlDidChange` drove the icon. It fires before the incoming document is presented, about 280ms
early on a bfcache restore, and more than once per navigation, so it always described the page
being left. Cancelling superseded work cannot fix that.

The page now reports its own state on `pageshow`, where `event.persisted` separates a restore
from a fresh load. Module scope survives a bfcache restore, so a module-level variable is enough
to remember it. `urlDidChange` no longer touches the icon. Same approach as `Ads.js` and
`ReaderMode.js`.

The report carries the reporting tab's `tabUUID`. The script runs in every tab, so a background
tab finishing a load must not overwrite what the user is looking at.

## :movie_camera: Demos

Translate the page, follow a link, then tap Back. The icon used to go grey on a page that was still translated. The purple visited link and the enabled forward arrow show the navigation actually happened.

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="pr35450-before-after-back-grey-icon" src="https://github.com/user-attachments/assets/f212eda3-925d-48e1-9e21-63463cee7a4d" /> | <img width="1206" height="2622" alt="pr35450-after-after-back-blue-icon" src="https://github.com/user-attachments/assets/f1022227-b2c1-4a24-aee1-dc6ca714a259" /> |

## :test_tube: Testing
1. Open a foreign-language page and translate it. Icon turns blue.
2. Tap a link to another page. Grey icon there.
3. Tap Back. Page is still translated and the icon is blue.
4. Go forward and back a few more times. State stays correct both ways.
5. Switch to another tab and back. The translated tab keeps its blue icon.
6. Tap the blue icon to restore the original, navigate away and back. Stays untranslated, grey.
7. Force quit and relaunch. The tab reloads untranslated with a grey icon.
8. Turn translations off in settings, then go back to a still-translated page. Icon is grey.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


