### PR TITLE
Refactor FXIOS-16630 [ToolbarAction refactor] action states for leading action and replace in AddressBarState

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -359,6 +359,7 @@
 		21996BAB2AE95AFC00E0D55F /* TabTrayPanelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21996BAA2AE95AFC00E0D55F /* TabTrayPanelType.swift */; };
 		2199A1D22DB80B6C00DC84BD /* ZoomPageManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2199A1D12DB80B6C00DC84BD /* ZoomPageManagerTests.swift */; };
 		2199A1D42DB8389000DC84BD /* MockZoomStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2199A1D32DB8389000DC84BD /* MockZoomStore.swift */; };
+		2199D3E230472D2800BB96F4 /* LeadingPageActionsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2199D3E130472D2800BB96F4 /* LeadingPageActionsBuilder.swift */; };
 		219AEE4A2E5E38BD00BF5F6F /* TabProviderAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219AEE492E5E38B200BF5F6F /* TabProviderAdapter.swift */; };
 		219AEECE2E5E524300BF5F6F /* MockTabProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219AEECD2E5E523600BF5F6F /* MockTabProviderProtocol.swift */; };
 		219F27152EA2956100AE4536 /* MockBrowserViewControllerWebViewDelegates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 219F27142EA2956100AE4536 /* MockBrowserViewControllerWebViewDelegates.swift */; };
@@ -3267,6 +3268,7 @@
 		21996BAA2AE95AFC00E0D55F /* TabTrayPanelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTrayPanelType.swift; sourceTree = "<group>"; };
 		2199A1D12DB80B6C00DC84BD /* ZoomPageManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomPageManagerTests.swift; sourceTree = "<group>"; };
 		2199A1D32DB8389000DC84BD /* MockZoomStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockZoomStore.swift; sourceTree = "<group>"; };
+		2199D3E130472D2800BB96F4 /* LeadingPageActionsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeadingPageActionsBuilder.swift; sourceTree = "<group>"; };
 		219AEE492E5E38B200BF5F6F /* TabProviderAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabProviderAdapter.swift; sourceTree = "<group>"; };
 		219AEECD2E5E523600BF5F6F /* MockTabProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabProviderProtocol.swift; sourceTree = "<group>"; };
 		219F27142EA2956100AE4536 /* MockBrowserViewControllerWebViewDelegates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBrowserViewControllerWebViewDelegates.swift; sourceTree = "<group>"; };
@@ -16943,6 +16945,7 @@
 		E1DE2F812BE394C80054BCDC /* Redux */ = {
 			isa = PBXGroup;
 			children = (
+				2199D3E130472D2800BB96F4 /* LeadingPageActionsBuilder.swift */,
 				2132A47030378FC20040B898 /* NavigationActionsState.swift */,
 				AAD1CD862EAABA7C00BEC90A /* TranslationsConfiguration.swift */,
 				E177989B2BD7D48500F6F0EB /* ToolbarAction.swift */,
@@ -20882,6 +20885,7 @@
 				8AEDB11529F9F00400F2A53B /* SceneContainer.swift in Sources */,
 				B23620512B9BAAF3000B1DE7 /* AddressFormData.swift in Sources */,
 				AB42CC742A1F5240003C9594 /* CreditCardBottomSheetViewController.swift in Sources */,
+				2199D3E230472D2800BB96F4 /* LeadingPageActionsBuilder.swift in Sources */,
 				8A93F87229D3A5AD004159D9 /* BrowserCoordinator.swift in Sources */,
 				8A3233FE28627446003E1C33 /* LocalDesktopFolder.swift in Sources */,
 				0AB768FA2F3DF280009458EB /* BlockedTrackersFooterView.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -326,10 +326,11 @@ struct AddressBarState: StateType, Sendable, Equatable {
             return defaultState(from: state)
         }
 
-        // Not a ToolbarAction, so shouldUseAlternativeLocationColor(action:) doesn't apply here —
-        // matches its own fallback branch for non-ToolbarAction callers.
+        // Not a ToolbarAction, so shouldUseAlternativeLocationColor(action:isNovaDesignEnabled:)
+        // doesn't apply here, matches its own fallback branch for non-ToolbarAction callers.
         let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: state.windowUUID)
-        let hasAlternativeLocationColor = shouldShowAlternativeLocationColor(toolbarState: toolbarState)
+        let hasAlternativeLocationColor = shouldShowAlternativeLocationColor(toolbarState: toolbarState,
+                                                                             isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: state.isEditing,
@@ -374,10 +375,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleWebsiteLoadingStateDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction,
+                                                                            isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: state.isEditing,
-            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions)
@@ -392,10 +395,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         let isEmptySearch = toolbarAction.url == nil
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction,
+                                                                            isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: state.isEditing,
-            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
 
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
@@ -444,10 +449,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleBackForwardButtonStateChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction,
+                                                                            isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: state.isEditing,
-            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions)
@@ -461,10 +468,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleTraitCollectionDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction,
+                                                                            isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: state.isEditing,
-            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions)
@@ -480,10 +489,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleShowMenuWarningBadgeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction,
+                                                                            isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: state.isEditing,
-            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions)
@@ -499,10 +510,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handlePositionChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction,
+                                                                            isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: state.isEditing,
-            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions)
@@ -524,10 +537,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
         // Declared once and reused so the actions computed here can never drift out of sync
         let isEditing = true
 
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction,
+                                                                            isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: isEditing,
-            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions)
@@ -554,11 +569,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
         // This action always puts the address bar into editing mode.
         // Declared once and reused so the actions computed here can never drift out of sync
         let isEditing = true
-
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction,
+                                                                            isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: isEditing,
-            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
             .copy(leadingPageActions: leadingPageActions)
@@ -598,11 +614,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
         // This action always leaves editing mode. Declared once and reused so the actions computed here
         // can never drift out of sync
         let isEditing = false
-
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction,
+                                                                            isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: isEditing,
-            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
 
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
@@ -629,11 +646,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
         // This action always puts the address bar into editing mode.
         // Declared once and reused so the actions computed here can never drift out of sync
         let isEditing = true
-
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction,
+                                                                            isNovaDesignEnabled: state.isNovaDesignEnabled)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: isEditing,
-            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
 
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
@@ -910,9 +928,11 @@ struct AddressBarState: StateType, Sendable, Equatable {
     /// `toolbarPositionChanged` carry a fresher value for these fields than what's already
     /// committed to `ToolbarState`; every other action reads `ToolbarState` directly, same as
     /// `shouldShowAlternativeLocationColor(toolbarState:)` below. Shared between
-    /// `leadingPageActions` and `trailingPageActions`.
+    /// `leadingPageActions` and `trailingPageActions`. Always false on Nova.
     @MainActor
-    private static func shouldUseAlternativeLocationColor(action: ToolbarAction) -> Bool {
+    private static func shouldUseAlternativeLocationColor(action: ToolbarAction, isNovaDesignEnabled: Bool) -> Bool {
+        guard !isNovaDesignEnabled else { return false }
+
         guard let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: action.windowUUID)
         else { return false }
 
@@ -932,15 +952,16 @@ struct AddressBarState: StateType, Sendable, Equatable {
         return toolbarPosition == .top && !isShowingTopTabs && isShowingNavigationToolbar
     }
 
-    /// Same check as `shouldUseAlternativeLocationColor(action:)` (top position, no top tabs, nav
-    /// toolbar visible), but reads `ToolbarState` directly with no action-specific override, for
-    /// callers that don't have a `ToolbarAction` to read overrides from like `TranslationsAction`).
+    /// Same check as `shouldUseAlternativeLocationColor(action:isNovaDesignEnabled:)`
+    /// (top position, no top tabs, nav toolbar visible), but reads `ToolbarState`
+    /// directly. To read overrides from  `TranslationsAction`). Always false on Nova
     @MainActor
-    private static func shouldShowAlternativeLocationColor(toolbarState: ToolbarState?) -> Bool {
-        guard let toolbarState else { return false }
-            return toolbarState.toolbarPosition == .top
-                && !toolbarState.isShowingTopTabs
-                && toolbarState.isShowingNavigationToolbar
+    private static func shouldShowAlternativeLocationColor(toolbarState: ToolbarState?, isNovaDesignEnabled: Bool) -> Bool {
+        guard !isNovaDesignEnabled, let toolbarState else { return false }
+
+        return toolbarState.toolbarPosition == .top
+            && !toolbarState.isShowingTopTabs
+            && toolbarState.isShowingNavigationToolbar
     }
 
     @MainActor

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -196,7 +196,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
             TranslationsActionType.receivedTranslationLanguage,
             TranslationsActionType.didReceiveErrorTranslating,
             TranslationsActionType.didTranslationSettingsChange:
-            return handleLeadingPageChangedAction(state: state, action: action)
+            return handleLeadingPageTranslationAction(state: state, action: action)
 
         case ToolbarActionType.didSummarizeSettingsChange:
             return handleSummarizeStateChangedAction(state: state, action: action)
@@ -321,15 +321,23 @@ struct AddressBarState: StateType, Sendable, Equatable {
     }
 
     @MainActor
-    private static func handleLeadingPageChangedAction(state: Self, action: Action) -> Self {
+    private static func handleLeadingPageTranslationAction(state: Self, action: Action) -> Self {
         guard let translationsAction = action as? TranslationsAction else {
             return defaultState(from: state)
         }
 
+        // Not a ToolbarAction, so shouldUseAlternativeLocationColor(action:) doesn't apply here —
+        // matches its own fallback branch for non-ToolbarAction callers.
+        let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: state.windowUUID)
+        let hasAlternativeLocationColor = toolbarState.map {
+            $0.toolbarPosition == .top && !$0.isShowingTopTabs && $0.isShowingNavigationToolbar
+        } ?? false
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: state.isEditing,
+            hasAlternativeLocationColor: hasAlternativeLocationColor)
         return state
-            .copy(leadingPageActions: leadingPageActions(action: translationsAction,
-                                                         addressBarState: state,
-                                                         isEditing: state.isEditing))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(translationConfiguration: translationsAction.translationConfiguration)
     }
 
@@ -368,11 +376,13 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleWebsiteLoadingStateDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: state.isEditing,
+            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
-            .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
-                                                         addressBarState: state,
-                                                         isEditing: state.isEditing))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
                                                            isEditing: state.isEditing))
@@ -384,12 +394,14 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         let isEmptySearch = toolbarAction.url == nil
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: state.isEditing,
+            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
 
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
-            .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
-                                                         addressBarState: state,
-                                                         isEditing: state.isEditing))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
                                                            isEditing: state.isEditing,
@@ -434,11 +446,13 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleBackForwardButtonStateChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: state.isEditing,
+            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
-            .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
-                                                         addressBarState: state,
-                                                         isEditing: state.isEditing))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
                                                            isEditing: state.isEditing))
@@ -449,11 +463,13 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleTraitCollectionDidChangeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: state.isEditing,
+            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
-            .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
-                                                         addressBarState: state,
-                                                         isEditing: state.isEditing))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
                                                            isEditing: state.isEditing))
@@ -466,11 +482,13 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handleShowMenuWarningBadgeAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: state.isEditing,
+            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
-            .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
-                                                         addressBarState: state,
-                                                         isEditing: state.isEditing))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
                                                            isEditing: state.isEditing))
@@ -483,11 +501,13 @@ struct AddressBarState: StateType, Sendable, Equatable {
     private static func handlePositionChangedAction(state: Self, action: Action) -> Self {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: state.isEditing,
+            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
-            .copy(leadingPageActions: leadingPageActions(action: toolbarAction,
-                                                         addressBarState: state,
-                                                         isEditing: state.isEditing))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
                                                            isEditing: state.isEditing))
@@ -502,17 +522,24 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
+        // Declared once and reused below (including in the `.copy(isEditing:)` call) so the actions
+        // computed here can never drift out of sync with the isEditing value this handler commits to.
+        let isEditing = true // this action always puts the address bar into editing mode
 
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: isEditing,
+            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
-            .copy(leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state, isEditing: true))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
-                                                           isEditing: true,
+                                                           isEditing: isEditing,
                                                            isEmptySearch: isEmptySearch))
-            .copy(browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: true))
+            .copy(browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: isEditing))
             .copy(searchTerm: toolbarAction.searchTerm)
-            .copy(isEditing: true)
+            .copy(isEditing: isEditing)
             .copy(shouldShowKeyboard: true)
             .copy(shouldSelectSearchTerm: false)
             .copy(didStartTyping: false)
@@ -526,17 +553,24 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let searchTerm = toolbarAction.searchTerm ?? state.searchTerm
         let locationText = searchTerm ?? state.url?.absoluteString
         let isEmptySearch = locationText == nil || locationText?.isEmpty == true
+        // Declared once and reused below (including in the `.copy(isEditing:)` call) so the actions
+        // computed here can never drift out of sync with the isEditing value this handler commits to.
+        let isEditing = true // this action always puts the address bar into editing mode
 
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: isEditing,
+            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
-            .copy(leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state, isEditing: true))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
-                                                           isEditing: true,
+                                                           isEditing: isEditing,
                                                            isEmptySearch: isEmptySearch))
-            .copy(browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: true))
+            .copy(browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: isEditing))
             .copy(searchTerm: searchTerm)
-            .copy(isEditing: true)
+            .copy(isEditing: isEditing)
             .copy(shouldShowKeyboard: true)
             .copy(shouldSelectSearchTerm: true)
             .copy(didStartTyping: false)
@@ -563,18 +597,26 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
         let url = toolbarAction.url ?? state.url
         let isEmptySearch = url == nil
+        // Declared once and reused below (including in the `.copy(isEditing:)` call) so the actions
+        // computed here can never drift out of sync with the isEditing value this handler commits to.
+        let isEditing = false // this action always leaves editing mode
+
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: isEditing,
+            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
 
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
-            .copy(leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
-                                                           isEditing: false,
+                                                           isEditing: isEditing,
                                                            isEmptySearch: isEmptySearch))
-            .copy(browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: false))
+            .copy(browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: isEditing))
             .copy(url: url)
             .copy(searchTerm: nil)
-            .copy(isEditing: false)
+            .copy(isEditing: isEditing)
             .copy(shouldShowKeyboard: false)
             .copy(shouldSelectSearchTerm: false)
             .copy(didStartTyping: false)
@@ -586,17 +628,25 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
+        // Declared once and reused below (including in the `.copy(isEditing:)` call) so the actions
+        // computed here can never drift out of sync with the isEditing value this handler commits to.
+        let isEditing = true // this action always puts the address bar into editing mode
+
+        let leadingPageActions = LeadingPageActionsBuilder.getActions(
+            action: action,
+            isEditing: isEditing,
+            hasAlternativeLocationColor: shouldUseAlternativeLocationColor(action: toolbarAction))
 
         return state
             .copy(navigationActionsState: NavigationActionsState.reducer.legacyReducer(state.navigationActionsState, action))
-            .copy(leadingPageActions: leadingPageActions(action: toolbarAction, addressBarState: state, isEditing: true))
+            .copy(leadingPageActions: leadingPageActions)
             .copy(trailingPageActions: trailingPageActions(action: toolbarAction,
                                                            addressBarState: state,
-                                                           isEditing: true,
+                                                           isEditing: isEditing,
                                                            isEmptySearch: isEmptySearch))
-            .copy(browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: true))
+            .copy(browserActions: browserActions(action: toolbarAction, addressBarState: state, isEditing: isEditing))
             .copy(searchTerm: toolbarAction.searchTerm)
-            .copy(isEditing: true)
+            .copy(isEditing: isEditing)
             .copy(shouldShowKeyboard: true)
             .copy(shouldSelectSearchTerm: false)
             .copy(didStartTyping: false)
@@ -716,76 +766,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
     }
 
     // MARK: - Address Toolbar Actions
-    @MainActor
-    private static func leadingPageActions(
-        action: Action,
-        addressBarState: AddressBarState,
-        isEditing: Bool = false
-    ) -> [ToolbarActionConfiguration] {
-        var actions = [ToolbarActionConfiguration]()
-
-        guard action is ToolbarAction || action is TranslationsAction else { return actions }
-
-        guard let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: action.windowUUID),
-              !isEditing
-        else { return actions }
-
-        let toolbarAction = action as? ToolbarAction
-        let actionTranslationConfiguration = TranslationConfiguration(from: action)
-        // For TranslationsAction the action's config is the sole authority — nil means "clear the icon".
-        // For ToolbarAction we fall back to state so the icon persists across unrelated toolbar updates.
-        let resolvedTranslationConfiguration: TranslationConfiguration? = action is TranslationsAction
-            ? actionTranslationConfiguration
-            : actionTranslationConfiguration ?? addressBarState.translationConfiguration
-        let isShowingNavigationToolbar = toolbarAction?.isShowingNavigationToolbar
-            ?? toolbarState.isShowingNavigationToolbar
-        let isURLDidChangeAction = action.actionType as? ToolbarActionType == .urlDidChange
-        let isHomepage = (isURLDidChangeAction ? toolbarAction?.url : toolbarState.addressToolbar.url) == nil
-        let isLoadingChangeAction = action.actionType as? ToolbarActionType == .websiteLoadingStateDidChange
-        let isLoading = isLoadingChangeAction ? toolbarAction?.isLoading : addressBarState.isLoading
-        let hasAlternativeLocationColor: Bool
-        if let toolbarAction {
-            hasAlternativeLocationColor = shouldUseAlternativeLocationColor(
-                action: toolbarAction,
-                isNovaDesignEnabled: addressBarState.isNovaDesignEnabled
-            )
-        } else {
-            hasAlternativeLocationColor = !addressBarState.isNovaDesignEnabled
-                && toolbarState.toolbarPosition == .top
-                && !toolbarState.isShowingTopTabs
-                && toolbarState.isShowingNavigationToolbar
-        }
-
-        if !isHomepage, !isShowingNavigationToolbar {
-            let shareAction = shareAction(enabled: isLoading == false,
-                                          hasAlternativeLocationColor: hasAlternativeLocationColor)
-            actions.append(shareAction)
-
-            if let translationAction = configureTranslationIcon(
-                translationConfiguration: resolvedTranslationConfiguration,
-                isLoading: isLoading,
-                hasAlternativeLocationColor: hasAlternativeLocationColor,
-                isNovaDesignEnabled: addressBarState.isNovaDesignEnabled
-            ) {
-                actions.append(translationAction)
-            }
-        } else if !isHomepage, isShowingNavigationToolbar {
-            let shareAction = shareAction(enabled: isLoading == false,
-                                          hasAlternativeLocationColor: hasAlternativeLocationColor)
-            actions.append(shareAction)
-
-            if let translationAction = configureTranslationIcon(
-                translationConfiguration: resolvedTranslationConfiguration,
-                isLoading: isLoading,
-                hasAlternativeLocationColor: hasAlternativeLocationColor,
-                isNovaDesignEnabled: addressBarState.isNovaDesignEnabled
-            ) {
-                actions.append(translationAction)
-            }
-        }
-
-        return actions
-    }
 
     // Checks whether we should show the translation icon based on the translation configuration
     // state and setups up the configuration for the translation icon on the toolbar (for iPad and iPhone)
@@ -944,28 +924,9 @@ struct AddressBarState: StateType, Sendable, Equatable {
         return googleLensAction
     }
 
-    // MARK: - Helper
+    // Shared between leadingPageActions (via LeadingPageActionsBuilder) and trailingPageActions.
     @MainActor
-    private static func toolbarPosition(action: ToolbarAction) -> AddressToolbarPosition? {
-        guard let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: action.windowUUID)
-        else { return nil }
-
-        guard action.actionType as? ToolbarActionType == .toolbarPositionChanged,
-              let toolbarPosition = action.toolbarPosition
-        else {
-            return toolbarState.toolbarPosition
-        }
-
-        switch toolbarPosition {
-        case .top: return .top
-        case .bottom: return .bottom
-        }
-    }
-
-    @MainActor
-    private static func shouldUseAlternativeLocationColor(action: ToolbarAction, isNovaDesignEnabled: Bool) -> Bool {
-        guard !isNovaDesignEnabled else { return false }
-
+    private static func shouldUseAlternativeLocationColor(action: ToolbarAction) -> Bool {
         guard let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: action.windowUUID)
         else { return false }
 
@@ -985,6 +946,24 @@ struct AddressBarState: StateType, Sendable, Equatable {
         return toolbarPosition == .top && !isShowingTopTabs && isShowingNavigationToolbar
     }
 
+    @MainActor
+    private static func toolbarPosition(action: ToolbarAction) -> AddressToolbarPosition? {
+        guard let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: action.windowUUID)
+        else { return nil }
+
+        guard action.actionType as? ToolbarActionType == .toolbarPositionChanged,
+              let toolbarPosition = action.toolbarPosition
+        else {
+            return toolbarState.toolbarPosition
+        }
+
+        switch toolbarPosition {
+        case .top: return .top
+        case .bottom: return .bottom
+        }
+    }
+
+    // MARK: - Helper
     private static func tabsAction(
         iconName: String?,
         numberOfTabs: Int = 1,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -522,9 +522,9 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
-        // Declared once and reused below (including in the `.copy(isEditing:)` call) so the actions
-        // computed here can never drift out of sync with the isEditing value this handler commits to.
-        let isEditing = true // this action always puts the address bar into editing mode
+        // This action always puts the address bar into editing mode.
+        // Declared once and reused so the actions computed here can never drift out of sync
+        let isEditing = true
 
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
@@ -553,9 +553,9 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let searchTerm = toolbarAction.searchTerm ?? state.searchTerm
         let locationText = searchTerm ?? state.url?.absoluteString
         let isEmptySearch = locationText == nil || locationText?.isEmpty == true
-        // Declared once and reused below (including in the `.copy(isEditing:)` call) so the actions
-        // computed here can never drift out of sync with the isEditing value this handler commits to.
-        let isEditing = true // this action always puts the address bar into editing mode
+        // This action always puts the address bar into editing mode.
+        // Declared once and reused so the actions computed here can never drift out of sync
+        let isEditing = true
 
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
@@ -597,9 +597,9 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
         let url = toolbarAction.url ?? state.url
         let isEmptySearch = url == nil
-        // Declared once and reused below (including in the `.copy(isEditing:)` call) so the actions
-        // computed here can never drift out of sync with the isEditing value this handler commits to.
-        let isEditing = false // this action always leaves editing mode
+        // This action always leaves editing mode. Declared once and reused so the actions computed here
+        // can never drift out of sync
+        let isEditing = false
 
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
@@ -628,9 +628,9 @@ struct AddressBarState: StateType, Sendable, Equatable {
         guard let toolbarAction = action as? ToolbarAction else { return defaultState(from: state) }
 
         let isEmptySearch = toolbarAction.searchTerm == nil || toolbarAction.searchTerm?.isEmpty == true
-        // Declared once and reused below (including in the `.copy(isEditing:)` call) so the actions
-        // computed here can never drift out of sync with the isEditing value this handler commits to.
-        let isEditing = true // this action always puts the address bar into editing mode
+        // This action always puts the address bar into editing mode.
+        // Declared once and reused so the actions computed here can never drift out of sync
+        let isEditing = true
 
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -329,9 +329,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         // Not a ToolbarAction, so shouldUseAlternativeLocationColor(action:) doesn't apply here —
         // matches its own fallback branch for non-ToolbarAction callers.
         let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: state.windowUUID)
-        let hasAlternativeLocationColor = toolbarState.map {
-            $0.toolbarPosition == .top && !$0.isShowingTopTabs && $0.isShowingNavigationToolbar
-        } ?? false
+        let hasAlternativeLocationColor = shouldShowAlternativeLocationColor(toolbarState: toolbarState)
         let leadingPageActions = LeadingPageActionsBuilder.getActions(
             action: action,
             isEditing: state.isEditing,
@@ -767,24 +765,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
     // MARK: - Address Toolbar Actions
 
-    // Checks whether we should show the translation icon based on the translation configuration
-    // state and setups up the configuration for the translation icon on the toolbar (for iPad and iPhone)
-    private static func configureTranslationIcon(
-        translationConfiguration: TranslationConfiguration?,
-        isLoading: Bool?,
-        hasAlternativeLocationColor: Bool,
-        isNovaDesignEnabled: Bool
-    ) -> ToolbarActionConfiguration? {
-        guard let config = translationConfiguration, config.isTranslationFeatureEnabled else { return nil }
-        guard let iconState = config.state else { return nil }
-        return translateAction(
-            enabled: isLoading == false,
-            state: iconState,
-            hasAlternativeLocationColor: hasAlternativeLocationColor,
-            isNovaDesignEnabled: isNovaDesignEnabled
-        )
-    }
-
     @MainActor
     private static func trailingPageActions(
         action: ToolbarAction,
@@ -924,7 +904,13 @@ struct AddressBarState: StateType, Sendable, Equatable {
         return googleLensAction
     }
 
-    // Shared between leadingPageActions (via LeadingPageActionsBuilder) and trailingPageActions.
+    /// Whether the address bar should render with the alternative "in-content" location color —
+    /// true when the toolbar is top-positioned, top tabs aren't shown, and the nav toolbar is
+    /// visible. Only accepts `ToolbarAction` because `traitCollectionDidChange` and
+    /// `toolbarPositionChanged` carry a fresher value for these fields than what's already
+    /// committed to `ToolbarState`; every other action reads `ToolbarState` directly, same as
+    /// `shouldShowAlternativeLocationColor(toolbarState:)` below. Shared between
+    /// `leadingPageActions` and `trailingPageActions`.
     @MainActor
     private static func shouldUseAlternativeLocationColor(action: ToolbarAction) -> Bool {
         guard let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: action.windowUUID)
@@ -944,6 +930,17 @@ struct AddressBarState: StateType, Sendable, Equatable {
 
         let toolbarPosition = toolbarPosition(action: action)
         return toolbarPosition == .top && !isShowingTopTabs && isShowingNavigationToolbar
+    }
+
+    /// Same check as `shouldUseAlternativeLocationColor(action:)` (top position, no top tabs, nav
+    /// toolbar visible), but reads `ToolbarState` directly with no action-specific override, for
+    /// callers that don't have a `ToolbarAction` to read overrides from like `TranslationsAction`).
+    @MainActor
+    private static func shouldShowAlternativeLocationColor(toolbarState: ToolbarState?) -> Bool {
+        guard let toolbarState else { return false }
+            return toolbarState.toolbarPosition == .top
+                && !toolbarState.isShowingTopTabs
+                && toolbarState.isShowingNavigationToolbar
     }
 
     @MainActor
@@ -1006,16 +1003,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
             a11yId: AccessibilityIdentifiers.Toolbar.settingsMenuButton)
     }
 
-    private static func shareAction(enabled: Bool, hasAlternativeLocationColor: Bool) -> ToolbarActionConfiguration {
-        return ToolbarActionConfiguration(
-            actionType: .share,
-            iconName: StandardImageIdentifiers.Medium.shareApple,
-            isEnabled: enabled,
-            hasCustomColor: !hasAlternativeLocationColor,
-            a11yLabel: .TabLocationShareAccessibilityLabel,
-            a11yId: AccessibilityIdentifiers.Toolbar.shareButton)
-    }
-
     private static func stopLoadingAction(hasAlternativeLocationColor: Bool) -> ToolbarActionConfiguration {
         return ToolbarActionConfiguration(
             actionType: .stopLoading,
@@ -1073,40 +1060,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
             a11yLabel: .Toolbars.ReaderModeWithSummarizerButtonAccessibilityLabel,
             a11yHint: .TabLocationReloadAccessibilityHint,
             a11yId: AccessibilityIdentifiers.Toolbar.readerModeWithSummarizerButton
-        )
-    }
-
-    // Sets up translation icon on the toolbar
-    //
-    // We handle tapping differently for translation button by showing a loading icon
-    // instead of a highlighted color.
-    // If we kept the highlighted color, then it will cause the translation icon to flicker
-    // when switching from inactive icon to loading icon when user taps on it. Hence, `hasHighlightedColor: false`.
-    private static func translateAction(
-        enabled: Bool,
-        state: TranslationConfiguration.IconState,
-        hasAlternativeLocationColor: Bool,
-        isNovaDesignEnabled: Bool
-    ) -> ToolbarActionConfiguration {
-        // We do not want to use template mode for translate active icon.
-        let isActiveState = state == .active
-
-        return ToolbarActionConfiguration(
-            actionType: .translate,
-            iconName: state.buttonImageName(isNovaDesignEnabled: isNovaDesignEnabled),
-            templateModeForImage: !isActiveState,
-            loadingConfig: LoadingConfig(
-                isLoading: state == .loading,
-                a11yLabel: .Translations.Sheet.AccessibilityLabels.LoadingCompletedAccessibilityLabel
-            ),
-            isEnabled: enabled,
-            isSelected: isActiveState,
-            hasCustomColor: !hasAlternativeLocationColor,
-            hasHighlightedColor: false,
-            contextualHintType: ContextualHintType.translation.rawValue,
-            a11yLabel: state.buttonA11yLabel,
-            a11yId: state.buttonA11yIdentifier,
-            cacheId: AccessibilityIdentifiers.Toolbar.translateButton
         )
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/LeadingPageActionsBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/LeadingPageActionsBuilder.swift
@@ -6,6 +6,7 @@ import Common
 import Redux
 import ToolbarKit
 
+/// TODO: Temporarily used in Reducer side will be moved to UI side next
 /// Builds the address bar's leading page actions (share + translate icon), shown on real
 /// websites, not the homepage, and not while editing. Every input is already
 /// owned by `AddressBarState`, so there's nothing here to persist across dispatches.

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/LeadingPageActionsBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/LeadingPageActionsBuilder.swift
@@ -1,0 +1,128 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import ToolbarKit
+
+/// Builds the address bar's leading page actions (share + translate icon), shown on real
+/// websites, not the homepage, and not while editing. Every input is already
+/// owned by `AddressBarState`, so there's nothing here to persist across dispatches.
+enum LeadingPageActionsBuilder {
+    @MainActor
+    static func getActions(action: Action,
+                           isEditing: Bool,
+                           hasAlternativeLocationColor: Bool) -> [ToolbarActionConfiguration] {
+        var actions = [ToolbarActionConfiguration]()
+
+        guard action is ToolbarAction || action is TranslationsAction else { return actions }
+
+        guard let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: action.windowUUID),
+              !isEditing
+        else { return actions }
+
+        let toolbarAction = action as? ToolbarAction
+        let actionTranslationConfiguration = TranslationConfiguration(from: action)
+        // For TranslationsAction the action's config is the sole authority — nil means "clear the icon".
+        // For ToolbarAction we fall back to state so the icon persists across unrelated toolbar updates.
+        let resolvedTranslationConfiguration: TranslationConfiguration? = action is TranslationsAction
+            ? actionTranslationConfiguration
+            : actionTranslationConfiguration ?? toolbarState.addressToolbar.translationConfiguration
+        let isShowingNavigationToolbar = toolbarAction?.isShowingNavigationToolbar
+            ?? toolbarState.isShowingNavigationToolbar
+        let isURLDidChangeAction = action.actionType as? ToolbarActionType == .urlDidChange
+        let isHomepage = (isURLDidChangeAction ? toolbarAction?.url : toolbarState.addressToolbar.url) == nil
+        let isLoadingChangeAction = action.actionType as? ToolbarActionType == .websiteLoadingStateDidChange
+        let isLoading = isLoadingChangeAction ? toolbarAction?.isLoading : toolbarState.addressToolbar.isLoading
+
+        if !isHomepage, !isShowingNavigationToolbar {
+            let shareAction = shareAction(enabled: isLoading == false,
+                                          hasAlternativeLocationColor: hasAlternativeLocationColor)
+            actions.append(shareAction)
+
+            if let translationAction = configureTranslationIcon(
+                translationConfiguration: resolvedTranslationConfiguration,
+                isLoading: isLoading,
+                hasAlternativeLocationColor: hasAlternativeLocationColor,
+                isNovaDesignEnabled: toolbarState.addressToolbar.isNovaDesignEnabled
+            ) {
+                actions.append(translationAction)
+            }
+        } else if !isHomepage, isShowingNavigationToolbar {
+            let shareAction = shareAction(enabled: isLoading == false,
+                                          hasAlternativeLocationColor: hasAlternativeLocationColor)
+            actions.append(shareAction)
+
+            if let translationAction = configureTranslationIcon(
+                translationConfiguration: resolvedTranslationConfiguration,
+                isLoading: isLoading,
+                hasAlternativeLocationColor: hasAlternativeLocationColor,
+                isNovaDesignEnabled: toolbarState.addressToolbar.isNovaDesignEnabled
+            ) {
+                actions.append(translationAction)
+            }
+        }
+
+        return actions
+    }
+
+    // Checks whether we should show the translation icon based on the translation configuration
+    // state and setups up the configuration for the translation icon on the toolbar (for iPad and iPhone)
+    private static func configureTranslationIcon(translationConfiguration: TranslationConfiguration?,
+                                                 isLoading: Bool?,
+                                                 hasAlternativeLocationColor: Bool,
+                                                 isNovaDesignEnabled: Bool) -> ToolbarActionConfiguration? {
+        guard let config = translationConfiguration, config.isTranslationFeatureEnabled else { return nil }
+        guard let iconState = config.state else { return nil }
+        return translateAction(
+            enabled: isLoading == false,
+            state: iconState,
+            hasAlternativeLocationColor: hasAlternativeLocationColor,
+            isNovaDesignEnabled: isNovaDesignEnabled
+        )
+    }
+
+    // MARK: - Helper
+    private static func shareAction(enabled: Bool, hasAlternativeLocationColor: Bool) -> ToolbarActionConfiguration {
+        return ToolbarActionConfiguration(
+            actionType: .share,
+            iconName: StandardImageIdentifiers.Medium.shareApple,
+            isEnabled: enabled,
+            hasCustomColor: !hasAlternativeLocationColor,
+            a11yLabel: .TabLocationShareAccessibilityLabel,
+            a11yId: AccessibilityIdentifiers.Toolbar.shareButton)
+    }
+
+    // Sets up translation icon on the toolbar
+    // We handle tapping differently for translation button by showing a loading icon instead of a highlighted color.
+    // If we kept the highlighted color, then it will cause the translation icon to flicker
+    // when switching from inactive icon to loading icon when user taps on it. Hence, `hasHighlightedColor: false`.
+    private static func translateAction(
+        enabled: Bool,
+        state: TranslationConfiguration.IconState,
+        hasAlternativeLocationColor: Bool,
+        isNovaDesignEnabled: Bool
+    ) -> ToolbarActionConfiguration {
+        // We do not want to use template mode for translate active icon.
+        let isActiveState = state == .active
+
+        return ToolbarActionConfiguration(
+            actionType: .translate,
+            iconName: state.buttonImageName(isNovaDesignEnabled: isNovaDesignEnabled),
+            templateModeForImage: !isActiveState,
+            loadingConfig: LoadingConfig(
+                isLoading: state == .loading,
+                a11yLabel: .Translations.Sheet.AccessibilityLabels.LoadingCompletedAccessibilityLabel
+            ),
+            isEnabled: enabled,
+            isSelected: isActiveState,
+            hasCustomColor: !hasAlternativeLocationColor,
+            hasHighlightedColor: false,
+            contextualHintType: ContextualHintType.translation.rawValue,
+            a11yLabel: state.buttonA11yLabel,
+            a11yId: state.buttonA11yIdentifier,
+            cacheId: AccessibilityIdentifiers.Toolbar.translateButton
+        )
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/LeadingPageActionsBuilder.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/LeadingPageActionsBuilder.swift
@@ -29,27 +29,14 @@ enum LeadingPageActionsBuilder {
         let resolvedTranslationConfiguration: TranslationConfiguration? = action is TranslationsAction
             ? actionTranslationConfiguration
             : actionTranslationConfiguration ?? toolbarState.addressToolbar.translationConfiguration
-        let isShowingNavigationToolbar = toolbarAction?.isShowingNavigationToolbar
-            ?? toolbarState.isShowingNavigationToolbar
         let isURLDidChangeAction = action.actionType as? ToolbarActionType == .urlDidChange
         let isHomepage = (isURLDidChangeAction ? toolbarAction?.url : toolbarState.addressToolbar.url) == nil
         let isLoadingChangeAction = action.actionType as? ToolbarActionType == .websiteLoadingStateDidChange
         let isLoading = isLoadingChangeAction ? toolbarAction?.isLoading : toolbarState.addressToolbar.isLoading
 
-        if !isHomepage, !isShowingNavigationToolbar {
-            let shareAction = shareAction(enabled: isLoading == false,
-                                          hasAlternativeLocationColor: hasAlternativeLocationColor)
-            actions.append(shareAction)
-
-            if let translationAction = configureTranslationIcon(
-                translationConfiguration: resolvedTranslationConfiguration,
-                isLoading: isLoading,
-                hasAlternativeLocationColor: hasAlternativeLocationColor,
-                isNovaDesignEnabled: toolbarState.addressToolbar.isNovaDesignEnabled
-            ) {
-                actions.append(translationAction)
-            }
-        } else if !isHomepage, isShowingNavigationToolbar {
+        // Whether the navigation toolbar is showing doesn't affect these actions — share/translate
+        // only depend on whether we're on the homepage.
+        if !isHomepage {
             let shareAction = shareAction(enabled: isLoading == false,
                                           hasAlternativeLocationColor: hasAlternativeLocationColor)
             actions.append(shareAction)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16630)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35329)

## :bulb: Description
- Create `LeadingPageActionsBuilder` as part of the ToolbarAction and AddressBarState refactors. Plan to move into the UI part of Redux flow instead of state/reducers side since the current usage computes the leadingActions based on the state, we will do this in two steps:
1- Create LeadingPageActionsBuilder and replace `AddressBarSate.leadingPageActions()` usage with LeadingPageActionsBuilder.getActions
2- Remove `leadingPageActions` from AddressBarState and move usage to UI side using the new concept of lens

## :movie_camera: Demos
- No UI changes

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

