### PR TITLE
Refactor FXIOS-16743 [Summarizer] Enable summarizer language expansion by default on all channels

### DIFF
--- a/firefox-ios/nimbus-features/summarizerLanguageExpansionFeature.yaml
+++ b/firefox-ios/nimbus-features/summarizerLanguageExpansionFeature.yaml
@@ -9,7 +9,7 @@ features:
         description: >
           Whether the feature is enabled or not.
         type: Boolean
-        default: false
+        default: true
       supportedLocales:
         description: >
           The list of supported locale identifiers for the summarizer language expansion according to BCP47 standard.
@@ -24,10 +24,3 @@ features:
           - "pt"
           - "ja"
           - "jp"
-    defaults:
-      - channel: beta
-        value:
-          enabled: true
-      - channel: developer
-        value:
-          enabled: true


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16743)

## :bulb: Description
Flips the `summarizerLanguageExpansionFeature` Nimbus flag default from `false` to `true` so the feature is on for every channel.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
