### PR TITLE
Refactor FXIOS-16727 [Quick Answers] Remove "from a Firefox partner" from opt-in consent text

### DIFF
--- a/BrowserKit/Sources/QuickAnswersKit/UI/OptInView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/OptInView.swift
@@ -16,7 +16,7 @@ final class OptInView: UIView, UITextViewDelegate, ThemeApplicable {
             trailing: 16.0
         )
         static let descriptionText = """
-        Ask a question out loud, and get a short answer from a Firefox partner. \
+        Ask a question out loud, and get a short answer. \
         We don't store your voice or questions.
         """
         static let learnMoreText = "Learn more"


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16727)

## :bulb: Description
Drops the "from a Firefox partner" wording from the Quick Answers opt-in description.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
