### PR TITLE
[MTE-6114] - Fix iPad credit card tests dropping the Add Card Save tap

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/CreditCardsTests.swift
@@ -191,7 +191,7 @@ class CreditCardsTests: BaseTestCase {
         tapCardName()
         nameOnCard.clearText()
         typeCardName(name: updatedName)
-        app.buttons["Save"].waitAndTap()
+        tapSaveAndWaitForCardFormToClose()
         // The name of the card is saved without issues
         mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons[updatedName])
         // Go to an saved credit card and change the credit card number
@@ -204,7 +204,7 @@ class CreditCardsTests: BaseTestCase {
         tapCardNr()
         clearTextUntilEmpty(element: cardNr)
         typeCardNr(cardNo: cards[1])
-        app.buttons["Save"].waitAndTap()
+        tapSaveAndWaitForCardFormToClose()
         // The credit card number is saved without issues
         mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons.elementContainingText("1111"))
         // Reach autofill website
@@ -358,7 +358,7 @@ class CreditCardsTests: BaseTestCase {
         mozWaitForElementToNotExist(app.otherElements.staticTexts["Enter a valid expiration date"])
         mozWaitForElementToExist(saveButton)
         XCTAssertTrue(saveButton.isEnabled)
-        saveButton.waitAndTap()
+        tapSaveAndWaitForCardFormToClose()
         // The credit card is saved
         let cardsInfo = ["Test", "5/40"]
         mozWaitForElementToExist(app.tables.cells.element(boundBy: 1).buttons.elementContainingText("1252"))
@@ -596,6 +596,13 @@ class CreditCardsTests: BaseTestCase {
         expiration.typeText(exprDate)
     }
 
+    /// Taps "Save" and waits for the card form to be dismissed. The form is presented as a form
+    /// sheet, so on iPad the list behind it stays visible and cannot be used as a barrier.
+    func tapSaveAndWaitForCardFormToClose() {
+        initCardFields()
+        app.buttons[creditCardsStaticTexts.AddCreditCard.save].tapUntilElementDisappears(cardNr)
+    }
+
     private func validateAutofillCardInfo(cardNr: String, expYear: String, expMonth: String, name: String) {
         if #available(iOS 18, *) {
             XCTAssertEqual(app.textFields["Card Number:"].value! as? String, cardNr)
@@ -765,7 +772,7 @@ class CreditCardsTests: BaseTestCase {
             retryExpirationNumber(expirationDate: expirationDate)
             mozWaitForElementToExist(saveButton)
         }
-        saveButton.waitAndTap()
+        tapSaveAndWaitForCardFormToClose()
     }
 
     private func addCreditCard_TAE(name: String, cardNumber: String, expirationDate: String) {
@@ -790,7 +797,7 @@ class CreditCardsTests: BaseTestCase {
             retryExpirationNumber(expirationDate: expirationDate)
             mozWaitForElementToExist(saveButton)
         }
-        saveButton.waitAndTap()
+        tapSaveAndWaitForCardFormToClose()
     }
 
     private func retryOnCardNumber(cardNumber: String) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/AddCreditCardScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/AddCreditCardScreen.swift
@@ -145,11 +145,13 @@ final class AddCreditCardScreen {
             BaseTestCase().mozWaitForElementToExist(creditCard_SaveButton)
         }
 
-        creditCard_SaveButton.waitAndTap()
-        // We need to dismiss the number pad first on iPad()
-        if BaseTestCase().iPad() {
-            creditCard_SaveButton.tapIfExists()
-        }
+        tapSaveAndWaitForFormToClose()
+    }
+
+    /// Taps "Save" and waits for the card form to be dismissed. The form is presented as a form
+    /// sheet, so on iPad the list behind it stays visible and cannot be used as a barrier.
+    func tapSaveAndWaitForFormToClose() {
+        creditCard_SaveButton.tapUntilElementDisappears(sel.CARD_NUMBER_FIELD_BUTTON.element(in: app))
     }
 
     func interactWithCreditCardForm() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/XCUIElementHelpers.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/XCUIElementHelpers.swift
@@ -219,6 +219,39 @@ extension XCUIElement {
         return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
     }
 
+    /// Waits until the element is gone. Returns false on timeout instead of failing.
+    @discardableResult
+    func waitUntilGone(timeout: TimeInterval = TIMEOUT) -> Bool {
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    /// Re-taps until `element` goes away, since a tap on a view that is presented as a form sheet
+    /// is silently dropped while the sheet settles. Returns false instead of failing when it stays.
+    @discardableResult
+    func tapUntilElementDisappears(
+        _ element: XCUIElement,
+        timeout: TimeInterval? = TIMEOUT,
+        disappearTimeout: TimeInterval = 5,
+        tapAttempts: Int = 3
+    ) -> Bool {
+        self.mozWaitForElementToExist(timeout: timeout)
+        var attempts = tapAttempts
+        repeat {
+            if !element.exists {
+                return true
+            }
+            waitUntilHittable(timeout: disappearTimeout)
+            self.tap(force: true)
+            if element.waitUntilGone(timeout: disappearTimeout) {
+                return true
+            }
+            attempts -= 1
+        } while attempts > 0
+        return !element.exists
+    }
+
     /// Re-taps until the element reports keyboard focus, since a tap is swallowed while the
     /// keyboard animates. Returns false instead of failing when focus is never acquired.
     @discardableResult


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-6114

## :bulb: Description
Follow-up to #35469 ([MTE-6113]). That fix worked — the keyboard-focus failure on the
credit card form is gone — and by letting the iPad tests run ~25s further, it exposed
the next problem.
Three tests now fail at the same point, right after `saveButton.waitAndTap()`:
`testErrorStatesCreditCards`, `testVerifyThatTheEditedCreditCardIsSaved`,
`testVerifyThatMultipleCardsCanBeAdded`.

### Root cause (iPad-only)

**The Save tap is dropped.** Every CI Save tap logs
`Computed hit point {-1, -1} after scrolling to visible` — XCUITest couldn't resolve a
hit point, the event went nowhere, the card was never saved. It happens when the expiry
field needed the `tapUntilKeyboardFocused` retry path and the sheet is still settling.

**The barrier that should catch it is a no-op.** After saving we wait on
`app.staticTexts["Payment Methods"]`, but `CreditCardSettingsViewController` presents the
form as `.formSheet` — on iPad the list behind it stays in the accessibility tree, so the
wait resolves ~10ms after the tap. On iPhone a form sheet is full-screen, so the same wait
is a real barrier; that's why the iPhone job is green.

So the tests sail past a failed save and time out 10s later on the first thing that needs
the card.

### The fix

- **`XCUIElementHelpers.swift`** — `waitUntilGone(timeout:)` and
  `tapUntilElementDisappears(_:...)`, shaped like the existing `waitUntilHittable` /
  `tapUntilKeyboardFocused` pair. The latter re-taps until the element leaves the
  hierarchy, so a dropped tap gets retried instead of silently doing nothing.
- **`CreditCardsTests.swift`** — `tapSaveAndWaitForCardFormToClose()` waits for the
  `number` field to disappear, i.e. on the actual sheet dismissal. Replaces all 5
  sheet-Save taps. The web-prompt Saves in `testSaveThisCardPrompt` / `testUpdatePrompt`
  are untouched — different UI, already passing.
- **`AddCreditCardScreen.swift`** — same barrier for the page-object path; subsumes the
  `if iPad() { creditCard_SaveButton.tapIfExists() }` double-tap workaround.

  The CI failures doesn't reproduce locally. Verified correct and non-regressing locally; confirming it clears CI needs an
  iPad job run.

[MTE-6113]: https://mozilla-hub.atlassian.net/browse/MTE-6113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ