### PR TITLE
[MTE-5839] - automate C2307037 — Homepage on Opening Screen

### DIFF
--- a/BrowserKit/Sources/Common/Constants/AppConstants.swift
+++ b/BrowserKit/Sources/Common/Constants/AppConstants.swift
@@ -28,6 +28,10 @@ public final class AppConstants {
     public static let isSessionRestoreEnabledForTests =
         ProcessInfo.processInfo.arguments.contains(LaunchArguments.EnableSessionRestore)
 
+    // Opt-in for the UI tests that assert on the Start at Home behaviour
+    public static let isStartAtHomeEnabledForTests =
+        ProcessInfo.processInfo.arguments.contains(LaunchArguments.EnableStartAtHome)
+
     public static let scheme: String = {
         guard let identifier = Bundle.main.bundleIdentifier else {
             return "unknown"

--- a/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
+++ b/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
@@ -17,6 +17,9 @@ public struct LaunchArguments {
     /// Re-enables tab session restore, which `Test` otherwise skips to give every UI test a clean
     /// tab state. Only needed by tests that relaunch the app and assert on the restored tabs.
     public static let EnableSessionRestore = "FIREFOX_ENABLE_SESSION_RESTORE"
+    /// Re-enables the Start at Home feature, which `Test` otherwise always skips. Only needed by
+    /// tests that assert on the Opening screen setting.
+    public static let EnableStartAtHome = "FIREFOX_ENABLE_START_AT_HOME"
     /// Clears the WKWebView website data store (cookies, local storage, cache) on launch. Web data
     /// lives in WKWebsiteDataStore, which ClearProfile does not touch.
     public static let ClearWebData = "FIREFOX_CLEAR_WEB_DATA"

--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeHelper.swift
@@ -15,22 +15,25 @@ class StartAtHomeHelper: UserFeaturePreferenceProvider {
     private var isRestoringTabs: Bool
     // Override only for UI tests to test `shouldSkipStartHome` logic
     private var isRunningUITest: Bool
+    private var isStartAtHomeEnabledForTests: Bool
     private let prefs: Prefs
     var launchSessionProvider: LaunchSessionProviderProtocol
 
     init(appSessionManager: AppSessionProvider = AppContainer.shared.resolve(),
          prefs: Prefs,
          isRestoringTabs: Bool,
-         isRunningUITest: Bool = AppConstants.isRunningUITests
+         isRunningUITest: Bool = AppConstants.isRunningUITests,
+         isStartAtHomeEnabledForTests: Bool = AppConstants.isStartAtHomeEnabledForTests
     ) {
         self.launchSessionProvider = appSessionManager.launchSessionProvider
         self.prefs = prefs
         self.isRestoringTabs = isRestoringTabs
         self.isRunningUITest = isRunningUITest
+        self.isStartAtHomeEnabledForTests = isStartAtHomeEnabledForTests
     }
 
     var shouldSkipStartHome: Bool {
-        return isRunningUITest ||
+        return (isRunningUITest && !isStartAtHomeEnabledForTests) ||
         DebugSettingsBundleOptions.skipSessionRestore ||
         isRestoringTabs ||
         launchSessionProvider.openedFromExternalSource

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHome/StartAtHomeHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StartAtHome/StartAtHomeHelperTests.swift
@@ -37,6 +37,18 @@ class StartAtHomeHelperTests: XCTestCase {
         XCTAssertFalse(shouldSkip, "Should not skip StartAtHome")
     }
 
+    func testShouldSkipStartAtHome_RunningUITest() throws {
+        setupHelper(isRunningUITest: true)
+        let shouldSkip = helper.shouldSkipStartHome
+        XCTAssertTrue(shouldSkip, "Expected to skip because a UI test is running")
+    }
+
+    func testShouldNotSkipStartAtHome_RunningUITestWithOptIn() throws {
+        setupHelper(isRunningUITest: true, isStartAtHomeEnabledForTests: true)
+        let shouldSkip = helper.shouldSkipStartHome
+        XCTAssertFalse(shouldSkip, "Expected not to skip because the UI test opted into Start at Home")
+    }
+
     func testShouldSkipStartAtHome_RestoringTabs() throws {
         setupHelper(isRestoringTabs: true)
         let shouldSkip = helper.shouldSkipStartHome
@@ -124,13 +136,16 @@ class StartAtHomeHelperTests: XCTestCase {
     // MARK: - Private
     private func setupHelper(
         appSessionManager: MockAppSessionManager = MockAppSessionManager(),
-        isRestoringTabs: Bool = false
+        isRestoringTabs: Bool = false,
+        isRunningUITest: Bool = false,
+        isStartAtHomeEnabledForTests: Bool = false
     ) {
         helper = StartAtHomeHelper(
             appSessionManager: appSessionManager,
             prefs: profile.prefs,
             isRestoringTabs: isRestoringTabs,
-            isRunningUITest: false
+            isRunningUITest: isRunningUITest,
+            isStartAtHomeEnabledForTests: isStartAtHomeEnabledForTests
         )
 
         helper.startAtHomeSetting = .afterFourHours

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -25,6 +25,8 @@ let TIMEOUT_LONG: TimeInterval = 20
 let PDF_TIMEOUT: TimeInterval = 60
 // TabDataStore throttles background saves by 2 seconds, plus one second of margin
 let tabPersistenceThrottleWait: UInt32 = 3
+// Start at Home set to "Homepage" triggers after 5 seconds of inactivity, plus two of margin
+let startAtHomeInactivityWait: TimeInterval = 7
 // Translation is network-bound and can take up to ~1 min to complete
 let TRANSLATION_TIMEOUT: TimeInterval = 90
 // Probe for optional UI that shows up immediately or not at all
@@ -55,13 +57,16 @@ class BaseTestCase: XCTestCase {
                            LaunchArguments.DisableAnimations
         ]
 
-    func restartInBackground() {
+    /// - Parameter inactiveFor: how long to stay backgrounded before foregrounding again, for tests
+    /// that need a minimum amount of inactivity to elapse.
+    func restartInBackground(inactiveFor seconds: TimeInterval = 0) {
         // Send app to background, and re-enter
         XCUIDevice.shared.press(.home)
         // Let's be sure the app is backgrounded
         _ = app.wait(for: XCUIApplication.State.runningBackgroundSuspended, timeout: TIMEOUT)
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         mozWaitForElementToExist(springboard.icons["XCUITests-Runner"])
+        idle(for: seconds)
         app.activate()
         // Wait until the app is fully opened (running in foreground) before continuing
         let predicate = NSPredicate(format: "state == %d", XCUIApplication.State.runningForeground.rawValue)
@@ -72,25 +77,38 @@ class BaseTestCase: XCTestCase {
         }
     }
 
-    func closeFromAppSwitcherAndRelaunch() {
+    /// - Parameter inactiveFor: how long to stay closed before relaunching, for tests that need a
+    /// minimum amount of inactivity to elapse.
+    func closeFromAppSwitcherAndRelaunch(inactiveFor seconds: TimeInterval = 0) {
         let swipeStart = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.999))
         let swipeEnd = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.001))
         _ = app.wait(for: .runningForeground, timeout: TIMEOUT)
         swipeStart.press(forDuration: 0.1, thenDragTo: swipeEnd)
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         mozWaitForElementToExist(springboard.icons["XCUITests-Runner"])
+        idle(for: seconds)
         app.activate()
+    }
+
+    /// Idles without blocking the runner: a `sleep()` while the app is not in the foreground gets
+    /// the test process killed.
+    func idle(for seconds: TimeInterval) {
+        guard seconds > 0 else { return }
+        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
     }
 
     /// Kills the app and relaunches it keeping the profile, so tabs and preferences set during the
     /// test survive the restart.
-    func forceCloseAndRelaunchApp() {
+    /// - Parameter inactiveFor: how long to stay closed before relaunching, for tests that need a
+    /// minimum amount of inactivity to elapse.
+    func forceCloseAndRelaunchApp(inactiveFor seconds: TimeInterval = 0) {
         // Backgrounding is what saves the tabs, and the app must outlive that throttled write.
         // It is foregrounded again first, as waiting at the home screen gets the runner killed.
         restartInBackground()
         sleep(tabPersistenceThrottleWait)
         app.terminate()
         _ = app.wait(for: .notRunning, timeout: TIMEOUT)
+        idle(for: seconds)
         // Session restore is opted into, as UI tests otherwise always start from a clean tab state
         let keptArguments = app.launchArguments.filter {
             $0 != LaunchArguments.ClearProfile && $0 != LaunchArguments.EnableSessionRestore

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/OpeningScreenTests.swift
@@ -2,13 +2,31 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
+import XCTest
+
 class OpeningScreenTests: BaseTestCase {
     private var browserScreen: BrowserScreen!
+    private var homePageScreen: HomePageScreen!
+    private var settingsHomepageScreen: SettingsHomepageScreen!
+    private var tabTrayScreen: TabTrayScreen!
+    private var toolbarScreen: ToolbarScreen!
+
+    private let startAtHomeTests = ["testHomepageOnOpeningScreen"]
 
     override func setUp() async throws {
+        if startAtHomeTests.contains(where: name.contains) {
+            // Start at Home is skipped under UI tests, and skipped again until tab restore has
+            // finished, which only ever happens when session restore is opted into as well
+            launchArguments += [LaunchArguments.EnableStartAtHome, LaunchArguments.EnableSessionRestore]
+        }
         try await super.setUp()
         browserScreen = BrowserScreen(app: app)
+        homePageScreen = HomePageScreen(app: app)
+        settingsHomepageScreen = SettingsHomepageScreen(app: app)
+        tabTrayScreen = TabTrayScreen(app: app)
+        toolbarScreen = ToolbarScreen(app: app)
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2307039
@@ -24,5 +42,39 @@ class OpeningScreenTests: BaseTestCase {
         restartInBackground()
         // After re-launching the app, the last visited page is displayed
         browserScreen.assertAddressBarContains(value: "localhost")
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/2307037
+    // Regression
+    func testHomepageOnOpeningScreen() {
+        // Select Homepage as the opening screen
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(HomeSettings)
+        settingsHomepageScreen.selectHomepageAsOpeningScreen()
+        navigator.goto(SettingsScreen)
+        navigator.goto(NewTabScreen)
+
+        // Open a web page
+        browserScreen.navigateToURL(path(forTestPage: TestPages.mozillaOrg))
+        waitUntilPageLoad()
+        browserScreen.assertAddressBarContains(value: "localhost")
+
+        // Background and foreground Firefox: the homepage is displayed in a new tab, next to the
+        // tab holding the web page
+        restartInBackground(inactiveFor: startAtHomeInactivityWait)
+        homePageScreen.assertHomepageIsDisplayed()
+        toolbarScreen.assertTabsButtonValue(expectedCount: "2", message: "The tab with the web page was not kept")
+
+        // Open a web page again
+        browserScreen.navigateToURL(path(forTestPage: TestPages.mozillaOrg))
+        waitUntilPageLoad()
+        browserScreen.assertAddressBarContains(value: "localhost")
+
+        // Close Firefox from the app switcher and relaunch it: the homepage is displayed again, and
+        // the tabs left behind confirm it is not merely the clean state of a fresh launch
+        closeFromAppSwitcherAndRelaunch(inactiveFor: startAtHomeInactivityWait)
+        homePageScreen.assertHomepageIsDisplayed()
+        toolbarScreen.tapOnTabsButton()
+        tabTrayScreen.assertTabCount(3)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomaPageScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomaPageScreen.swift
@@ -40,6 +40,10 @@ final class HomePageScreen {
         BaseTestCase().mozWaitElementHittable(element: tabsButton, timeout: timeout)
     }
 
+    func assertHomepageIsDisplayed() {
+        BaseTestCase().waitForElementsToExist([collection, homeLogo])
+    }
+
     func assertHomeLogoExists() {
         BaseTestCase().mozWaitForElementToExist(homeLogo)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingsHomepageScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingsHomepageScreen.swift
@@ -23,6 +23,27 @@ final class SettingsHomepageScreen {
         BaseTestCase().mozWaitForElementToExist(sel.START_AT_HOME_AFTER_4H.element(in: app))
     }
 
+    /// Selects "Homepage" in the Opening screen section, i.e. Start at Home set to always.
+    func selectHomepageAsOpeningScreen() {
+        sel.START_AT_HOME_ALWAYS.element(in: app).waitAndTap()
+        assertHomepageIsSelectedAsOpeningScreen()
+    }
+
+    func assertHomepageIsSelectedAsOpeningScreen() {
+        let homepageOption = sel.START_AT_HOME_ALWAYS.element(in: app)
+        BaseTestCase().mozWaitForElementToExist(homepageOption)
+        // The checkmark is applied on a table reload, so the selected state settles asynchronously
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "isSelected == true"),
+            object: homepageOption
+        )
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [expectation], timeout: TIMEOUT),
+            .completed,
+            "Homepage is not selected as the opening screen"
+        )
+    }
+
     func assertStoriesSwitch(isOn expected: Bool) {
         let sw = sel.STORIES_SWITCH.element(in: app)
         BaseTestCase().mozWaitForElementToExist(sw)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/ToolbarScreen.swift
@@ -77,10 +77,12 @@ final class ToolbarScreen {
         BaseTestCase().mozWaitForElementToExist(newTabButton)
     }
 
-    func assertTabsButtonValue(expectedCount: String) {
+    /// Polls before failing, as the counter settles asynchronously after a tab is added or restored.
+    func assertTabsButtonValue(expectedCount: String, message: String? = nil) {
         BaseTestCase().mozWaitForElementToExist(tabsButton)
-        let tabsButtonValue = tabsButton.value as? String
-        XCTAssertEqual(expectedCount, tabsButtonValue, "Expected \(expectedCount) open tabs after switching")
+        guard !tabsButtonHasValue(expectedCount) else { return }
+        let actual = tabsButton.value as? String ?? "none"
+        XCTFail("\(message ?? "Unexpected number of open tabs"). Expected \(expectedCount), found \(actual)")
     }
 
     func tabsButtonHasValue(_ expectedCount: String, timeout: TimeInterval = TIMEOUT) -> Bool {


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5839

## :bulb: Description
The test sets Settings → Homepage → Opening screen to Homepage, opens a web page, then sends Firefox to the background and brings it back — expecting the homepage instead of the web page. It then repeats the check after closing Firefox from the app switcher and reopening it. In both cases it also verifies the previously opened tabs are still there, so we know the homepage really was opened on top of the session rather than the app simply starting fresh.

Why a production change was needed: the Start at Home feature is switched off for all UI tests, so this behaviour could not be tested at all. I added an opt-in launch argument (FIREFOX_ENABLE_START_AT_HOME) that a test can pass to turn the feature back on for itself. Without that argument nothing changes — the feature stays off for every other UI test, and app behaviour for users is untouched.

What's in the PR:
- Opt-in switch for Start at Home in UI tests, following the same pattern as the existing session-restore opt-in. Covered by two new unit tests: the feature stays off for a normal UI test, and turns on only with the opt-in.
- Test helpers: the existing "background / relaunch the app"to stay closed for a given time before coming back, because
Start at Home only kicks in after a few seconds of inactivitaffected — the wait defaults to zero.
- Page-object additions: picking "Homepage" in the Homepage settings, and checking that the homepage is on screen.
- Small improvement to the shared tab-counter assertion: it now waits briefly for the counter to settle before failing, and reports the actual count in the failure message instead of only the expected one.

No test plan changes needed — this test class already runs o plan.

Verified locally (iPhone 17e / iOS 26.5)

- OpeningScreenTests — both cases pass (new test and the pre
- StartAtHomeHelperTests + StartAtHomeMiddlewareTests — 16/1
- Spot-checked existing users of the changed helpers: TabCounterTests, PrivateBrowsingTest/testForceCloseDuringPrivateBrowsingSession — pass

