### PR TITLE
Bugfix FXIOS-34896 [Bookmarks] Prevent navigation bar from reappearing during vertical scroll

### DIFF
--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -438,7 +438,7 @@ class LibraryViewController: UIViewController, Themeable {
     func setNavigationBarHidden(_ value: Bool) {
         navigationController?.setToolbarHidden(value, animated: true)
         navigationController?.setNavigationBarHidden(value, animated: false)
-        let controlbarHeight = librarySegmentControl.frame.height
+        let controlbarHeight = UX.NavigationMenu.height
         librarySegmentControl.transform = value ? .init(translationX: 0, y: -controlbarHeight) : .identity
         controllerContainerView.transform = value ? .init(translationX: 0, y: -controlbarHeight) : .identity
 


### PR DESCRIPTION
## :scroll: Tickets
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34896)

## :bulb: Description
### Problem
In the Bookmarks panel, scrolling vertically within the "New Folder" view (`GroupedEditFolderViewController`) causes the underlying library navigation bar (`librarySegmentControl`) to unintentionally reappear over the screen.

### Cause
When the scroll view hits the top edge and bounces, iOS interprets this as the beginning of an interactive sheet dismissal, calling `viewWillDisappear`. When the bounce settles and the gesture is cancelled, `viewWillAppear` is called to restore the views:
1. `LibraryViewController.viewWillAppear` recreates `librarySegmentControl`. Because layout has not yet completed, `librarySegmentControl.frame.height` evaluates to `0.0`.
2. `GroupedEditFolderViewController.viewWillAppear` subsequently calls `setNavigationBarHidden(true)`.
3. `setNavigationBarHidden` calculates the upward shift using `librarySegmentControl.frame.height`. Since the height is `0.0`, the transform evaluates to `.identity` (0 offset), causing the segmented control to remain visible in its default position.

### Solution
Updated `LibraryViewController.setNavigationBarHidden(_:)` to compute the hide offset using the static constant `UX.NavigationMenu.height` instead of `librarySegmentControl.frame.height`. This ensures the transform is consistently evaluated to `-40` points regardless of layout lifecycle timing.

## :movie_camera: Demos

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/f225e5d3-aa76-4806-900f-3d5573423879" width="300" /> | <video src="https://github.com/user-attachments/assets/357c3678-c3cd-47d4-87ee-31c96022b9c5" width="300" /> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

