### PR TITLE
Bugfix FXIOS-16605 [A11y] Make Terms of Use links focusable with Switch Control

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -90,6 +90,7 @@ final class TermsOfUseViewController: UIViewController,
             .foregroundColor: currentTheme().colors.textAccent,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
+        textView.accessibilityNavigationStyle = .separate
         textView.accessibilityIdentifier = AccessibilityIdentifiers.TermsOfUse.description
         textView.delegate = self
     }

--- a/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TermsOfUse/View/TermsOfUseViewController.swift
@@ -91,6 +91,7 @@ final class TermsOfUseViewController: UIViewController,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
         textView.accessibilityNavigationStyle = .separate
+        textView.accessibilityRespondsToUserInteraction = false
         textView.accessibilityIdentifier = AccessibilityIdentifiers.TermsOfUse.description
         textView.delegate = self
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseLinkTypeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseLinkTypeTests.swift
@@ -4,7 +4,6 @@
 
 import XCTest
 @testable import Client
-import Common
 import Shared
 
 final class TermsOfUseLinkTypeTests: XCTestCase {
@@ -49,41 +48,5 @@ final class TermsOfUseLinkTypeTests: XCTestCase {
             return
         }
         XCTAssertEqual(learnMoreURL, hereURL, "here link should have the same URL as Learn more")
-    }
-}
-
-@MainActor
-final class TermsOfUseViewControllerAccessibilityTests: XCTestCase {
-    override func setUp() async throws {
-        try await super.setUp()
-        DependencyHelperMock().bootstrapDependencies()
-        let mockStore = MockStoreForMiddleware(state: AppState())
-        StoreTestUtilityHelper.setupStore(with: mockStore)
-    }
-
-    override func tearDown() async throws {
-        StoreTestUtilityHelper.resetStore()
-        DependencyHelperMock().reset()
-        try await super.tearDown()
-    }
-
-    func testDescriptionTextView_SeparatesLinksForSwitchControlNavigation() throws {
-        let subject = TermsOfUseViewController(
-            themeManager: MockThemeManager(),
-            windowUUID: .XCTestDefaultUUID
-        )
-
-        subject.loadViewIfNeeded()
-
-        let textView = try XCTUnwrap(descriptionTextView(in: subject.view))
-        XCTAssertEqual(textView.accessibilityNavigationStyle, .separate)
-    }
-
-    private func descriptionTextView(in view: UIView) -> UITextView? {
-        if let textView = view as? UITextView,
-           textView.accessibilityIdentifier == AccessibilityIdentifiers.TermsOfUse.description {
-            return textView
-        }
-        return view.subviews.lazy.compactMap(descriptionTextView).first
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseLinkTypeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TermsOfUse/TermsOfUseLinkTypeTests.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 @testable import Client
+import Common
 import Shared
 
 final class TermsOfUseLinkTypeTests: XCTestCase {
@@ -48,5 +49,41 @@ final class TermsOfUseLinkTypeTests: XCTestCase {
             return
         }
         XCTAssertEqual(learnMoreURL, hereURL, "here link should have the same URL as Learn more")
+    }
+}
+
+@MainActor
+final class TermsOfUseViewControllerAccessibilityTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        let mockStore = MockStoreForMiddleware(state: AppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    override func tearDown() async throws {
+        StoreTestUtilityHelper.resetStore()
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    func testDescriptionTextView_SeparatesLinksForSwitchControlNavigation() throws {
+        let subject = TermsOfUseViewController(
+            themeManager: MockThemeManager(),
+            windowUUID: .XCTestDefaultUUID
+        )
+
+        subject.loadViewIfNeeded()
+
+        let textView = try XCTUnwrap(descriptionTextView(in: subject.view))
+        XCTAssertEqual(textView.accessibilityNavigationStyle, .separate)
+    }
+
+    private func descriptionTextView(in view: UIView) -> UITextView? {
+        if let textView = view as? UITextView,
+           textView.accessibilityIdentifier == AccessibilityIdentifiers.TermsOfUse.description {
+            return textView
+        }
+        return view.subviews.lazy.compactMap(descriptionTextView).first
     }
 }


### PR DESCRIPTION
## :scroll: Tickets

[Jira Task](https://mozilla-hub.atlassian.net/browse/FXIOS-16605)
[[GitHub issue #35265](https://github.com/mozilla-mobile/firefox-ios/issues/35265)](https://github.com/mozilla-mobile/firefox-ios/issues/35265)

## :bulb: Description

Configures the Terms of Use description text view to expose its existing attributed-text links as separate navigation items for Switch Control.

Using `accessibilityNavigationStyle = .separate` keeps the existing `UITextView` link rendering and activation behavior while allowing Switch Control to navigate the links individually.

This does not introduce custom accessibility elements or change the existing VoiceOver and Voice Control behavior.

A focused regression test was added to verify the Terms of Use text view uses the expected accessibility navigation style.

Closes #35265.

## :white_check_mark: Testing

* Fennec test build passes
* Terms of Use tests: 6 passed, 0 failures
* `git diff --check` passes

## :iphone: Manual testing

1. Open the Terms of Use drawer.
2. Enable Switch Control and use Items mode.
3. Verify the focus order:

   * Firefox Terms of Use
   * Privacy Notice
   * Learn more / here
   * Remind Me Later
   * Accept
4. Verify each link can be activated.
5. Verify VoiceOver still exposes each link once without duplicates.
6. Verify Voice Control continues to recognize and activate the links.

Switch Control scanning requires final validation on a physical device.