### PR TITLE
Bugfix FXIOS-16631 [Nova] [Addresses] Cancel and Save buttons not purple

### DIFF
--- a/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/AddressListView.swift
@@ -34,6 +34,7 @@ struct AddressListView: View {
     @State var subTextColor: Color = .clear
     @State var imageColor: Color = .clear
     @State var listColor: Color = .clear
+    @State private var accentColor: Color?
 
     @State private var isLandscape = false
 
@@ -82,6 +83,7 @@ struct AddressListView: View {
                     editAddressView
                 }
             }
+            .tint(accentColor)
         }
         .onAppear {
             applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
@@ -150,6 +152,7 @@ struct AddressListView: View {
         subTextColor = Color(color.textSecondary)
         imageColor = Color(color.iconSecondary)
         listColor = Color(color.layer1)
+        accentColor = theme.isNova ? Color(color.actionPrimary) : nil
     }
 
     @ViewBuilder var contentUnavailableView: some View {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16631)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR adds Nova color scheme to buttons Cancel and Save from Addresses.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

