### PR TITLE
Add FXIOS-16685 [FxA Pairflow] Support pairing v2 via WebChannel OAuth Part 1

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		0AC0F9482E3CA17900E826D8 /* MainMenuConfigurationUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC0F9472E3CA17500E826D8 /* MainMenuConfigurationUtilityTests.swift */; };
 		0AC659272BF35854005C614A /* FxAWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC659262BF35854005C614A /* FxAWebViewModelTests.swift */; };
 		0AC659292BF493CE005C614A /* MockFxAWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */; };
+		0AC6592B2BF50000005C614A /* FxAPairingOAuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC6592A2BF50000005C614A /* FxAPairingOAuthHandler.swift */; };
+		0AC6592D2BF50000005C614A /* FxAPairingOAuthHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC6592C2BF50000005C614A /* FxAPairingOAuthHandlerTests.swift */; };
 		0AD315DC2F8FBECB00DAD6D1 /* TabCellCustomImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD315DB2F8FBEBA00DAD6D1 /* TabCellCustomImageView.swift */; };
 		0AD3EEAC2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD3EEAB2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift */; };
 		0AEA26D42F506C1900B512EB /* BlockedTrackersLearnMoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEA26D32F506BDA00B512EB /* BlockedTrackersLearnMoreViewController.swift */; };
@@ -2846,6 +2848,8 @@
 		0AC0F9472E3CA17500E826D8 /* MainMenuConfigurationUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuConfigurationUtilityTests.swift; sourceTree = "<group>"; };
 		0AC659262BF35854005C614A /* FxAWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAWebViewModelTests.swift; sourceTree = "<group>"; };
 		0AC659282BF493CE005C614A /* MockFxAWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFxAWebViewModel.swift; sourceTree = "<group>"; };
+		0AC6592A2BF50000005C614A /* FxAPairingOAuthHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAPairingOAuthHandler.swift; sourceTree = "<group>"; };
+		0AC6592C2BF50000005C614A /* FxAPairingOAuthHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAPairingOAuthHandlerTests.swift; sourceTree = "<group>"; };
 		0AD315DB2F8FBEBA00DAD6D1 /* TabCellCustomImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCellCustomImageView.swift; sourceTree = "<group>"; };
 		0AD3EEAB2C2485A7001044E5 /* ThemedCenteredTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedCenteredTableViewCell.swift; sourceTree = "<group>"; };
 		0AE9462E8A8E05CE07D4973D /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -16284,6 +16288,7 @@
 				CDB3BE8624746787009320EE /* FirefoxAccountSignInViewController.swift */,
 				8ADC2A112A3375B900543DAA /* FxAEntryPoint.swift */,
 				8ADC2A0F2A33758E00543DAA /* FxALaunchParams.swift */,
+				0AC6592A2BF50000005C614A /* FxAPairingOAuthHandler.swift */,
 				8ADC2A172A33775F00543DAA /* FxASignInViewParameters.swift */,
 				C8E2E80723D20FB3005AACE6 /* FxAWebViewController.swift */,
 				5F130D2D2483508E00B0F7D0 /* FxAWebViewModel.swift */,
@@ -17514,6 +17519,7 @@
 				C787D8C22C1CB77900940123 /* FirefoxAccountSignInViewControllerTests.swift */,
 				E1AEC16D286E0CF500062E29 /* Frontend */,
 				3943A81C1E9807C700D4F6DC /* FxAPushMessageTest.swift */,
+				0AC6592C2BF50000005C614A /* FxAPairingOAuthHandlerTests.swift */,
 				0AC659262BF35854005C614A /* FxAWebViewModelTests.swift */,
 				8C6AF2692D38FB1500254698 /* GleanLifecycleObserverTests.swift */,
 				E1E6F8CD29D4B7E700068D8D /* GleanPlumbContextProviderTests.swift */,
@@ -19758,6 +19764,7 @@
 				BA1237C12DAE6D2C00BB6333 /* AddressBarSelectionView.swift in Sources */,
 				8A4EA0D12C010BE700E4E4F1 /* MicrosurveySurfaceManager.swift in Sources */,
 				5F130D2E2483508E00B0F7D0 /* FxAWebViewModel.swift in Sources */,
+				0AC6592B2BF50000005C614A /* FxAPairingOAuthHandler.swift in Sources */,
 				D0FCF7F51FE45842004A7995 /* UserScriptManager.swift in Sources */,
 				5A9F83422B2B796800272819 /* TabPeekState.swift in Sources */,
 				C796E22A2E3D48D3005D6A1D /* ShortcutsLibraryViewController.swift in Sources */,
@@ -21245,6 +21252,7 @@
 				C8E78BDD27F4A1E700C48BAA /* HistoryDeletionUtilityTests.swift in Sources */,
 				8A3EAFE52D5F9AA40060AB87 /* TabManagerMiddlewareTests.swift in Sources */,
 				0AC659272BF35854005C614A /* FxAWebViewModelTests.swift in Sources */,
+				0AC6592D2BF50000005C614A /* FxAPairingOAuthHandlerTests.swift in Sources */,
 				8AB893A72C73AFCC00DAEED7 /* MockLoginViewModelDelegate.swift in Sources */,
 				8AC8841F2D5261170033ABF5 /* MockCrashTracker.swift in Sources */,
 				8A11C8132731E54800AC7318 /* DictionaryExtensionsTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -25,7 +25,6 @@ import struct MozillaAppServices.Login
 import enum MozillaAppServices.BookmarkRoots
 import struct MozillaAppServices.VisitObservation
 import enum MozillaAppServices.VisitType
-import enum MozillaAppServices.OAuthScope
 
 class BrowserViewController: UIViewController,
                              SearchBarLocationProvider,
@@ -266,6 +265,9 @@ class BrowserViewController: UIViewController,
 
     var navigationHintDoubleTapTimer: Timer?
     var googleLensTipObservationTask: Task<Void, Never>?
+
+    /// Outstanding wait for the account manager before the pairing modal can present.
+    private var pairingWaitToken: ActionToken?
     weak var googleLensTipViewController: UIViewController?
     private(set) lazy var navigationContextHintVC: ContextualHintViewController = {
         let navigationViewProvider = ContextualHintViewProvider(forHintType: .navigation, with: profile)
@@ -509,6 +511,9 @@ class BrowserViewController: UIViewController,
             unsubscribeFromRedux()
             stopObservingAllWebViews()
             googleLensTipObservationTask?.cancel()
+            if let pairingWaitToken {
+                AppEventQueue.cancelAction(token: pairingWaitToken)
+            }
         }
     }
 
@@ -3403,27 +3408,37 @@ class BrowserViewController: UIViewController,
     }
 
     func presentPairingViewController(_ pairingURL: URL) {
-        guard let accountManager = profile.rustFxA.accountManager else { return }
-
-        accountManager.beginPairingAuthentication(
-            pairingUrl: pairingURL.absoluteString,
-            entrypoint: "pairing_\(FxAEntrypoint.fxaDeepLinkNavigation.rawValue)",
-            scopes: [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session]
-        ) { [weak self] result in
-            guard let self, case .success(let supplicantURL) = result else { return }
-            let viewController = FxAWebViewController(
-                pageType: .qrCode(url: supplicantURL),
-                profile: profile,
-                dismissalStyle: .dismiss,
-                deepLinkParams: FxALaunchParams(entrypoint: .fxaDeepLinkNavigation, query: [:])
-            )
-            presentThemedViewController(
-                navItemLocation: .Left,
-                navItemText: .Close,
-                vcBeingPresented: viewController,
-                topTabsVisible: UIDevice.current.userInterfaceIdiom == .pad
-            )
+        // Without an account manager the web view never loads its first page, so the modal would
+        // present empty with no error and no way out. A cold-launch deep link can arrive before the
+        // account manager finishes initializing, so wait for it rather than dropping the route.
+        pairingWaitToken = AppEventQueue.wait(for: .accountManagerInitialized) { [weak self] in
+            ensureMainThread { [weak self] in
+                self?.pairingWaitToken = nil
+                self?.presentPairingWebView(pairingURL)
+            }
         }
+    }
+
+    private func presentPairingWebView(_ pairingURL: URL) {
+        guard profile.rustFxA.accountManager != nil else {
+            logger.log("Cannot present the pairing flow without an account manager",
+                       level: .warning,
+                       category: .sync)
+            return
+        }
+
+        let viewController = FxAWebViewController(
+            pageType: .pairingV2(url: pairingURL),
+            profile: profile,
+            dismissalStyle: .dismiss,
+            deepLinkParams: FxALaunchParams(entrypoint: .fxaDeepLinkNavigation, query: [:])
+        )
+        presentThemedViewController(
+            navItemLocation: .Left,
+            navItemText: .Close,
+            vcBeingPresented: viewController,
+            topTabsVisible: UIDevice.current.userInterfaceIdiom == .pad
+        )
     }
 
     // MARK: - Handle Deeplink open URL / query

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/LaunchPairingFromURLSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/LaunchPairingFromURLSetting.swift
@@ -70,9 +70,7 @@ class LaunchPairingFromURLSetting: HiddenSetting {
               let profile = settings.profile,
               let accountManager = pairingAuthenticatorProvider() else { return }
 
-        // Converts the raw /pair URL into the supplicant OAuth URL; loading /pair
-        // directly sends non-desktop browsers to /pair/unsupported. Mirrors the
-        // real-scan path in FirefoxAccountSignInViewController.
+        // Mirrors the in-app QR scanner path in FirefoxAccountSignInViewController.
         accountManager.beginPairingAuthentication(
             pairingUrl: pairingUrl,
             entrypoint: "pairing_debug",

--- a/firefox-ios/RustFxA/FxAPairingOAuthHandler.swift
+++ b/firefox-ios/RustFxA/FxAPairingOAuthHandler.swift
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Common
+
+import class MozillaAppServices.FxAccountManager
+import enum MozillaAppServices.OAuthScope
+
+@MainActor
+protocol FxAOAuthAuthenticating: AnyObject {
+    func beginAuthentication(entrypoint: String,
+                             scopes: [String],
+                             completionHandler: @escaping @MainActor @Sendable (Result<URL, Error>) -> Void
+    )
+}
+
+extension FxAccountManager: FxAOAuthAuthenticating {}
+
+enum FxAPairingOAuthHandlerError: Error, Sendable {
+    case failedToStart
+}
+
+@MainActor
+final class FxAPairingOAuthHandler {
+    static let errorMessage = "Failed to begin a pairing OAuth flow"
+
+    private static let entrypoint = "webchannel-pairing"
+    private static let scopes = [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session]
+    private static let parameterNames = ["state", "scope", "code_challenge", "code_challenge_method", "keys_jwk"]
+
+    private let authenticatorProvider: () -> FxAOAuthAuthenticating?
+    private let logger: Logger
+
+    init(authenticatorProvider: @escaping () -> FxAOAuthAuthenticating?,
+         logger: Logger = DefaultLogger.shared) {
+        self.authenticatorProvider = authenticatorProvider
+        self.logger = logger
+    }
+
+    func start(
+        completion: @escaping @MainActor @Sendable (Result<[String: String], FxAPairingOAuthHandlerError>) -> Void
+    ) {
+        guard let authenticator = authenticatorProvider() else {
+            completion(.failure(.failedToStart))
+            return
+        }
+
+        authenticator.beginAuthentication(
+            entrypoint: Self.entrypoint,
+            scopes: Self.scopes
+        ) { [weak self] result in
+            // The page is waiting on this reply, so a deallocated handler must still resolve it.
+            guard let self else {
+                completion(.failure(.failedToStart))
+                return
+            }
+
+            switch result {
+            case .success(let url):
+                guard let parameters = parameters(from: url) else {
+                    completion(.failure(.failedToStart))
+                    return
+                }
+                completion(.success(parameters))
+            case .failure(let error):
+                logger.log("Failed to begin a pairing OAuth flow: \(error.localizedDescription)",
+                           level: .warning,
+                           category: .sync)
+                completion(.failure(.failedToStart))
+            }
+        }
+    }
+
+    func parameters(from url: URL) -> [String: String]? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+        var parameters = [String: String]()
+
+        for name in Self.parameterNames {
+            guard let value = components.queryItems?.first(where: { $0.name == name })?.value else {
+                logger.log("Pairing OAuth URL is missing the \(name) parameter", level: .warning, category: .sync)
+                return nil
+            }
+            parameters[name] = value
+        }
+
+        return parameters
+    }
+}

--- a/firefox-ios/RustFxA/FxAWebViewModel.swift
+++ b/firefox-ios/RustFxA/FxAWebViewModel.swift
@@ -15,7 +15,57 @@ import struct MozillaAppServices.FxaAuthData
 enum FxAPageType: Equatable {
     case emailLoginFlow
     case qrCode(url: URL)
+    /// A pairing v2 deep link loaded straight from the content server. Distinct from `qrCode`
+    /// because that case is also used by the v1 flows, which start their own OAuth flow through
+    /// `beginPairingAuthentication` before the page loads. Only this case may mint OAuth
+    /// parameters on the page's request.
+    case pairingV2(url: URL)
     case settingsPage
+
+    /// Whether a page of this type may ask the app to start an OAuth flow on its behalf.
+    var allowsPairOAuthStart: Bool {
+        if case .pairingV2 = self { return true }
+        return false
+    }
+}
+
+/// The two shapes a `fxaccounts:pair_oauth_start` reply can take.
+enum PairOAuthReply: Equatable {
+    case parameters([String: String])
+    case error(String)
+
+    var jsonObject: [String: Any] {
+        switch self {
+        case .parameters(let parameters):
+            return parameters
+        case .error(let message):
+            return ["error": ["message": message]]
+        }
+    }
+}
+
+enum FxAAuthenticationStatusResponse {
+    private static let pairingVersion = 2
+
+    static func json(localeProvider: LocaleProvider = SystemLocaleProvider()) -> String? {
+        let response = ["capabilities": authenticationStatusCapabilities(localeProvider: localeProvider)]
+        return FxAWebViewModel.webChannelJSONString(from: response)
+    }
+
+    private static func authenticationStatusCapabilities(
+        localeProvider: LocaleProvider
+    ) -> [String: Any] {
+        var engines = ["bookmarks", "history", "tabs", "passwords", "creditcards"]
+        if AddressLocaleFeatureValidator.isValidRegion(for: localeProvider.regionCode()) {
+            engines.append("addresses")
+        }
+
+        return [
+            "choose_what_to_sync": true,
+            "pairingVersion": pairingVersion,
+            "engines": engines
+        ]
+    }
 }
 
 // See https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/fxa-webchannel-protocol
@@ -24,6 +74,7 @@ private enum RemoteCommand: String {
     case canLinkAccount = "fxaccounts:can_link_account"
     // case loaded = "fxaccounts:loaded"
     case status = "fxaccounts:fxa_status"
+    case pairOAuthStart = "fxaccounts:pair_oauth_start"
     case oauthLogin = "fxaccounts:oauth_login"
     case login = "fxaccounts:login"
     case changePassword = "fxaccounts:change_password"
@@ -46,6 +97,10 @@ class FxAWebViewModel {
     static let mobileUserAgent = UserAgent.mobileUserAgent()
 
     var userDefaults: UserDefaultsInterface = UserDefaults.standard
+    private lazy var pairingOAuthHandler = FxAPairingOAuthHandler(
+        authenticatorProvider: { [weak self] in self?.profile.rustFxA.accountManager },
+        logger: logger
+    )
 
     var blobToDataScript = """
                 async function createBlobFromUrl(url) {
@@ -68,6 +123,18 @@ class FxAWebViewModel {
                 const url = await createBlobFromUrl(blobUrl)
                 return await blobToDataURLAsync(url)
             """
+
+    /// Serialize a WebChannel payload for injection into the reply script.
+    ///
+    /// `fileprivate` rather than `private` so `FxAAuthenticationStatusResponse` can reuse it, and
+    /// `nonisolated` because that caller is not on the main actor. The body touches no state.
+    nonisolated fileprivate static func webChannelJSONString(from object: Any) -> String? {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object),
+              let json = String(data: data, encoding: .utf8)
+        else { return nil }
+        return json
+    }
 
     func setupUserScript(for controller: WKUserContentController) {
         guard let path = Bundle.main.path(forResource: "FxASignIn", ofType: "js"),
@@ -139,7 +206,7 @@ class FxAWebViewModel {
                             completion(self.makeRequest(url), .emailLogin)
                         }
                     }
-                case let .qrCode(url):
+                case let .qrCode(url), let .pairingV2(url):
                     self.baseURL = url
                     completion(self.makeRequest(url), .qrPairing)
                 case .settingsPage:
@@ -225,6 +292,13 @@ extension FxAWebViewModel {
               let webView = message.webView
         else { return }
 
+        // The handler is exposed to every frame regardless of the user script's `forMainFrameOnly`,
+        // and only the top-level document is ever the content server's own page.
+        guard message.frameInfo.isMainFrame else {
+            logger.log("Ignoring message from a subframe", level: .warning, category: .sync)
+            return
+        }
+
         let origin = message.frameInfo.securityOrigin
         guard origin.`protocol` == url.scheme && origin.host == url.host && origin.port == (url.port ?? 0) else {
             logger.log("Ignoring message - \(origin) does not match expected origin: \(url.origin ?? "nil")",
@@ -240,7 +314,7 @@ extension FxAWebViewModel {
               let cmd = msg["command"] as? String
         else { return }
 
-        let id = Int(msg["messageId"] as? String ?? "")
+        let id = messageID(from: msg["messageId"])
         handleRemote(command: cmd, id: id, data: msg["data"], webView: webView)
     }
 
@@ -249,6 +323,20 @@ extension FxAWebViewModel {
         logger.log("webchannel message: \(rawValue)", level: .info, category: .sync)
         let command = RemoteCommand(rawValue: rawValue) ?? .unknown
         switch command {
+        case .pairOAuthStart:
+            guard let id else {
+                logger.log("Ignoring \(rawValue) with no usable messageId", level: .warning, category: .sync)
+                return
+            }
+            // Only the v2 pairing deep link has a reason to mint OAuth parameters for the page.
+            // The other flows share this bridge and have already started their own OAuth flow, so
+            // starting a second one would clobber the state their sign-in depends on.
+            guard pageType.allowsPairOAuthStart else {
+                logger.log("Ignoring \(rawValue) outside the pairing flow", level: .warning, category: .sync)
+                sendPairOAuth(id: id, webView: webView, reply: .error(FxAPairingOAuthHandler.errorMessage))
+                return
+            }
+            onPairOAuthStart(id: id, webView: webView)
         case .oauthLogin:
             if let data = data {
                 onLoginComplete(data: data, webView: webView)
@@ -292,9 +380,29 @@ extension FxAWebViewModel {
         }
     }
 
+    /// The WebChannel sends `messageId` as a string today, but accept a number too so a numeric
+    /// sender cannot silently strand every reply. Internal rather than private so tests reach it.
+    func messageID(from value: Any?) -> Int? {
+        if let value = value as? Int {
+            return value
+        }
+        if let value = value as? String {
+            return Int(value)
+        }
+        return nil
+    }
+
     /// Send a message to web content using the required message structure.
-    private func runJS(webView: WKWebView, typeId: String, messageId: Int, command: String, data: String = "{}") {
-        let msg = """
+    /// The reply envelope the WebChannel expects. `messageId` is emitted unquoted so the page
+    /// matches it against the id it sent. Internal rather than private so tests can assert the
+    /// shape, which is a protocol contract with the content server.
+    nonisolated static func webChannelReplyScript(
+        typeId: String,
+        messageId: Int,
+        command: String,
+        data: String
+    ) -> String {
+        return """
             var msg = {
                 id: "\(typeId)",
                 message: {
@@ -305,6 +413,15 @@ extension FxAWebViewModel {
             };
             window.dispatchEvent(new CustomEvent('WebChannelMessageToContent', { detail: JSON.stringify(msg) }));
         """
+    }
+
+    private func runJS(webView: WKWebView, typeId: String, messageId: Int, command: String, data: String = "{}") {
+        let msg = Self.webChannelReplyScript(
+            typeId: typeId,
+            messageId: messageId,
+            command: command,
+            data: data
+        )
 
         webView.evaluateJavascriptInDefaultContentWorld(msg)
     }
@@ -313,11 +430,6 @@ extension FxAWebViewModel {
     /// user info (for settings), or by passing CWTS setup info (in case the user is
     /// signing up for an account). This latter case is also used for the sign-in state.
     private func onSessionStatus(id: Int, webView: WKWebView, localeProvider: LocaleProvider = SystemLocaleProvider()) {
-        let addressAutofillStatus = AddressLocaleFeatureValidator.isValidRegion(for: localeProvider.regionCode())
-
-        let creditCardCapability = ", \"creditcards\""
-        let addressAutofillCapability =  addressAutofillStatus ? ", \"addresses\"" : ""
-
         guard let fxa = profile.rustFxA.accountManager else { return }
         let cmd = "fxaccounts:fxa_status"
         let typeId = "account_updates"
@@ -331,15 +443,49 @@ extension FxAWebViewModel {
                     signedInUser: \(signedInUserJson),
                 }
                 """
-        case .emailLoginFlow, .qrCode:
-            data = """
-                    { capabilities:
-                        { choose_what_to_sync: true, engines: ["bookmarks", "history", "tabs", "passwords"\(creditCardCapability)\(addressAutofillCapability)] },
-                    }
-                """
+        case .emailLoginFlow, .qrCode, .pairingV2:
+            guard let status = FxAAuthenticationStatusResponse.json(localeProvider: localeProvider) else {
+                logger.log("Failed to serialize the \(cmd) reply", level: .warning, category: .sync)
+                return
+            }
+            data = status
         }
 
         runJS(webView: webView, typeId: typeId, messageId: id, command: cmd, data: data)
+    }
+
+    private func onPairOAuthStart(id: Int, webView: WKWebView) {
+        // Captured strongly so the dropped-reply case below still logs once self is gone.
+        let logger = self.logger
+        pairingOAuthHandler.start { [weak self, weak webView] result in
+            guard let self, let webView else {
+                logger.log("Pair OAuth reply dropped. View model or web view deallocated",
+                           level: .info,
+                           category: .sync)
+                return
+            }
+
+            switch result {
+            case .success(let parameters):
+                sendPairOAuth(id: id, webView: webView, reply: .parameters(parameters))
+            case .failure:
+                sendPairOAuth(id: id, webView: webView, reply: .error(FxAPairingOAuthHandler.errorMessage))
+            }
+        }
+    }
+
+    private func sendPairOAuth(id: Int, webView: WKWebView, reply: PairOAuthReply) {
+        guard let dataJSON = Self.webChannelJSONString(from: reply.jsonObject) else {
+            logger.log("Failed to serialize the \(RemoteCommand.pairOAuthStart.rawValue) reply",
+                       level: .warning,
+                       category: .sync)
+            return
+        }
+        runJS(webView: webView,
+              typeId: "account_updates",
+              messageId: id,
+              command: RemoteCommand.pairOAuthStart.rawValue,
+              data: dataJSON)
     }
 
     private func onLoginComplete(data: Any, webView: WKWebView) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FxAPairingOAuthHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FxAPairingOAuthHandlerTests.swift
@@ -1,0 +1,128 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+import XCTest
+import enum MozillaAppServices.OAuthScope
+
+@MainActor
+final class FxAPairingOAuthHandlerTests: XCTestCase {
+    private lazy var handler = FxAPairingOAuthHandler(authenticatorProvider: { nil })
+
+    func testStartUsesPairingConfigurationAndReturnsParameters() throws {
+        let authenticator = MockPairingOAuthAuthenticator(result: .success(pairingAuthenticationURL()))
+        let handler = FxAPairingOAuthHandler(authenticatorProvider: { authenticator })
+        var receivedResult: Result<[String: String], FxAPairingOAuthHandlerError>?
+
+        handler.start { result in
+            receivedResult = result
+        }
+
+        XCTAssertEqual(authenticator.entrypoint, "webchannel-pairing")
+        XCTAssertEqual(
+            authenticator.scopes,
+            [OAuthScope.profile, OAuthScope.oldSync, OAuthScope.session]
+        )
+        XCTAssertEqual(try XCTUnwrap(receivedResult).get(), handler.parameters(from: pairingAuthenticationURL()))
+    }
+
+    func testStartReturnsFailureWhenAuthenticatorIsUnavailable() {
+        var receivedResult: Result<[String: String], FxAPairingOAuthHandlerError>?
+
+        handler.start { result in
+            receivedResult = result
+        }
+
+        assertFailedToStart(receivedResult)
+    }
+
+    func testStartReturnsFailureWhenAuthenticationFails() {
+        let error = NSError(domain: "FxAPairingOAuthHandlerTests", code: 1)
+        let authenticator = MockPairingOAuthAuthenticator(result: .failure(error))
+        let handler = FxAPairingOAuthHandler(authenticatorProvider: { authenticator })
+        var receivedResult: Result<[String: String], FxAPairingOAuthHandlerError>?
+
+        handler.start { result in
+            receivedResult = result
+        }
+
+        assertFailedToStart(receivedResult)
+    }
+
+    func testStartReturnsFailureWhenParametersAreMissing() {
+        let incompleteURL = URL(string: "https://accounts.firefox.com/authorization?state=st8")!
+        let authenticator = MockPairingOAuthAuthenticator(result: .success(incompleteURL))
+        let handler = FxAPairingOAuthHandler(authenticatorProvider: { authenticator })
+        var receivedResult: Result<[String: String], FxAPairingOAuthHandlerError>?
+
+        handler.start { result in
+            receivedResult = result
+        }
+
+        assertFailedToStart(receivedResult)
+    }
+
+    func testParametersReturnsRequiredParameters() {
+        XCTAssertEqual(
+            handler.parameters(from: pairingAuthenticationURL()),
+            [
+                "state": "st8",
+                "scope": "profile https://identity.mozilla.com/apps/oldsync",
+                "code_challenge": "chal8",
+                "code_challenge_method": "S256",
+                "keys_jwk": "jwk8"
+            ]
+        )
+    }
+
+    func testParametersReturnsNilWhenAParameterIsMissing() {
+        let url = URL(string: "https://accounts.firefox.com/authorization?state=st8")!
+
+        XCTAssertNil(handler.parameters(from: url))
+    }
+
+    private func pairingAuthenticationURL() -> URL {
+        var components = URLComponents(string: "https://accounts.firefox.com/authorization")!
+        components.queryItems = [
+            URLQueryItem(name: "state", value: "st8"),
+            URLQueryItem(name: "scope", value: "profile https://identity.mozilla.com/apps/oldsync"),
+            URLQueryItem(name: "code_challenge", value: "chal8"),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "keys_jwk", value: "jwk8")
+        ]
+        return components.url!
+    }
+
+    private func assertFailedToStart(
+        _ result: Result<[String: String], FxAPairingOAuthHandlerError>?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let result, case .failure(.failedToStart) = result else {
+            XCTFail("Expected the pairing OAuth flow to fail to start", file: file, line: line)
+            return
+        }
+    }
+}
+
+@MainActor
+private final class MockPairingOAuthAuthenticator: FxAOAuthAuthenticating {
+    private let result: Result<URL, Error>
+    private(set) var entrypoint: String?
+    private(set) var scopes: [String]?
+
+    init(result: Result<URL, Error>) {
+        self.result = result
+    }
+
+    func beginAuthentication(
+        entrypoint: String,
+        scopes: [String],
+        completionHandler: @escaping @MainActor @Sendable (Result<URL, Error>) -> Void
+    ) {
+        self.entrypoint = entrypoint
+        self.scopes = scopes
+        completionHandler(result)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FxAWebViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FxAWebViewModelTests.swift
@@ -5,6 +5,9 @@
 @testable import Client
 import XCTest
 import PDFKit
+import WebKit
+
+import class Account.RustFirefoxAccounts
 
 @MainActor
 class FxAWebViewModelTests: XCTestCase {
@@ -116,6 +119,199 @@ class FxAWebViewModelTests: XCTestCase {
         let result: Result<Any?, Error> = .success(MockFxAWebViewModel().invalidPDFDataURL)
         let outputURL = viewModel.createURLForPDF(result: result)
         XCTAssertNil(outputURL, "Should return nil on .success with an URL but not a PDF one.")
+    }
+
+    func testAuthenticationStatusResponseAdvertisesPairingVersionTwo() throws {
+        let capabilities = try authenticationStatusCapabilities()
+
+        XCTAssertEqual(capabilities["pairingVersion"] as? Int, 2)
+    }
+
+    func testAuthenticationStatusResponseEnablesChooseWhatToSync() throws {
+        let capabilities = try authenticationStatusCapabilities()
+
+        XCTAssertEqual(capabilities["choose_what_to_sync"] as? Bool, true)
+    }
+
+    func testAuthenticationStatusResponseIncludesAddressesForASupportedRegion() throws {
+        let capabilities = try authenticationStatusCapabilities(regionCode: "US")
+
+        XCTAssertEqual(
+            capabilities["engines"] as? [String],
+            ["bookmarks", "history", "tabs", "passwords", "creditcards", "addresses"]
+        )
+    }
+
+    func testAuthenticationStatusResponseOmitsAddressesForAnUnsupportedRegion() throws {
+        let capabilities = try authenticationStatusCapabilities(regionCode: "XX")
+
+        XCTAssertEqual(
+            capabilities["engines"] as? [String],
+            ["bookmarks", "history", "tabs", "passwords", "creditcards"]
+        )
+    }
+
+    // MARK: - Message id parsing
+
+    func testMessageIDAcceptsAnInt() {
+        XCTAssertEqual(viewModel.messageID(from: 42), 42)
+    }
+
+    func testMessageIDAcceptsANumericString() {
+        XCTAssertEqual(viewModel.messageID(from: "42"), 42)
+    }
+
+    func testMessageIDRejectsANonNumericString() {
+        XCTAssertNil(viewModel.messageID(from: "abc"))
+    }
+
+    func testMessageIDRejectsAMissingValue() {
+        XCTAssertNil(viewModel.messageID(from: nil))
+    }
+
+    // MARK: - Pair OAuth page-type gate
+
+    func testOnlyThePairingV2PageMayStartAPairOAuthFlow() {
+        let url = URL(string: "https://accounts.firefox.com/pair")!
+
+        XCTAssertTrue(FxAPageType.pairingV2(url: url).allowsPairOAuthStart)
+    }
+
+    /// `qrCode` covers the in-app scanner and the debug setting, and both have already started an
+    /// OAuth flow through `beginPairingAuthentication` before the page loads. Starting a second one
+    /// would hand the page OAuth state belonging to a flow it did not begin.
+    func testQRCodePageMayNotStartAPairOAuthFlow() {
+        let url = URL(string: "https://accounts.firefox.com/pair")!
+
+        XCTAssertFalse(FxAPageType.qrCode(url: url).allowsPairOAuthStart)
+    }
+
+    func testEmailAndSettingsPagesMayNotStartAPairOAuthFlow() {
+        XCTAssertFalse(FxAPageType.emailLoginFlow.allowsPairOAuthStart)
+        XCTAssertFalse(FxAPageType.settingsPage.allowsPairOAuthStart)
+    }
+
+    // MARK: - Pair OAuth reply
+
+    func testPairOAuthReplyParametersSerializesTheParametersVerbatim() {
+        let parameters = ["state": "st8", "code_challenge": "chal8"]
+
+        XCTAssertEqual(
+            PairOAuthReply.parameters(parameters).jsonObject as? [String: String],
+            parameters
+        )
+    }
+
+    func testPairOAuthReplyErrorNestsTheMessage() throws {
+        let jsonObject = PairOAuthReply.error("boom").jsonObject
+        let error = try XCTUnwrap(jsonObject["error"] as? [String: String])
+
+        XCTAssertEqual(error, ["message": "boom"])
+    }
+
+    // MARK: - WebChannel reply envelope
+
+    /// The page matches the reply against the id it sent, so the id must be a number, not a string.
+    func testReplyScriptEmitsTheMessageIDUnquoted() {
+        let script = FxAWebViewModel.webChannelReplyScript(
+            typeId: "account_updates",
+            messageId: 42,
+            command: "fxaccounts:pair_oauth_start",
+            data: "{}"
+        )
+
+        XCTAssertTrue(script.contains("messageId: 42"))
+        XCTAssertFalse(script.contains("messageId: \"42\""))
+    }
+
+    func testReplyScriptCarriesTheChannelIDAndCommand() {
+        let script = FxAWebViewModel.webChannelReplyScript(
+            typeId: "account_updates",
+            messageId: 1,
+            command: "fxaccounts:fxa_status",
+            data: "{}"
+        )
+
+        XCTAssertTrue(script.contains("id: \"account_updates\""))
+        XCTAssertTrue(script.contains("command: \"fxaccounts:fxa_status\""))
+    }
+
+    func testReplyScriptEmbedsThePayloadVerbatimAndDispatchesTheEvent() {
+        let payload = "{\"state\":\"st8\"}"
+        let script = FxAWebViewModel.webChannelReplyScript(
+            typeId: "account_updates",
+            messageId: 7,
+            command: "fxaccounts:pair_oauth_start",
+            data: payload
+        )
+
+        XCTAssertTrue(script.contains(payload))
+        XCTAssertTrue(script.contains("WebChannelMessageToContent"))
+    }
+
+    // MARK: - Redirect handling after login
+
+    /// The app finishes login in native UI, so the web view must never follow the OAuth redirect.
+    func testRedirectToTheOAuthRedirectURLIsCancelled() {
+        let redirect = URL(string: RustFirefoxAccounts.redirectURL)
+
+        XCTAssertEqual(viewModel.shouldAllowRedirectAfterLogIn(basedOn: redirect), .cancel)
+    }
+
+    func testNavigationToTheContentServerIsAllowed() {
+        let url = URL(string: "https://accounts.firefox.com/settings")
+
+        XCTAssertEqual(viewModel.shouldAllowRedirectAfterLogIn(basedOn: url), .allow)
+    }
+
+    func testMissingNavigationURLIsAllowed() {
+        XCTAssertEqual(viewModel.shouldAllowRedirectAfterLogIn(basedOn: nil), .allow)
+    }
+
+    // MARK: - Title
+
+    func testComposeTitleShowsALockForSecureContent() {
+        let url = URL(string: "https://accounts.firefox.com/pair")
+
+        XCTAssertEqual(viewModel.composeTitle(basedOn: url, hasOnlySecureContent: true), "🔒 accounts.firefox.com")
+    }
+
+    func testComposeTitleOmitsTheLockForInsecureContent() {
+        let url = URL(string: "http://localhost:3030/pair")
+
+        XCTAssertEqual(viewModel.composeTitle(basedOn: url, hasOnlySecureContent: false), "localhost")
+    }
+
+    func testComposeTitleIsEmptyWithoutAURL() {
+        XCTAssertEqual(viewModel.composeTitle(basedOn: nil, hasOnlySecureContent: false), "")
+    }
+
+    // MARK: - User script
+
+    func testSetupUserScriptAddsTheWebChannelScript() {
+        let controller = WKUserContentController()
+
+        viewModel.setupUserScript(for: controller)
+
+        XCTAssertEqual(controller.userScripts.count, 1)
+        XCTAssertEqual(controller.userScripts.first?.injectionTime, .atDocumentStart)
+        XCTAssertTrue(controller.userScripts.first?.isForMainFrameOnly == true)
+    }
+
+    private func authenticationStatusCapabilities(
+        regionCode: String = "US",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> [String: Any] {
+        let provider = MockLocaleProvider(regionCode: regionCode)
+        let json = try XCTUnwrap(FxAAuthenticationStatusResponse.json(localeProvider: provider), file: file, line: line)
+        let data = try XCTUnwrap(json.data(using: .utf8), file: file, line: line)
+        let response = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any],
+            file: file,
+            line: line
+        )
+        return try XCTUnwrap(response["capabilities"] as? [String: Any], file: file, line: line)
     }
 }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16685)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35393)

## :bulb: Description

In v2 the *page* drives pairing: it asks the browser for OAuth parameters over the WebChannel rather than the app minting a supplicant URL itself. Follows the [Android implementation](https://phabricator.services.mozilla.com/D319867).

> **Scope note.** This PR was split. It now contains only the pairing v2 feature. The changes that let the parser accept a local FxA stack, plus the `testPairingV2` UI test that drives the whole flow, move to a follow-up on `fxa-pair-ios-v2-e2e`, which I will open once this merges. See [Testing](#testing).

### What changed

- `FxAPairingOAuthHandler` (new) answers `fxaccounts:pair_oauth_start`, calling `beginAuthentication` and returning `state`, `scope`, `code_challenge`, `code_challenge_method` and `keys_jwk`. Scopes are `profile`, `oldsync` and `session`.
- `FxAWebViewModel` advertises `pairingVersion: 2` in the `fxaccounts:fxa_status` reply. That reply is now built with `JSONSerialization` instead of string interpolation, removing an escaping hazard in the engines list.
- `presentPairingViewController` no longer routes through `beginPairingAuthentication`. The page starts pairing, so the app loads the pairing URL directly.
- `FxAPageType.pairingV2` (new) is the only page type allowed to satisfy `pair_oauth_start`. See below.
- The pairing modal waits on `.accountManagerInitialized` rather than dropping a cold-launch deep link that arrives before the account manager is ready.
- The WebChannel bridge ignores messages from subframes.
- Message ids are accepted as either `Int` or `String`.

### Acceptance criteria

- ✅ Report `pairingVersion: 2` in the `fxaccounts:fxa_status` response
- ✅ Handle `fxaccounts:pair_oauth_start` and return the OAuth parameters required to continue pairing, with the `profile`, `oldsync` and `session` scopes; pairing is started by the webpage
- ⚠️ A successful pairing signs the user into Firefox, starts Sync and closes the pairing modal — verified end to end before the split, and asserted by `PairingTests/testPairingV2`, which lands in the follow-up
- ✅ Existing email sign-in and in-app QR pairing continue working: both keep the v1 `beginPairingAuthentication` path and cannot trigger `pair_oauth_start`
- ✅ Non-v2 pairing links retain their existing behavior: `FxAPairingURLParser` returns `.notPairing` without `v=2`, so they fall through to normal URL handling

### Testing

37 unit tests pass on this branch, covering the OAuth handler, the `fxa_status` capabilities, the pair OAuth reply shapes and the page-type gate.

The full flow was verified end to end before the split, driven by a Playwright functional test in `mozilla/fxa` (`pairingFlowV2iOS.spec.ts`): a real Firefox Nightly authority over Marionette, an iOS Simulator supplicant and a live local FxA stack. The authority reached `sync_success`, and the device registered on the account and appeared in Connected Services.

That test cannot run against this branch alone. It pairs against `http://localhost:3030`, which the current `FxAPairingURLParser` allowlist rejects, so the parser change and the UI test ship together in the follow-up.

Depends on the FxA-side counterpart for the `pair_oauth_start` round trip.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver) — n/a, no new native UI
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review — n/a, no telemetry added
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n — n/a, no strings added or modified
- [x] If needed, I updated documentation and added comments to complex code
