### PR TITLE
[MTE-6113] Fix flaky iPad credit card tests

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -560,45 +560,39 @@ class CreditCardsTests: BaseTestCase {
     }
 
     private func pressDelete() {
-        if iPad() {
-            mozWaitForElementToExist(app.keyboards.keys["delete"])
-            app.keyboards.keys["delete"].press(forDuration: 2.2)
-        } else {
-            mozWaitForElementToExist(app.keyboards.keys["Delete"])
-            app.keyboards.keys["Delete"].press(forDuration: 2.2)
-        }
+        let deleteKey = iPad() ? app.keyboards.keys["delete"] : app.keyboards.keys["Delete"]
+        mozWaitForElementToExist(deleteKey)
+        deleteKey.waitUntilHittable()
+        deleteKey.press(forDuration: 2.2)
     }
 
     func tapCardName() {
         initCardFields()
-        nameOnCard.waitAndTap()
-        mozWaitForElementToExist(nameOnCard)
+        nameOnCard.tapUntilKeyboardFocused()
     }
 
     func tapCardNr() {
         initCardFields()
-        cardNr.waitAndTap()
-        mozWaitForElementToExist(cardNr)
+        cardNr.tapUntilKeyboardFocused()
     }
 
     func tapExpiration() {
         initCardFields()
-        expiration.waitAndTap()
-        mozWaitForElementToExist(expiration)
+        expiration.tapUntilKeyboardFocused()
     }
 
     func typeCardName(name: String) {
-        initCardFields()
+        tapCardName()
         nameOnCard.typeText(name)
     }
 
     func typeCardNr(cardNo: String) {
-        initCardFields()
+        tapCardNr()
         cardNr.typeTextWithDelay(cardNo, delay: 0.1)
     }
 
     func typeExpirationDate(exprDate: String) {
-        initCardFields()
+        tapExpiration()
         expiration.typeText(exprDate)
     }
 
@@ -767,8 +761,7 @@ class CreditCardsTests: BaseTestCase {
         let saveButton = app.buttons[creditCardsStaticTexts.AddCreditCard.save]
         if !saveButton.isEnabled {
             retryOnCardNumber(cardNumber: cardNumber)
-            mozWaitForElementToExist(expiration)
-            expiration.typeText(expirationDate)
+            typeExpirationDate(exprDate: expirationDate)
             retryExpirationNumber(expirationDate: expirationDate)
             mozWaitForElementToExist(saveButton)
         }
@@ -793,8 +786,7 @@ class CreditCardsTests: BaseTestCase {
         let saveButton = app.buttons[creditCardsStaticTexts.AddCreditCard.save]
         if !saveButton.isEnabled {
             retryOnCardNumber(cardNumber: cardNumber)
-            mozWaitForElementToExist(expiration)
-            expiration.typeText(expirationDate)
+            typeExpirationDate(exprDate: expirationDate)
             retryExpirationNumber(expirationDate: expirationDate)
             mozWaitForElementToExist(saveButton)
         }
@@ -824,7 +816,7 @@ class CreditCardsTests: BaseTestCase {
 
 extension XCUIElement {
     func clearText() {
-        tap()
+        tapUntilKeyboardFocused()
         if let stringValue = value as? String, !stringValue.isEmpty {
             let deleteString = stringValue.map { _ in "\u{8}" }.joined()
             typeText(deleteString)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/AddCreditCardScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/AddCreditCardScreen.swift
@@ -89,28 +89,28 @@ final class AddCreditCardScreen {
 
     private func fillName(_ name: String) {
         let nameField = sel.NAME_FIELD_BUTTON.element(in: app)
-        nameField.waitAndTap()
+        nameField.tapUntilKeyboardFocused()
         nameField.typeText(name)
     }
 
     private func fillCardNumber(_ number: String) {
         let cardNumber = sel.CARD_NUMBER_FIELD_BUTTON.element(in: app)
-        cardNumber.waitAndTap()
+        cardNumber.tapUntilKeyboardFocused()
         cardNumber.typeTextWithDelay(number, delay: 0.1)
     }
 
     private func fillExpiration(_ expiration: String) {
-        creditCard_ExpirationFieldButton.waitAndTap()
+        creditCard_ExpirationFieldButton.tapUntilKeyboardFocused()
         creditCard_ExpirationFieldButton.typeText(expiration)
     }
 
     private func retryCardNumberIfInvalid(_ number: String) {
         if creditCard_InvalidCardNumberMessage.exists {
             let cardNumber = sel.CARD_NUMBER_FIELD_BUTTON.element(in: app)
-            cardNumber.waitAndTap()
+            cardNumber.tapUntilKeyboardFocused()
             pressDelete()
             fillCardNumber(number)
-            sel.EXPIRATION_FIELD_BUTTON.element(in: app).waitAndTap()
+            sel.EXPIRATION_FIELD_BUTTON.element(in: app).tapUntilKeyboardFocused()
         }
     }
 
@@ -131,7 +131,7 @@ final class AddCreditCardScreen {
         fillName(name)
         fillCardNumber(cardNumber)
 
-        sel.EXPIRATION_FIELD_BUTTON.element(in: app).waitAndTap()
+        sel.EXPIRATION_FIELD_BUTTON.element(in: app).tapUntilKeyboardFocused()
         retryCardNumberIfInvalid(cardNumber)
 
         fillExpiration(expirationDate)
@@ -181,16 +181,15 @@ final class AddCreditCardScreen {
     }
 
     private func pressDelete() {
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            BaseTestCase().mozWaitForElementToExist(app.keyboards.keys["delete"])
-            app.keyboards.keys["delete"].press(forDuration: 2.2)
-        } else {
-            BaseTestCase().mozWaitForElementToExist(app.keyboards.keys["Delete"])
-            app.keyboards.keys["Delete"].press(forDuration: 2.2)
-        }
+        let isPad = UIDevice.current.userInterfaceIdiom == .pad
+        let deleteKey = isPad ? app.keyboards.keys["delete"] : app.keyboards.keys["Delete"]
+        BaseTestCase().mozWaitForElementToExist(deleteKey)
+        deleteKey.waitUntilHittable()
+        deleteKey.press(forDuration: 2.2)
     }
 
     private func typeExpiration(_ expiration: String) {
+        creditCard_ExpirationFieldButton.tapUntilKeyboardFocused()
         creditCard_ExpirationFieldButton.typeText(expiration)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/XCUIElementHelpers.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/XCUIElementHelpers.swift
@@ -211,16 +211,18 @@ extension XCUIElement {
         return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
     }
 
-    /// Taps and types text, but only once the field has keyboard focus.
-    ///
-    /// On CI some fields (the springboard passcode overlay, the address bar) are occasionally
-    /// presented without keyboard focus, so a plain `typeText` raises "Neither element nor any
-    /// descendant has keyboard focus" and aborts the test. This re-taps up to `tapAttempts` times
-    /// until focus is acquired before typing, and returns false (rather than failing hard) if it
-    /// never is, so callers can retry.
+    /// Waits until the element is hittable. Returns false on timeout instead of failing.
     @discardableResult
-    func tapAndTypeTextWhenFocused(
-        _ text: String,
+    func waitUntilHittable(timeout: TimeInterval = TIMEOUT) -> Bool {
+        let predicate = NSPredicate(format: "exists == true && hittable == true")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    /// Re-taps until the element reports keyboard focus, since a tap is swallowed while the
+    /// keyboard animates. Returns false instead of failing when focus is never acquired.
+    @discardableResult
+    func tapUntilKeyboardFocused(
         timeout: TimeInterval? = TIMEOUT,
         focusTimeout: TimeInterval = 5,
         tapAttempts: Int = 3
@@ -228,15 +230,32 @@ extension XCUIElement {
         self.mozWaitForElementToExist(timeout: timeout)
         var attempts = tapAttempts
         repeat {
-            if !hasKeyboardFocus {
-                self.tap()
+            if hasKeyboardFocus {
+                return true
             }
+            waitUntilHittable(timeout: focusTimeout)
+            self.tap(force: true)
             if waitForKeyboardFocus(timeout: focusTimeout) {
-                self.typeText(text)
                 return true
             }
             attempts -= 1
         } while attempts > 0
-        return false
+        return hasKeyboardFocus
+    }
+
+    /// Taps and types text, but only once the field has keyboard focus.
+    /// Returns false instead of failing when focus is never acquired, so callers can retry.
+    @discardableResult
+    func tapAndTypeTextWhenFocused(
+        _ text: String,
+        timeout: TimeInterval? = TIMEOUT,
+        focusTimeout: TimeInterval = 5,
+        tapAttempts: Int = 3
+    ) -> Bool {
+        guard tapUntilKeyboardFocused(timeout: timeout,
+                                      focusTimeout: focusTimeout,
+                                      tapAttempts: tapAttempts) else { return false }
+        self.typeText(text)
+        return true
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-6113

## :bulb: Description
Four `CreditCardsTests` fail intermittently on the iPad full-functional job, all at the point
where the expiration date is typed:
> `Failed to synthesize event: Neither element nor any descendant has keyboard focus.`
### Fix

The repo already had `hasKeyboardFocus` / `waitForKeyboardFocus` / `tapAndTypeTextWhenFocused` in
`XCUIElementHelpers.swift` for this exact failure on the passcode overlay and address bar. This PR
extracts the focus-acquiring half into a reusable `tapUntilKeyboardFocused()` (wait hittable ->
tap -> wait for focus, up to 3 attempts) and routes the credit card flow through it:

- `XCUIElementHelpers.swift` — adds `tapUntilKeyboardFocused()` and a soft `waitUntilHittable()`;
  `tapAndTypeTextWhenFocused` now delegates to the new helper, so its three existing call sites are
  unchanged.
- `CreditCardsTests.swift` — `tapCardName` / `tapCardNr` / `tapExpiration` acquire focus; the
  matching `type…` helpers re-assert it before typing; the two inline `expiration.typeText` retry
  paths funnel through `typeExpirationDate`; `clearText()` and `pressDelete()` hardened the same way.
- `PageScreens/AddCreditCardScreen.swift` — the page object encodes the same flow, so it gets the
  same treatment.

Note this flake does not reproduce locally on demand, so a green local run is not proof it is gone;
it establishes that the new path works end-to-end on the exact CI device/OS and does not regress
iPhone. CI on `firefox-ios-full-functional-ipad` is the real confirmation.
