### PR TITLE
Bugfix FXIOS-15762 Only Save Bookmark/Folder Edits on Explicit Save

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/EditBookmarkViewController.swift
@@ -119,10 +119,6 @@ class EditBookmarkViewController: UIViewController,
         if let isDragging = transitionCoordinator?.isInteractive, !isDragging {
             navigationController?.setNavigationBarHidden(true, animated: false)
         }
-        // Save when popping the view off the navigation stack (when in library)
-        if isMovingFromParent {
-            viewModel.saveBookmark()
-        }
         onViewWillDisappear?()
     }
 
@@ -146,12 +142,11 @@ class EditBookmarkViewController: UIViewController,
 
     @objc
     func saveButtonAction() {
-        // If we are in the standalone version of edit bookmark, we should save before dismissing
         if navigationController?.viewControllers.first == self {
             viewModel.saveBookmark()
             viewModel.didFinish()
         } else {
-            // If we are in the library, save will happen in viewWillDisappear
+            viewModel.saveBookmark()
             navigationController?.popViewController(animated: true)
         }
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Bookmark/GroupedEditBookmarkViewController.swift
@@ -124,10 +124,6 @@ final class GroupedEditBookmarkViewController: UIViewController,
         if let isDragging = transitionCoordinator?.isInteractive, !isDragging {
             navigationController?.setNavigationBarHidden(true, animated: false)
         }
-        // Save when popping the view off the navigation stack (when in library)
-        if isMovingFromParent {
-            viewModel.saveBookmark()
-        }
         onViewWillDisappear?()
     }
 
@@ -151,12 +147,11 @@ final class GroupedEditBookmarkViewController: UIViewController,
 
     @objc
     func saveButtonAction() {
-        // If we are in the standalone version of edit bookmark, we should save before dismissing
         if navigationController?.viewControllers.first == self {
             viewModel.saveBookmark()
             viewModel.didFinish()
         } else {
-            // If we are in the library, save will happen in viewWillDisappear
+            viewModel.saveBookmark()
             navigationController?.popViewController(animated: true)
         }
     }

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/EditFolderViewController.swift
@@ -109,11 +109,6 @@ class EditFolderViewController: UIViewController,
             navigationController?.setNavigationBarHidden(true, animated: false)
         }
         onViewWillDisappear?()
-
-        // Only save when clicking the back button, not when we swipe the view controller away
-        if isMovingFromParent {
-            viewModel.save()
-        }
     }
 
     private func setupSubviews() {
@@ -130,7 +125,7 @@ class EditFolderViewController: UIViewController,
 
     @objc
     func saveButtonAction() {
-        // Save will happen in viewWillDisappear
+        viewModel.save()
         navigationController?.popViewController(animated: true)
     }
 

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Edit Folder/GroupedEditFolderViewController.swift
@@ -113,11 +113,6 @@ final class GroupedEditFolderViewController: UIViewController,
             navigationController?.setNavigationBarHidden(true, animated: false)
         }
         onViewWillDisappear?()
-
-        // Only save when clicking the back button, not when we swipe the view controller away
-        if isMovingFromParent {
-            viewModel.save()
-        }
     }
 
     private func setupSubviews() {
@@ -134,7 +129,7 @@ final class GroupedEditFolderViewController: UIViewController,
 
     @objc
     func saveButtonAction() {
-        // Save will happen in viewWillDisappear
+        viewModel.save()
         navigationController?.popViewController(animated: true)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditBookmarkViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditBookmarkViewControllerTests.swift
@@ -159,6 +159,21 @@ final class GroupedEditBookmarkViewControllerTests: XCTestCase {
         XCTAssertFalse(navController.viewControllers.contains(subject))
     }
 
+    func test_saveButtonAction_whenInLibrary_savesBookmark() {
+        let viewModel = createViewModel()
+        let subject = createSubject(viewModel: viewModel)
+        let navController = UINavigationController()
+        navController.pushViewController(UIViewController(), animated: false)
+        navController.pushViewController(subject, animated: false)
+
+        let expectation = XCTestExpectation(description: "bookmark saved")
+        viewModel.onBookmarkSaved = { expectation.fulfill() }
+
+        subject.saveButtonAction()
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     // MARK: - Private
 
     private func createSubject(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Library/Bookmarks/GroupedEditFolderViewControllerTests.swift
@@ -178,6 +178,19 @@ final class GroupedEditFolderViewControllerTests: XCTestCase {
         XCTAssert(!navController.viewControllers.contains(subject))
     }
 
+    func test_saveButtonAction_savesFolder() {
+        let folder = makeFolder()
+        let viewModel = createViewModel(folder: folder)
+        let subject = createSubject(viewModel: viewModel)
+
+        let expectation = XCTestExpectation(description: "folder saved")
+        viewModel.onBookmarkSaved = { expectation.fulfill() }
+
+        subject.saveButtonAction()
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     // MARK: - Private
 
     private func createSubject(
@@ -213,6 +226,19 @@ final class GroupedEditFolderViewControllerTests: XCTestCase {
             folder: folder,
             bookmarkSaver: MockBookmarksSaver(),
             folderFetcher: folderFetcher ?? MockGroupedFolderHierarchyFetcher()
+        )
+    }
+
+    private func makeFolder() -> BookmarkFolderData {
+        BookmarkFolderData(
+            guid: "folder_guid",
+            dateAdded: 0,
+            lastModified: 0,
+            parentGUID: "parent_guid",
+            position: 0,
+            title: "My Folder",
+            childGUIDs: [],
+            children: nil
         )
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15762)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33702)

## :bulb: Description
This PR moves saving changes for bookmarks/folders to the save button action to make it so that the save button is what triggers saving the changes. The change is mirrored in both the regular controllers and the grouped versions which will eventually roll out as the new controller to show the new UI.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

