### PR TITLE
Bugfix FXIOS-16693 - [Toolbar] Autocomplete re-inserts a stale suggestion

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -172,14 +172,14 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
     func setAutocompleteSuggestion(_ suggestion: String?) {
         let searchText = text ?? ""
 
-        guard let suggestion = suggestion, isEditing && markedTextRange == nil else {
-            hideCursor = false
+        guard let suggestion, isEditing && markedTextRange == nil else {
+            cancelPendingCompletion()
             return
         }
 
         let normalized = normalizeString(searchText)
         guard suggestion.hasPrefix(normalized) && normalized.count < suggestion.count else {
-            hideCursor = false
+            cancelPendingCompletion()
             return
         }
 
@@ -190,8 +190,8 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
     }
 
     func handleInputModeDidChange() {
-        guard !lastMarkedText.isEmpty, let currentText = self.text else { return }
-        self.text = currentText.replacingOccurrences(of: lastMarkedText, with: "")
+        guard !lastMarkedText.isEmpty, let currentText = text, currentText.hasSuffix(lastMarkedText) else { return }
+        self.text = String(currentText.dropLast(lastMarkedText.count))
         hideCursor = true
         setMarkedText(lastMarkedText, selectedRange: NSRange())
     }
@@ -221,6 +221,11 @@ final class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable
     }
 
     // MARK: - Private
+    private func cancelPendingCompletion() {
+        hideCursor = false
+        if markedTextRange == nil { lastMarkedText = "" }
+    }
+
     @objc
     private func textDidChange() {
         // When marked text (autocomplete suggestion) is set this method is called

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/LocationTextFieldTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/LocationTextFieldTests.swift
@@ -51,6 +51,38 @@ final class LocationTextFieldTests: XCTestCase {
         XCTAssertNotNil(textField.markedTextRange)
     }
 
+    func testHandleInputModeDidChange_whenSuggestionNoLongerMatchesTypedText_doesNotRestoreIt() {
+        makeTextFieldEditing()
+        textField.text = "y"
+        textField.setAutocompleteSuggestion("youtube.com")
+        XCTAssertEqual(textField.text, "youtube.com")
+
+        // The user types a second "y", replacing the completion with text that matches no suggestion.
+        _ = textField.textField(
+            textField,
+            shouldChangeCharactersIn: NSRange(location: 1, length: 10),
+            replacementString: "y"
+        )
+        textField.text = "yy"
+        textField.setAutocompleteSuggestion(nil)
+
+        textField.handleInputModeDidChange()
+
+        XCTAssertEqual(textField.text, "yy", "The dismissed suggestion should not come back on input mode change.")
+        XCTAssertNil(textField.markedTextRange)
+    }
+
+    func testHandleInputModeDidChange_whenTextDoesNotEndWithLastMarkedText_doesNothing() {
+        textField.text = "wiki"
+        textField.setMarkedText("pedia.com", selectedRange: NSRange())
+        textField.text = "yy"
+
+        textField.handleInputModeDidChange()
+
+        XCTAssertEqual(textField.text, "yy")
+        XCTAssertNil(textField.markedTextRange)
+    }
+
     func testAutocompleteSuggestion_whenInsertingAtStartOfText_appendsSuggestionAtEnd() {
         // Start with "o" already in the text field.
         makeTextFieldEditing()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16693)


## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

### The Problem
The bug stale state is caused by `lastMarkedText`.

`lastMarkedText` caches the current suggestion so `handleInputModeDidChange()` can reapply it (switching keyboards wipes UIKit's marked text). But `lastMarkedText` was only cleared in `deleteBackward()` and `applyCompletion()`, never when a new keystroke invalidates the suggestion. So `handleInputModeDidChange` was gating on a value that no longer described reality, and `replacingOccurrences` silently did nothing before reappending the dead suggestion.

### The Fix
Add `cancelPendingCompletion()` method. The two early return paths in `setAutocompleteSuggestion` now forget the cached completion instead of only resetting `hideCursor`. It clears only when `markedTextRange == nil`, so a completion that is currently on screen stays restorable.

 Suffix guard in `handleInputModeDidChange`. The completion is by construction a suffix of the text, so it now requires `currentText.hasSuffix(lastMarkedText)` and strips with `dropLast` instead of `replacingOccurrences`.  

Adds two tests to `LocationTextFieldTests`, one replaying the exact repro and one covering the suffix guard in isolation.
## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

### Before

https://github.com/user-attachments/assets/df7fabd6-0648-4e49-aeaa-57f4b58e19c1

### After

https://github.com/user-attachments/assets/322f2f72-3a93-41bd-9344-408a56ab51a0


</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

