### PR TITLE
[MTE-5840] - Automate C2306878 keyboard behaviour on blank new tabs

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -141,6 +141,7 @@
         "ModernOnboardingTests",
         "MultiWindowTests",
         "NavigationTest",
+        "NewTabSettingsTest\/testKeyboardRaisedWhenBlankTabOpenedFromContextMenusAndWidget()",
         "NightModeTests",
         "O_AddressesTests",
         "OnboardingTests\/testValidateContinueButton()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -403,6 +403,7 @@
         "NewTabSettingsTest\/testChangeNewTabSettingsShowFirefoxHome_tabTrayExperimentOff()",
         "NewTabSettingsTest\/testChangeNewTabSettingsShowFirefoxHome_tabTrayExperimentOff_swipingTabsExperimentOff()",
         "NewTabSettingsTest\/testChangeNewTabSettingsShowFirefoxHome_tabTrayExperimentOff_swipingTabsExperimentOn()",
+        "NewTabSettingsTest\/testKeyboardRaisedWhenBlankTabOpenedFromContextMenusAndWidget()",
         "NightModeTests",
         "O_AddressesTests\/testAddNewAddressCityFilled()",
         "O_AddressesTests\/testAddNewAddressCountry()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -691,7 +691,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
         mozWaitForElementToExist(app.navigationBars["App Icon"])
     }
 
-    // https://mozilla.testrail.io/index.php?/cases/edit/3408300
+    // https://mozilla.testrail.io/index.php?/cases/view/3408300
     func testLongTapFirefoxIconOpenLastBookmark() throws {
         guard #available(iOS 18, *) else {
             throw XCTSkip("Test requires iOS 18+ due to app icon springboard context menu behavior")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NewTabSettings.swift
@@ -147,6 +147,80 @@ class NewTabSettingsTest: BaseTestCase {
         browserScreen.assertKeyboardBehaviorOnNewTab()
     }
 
+    // https://mozilla.testrail.io/index.php?/cases/view/2306878
+    // Regression
+    func testKeyboardRaisedWhenBlankTabOpenedFromContextMenusAndWidget() throws {
+        guard #available(iOS 18, *) else {
+            throw XCTSkip("Test requires iOS 18+ due to app icon springboard behavior")
+        }
+        if !isFennec {
+            throw XCTSkip("The Firefox widget is only added to the home screen on the Fennec scheme")
+        }
+        browserScreen = BrowserScreen(app: app)
+        newTabSettingsScreen = NewTabSettingsScreen(app: app)
+        toolbarScreen = ToolbarScreen(app: app)
+        topSiteScreen = TopSitesScreen(app: app)
+        let springBoardScreen = SpringboardScreen(springboard: springboard)
+
+        // Step 1: set the new tab page to Blank
+        toolbarScreen.assertSettingsButtonExists()
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(NewTabSettings)
+        newTabSettingsScreen.assertNewTabNavigationBarIsVisible()
+        navigator.performAction(Action.SelectNewTabAsBlankPage)
+
+        // Steps 2-3: a new tab opens blank, and tapping the address bar raises the keyboard
+        navigator.performAction(Action.OpenNewTabFromTabTray)
+        topSiteScreen.assertNotVisibleTopSites()
+        browserScreen.tapAddressBar()
+        browserScreen.assertAddressBarFocusedWithKeyboard()
+        leaveAddressBarEditing()
+
+        // Steps 4-6: the tab tray long press menu, which is not offered on iPad
+        if !iPad() {
+            navigator.nowAt(NewTabScreen)
+            navigator.performAction(Action.OpenNewTabLongPressTabsButton)
+            assertBlankTabOpenedWithKeyboardRaised()
+            leaveAddressBarEditing()
+        }
+
+        // Steps 7-9: the app icon's New Tab quick action
+        navigator.nowAt(NewTabScreen)
+        springBoardScreen.pressHomeButton()
+        springBoardScreen.assertFennecIconExists()
+        springBoardScreen.longPressFennecIcon(at: 0, duration: 1.5)
+        springBoardScreen.tapNewTabButton()
+        assertBlankTabOpenedWithKeyboardRaised()
+        leaveAddressBarEditing()
+
+        // Steps 10-12: the Firefox widget's New Search shortcut
+        springBoardScreen.pressHomeButton()
+        springBoardScreen.goToWidgetPage()
+        if !springBoardScreen.isFirefoxWidgetPresent() {
+            springBoardScreen.addFirefoxQuickActionsWidget(named: "Fennec")
+        }
+        springBoardScreen.tapFirefoxWidget()
+        assertBlankTabOpenedWithKeyboardRaised()
+    }
+
+    /// Each entry point leaves the address bar being edited, which the screen graph has no state
+    /// for, so the editing state is dropped before navigating on.
+    private func leaveAddressBarEditing() {
+        browserScreen.tapCancelEditButton()
+        browserScreen.assertAddressBarUnfocusedWithoutKeyboard()
+    }
+
+    /// Steps 4-6, 7-9 and 10-12 all repeat: the new tab is blank with the keyboard raised, the "<"
+    /// button leaves the editing state, and tapping the address bar raises the keyboard again.
+    private func assertBlankTabOpenedWithKeyboardRaised() {
+        topSiteScreen.assertNotVisibleTopSites()
+        browserScreen.assertAddressBarFocusedWithKeyboard()
+        browserScreen.tapCancelEditButton()
+        browserScreen.assertAddressBarUnfocusedWithoutKeyboard()
+        browserScreen.tapAddressBar()
+        browserScreen.assertAddressBarFocusedWithKeyboard()
+    }
+
     // https://mozilla.testrail.io/index.php?/cases/view/2306875
     // Smoketest
     func testNewTabCustomURLKeyboardNotRaised() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -219,6 +219,28 @@ final class BrowserScreen {
         }
     }
 
+    func tapAddressBar() {
+        addressBar.waitAndTap()
+    }
+
+    /// Taps the "<" chevron shown next to the address bar while it is being edited.
+    func tapCancelEditButton() {
+        cancelButton.waitAndTap()
+    }
+
+    /// Opening a blank new tab focuses the address bar, so the keyboard is raised on both idioms.
+    func assertAddressBarFocusedWithKeyboard() {
+        BaseTestCase().mozWaitForElementToExist(addressBar)
+        XCTAssertTrue(addressBar.waitForKeyboardFocus(), "The address bar should have keyboard focus.")
+        BaseTestCase().mozWaitForElementToExist(app.keyboards.element)
+    }
+
+    func assertAddressBarUnfocusedWithoutKeyboard() {
+        BaseTestCase().mozWaitForElementToExist(addressBar)
+        BaseTestCase().mozWaitForElementToNotExist(app.keyboards.element)
+        XCTAssertFalse(addressBar.hasKeyboardFocus, "The address bar should not have keyboard focus.")
+    }
+
     func dismissKeyboardIfVisible(maxTaps: Int = 3) {
         let keyboard = app.keyboards.firstMatch
         var remainingTaps = maxTaps

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SpringboardScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SpringboardScreen.swift
@@ -48,6 +48,18 @@ final class SpringboardScreen {
         sel.APP_ICON_BUTTON.element(in: springboard)
     }
 
+    private var firefoxWidget: XCUIElement {
+        sel.FIREFOX_WIDGET.element(in: springboard)
+    }
+
+    private var screenTimeIcon: XCUIElement {
+        sel.SCREEN_TIME_ICON.element(in: springboard)
+    }
+
+    private var searchWidgetsField: XCUIElement {
+        sel.SEARCH_WIDGETS_FIELD.element(in: springboard)
+    }
+
     private var notificationsPermissionAlert: XCUIElement {
         sel.NOTIFICATIONS_PERMISSION_ALERT.element(in: springboard)
     }
@@ -101,6 +113,62 @@ final class SpringboardScreen {
 
     func tapAppIconButton() {
         appIconButton.waitAndTap()
+    }
+
+    // MARK: - Widget Actions
+
+    /// Swipes to the page that holds the widgets, left of the first home screen page.
+    func goToWidgetPage() {
+        if #available(iOS 26, *) {
+            springboard.swipeRight()
+            springboard.swipeRight()
+        } else {
+            while !screenTimeIcon.exists {
+                springboard.swipeRight()
+            }
+        }
+    }
+
+    func isFirefoxWidgetPresent(maxSwipes: Int = 3) -> Bool {
+        var numberOfSwipes = 0
+        while !firefoxWidget.exists && numberOfSwipes < maxSwipes {
+            springboard.swipeUp()
+            numberOfSwipes += 1
+        }
+        return firefoxWidget.exists
+    }
+
+    /// Adds the Firefox Quick Actions widget, the first one the gallery offers for the app.
+    func addFirefoxQuickActionsWidget(named widgetName: String) {
+        if BaseTestCase().iPad() {
+            springboard.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).press(forDuration: 3)
+        } else {
+            screenTimeIcon.press(forDuration: 3)
+            sel.EDIT_HOME_SCREEN_BUTTON.element(in: springboard).tapIfExists()
+            sel.EDIT_BUTTON.element(in: springboard).tapIfExists()
+        }
+        sel.ADD_WIDGET_BUTTON.element(in: springboard).waitAndTap()
+        searchWidgetsField.mozWaitElementHittable(timeout: TIMEOUT)
+        searchWidgetsField.waitAndTap()
+        searchWidgetsField.typeText(widgetName)
+        springboard.cells
+            .matching(NSPredicate(format: "label CONTAINS[c] %@", widgetName + " ("))
+            .element
+            .waitAndTap()
+        BaseTestCase().mozWaitForElementToExist(sel.QUICK_ACTIONS_LABEL.element(in: springboard))
+        sel.CONFIRM_ADD_WIDGET_BUTTON.element(in: springboard).waitAndTap()
+        springboard.swipeDown()
+        sel.DONE_BUTTON.element(in: springboard).waitAndTap()
+    }
+
+    func tapFirefoxWidget() {
+        guard isFirefoxWidgetPresent() else {
+            let labels = springboard.buttons.allElementsBoundByIndex.map { $0.label }
+            XCTFail("Firefox widget not found on the home screen. Springboard buttons: \(labels)")
+            return
+        }
+        firefoxWidget.mozWaitElementHittable(timeout: TIMEOUT)
+        firefoxWidget.waitAndTap()
     }
 
     // MARK: - Notifications Permission Actions

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SelectorShortcuts.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SelectorShortcuts.swift
@@ -130,6 +130,21 @@ extension Selector {
         )
     }
 
+    static func iconById(_ id: String, description: String, groups: [String] = []) -> Selector {
+        Selector(
+            strategy: .predicate(
+                NSPredicate(
+                    format: "elementType == %d AND identifier == %@",
+                    XCUIElement.ElementType.icon.rawValue,
+                    id
+                )
+            ),
+            value: id,
+            description: description,
+            groups: groups
+        )
+    }
+
     static func staticTextByExactLabel(_ label: String, description: String, groups: [String] = []) -> Selector {
         Selector(
             strategy: .predicate(
@@ -179,6 +194,20 @@ extension Selector {
                  value: id,
                  description: description,
                  groups: groups
+        )
+    }
+
+    static func searchFieldByIdOrLabel(_ value: String, description: String, groups: [String] = []) -> Selector {
+        let predicate = NSPredicate(
+            format: "elementType == %d AND (identifier == %@ OR label == %@)",
+            XCUIElement.ElementType.searchField.rawValue,
+            value,
+            value
+        )
+        return Selector(strategy: .predicate(predicate),
+                        value: value,
+                        description: description,
+                        groups: groups
         )
     }
 
@@ -296,6 +325,26 @@ extension Selector {
             format: "elementType == %d AND label CONTAINS[c] %@",
             XCUIElement.ElementType.button.rawValue,
             text
+        )
+
+        return Selector(
+            strategy: .predicate(predicate),
+            value: text,
+            description: description,
+            groups: groups
+        )
+    }
+
+    /// Matches a button whose label contains either text, for elements labelled differently per scheme.
+    static func buttonLabelContainsEither(_ text: String,
+                                          or otherText: String,
+                                          description: String,
+                                          groups: [String] = []) -> Selector {
+        let predicate = NSPredicate(
+            format: "elementType == %d AND (label CONTAINS[c] %@ OR label CONTAINS[c] %@)",
+            XCUIElement.ElementType.button.rawValue,
+            text,
+            otherText
         )
 
         return Selector(

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SpringboardSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SpringboardSelectors.swift
@@ -14,6 +14,15 @@ protocol SpringboardSelectorsSet {
     var NOTIFICATIONS_PERMISSION_ALERT: Selector { get }
     var ALLOW_NOTIFICATIONS_BUTTON: Selector { get }
     var DONT_ALLOW_NOTIFICATIONS_BUTTON: Selector { get }
+    var FIREFOX_WIDGET: Selector { get }
+    var SCREEN_TIME_ICON: Selector { get }
+    var EDIT_HOME_SCREEN_BUTTON: Selector { get }
+    var EDIT_BUTTON: Selector { get }
+    var ADD_WIDGET_BUTTON: Selector { get }
+    var CONFIRM_ADD_WIDGET_BUTTON: Selector { get }
+    var SEARCH_WIDGETS_FIELD: Selector { get }
+    var QUICK_ACTIONS_LABEL: Selector { get }
+    var DONE_BUTTON: Selector { get }
     var all: [Selector] { get }
 }
 
@@ -31,6 +40,17 @@ struct SpringboardSelectors: SpringboardSelectorsSet {
         static let notificationsPermissionAlert = "Would Like to Send You Notifications"
         static let allowNotificationsButton = "Allow"
         static let dontAllowNotificationsButton = "Don’t Allow"
+        // The home screen widget is labelled after the product, not the scheme.
+        static let firefoxWidget = "Firefox"
+        static let screenTimeIcon = "Screen Time"
+        static let editHomeScreenButton = "Edit Home Screen"
+        static let editButton = "Edit"
+        static let addWidgetButton = "Add Widget"
+        // The widget gallery's own confirm button carries a leading space in its label.
+        static let confirmAddWidgetButton = " Add Widget"
+        static let searchWidgetsField = "Search Widgets"
+        static let quickActionsLabel = "Quick Actions"
+        static let doneButton = "Done"
     }
 
     let FENNEC_ICONS = Selector(
@@ -100,6 +120,63 @@ struct SpringboardSelectors: SpringboardSelectorsSet {
         groups: ["springboard", "notifications"]
     )
 
+    // The widget is labelled after the product on release schemes and after the scheme on Fennec.
+    let FIREFOX_WIDGET = Selector.buttonLabelContainsEither(
+        IDs.firefoxWidget,
+        or: IDs.fennecIconsPrefix,
+        description: "Firefox Quick Actions widget on the home screen",
+        groups: ["springboard", "widget"]
+    )
+
+    let SCREEN_TIME_ICON = Selector.iconById(
+        IDs.screenTimeIcon,
+        description: "Screen Time icon, used as an anchor on the widget page",
+        groups: ["springboard", "widget"]
+    )
+
+    let EDIT_HOME_SCREEN_BUTTON = Selector.buttonId(
+        IDs.editHomeScreenButton,
+        description: "Edit Home Screen button in the home screen context menu",
+        groups: ["springboard", "widget"]
+    )
+
+    let EDIT_BUTTON = Selector.buttonId(
+        IDs.editButton,
+        description: "Edit button on the widget page",
+        groups: ["springboard", "widget"]
+    )
+
+    let ADD_WIDGET_BUTTON = Selector.buttonId(
+        IDs.addWidgetButton,
+        description: "Add Widget button that opens the widget gallery",
+        groups: ["springboard", "widget"]
+    )
+
+    let CONFIRM_ADD_WIDGET_BUTTON = Selector.buttonId(
+        IDs.confirmAddWidgetButton,
+        description: "Add Widget button that confirms the selected widget",
+        groups: ["springboard", "widget"]
+    )
+
+    // The gallery's search field exposes "Search Widgets" as its label, not its identifier.
+    let SEARCH_WIDGETS_FIELD = Selector.searchFieldByIdOrLabel(
+        IDs.searchWidgetsField,
+        description: "Search field in the widget gallery",
+        groups: ["springboard", "widget"]
+    )
+
+    let QUICK_ACTIONS_LABEL = Selector.staticTextByLabel(
+        IDs.quickActionsLabel,
+        description: "Quick Actions widget name in the widget gallery",
+        groups: ["springboard", "widget"]
+    )
+
+    let DONE_BUTTON = Selector.buttonId(
+        IDs.doneButton,
+        description: "Done button that leaves home screen edit mode",
+        groups: ["springboard", "widget"]
+    )
+
     var all: [Selector] {
         [
             FENNEC_ICONS,
@@ -110,7 +187,16 @@ struct SpringboardSelectors: SpringboardSelectorsSet {
             OPEN_LAST_BOOKMARK_BUTTON,
             NOTIFICATIONS_PERMISSION_ALERT,
             ALLOW_NOTIFICATIONS_BUTTON,
-            DONT_ALLOW_NOTIFICATIONS_BUTTON
+            DONT_ALLOW_NOTIFICATIONS_BUTTON,
+            FIREFOX_WIDGET,
+            SCREEN_TIME_ICON,
+            EDIT_HOME_SCREEN_BUTTON,
+            EDIT_BUTTON,
+            ADD_WIDGET_BUTTON,
+            CONFIRM_ADD_WIDGET_BUTTON,
+            SEARCH_WIDGETS_FIELD,
+            QUICK_ACTIONS_LABEL,
+            DONE_BUTTON
         ]
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5840

## :bulb: Description
Automates TestRail case [C2306878](https://mozilla.testrail.io/index.php?/cases/view/2306878) —
"New Tab set as Blank - Keyboard is raised up when the tab is opened from context menus or FF
widgets" — as a single test covering all 12 steps.

With the new tab page set to Blank, the test opens a new tab from each entry point in the case and
checks the same thing every time: the tab opens blank with the keyboard up, tapping "<" closes the
keyboard, and tapping the address bar brings it back. The entry points are a normal new tab, the
tab tray long-press menu, the app icon's New Tab shortcut, and the Firefox home screen widget.

### Notes

- The tab tray long-press menu doesn't exist on iPad, so that step is skipped there. The iPad run
  covers the other 11 steps.
- The test takes around 3-4 minutes, almost all of it the widget part, which has to add the widget
  to the home screen before it can be used. Keeping all 12 steps together was deliberate; if we'd
  rather have a fast test, the widget check could move into the existing `testNewSearchWidget`
  instead and bring it down to well under a minute.
- Runs in the full functional plan only.
- Helpers for the widget were added next to the existing home screen helpers. `TodayWidgetTests`
  still has its own private copies of similar code — worth merging the two at some point, but left
  alone here so a passing suite isn't disturbed.

