### PR TITLE
Bugfix FXIOS-11505 Improve tinted widget labels

### DIFF
--- a/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
+++ b/firefox-ios/WidgetKit/ImageButtonWithLabel.swift
@@ -107,11 +107,13 @@ struct ImageButtonWithLabel: View {
                     .font(.headline)
                     .minimumScaleFactor(0.75)
                     .layoutPriority(1000)
+                    .widgetAccentableCompat()
             } else {
                 Text(link.label)
                     .font(.footnote)
                     .minimumScaleFactor(0.75)
                     .layoutPriority(1000)
+                    .widgetAccentableCompat()
             }
         }
     }


### PR DESCRIPTION
## :scroll: Tickets

[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-11505)  
[GitHub issue](https://github.com/mozilla-mobile/firefox-ios/issues/25042)

## :bulb: Description

- Apply `widgetAccentableCompat()` directly to shortcut labels in `ImageButtonWithLabel`.
- Keep widget tile/background rendering unchanged.
- Preserve the existing accented image rendering behavior and iOS 15 compatibility.

The background part of the original issue is already handled by the current widget rendering implementation. This PR addresses the remaining label behavior so shortcut text participates in the accented rendering group without accenting the surrounding container.

## :test_tube: Testing

- `git diff --check` passes.
- `ImageButtonWithLabel.swift` compiled successfully as part of `WidgetKitExtension`.
- Full Fennec validation is blocked locally because the repository requires Xcode 26.5 while my environment has Xcode 26.3.
- Manual Home Screen Tinted-mode verification remains required on a compatible toolchain/device.

## :pencil: Checklist

- [x] Filled in the above information
- [x] Updated the PR name to follow the PR naming guidelines
- [x] Verified the changed widget source compiles
- [x] No unrelated changes
- [x] No documentation updates required