### PR TITLE
Bugfix FXIOS-16640 Sync and save data button and sync icon are not purple

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/RoundedButtonWithImage.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/RoundedButtonWithImage.swift
@@ -144,9 +144,9 @@ public final class RoundedButtonWithImage: ResizableButton, ThemeApplicable {
     // MARK: ThemeApplicable
 
     public func applyTheme(theme: Theme) {
-        highlightedBackgroundColor = theme.colors.actionSecondaryHover
-        normalBackgroundColor = theme.colors.actionSecondary
-        foregroundColor = theme.colors.textPrimary
+        highlightedBackgroundColor = theme.isNova ? theme.colors.actionPrimaryHover : theme.colors.actionSecondaryHover
+        normalBackgroundColor = theme.isNova ? theme.colors.actionPrimary : theme.colors.actionSecondary
+        foregroundColor = theme.isNova ? theme.colors.textInverted : theme.colors.textPrimary
         disabledBackgroundColor = theme.colors.actionSecondaryDisabled
         foregroundDisabledColor = theme.colors.textDisabled
         imageTintColor = theme.colors.iconAccentBlue

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
@@ -150,7 +150,7 @@ class ExperimentRemoteTabsEmptyView: UIView,
     }
 
     func applyTheme(theme: Theme) {
-        iconImageView.tintColor = theme.colors.iconDisabled
+        iconImageView.tintColor = theme.isNova ? theme.colors.actionPrimary : theme.colors.iconDisabled
         titleLabel.textColor = theme.colors.textPrimary
         descriptionLabel.textColor = theme.colors.textPrimary
         signInButton.applyTheme(theme: theme)

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -214,6 +214,8 @@ final class TabTrayViewController: UIViewController,
                           StandardImageIdentifiers.Large.checkmark,
                           background: theme.colors.actionPrimary,
                           glyph: theme.colors.iconInverted)
+        syncTabButton.style = .prominent
+        syncTabButton.tintColor = glassTint
     }
 
     @available(iOS 26.0, *)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16640)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates the Sync and save data button and sync icon from Remote Tabs Empty view to follow Nova design scheme.

<img width="1206" height="2622" alt="simulator_screenshot_8281F57B-CC39-424E-B8A0-B1CF1DEB4B64" src="https://github.com/user-attachments/assets/67681280-6ba0-4e13-aa3a-28132f58dab9" />

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

