### PR TITLE
Refactor FXIOS-16736 [A11y] Date under "Sync Now" should be read in natural format in Voice Over

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/SyncNowSetting.swift
@@ -39,7 +39,8 @@ class SyncNowSetting: WithAccountSetting,
 
     private lazy var timestampFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .medium
         return formatter
     }()
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16736)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35484)

## :bulb: Description
Use system formats for date and time so that dates are localized and read correctly in Voice Over.

## :movie_camera: Demos
<details>
<summary>Demo</summary>

**Before:**
https://github.com/user-attachments/assets/c97033db-5b06-4c68-9c07-bb9e48abed42

**After with region set to Germany**
https://github.com/user-attachments/assets/74730ffb-e130-4c59-8893-c581eb6a85ba

**After with region set to United States**
https://github.com/user-attachments/assets/2d7e4dac-aa2d-4559-b151-97bc19360a4c

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

