### PR TITLE
Document FXIOS-16744 [Build Instructions] Note the Xcode Swift macro approval prompt

### DIFF
--- a/firefox-ios/README.md
+++ b/firefox-ios/README.md
@@ -32,6 +32,7 @@ For information on how to contribute to this project, including communication ch
 1. Make sure to select the `Fennec` [scheme](https://developer.apple.com/documentation/xcode/build-system?changes=_2) in Xcode.
 1. Select the destination device you want to build on.
 1. Run the app with `Cmd + R` or by pressing the `build and run` button.
+1. On your first build in Xcode, you may be asked to approve the `ModifiedCopy` Swift macro. Click `Trust & Enable` to let the build continue. This is expected, and the prompt comes back if the macro package changes.
 
 ⚠️ Important: In case you have dependencies issues with SPM, please try the following:
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16744)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35499)

## :bulb: Description

Xcode requires an explicit approval before it will build the `ModifiedCopy` Swift macro, so the first build after a fresh clone stops on a `Trust & Enable` dialog. Nothing in the README mentions it, and dismissing it fails the build with a macro validation error that reads like a broken checkout rather than a pending approval.

Adds one line to the build steps so the prompt is expected. It also notes the prompt can return later, since the approval is tied to the resolved package version.

No change to `focus-ios/README.md` — Focus does not depend on the macro.

**Request for someone with wiki access:** the same note would help on [Automated Project Setup with FXIOS](https://github.com/mozilla-mobile/firefox-ios/wiki/Automated-Project-Setup-with-FXIOS), where the page hands off to opening Xcode. `fxios` passes `-skipMacroValidation`, so nothing prompts during automated setup itself — the dialog only appears later on the first Cmd+R. I don't have wiki access.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] If needed, I updated documentation and added comments to complex code
