### PR TITLE
Bugfix FXIOS-16715 Keep a translation from landing on the wrong document

### DIFF
--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsService.swift
@@ -68,11 +68,19 @@ final class TranslationsService: TranslationsServiceProtocol {
         }
         onLanguageIdentified?(pageLanguage, targetLanguage)
         let webView = try currentWebView(for: windowUUID)
+        // The tab's WKWebView outlives its documents, and prewarming can take seconds.
+        let expectedDocumentId = try await currentDocumentIdJS(on: webView)
         // Prewarm resources prior to calling the JS translation API.
         await modelsFetcher.prewarmResources(for: pageLanguage, to: targetLanguage)
+        try Task.checkCancellation()
         // Create a bridge to the translations engine.
         _ = translationsEngine.bridge(to: webView)
-        try await startTranslationsJS(on: webView, from: pageLanguage, to: targetLanguage)
+        try await startTranslationsJS(
+            on: webView,
+            from: pageLanguage,
+            to: targetLanguage,
+            expecting: expectedDocumentId
+        )
     }
 
     /// Checks whether initial translation output has been produced.
@@ -101,20 +109,50 @@ final class TranslationsService: TranslationsServiceProtocol {
         }
     }
 
+    private func currentDocumentIdJS(on webView: WKWebView) async throws -> String {
+        let failure = TranslationsServiceError.jsEvaluationFailed(
+            reason: "JS evaluation failed: currentDocumentIdJS"
+        )
+        let js = "return window.__firefox__.Translations.documentId()"
+        let result: Any?
+        do {
+            result = try await webView.callAsyncJavaScript(js, contentWorld: .defaultClient)
+        } catch {
+            logger.log(
+                "Could not read the document id: \(error.localizedDescription)",
+                level: .warning,
+                category: .translations
+            )
+            throw failure
+        }
+
+        guard let documentId = result as? String, !documentId.isEmpty else { throw failure }
+        return documentId
+    }
+
     /// Starts translations by calling into the JS bridge.
+    /// Throws `.documentChanged` when the page navigated since the translation was requested.
     private func startTranslationsJS(on webView: WKWebView,
                                      from: String,
-                                     to: String) async throws {
-        let jsArgs = "{from: \"\(from)\", to: \"\(to)\"}"
-        let js = "window.__firefox__.Translations.startTranslations(\(jsArgs))"
+                                     to: String,
+                                     expecting documentId: String) async throws {
+        let jsArgs = "{from: \"\(from)\", to: \"\(to)\", expectedDocumentId: \"\(documentId)\"}"
+        let js = "return window.__firefox__.Translations.startTranslations(\(jsArgs))"
 
+        let result: Any?
         do {
-            _ = try await webView.callAsyncJavaScript(js, contentWorld: .defaultClient)
+            result = try await webView.callAsyncJavaScript(js, contentWorld: .defaultClient)
         } catch {
             /// NOTE: It would be safe to pass in the js string directly here, but it would just add too much noise 
             /// since from and to could be any language code. We only care that startTranslationsJS failed.
             throw TranslationsServiceError.jsEvaluationFailed(reason: "JS evaluation failed: startTranslationsJS")
         }
+
+        // Anything other than an explicit answer means the bridge is broken, not a navigation.
+        guard let didStart = result as? Bool else {
+            throw TranslationsServiceError.jsEvaluationFailed(reason: "JS evaluation failed: startTranslationsJS")
+        }
+        guard didStart else { throw TranslationsServiceError.documentChanged }
     }
 
     /// Evaluates the JS hook to check whether initial translation output has been produced.

--- a/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceError.swift
+++ b/firefox-ios/Client/Frontend/Translations/Service/TranslationsServiceError.swift
@@ -5,6 +5,8 @@
 /// Errors thrown by `TranslationsService` when preconditions or WebView state are invalid.
 enum TranslationsServiceError: Error, Equatable {
     case missingWebView
+    /// The page navigated before the translation started, so the request is dropped.
+    case documentChanged
     case jsEvaluationFailed(reason: String)
     case pageLanguageDetectionFailed(description: String)
     case unknown(domain: String, code: Int)
@@ -25,6 +27,8 @@ enum TranslationsServiceError: Error, Equatable {
         switch self {
         case .missingWebView:
             return "missing_webview"
+        case .documentChanged:
+            return "document_changed"
         case .jsEvaluationFailed(let reason):
             /// reason is already a stable token like "JS evaluation failed: startTranslationsJS"
             return "js_evaluation_failed(\(reason))"

--- a/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Translations/TranslationsMiddleware.swift
@@ -653,6 +653,17 @@ final class TranslationsMiddleware: FeatureFlaggable, Notifiable {
         } catch {
             guard !Task.isCancelled else { return }
             let serviceError = TranslationsServiceError.fromUnknown(error)
+            // Not a failure, but the icon and the telemetry flow still have to be closed out.
+            if serviceError == .documentChanged {
+                logger.log(
+                    "Translation dropped because the page changed before it started.",
+                    level: .info,
+                    category: .translations
+                )
+                dispatchClearTranslationIcon(windowUUID: windowUUID, on: tab)
+                translationFlowIds[windowUUID] = nil
+                return
+            }
             translationsTelemetry.translationFailed(
                 translationFlowId: flowId(for: windowUUID),
                 errorType: serviceError.telemetryDescription

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/MainFrame/AtDocumentStart/TranslationsEntrypoint.js
@@ -72,9 +72,14 @@ const reportPageState = () => {
 
 window.addEventListener("pageshow", reportPageState);
 
+const documentId = () => innerWindowId;
+
 /// NOTE: This should be called to start the translation process for this document.
 /// This creates the TranslationsDocument instance that manages the translation lifecycle.
-const startTranslations = ({from, to}) => {
+const startTranslations = ({from, to, expectedDocumentId}) => {
+    if (expectedDocumentId !== innerWindowId) {
+        return false;
+    }
     pendingTranslation = { from, to };
     resetIsDone();
     const languagePair = {sourceLanguage: from, targetLanguage: to}
@@ -98,6 +103,7 @@ const startTranslations = ({from, to}) => {
         innerWindowId,
     };
     sendToEngine(message);
+    return true;
 };
 
 /// NOTE: This should be called when we teardown the translations for this document.
@@ -132,5 +138,5 @@ Object.defineProperty(window.__firefox__, "Translations", {
     enumerable: false,
     configurable: false,
     writable: false,
-    value: Object.freeze({ getLanguageSampleWhenReady, startTranslations, isDone, discardTranslations })
+    value: Object.freeze({ getLanguageSampleWhenReady, documentId, startTranslations, isDone, discardTranslations })
 });

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TranslationsTests/TranslationsMiddlewareTests.swift
@@ -692,6 +692,60 @@ final class TranslationsMiddlewareIntegrationTests: XCTestCase, StoreTestUtility
         XCTAssertEqual(mockStore.dispatchedActions.count, 0)
     }
 
+    func test_didSelectTargetLanguage_whenDocumentChanged_doesNotDispatchError() throws {
+        setTranslationsFeatureEnabled(enabled: true)
+        let mockTranslationsService = MockTranslationsService(
+            translateResult: .failure(TranslationsServiceError.documentChanged)
+        )
+        let subject = createSubject(translationsService: mockTranslationsService)
+        let action = TranslationLanguageSelectedAction(
+            windowUUID: .XCTestDefaultUUID,
+            targetLanguage: "de",
+            actionType: TranslationsActionType.didSelectTargetLanguage
+        )
+
+        let loadingExpectation = XCTestExpectation(description: "didStartTranslatingPage dispatched")
+        mockStore.dispatchCalled = { [weak mockStore] in
+            if (mockStore?.dispatchedActions.last?.actionType as? TranslationsActionType) == .didStartTranslatingPage {
+                loadingExpectation.fulfill()
+            }
+        }
+
+        subject.translationsProvider.legacyMiddleware(mockStore.state, action)
+        wait(for: [loadingExpectation], timeout: 1.0)
+
+        // The user navigated away before the translation started. The page they are on now was
+        // never translated, so it must not be told that a translation failed.
+        let errorExpectation = XCTestExpectation(description: "didReceiveErrorTranslating should not be dispatched")
+        errorExpectation.isInverted = true
+        mockStore.dispatchCalled = { [weak mockStore] in
+            if (mockStore?.dispatchedActions.last?.actionType as? TranslationsActionType) == .didReceiveErrorTranslating {
+                errorExpectation.fulfill()
+            }
+        }
+        wait(for: [errorExpectation], timeout: 1.0)
+
+        let errorActions = mockStore.dispatchedActions.filter {
+            ($0.actionType as? TranslationsActionType) == .didReceiveErrorTranslating
+        }
+        XCTAssertTrue(errorActions.isEmpty)
+
+        let toastActions = mockStore.dispatchedActions.filter {
+            ($0.actionType as? GeneralBrowserActionType) == .showToast
+        }
+        XCTAssertTrue(toastActions.isEmpty)
+
+        XCTAssertEqual(mockTranslationsTelemetry.translationFailedCalledCount, 0)
+
+        // Dropping the request must still take the icon off `.loading`, or the spinner never ends.
+        let tab = try XCTUnwrap(mockTabManager.selectedTab)
+        XCTAssertNotEqual(tab.translationConfiguration?.state, .loading)
+        let clearActions = mockStore.dispatchedActions.filter {
+            ($0.actionType as? TranslationsActionType) == .receivedTranslationLanguage
+        }
+        XCTAssertFalse(clearActions.isEmpty)
+    }
+
     func test_didSelectTargetLanguage_withTranslationError_dispatchToastAction() throws {
         setTranslationsFeatureEnabled(enabled: true)
         enum TestError: Error { case example }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16715)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
Stacked on [#35450](https://github.com/mozilla-mobile/firefox-ios/pull/35450), review that first.

Ask for a translation, navigate before it starts, and it lands on the page you moved to, with a
grey icon over visibly translated text.

`translateCurrentPage` awaited the model prewarm and then called into the page, with no
cancellation or document check in between. A tab's `WKWebView` outlives its documents, so a slow
prewarm, which is what the first use of a language pair gives you, means the JS arrives in
whatever loaded meanwhile.

The page now exposes a per-document id. Native reads it before the prewarm and passes it back
when starting, and `startTranslations` refuses a mismatch. Only an explicit `false` maps to
`documentChanged`, so a broken bridge still reports as a failure instead of going quiet.
Navigating away clears the icon and closes the telemetry flow rather than showing a translation
error on the new page.

## :movie_camera: Demos

Translate with a model that has never been downloaded, then navigate away within a second. The page you land on used to be rendered in the target language under a grey icon, despite never being translated. Now it stays in its original language and no error toast appears.

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="pr35451-before-leak-english-on-untranslated-page" src="https://github.com/user-attachments/assets/0201db76-c197-4b21-afe8-69819377fef2" /> | <img width="1206" height="2622" alt="pr35451-after-page-stays-french" src="https://github.com/user-attachments/assets/1e864d34-6243-4320-ab92-8d9e0d894cb3" /> |

## :test_tube: Testing
Needs a language model that has never been downloaded on the device. With a cached model the
gap is a few hundred ms and the race cannot be hit.

1. Settings, Translation, Preferred Languages, add a language you have never translated to.
2. Open a page in a foreign language.
3. Tap Translate and pick that new language.
4. Within about two seconds, navigate away (tap Back, or follow a link).
5. Wait about 30 seconds.
6. The page you land on stays in its original language with a grey icon, and no error toast
   appears. The icon is not left spinning.
7. Translate normally with a cached model and confirm it still works.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code


