### PR TITLE
Add FXIOS-16429 [PrivacyDashboard] Hook up UI with data, minor UI and string updates

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -486,6 +486,8 @@
 		394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394CF6CE1BAA493C00906917 /* DefaultSuggestedSites.swift */; };
 		3954D0F12F74288E00CDC338 /* MerinoStoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3954D0F02F74286800CDC338 /* MerinoStoryResponse.swift */; };
 		39673BC12B6D82F400653F4A /* FxNimbusMessaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39673BC02B6D82F400653F4A /* FxNimbusMessaging.swift */; };
+		396A0A0E3048634C001BF33A /* TrackerBlockerSheetStateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396A0A0D3048634A001BF33A /* TrackerBlockerSheetStateProviderTests.swift */; };
+		396A0A1130486377001BF33A /* TrackerBlockerSheetStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396A0A1030486376001BF33A /* TrackerBlockerSheetStateProvider.swift */; };
 		396E38CC1EE0816C00CC180F /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34DC84D1A16C40C00D49B7B /* Profile.swift */; };
 		396E38DD1EE081DA00CC180F /* SyncDisplayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60D03171D511398002FE3F6 /* SyncDisplayState.swift */; };
 		396E38F11EE0C8EC00CC180F /* FxAPushMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3905B4D41E8E7A6B0027D953 /* FxAPushMessageHandler.swift */; };
@@ -800,7 +802,6 @@
 		630FE1352C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630FE1322C7FB42500D9D6B2 /* NativeErrorPageViewControllerTests.swift */; };
 		631A369F2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A369E2CC0A4FE0044DFEB /* NativeErrorPageMiddleware.swift */; };
 		631A36A32CC0B2470044DFEB /* NativeErrorPageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A36A22CC0B2470044DFEB /* NativeErrorPageHelper.swift */; };
-		A1D8E7F93010234500C0DA7A /* SystemCellularDataStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D8E7F83010234500C0DA7A /* SystemCellularDataStateProvider.swift */; };
 		635183FB2CF5555C00EDFCE2 /* NativeErrorPageStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635183FA2CF5555C00EDFCE2 /* NativeErrorPageStateTests.swift */; };
 		638201093038D86C003C51C5 /* SectionHeaderConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638201083038D85F003C51C5 /* SectionHeaderConfigurationTests.swift */; };
 		63B213282CCA796D00A466DB /* NativeErrorPageAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B213272CCA796D00A466DB /* NativeErrorPageAction.swift */; };
@@ -1441,6 +1442,7 @@
 		A0B6D6632EB49C0400574E34 /* MockTelemetryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9A09D328B01D8700B6F51E /* MockTelemetryWrapper.swift */; };
 		A1B2C3D40000000000000002 /* GoogleLensTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000001 /* GoogleLensTelemetry.swift */; };
 		A1B2C3D40000000000000004 /* GoogleLensTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000003 /* GoogleLensTelemetryTests.swift */; };
+		A1D8E7F93010234500C0DA7A /* SystemCellularDataStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D8E7F83010234500C0DA7A /* SystemCellularDataStateProvider.swift */; };
 		A1F0D0012F70000100ABC001 /* NewsTransitionHeaderCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F0D0002F70000100ABC001 /* NewsTransitionHeaderCellTests.swift */; };
 		A5163EFB4448DCBC295F4B00 /* GCDWebServers in Frameworks */ = {isa = PBXBuildFile; productRef = 3802E29A8D8E43B4A359EBC5 /* GCDWebServers */; };
 		A83E5B1A1C1DA8BF0026D912 /* image.gif in Resources */ = {isa = PBXBuildFile; fileRef = A83E5B181C1DA8BF0026D912 /* image.gif */; };
@@ -1962,7 +1964,6 @@
 		D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B6923C1B9F9444004B87A4 /* FindInPageBar.swift */; };
 		D3B6923F1B9F9A58004B87A4 /* FindInPageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B6923E1B9F9A58004B87A4 /* FindInPageHelper.swift */; };
 		D3BA41681BD82F2200DA5457 /* XCTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */; };
-		DB58110000000000000006 /* SwiftUIViewTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB58110000000000000005 /* SwiftUIViewTestHelpers.swift */; };
 		D3BA7E0E1B0E934F00153782 /* ContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */; };
 		D3BE7B261B054D4400641031 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B251B054D4400641031 /* main.swift */; };
 		D3BE7B461B054F8600641031 /* UITestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BE7B451B054F8600641031 /* UITestAppDelegate.swift */; };
@@ -2032,9 +2033,10 @@
 		DA9FD88624E213CD00168D1E /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9FD88524E213CC00168D1E /* Helpers.swift */; };
 		DA9FD88824E213DD00168D1E /* QuickLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9FD88724E213DC00168D1E /* QuickLink.swift */; };
 		DACDE996225E537900C8F37F /* VersionSettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACDE995225E537900C8F37F /* VersionSettingTests.swift */; };
+		DAE6DF1B29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE6DF1A29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift */; };
 		DB58110000000000000002 /* GenericSelectableItemCellViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB58110000000000000001 /* GenericSelectableItemCellViewTests.swift */; };
 		DB58110000000000000004 /* NavigationBarMiddleButtonSelectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB58110000000000000003 /* NavigationBarMiddleButtonSelectionViewTests.swift */; };
-		DAE6DF1B29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE6DF1A29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift */; };
+		DB58110000000000000006 /* SwiftUIViewTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB58110000000000000005 /* SwiftUIViewTestHelpers.swift */; };
 		DD31E0FB1B382B520077078A /* TabPrintPageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD31E0FA1B382B520077078A /* TabPrintPageRenderer.swift */; };
 		DF8C6DD72A52EED1007FAAF2 /* ClientSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8C6DD62A52EED1007FAAF2 /* ClientSyncManagerTests.swift */; };
 		DFACBF7F277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACBF7E277B5F7B003D5F41 /* LegacyWallpaperBackgroundView.swift */; };
@@ -3560,6 +3562,8 @@
 		3954D0F02F74286800CDC338 /* MerinoStoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerinoStoryResponse.swift; sourceTree = "<group>"; };
 		3964F5FB2656D2B500065278 /* initial_experiments.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = initial_experiments.json; path = Client/Experiments/initial_experiments.json; sourceTree = SOURCE_ROOT; };
 		39673BC02B6D82F400653F4A /* FxNimbusMessaging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxNimbusMessaging.swift; sourceTree = "<group>"; };
+		396A0A0D3048634A001BF33A /* TrackerBlockerSheetStateProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerBlockerSheetStateProviderTests.swift; sourceTree = "<group>"; };
+		396A0A1030486376001BF33A /* TrackerBlockerSheetStateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerBlockerSheetStateProvider.swift; sourceTree = "<group>"; };
 		397848DB1ED86605004C0C0B /* NotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		397848DD1ED86605004C0C0B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		397848DF1ED86605004C0C0B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -10408,6 +10412,7 @@
 		A1B2C3D40000000000000003 /* GoogleLensTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLensTelemetryTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6789012345678 /* FeatureFlagsProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsProviderTests.swift; sourceTree = "<group>"; };
 		A1BF498F8BBB5DC36E678327 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
+		A1D8E7F83010234500C0DA7A /* SystemCellularDataStateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemCellularDataStateProvider.swift; sourceTree = "<group>"; };
 		A1E14C52A9764D105546D292 /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		A1F0D0002F70000100ABC001 /* NewsTransitionHeaderCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsTransitionHeaderCellTests.swift; sourceTree = "<group>"; };
 		A214487DA2ACCB4BA604AD56 /* my */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = my; path = my.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
@@ -11242,7 +11247,6 @@
 		D3B6923C1B9F9444004B87A4 /* FindInPageBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageBar.swift; sourceTree = "<group>"; };
 		D3B6923E1B9F9A58004B87A4 /* FindInPageHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageHelper.swift; sourceTree = "<group>"; };
 		D3BA41671BD82F2200DA5457 /* XCTestCaseExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCaseExtensions.swift; sourceTree = "<group>"; };
-		DB58110000000000000005 /* SwiftUIViewTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewTestHelpers.swift; sourceTree = "<group>"; };
 		D3BA7E0D1B0E934F00153782 /* ContextMenuHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextMenuHelper.swift; sourceTree = "<group>"; };
 		D3BE7B251B054D4400641031 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		D3BE7B451B054F8600641031 /* UITestAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITestAppDelegate.swift; sourceTree = "<group>"; };
@@ -11628,11 +11632,12 @@
 		DAAE4D2BB25BB3FB7F927CBF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ErrorPages.strings; sourceTree = "<group>"; };
 		DAC044248882A2485365F9A2 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Menu.strings; sourceTree = "<group>"; };
 		DACDE995225E537900C8F37F /* VersionSettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionSettingTests.swift; sourceTree = "<group>"; };
-		DB58110000000000000001 /* GenericSelectableItemCellViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericSelectableItemCellViewTests.swift; sourceTree = "<group>"; };
-		DB58110000000000000003 /* NavigationBarMiddleButtonSelectionViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarMiddleButtonSelectionViewTests.swift; sourceTree = "<group>"; };
 		DAD46F3324A1606C001B3967 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		DAD46F3524A1606C001B3967 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		DAE6DF1A29AD78DA0094BD1B /* BrowserViewController+ZoomPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+ZoomPage.swift"; sourceTree = "<group>"; };
+		DB58110000000000000001 /* GenericSelectableItemCellViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericSelectableItemCellViewTests.swift; sourceTree = "<group>"; };
+		DB58110000000000000003 /* NavigationBarMiddleButtonSelectionViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarMiddleButtonSelectionViewTests.swift; sourceTree = "<group>"; };
+		DB58110000000000000005 /* SwiftUIViewTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewTestHelpers.swift; sourceTree = "<group>"; };
 		DB7B460BB39A2062E44CB8EF /* is */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = is; path = is.lproj/Menu.strings; sourceTree = "<group>"; };
 		DBA640A89E36CC846A5AE368 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		DC2B41EC8CA7785480D94F0D /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/HistoryPanel.strings"; sourceTree = "<group>"; };
@@ -11949,7 +11954,6 @@
 		EBBB440898B7A7DD4702405D /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		EBC486982195F46A00CDA48D /* InternalSchemeHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalSchemeHandler.swift; sourceTree = "<group>"; };
 		EBC4869A2195F58200CDA48D /* ErrorPageHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorPageHelper.swift; sourceTree = "<group>"; };
-		A1D8E7F83010234500C0DA7A /* SystemCellularDataStateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemCellularDataStateProvider.swift; sourceTree = "<group>"; };
 		EBC4869B2195F58200CDA48D /* AboutHomeHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutHomeHandler.swift; sourceTree = "<group>"; };
 		EBE26B4E220C959D00D1D99A /* BrowserViewController+ToolBarActionMenuDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BrowserViewController+ToolBarActionMenuDelegate.swift"; sourceTree = "<group>"; };
 		EBF47E6F1F7979DF00899189 /* TelemetryWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWrapper.swift; sourceTree = "<group>"; };
@@ -13375,6 +13379,7 @@
 				C2F700B22FBC000100112233 /* TrackerBlockerModuleCell.swift */,
 				C2F700C32FBC000100112233 /* TrackerBlockerSheetViewController.swift */,
 				C2F70B012FBC000100112233 /* TrackerBlockerSheetState.swift */,
+				396A0A1030486376001BF33A /* TrackerBlockerSheetStateProvider.swift */,
 				C2F70B032FBC000100112233 /* TrackerBlockerProgressBarView.swift */,
 				C2F70B042FBC000100112233 /* TrackerCategoryRowView.swift */,
 				C2F700B32FBC000100112233 /* TrackerBlockerModuleState.swift */,
@@ -14125,6 +14130,7 @@
 				638201083038D85F003C51C5 /* SectionHeaderConfigurationTests.swift */,
 				39CC6FD3301A792500164DCA /* TrackerBlockerModuleCellTests.swift */,
 				C2F70B052FBC000100112233 /* TrackerBlockerSheetViewControllerTests.swift */,
+				396A0A0D3048634A001BF33A /* TrackerBlockerSheetStateProviderTests.swift */,
 				8A09BCC12D22F1A500CFDF60 /* ContextMenu */,
 				8AA0A6662CAC745300AC7EB3 /* HomepageDiffableDataSourceTests.swift */,
 				8AD3AFC42D143F0D00CFC887 /* HomepageDimensionCalculatorTests.swift */,
@@ -20627,6 +20633,7 @@
 				8A93F85E29D36DA9004159D9 /* Coordinator.swift in Sources */,
 				1D2F68B12ACCA22000524B92 /* RemoteTabsEmptyView.swift in Sources */,
 				1DCEC4102D822F1A00129966 /* ASRemoteSettingsCollection.swift in Sources */,
+				396A0A1130486377001BF33A /* TrackerBlockerSheetStateProvider.swift in Sources */,
 				EDF2C0582D693B7D00723609 /* AppIconSelectionView.swift in Sources */,
 				43D16B8729831EEF009F8279 /* RemoveCardButton.swift in Sources */,
 				D59431ED25E9912900F0BA82 /* WidgetIntents.intentdefinition in Sources */,
@@ -20941,6 +20948,7 @@
 				E18259E329B2A51B00E6BE76 /* MockNotificationManager.swift in Sources */,
 				2154A0FD2F115EEE0067EA43 /* MockPasswordGeneratorScriptEvaluator.swift in Sources */,
 				96A5F736298D8EDF00234E5F /* MockSearchEngineProvider.swift in Sources */,
+				396A0A0E3048634C001BF33A /* TrackerBlockerSheetStateProviderTests.swift in Sources */,
 				8A5D1CA02A30C9D7005AD35C /* MockAppSettingsDelegate.swift in Sources */,
 				8CF40B482DFC22C200DCB7F0 /* OnboardingServiceTests.swift in Sources */,
 				8AEF41602D15D6290013925D /* TopSitesSectionStateTests.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -836,10 +836,12 @@ final class BrowserCoordinator: BaseCoordinator,
     }
 
     func showTrackerBlockerSheet() {
-        // TODO: FXIOS-16429 - Pass the real blocked-tracker data once it is available.
+        let stateProvider = TrackerBlockerSheetStateProvider(
+            statsStore: DefaultTrackerBlockStatsStoreUtility(prefs: profile.prefs)
+        )
         let viewController = TrackerBlockerSheetViewController(
             windowUUID: windowUUID,
-            state: .empty,
+            state: stateProvider.sheetState(),
             themeManager: themeManager
         )
         router.present(viewController, animated: true)

--- a/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetState.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Shared
 import UIKit
 
 /// The content shown by `TrackerBlockerSheetViewController`.
@@ -38,13 +39,12 @@ struct TrackerBlockerSheetState {
                 }
             }
 
-            // TODO: FXIOS-16429 - Replace with localized strings once available.
-            var placeholderTitle: String {
+            var localizedTitle: String {
                 switch self {
-                case .crossSiteTrackingCookies: return "Cross-Site Tracking Cookies"
-                case .fingerprinters: return "Fingerprinters"
-                case .trackingContent: return "Tracking Content"
-                case .socialMediaTrackers: return "Social Media Trackers"
+                case .crossSiteTrackingCookies: return .PrivacyDashboard.CrossSiteTrackers
+                case .fingerprinters: return .PrivacyDashboard.Fingerprinters
+                case .trackingContent: return .PrivacyDashboard.TrackingContent
+                case .socialMediaTrackers: return .PrivacyDashboard.SocialTrackers
                 }
             }
         }
@@ -56,7 +56,7 @@ struct TrackerBlockerSheetState {
 
         init(kind: Kind, count: Int?, title: String? = nil) {
             self.kind = kind
-            self.title = title ?? kind.placeholderTitle
+            self.title = title ?? kind.localizedTitle
             self.count = count
         }
     }
@@ -69,8 +69,9 @@ struct TrackerBlockerSheetState {
         let sinceDate: String
 
         var countText: String { count.formatted(.number) }
-        // TODO: FXIOS-16429 - Replace with a localized format string once available.
-        var text: String { "\(countText) since \(sinceDate) 🎉" }
+        var text: String {
+            String(format: .PrivacyDashboard.TotalTrackersBlockedSince, countText, sinceDate)
+        }
     }
 
     /// Trackers blocked this week. `nil` puts the sheet in its empty state.
@@ -92,12 +93,12 @@ struct TrackerBlockerSheetState {
 }
 
 extension TrackerBlockerSheetState {
-    // TODO: FXIOS-16429 - Replace the message with a localized string once available.
     /// What the sheet shows until it is handed real blocked-tracker data: every category listed, no counts.
     static var empty: TrackerBlockerSheetState {
         TrackerBlockerSheetState(
             weeklyCount: nil,
-            emptyMessage: "Firefox blocks trackers as you browse, you'll see them here.",
+            emptyMessage: String(format: .PrivacyDashboard.HeaderLabelForNoTrackersBlocked,
+                                 AppName.shortName.rawValue),
             categories: Category.Kind.allCases.map { Category(kind: $0, count: nil) },
             total: nil
         )

--- a/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetState.swift
@@ -15,9 +15,7 @@ import UIKit
 /// - **Weekly reset** – the same as filled but with `weeklyCount == 0` and empty category bars, while the lifetime
 ///   `total` still exists.
 ///
-/// Nothing populates the filled states yet: `empty` is the only one the app constructs, and it is what the sheet
-/// is presented with until the blocked-tracker data is wired up separately. The populated states are exercised
-/// from sample data in `TrackerBlockerSheetViewControllerTests`.
+/// `TrackerBlockerSheetStateProvider` builds whichever of the three the persisted stats call for.
 struct TrackerBlockerSheetState {
     /// A single tracker category row.
     struct Category {
@@ -93,7 +91,7 @@ struct TrackerBlockerSheetState {
 }
 
 extension TrackerBlockerSheetState {
-    /// What the sheet shows until it is handed real blocked-tracker data: every category listed, no counts.
+    /// What the sheet shows before anything has ever been blocked: every category listed, no counts.
     static var empty: TrackerBlockerSheetState {
         TrackerBlockerSheetState(
             weeklyCount: nil,

--- a/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetStateProvider.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetStateProvider.swift
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+
+/// Builds the state the tracker blocker sheet is presented with, out of the persisted blocked-tracker stats.
+///
+/// The sheet is a snapshot taken when it is presented: nothing is blocked while it is on screen, since the user
+/// isn't browsing, so it doesn't observe the store for changes.
+protocol TrackerBlockerSheetStateProviding {
+    func sheetState() -> TrackerBlockerSheetState
+}
+
+struct TrackerBlockerSheetStateProvider: TrackerBlockerSheetStateProviding {
+    /// The category rows, in the order the sheet lists them, and the blocklist category each one counts.
+    /// Mirrors the breakdown the enhanced tracking protection panel shows (see
+    /// `BlockedTrackersTableModel.getItems()`). `cryptomining` has no row on either surface, but it still
+    /// counts towards the weekly and lifetime totals.
+    private static let rowCategories: [(kind: TrackerBlockerSheetState.Category.Kind, blocklist: BlocklistCategory)] = [
+        (.crossSiteTrackingCookies, .advertising),
+        (.fingerprinters, .fingerprinting),
+        (.trackingContent, .analytics),
+        (.socialMediaTrackers, .social)
+    ]
+
+    private let statsStore: TrackerBlockStatsStore
+    private let dateProvider: DateProvider
+
+    init(statsStore: TrackerBlockStatsStore, dateProvider: DateProvider = SystemDateProvider()) {
+        self.statsStore = statsStore
+        self.dateProvider = dateProvider
+    }
+
+    func sheetState() -> TrackerBlockerSheetState {
+        let lifetimeTotal = statsStore.lifetimeTotal()
+        // Nothing has ever been blocked, so there is no breakdown to show yet.
+        guard lifetimeTotal > 0 else { return .empty }
+
+        let now = dateProvider.now()
+        let weeklyByCategory = statsStore.currentWeekByCategory(for: now)
+
+        return TrackerBlockerSheetState(
+            weeklyCount: statsStore.currentWeekTotal(for: now),
+            emptyMessage: nil,
+            categories: Self.rowCategories.map {
+                TrackerBlockerSheetState.Category(kind: $0.kind, count: weeklyByCategory[$0.blocklist] ?? 0)
+            },
+            // The footer needs a date to count from; without one the counts are still shown on their own.
+            total: statsStore.trackingStartDate().map {
+                TrackerBlockerSheetState.Total(count: lifetimeTotal, sinceDate: Self.dateText(for: $0))
+            }
+        )
+    }
+
+    private static func dateText(for date: Date) -> String {
+        return date.formatted(date: .numeric, time: .omitted)
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetViewController.swift
@@ -261,9 +261,8 @@ final class TrackerBlockerSheetViewController: UIViewController, Themeable, Noti
     }
 
     private func setupCloseButton() {
-        // TODO: FXIOS-16429 - Use a localized close-button a11y label once strings land.
         let closeButtonViewModel = CloseButtonViewModel(
-            a11yLabel: "Close",
+            a11yLabel: .CloseButtonTitle,
             a11yIdentifier: AccessibilityIdentifiers.FirefoxHomepage.TrackerBlockerModule.Sheet.closeButton
         )
         closeButton.configure(viewModel: closeButtonViewModel, notificationCenter: notificationCenter)
@@ -314,13 +313,14 @@ final class TrackerBlockerSheetViewController: UIViewController, Themeable, Noti
 
         rebuildCategoryRows(with: state, theme: theme)
 
-        // TODO: FXIOS-16429 - Replace the weekly copy and its a11y label with localized strings once available.
         if let weeklyCount = state.weeklyCount {
+            let countText = weeklyCount.formatted(.number)
             weeklyCountLabel.isHidden = false
-            weeklyCountLabel.text = weeklyCount.formatted(.number)
-            weeklyCountLabel.accessibilityLabel = "\(weeklyCount) trackers blocked this week"
+            weeklyCountLabel.text = countText
+            // The count and the header read as one sentence, so the count carries both for VoiceOver.
+            weeklyCountLabel.accessibilityLabel = "\(countText) \(String.PrivacyDashboard.HeaderLabel)"
 
-            headerLabel.text = "Trackers blocked this week"
+            headerLabel.text = .PrivacyDashboard.HeaderLabel
             headerLabel.font = FXFontStyles.Regular.body.scaledFont()
             headerLabel.isAccessibilityElement = true
         } else {

--- a/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetViewController.swift
@@ -318,11 +318,11 @@ final class TrackerBlockerSheetViewController: UIViewController, Themeable, Noti
             weeklyCountLabel.isHidden = false
             weeklyCountLabel.text = countText
             // The count and the header read as one sentence, so the count carries both for VoiceOver.
-            weeklyCountLabel.accessibilityLabel = "\(countText) \(String.PrivacyDashboard.HeaderLabel)"
-
+            weeklyCountLabel.accessibilityLabel = String(format: .PrivacyDashboard.HeaderLabelAccessibilityLabel,
+                                                         countText)
             headerLabel.text = .PrivacyDashboard.HeaderLabel
             headerLabel.font = FXFontStyles.Regular.body.scaledFont()
-            headerLabel.isAccessibilityElement = true
+            headerLabel.isAccessibilityElement = false
         } else {
             weeklyCountLabel.isHidden = true
             headerLabel.text = state.emptyMessage

--- a/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerBlockerSheetViewController.swift
@@ -58,8 +58,8 @@ final class TrackerBlockerSheetViewController: UIViewController, Themeable, Noti
     // MARK: - UI
     private let backgroundGradientView: GradientView = .build()
 
-    private lazy var closeButton: CloseButton = .build { [weak self] button in
-        button.addTarget(self, action: #selector(self?.closeButtonTapped), for: .touchUpInside)
+    private lazy var closeButton: CloseButton = .build { [unowned self] button in
+        button.addTarget(self, action: #selector(self.closeButtonTapped), for: .touchUpInside)
     }
 
     private let contentScrollView: UIScrollView = .build { scrollView in
@@ -322,7 +322,7 @@ final class TrackerBlockerSheetViewController: UIViewController, Themeable, Noti
 
             headerLabel.text = "Trackers blocked this week"
             headerLabel.font = FXFontStyles.Regular.body.scaledFont()
-            headerLabel.isAccessibilityElement = false
+            headerLabel.isAccessibilityElement = true
         } else {
             weeklyCountLabel.isHidden = true
             headerLabel.text = state.emptyMessage

--- a/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerCategoryRowView.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TrackerBlockerModule/TrackerCategoryRowView.swift
@@ -133,12 +133,14 @@ final class TrackerCategoryRowView: UIView, ThemeApplicable {
         titleLabel.text = category.title
         iconImageView.image = UIImage(named: category.kind.imageName)?.withRenderingMode(.alwaysTemplate)
 
-        // TODO: FXIOS-16429 - Replace the a11y label with a localized format string once available.
         if let count = category.count {
-            countLabel.text = count.formatted(.number)
+            let countText = count.formatted(.number)
+            countLabel.text = countText
             setDetailsVisible(true)
             progressBar.setFillRatio(fillRatio)
-            accessibilityLabel = "\(category.title), \(count) blocked"
+            accessibilityLabel = String(format: .PrivacyDashboard.CategoryAccessibilityLabel,
+                                        category.title,
+                                        countText)
         } else {
             setDetailsVisible(false)
             accessibilityLabel = category.title

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2464,6 +2464,12 @@ extension String {
             value: "Trackers blocked this week",
             comment: "On the Privacy Dashboard popup, the text for the header when we have blocked some trackers this week. This is going to have, above it, in bold letters, the number of trackers blocked this week."
         )
+        public static let HeaderLabelAccessibilityLabel = MZLocalizedString(
+            key: "PrivacyDashboard.HeaderLabelAccessibilityLabel.v156",
+            tableName: "PrivacyDashboard",
+            value: "%@ trackers blocked this week",
+            comment: "On the Privacy Dashboard popup, the accessibility label read out for the weekly count. The count and the header below it are two separate labels on screen, but are read out as this one sentence. The placeholder (%@) is how many trackers we've blocked this week, in a localized format (provided by Swift's built in number localization)."
+        )
         public static let CrossSiteTrackers = MZLocalizedString(
             key: "PrivacyDashboard.CrossSiteTrackers.v155",
             tableName: "PrivacyDashboard",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2488,6 +2488,12 @@ extension String {
             value: "Social Media Trackers",
             comment: "On the Privacy Dashboard popup, the title text for the bar & label showing how many social media trackers we've blocked."
         )
+        public static let CategoryAccessibilityLabel = MZLocalizedString(
+            key: "PrivacyDashboard.CategoryAccessibilityLabel.v156",
+            tableName: "PrivacyDashboard",
+            value: "%1$@, %2$@ blocked",
+            comment: "On the Privacy Dashboard popup, the accessibility label read out for one of the tracker category rows. The first placeholder (%1$@) is the category's name, such as Fingerprinters. The second placeholder (%2$@) is how many trackers of that category we've blocked this week, in a localized format (provided by Swift's built in number localization)."
+        )
         public static let TotalTrackersBlockedSince = MZLocalizedString(
             key: "PrivacyDashboard.TotalTrackersBlockedSince.v155",
             tableName: "PrivacyDashboard",

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2467,8 +2467,8 @@ extension String {
         public static let HeaderLabelAccessibilityLabel = MZLocalizedString(
             key: "PrivacyDashboard.HeaderLabelAccessibilityLabel.v156",
             tableName: "PrivacyDashboard",
-            value: "%@ trackers blocked this week",
-            comment: "On the Privacy Dashboard popup, the accessibility label read out for the weekly count. The count and the header below it are two separate labels on screen, but are read out as this one sentence. The placeholder (%@) is how many trackers we've blocked this week, in a localized format (provided by Swift's built in number localization)."
+            value: "Trackers blocked this week: %@",
+            comment: "On the Privacy Dashboard popup, the accessibility label read out for the weekly count. The count and the header below it are two separate labels on screen, but are read out as this one sentence. The placeholder (%@) is how many trackers we've blocked this week."
         )
         public static let CrossSiteTrackers = MZLocalizedString(
             key: "PrivacyDashboard.CrossSiteTrackers.v155",
@@ -2497,8 +2497,8 @@ extension String {
         public static let CategoryAccessibilityLabel = MZLocalizedString(
             key: "PrivacyDashboard.CategoryAccessibilityLabel.v156",
             tableName: "PrivacyDashboard",
-            value: "%1$@, %2$@ blocked",
-            comment: "On the Privacy Dashboard popup, the accessibility label read out for one of the tracker category rows. The first placeholder (%1$@) is the category's name, such as Fingerprinters. The second placeholder (%2$@) is how many trackers of that category we've blocked this week, in a localized format (provided by Swift's built in number localization)."
+            value: "%1$@, blocked: %2$@",
+            comment: "On the Privacy Dashboard popup, the accessibility label read out for one of the tracker category rows. The first placeholder (%1$@) is the category's name, such as Fingerprinters. The second placeholder (%2$@) is how many trackers of that category we've blocked this week."
         )
         public static let TotalTrackersBlockedSince = MZLocalizedString(
             key: "PrivacyDashboard.TotalTrackersBlockedSince.v155",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TrackerBlockerSheetStateProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TrackerBlockerSheetStateProviderTests.swift
@@ -1,0 +1,162 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import XCTest
+
+@testable import Client
+
+final class TrackerBlockerSheetStateProviderTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_770_000_000)
+
+    func test_sheetState_withNothingEverBlocked_isEmptyState() {
+        let store = MockTrackerBlockStatsStore()
+
+        let state = createSubject(store: store).sheetState()
+
+        XCTAssertTrue(state.isEmpty)
+        XCTAssertNil(state.weeklyCount)
+        XCTAssertNil(state.total)
+        XCTAssertEqual(state.categories.count, TrackerBlockerSheetState.Category.Kind.allCases.count)
+        XCTAssertTrue(state.categories.allSatisfy { $0.count == nil })
+    }
+
+    func test_sheetState_withBlockedTrackers_usesTheCurrentWeekCounts() {
+        let store = MockTrackerBlockStatsStore()
+        store.lifetimeTotalToReturn = 4321
+        store.currentWeekTotalToReturn = 210
+        store.currentWeekByCategoryToReturn = [
+            .advertising: 100,
+            .fingerprinting: 60,
+            .analytics: 40,
+            .social: 10
+        ]
+
+        let state = createSubject(store: store).sheetState()
+
+        XCTAssertFalse(state.isEmpty)
+        XCTAssertEqual(state.weeklyCount, 210)
+        XCTAssertNil(state.emptyMessage)
+        XCTAssertEqual(counts(in: state), [100, 60, 40, 10])
+    }
+
+    /// The rows are in the sheet's fixed display order, each counting the blocklist category the enhanced
+    /// tracking protection panel shows it for.
+    func test_sheetState_mapsEachRowToItsBlocklistCategory() {
+        let store = MockTrackerBlockStatsStore()
+        store.lifetimeTotalToReturn = 10
+        store.currentWeekByCategoryToReturn = [.advertising: 1, .fingerprinting: 2, .analytics: 3, .social: 4]
+
+        let state = createSubject(store: store).sheetState()
+
+        XCTAssertEqual(state.categories.map { $0.kind },
+                       [.crossSiteTrackingCookies, .fingerprinters, .trackingContent, .socialMediaTrackers])
+        XCTAssertEqual(counts(in: state), [1, 2, 3, 4])
+    }
+
+    func test_sheetState_withCategoryMissingFromTheWeek_countsItAsZero() {
+        let store = MockTrackerBlockStatsStore()
+        store.lifetimeTotalToReturn = 10
+        store.currentWeekByCategoryToReturn = [.advertising: 10]
+
+        let state = createSubject(store: store).sheetState()
+
+        XCTAssertEqual(counts(in: state), [10, 0, 0, 0])
+    }
+
+    func test_sheetState_readsTheCurrentWeekForTheProvidedDate() {
+        let store = MockTrackerBlockStatsStore()
+        store.lifetimeTotalToReturn = 10
+
+        _ = createSubject(store: store).sheetState()
+
+        XCTAssertEqual(store.currentWeekTotalDates, [now])
+        XCTAssertEqual(store.currentWeekByCategoryDates, [now])
+    }
+
+    /// The week can roll over while the lifetime total stays: the bars empty out but the footer remains.
+    func test_sheetState_withNothingBlockedThisWeek_keepsTheLifetimeTotal() {
+        let store = MockTrackerBlockStatsStore()
+        store.lifetimeTotalToReturn = 5305
+        store.currentWeekTotalToReturn = 0
+        store.currentWeekByCategoryToReturn = [:]
+
+        let state = createSubject(store: store).sheetState()
+
+        XCTAssertFalse(state.isEmpty)
+        XCTAssertEqual(state.weeklyCount, 0)
+        XCTAssertEqual(state.total?.count, 5305)
+        XCTAssertEqual(counts(in: state), [0, 0, 0, 0])
+    }
+
+    func test_sheetState_footerCountsFromTheTrackingStartDate() throws {
+        let startDate = Date(timeIntervalSince1970: 1_760_000_000)
+        let store = MockTrackerBlockStatsStore()
+        store.lifetimeTotalToReturn = 43251
+        store.trackingStartDateToReturn = startDate
+
+        let total = try XCTUnwrap(createSubject(store: store).sheetState().total)
+
+        XCTAssertEqual(total.count, 43251)
+        XCTAssertEqual(total.sinceDate, startDate.formatted(date: .numeric, time: .omitted))
+    }
+
+    /// The footer copy needs a date to count from, so it is dropped rather than shown without one.
+    func test_sheetState_withoutATrackingStartDate_hasNoFooterTotal() {
+        let store = MockTrackerBlockStatsStore()
+        store.lifetimeTotalToReturn = 43251
+        store.currentWeekTotalToReturn = 12
+        store.trackingStartDateToReturn = nil
+
+        let state = createSubject(store: store).sheetState()
+
+        XCTAssertNil(state.total)
+        XCTAssertEqual(state.weeklyCount, 12)
+    }
+
+    // MARK: - Helpers
+
+    private func counts(in state: TrackerBlockerSheetState) -> [Int?] {
+        return state.categories.map { $0.count }
+    }
+
+    private func createSubject(store: MockTrackerBlockStatsStore) -> TrackerBlockerSheetStateProvider {
+        return TrackerBlockerSheetStateProvider(statsStore: store, dateProvider: MockDateProvider(date: now))
+    }
+}
+
+private struct MockDateProvider: DateProvider {
+    let date: Date
+    func now() -> Date { return date }
+}
+
+private final class MockTrackerBlockStatsStore: TrackerBlockStatsStore {
+    var lifetimeTotalToReturn = 0
+    var currentWeekTotalToReturn = 0
+    var currentWeekByCategoryToReturn = [BlocklistCategory: Int]()
+    var trackingStartDateToReturn: Date? = Date(timeIntervalSince1970: 1_760_000_000)
+    var highestReportedFiguresToReturn = 0
+
+    var currentWeekTotalDates = [Date]()
+    var currentWeekByCategoryDates = [Date]()
+
+    func record(category: BlocklistCategory, count: Int, date: Date) {}
+    func lifetimeTotal() -> Int { return lifetimeTotalToReturn }
+    func lifetimeByCategory() -> [BlocklistCategory: Int] { return [:] }
+
+    func currentWeekTotal(for date: Date) -> Int {
+        currentWeekTotalDates.append(date)
+        return currentWeekTotalToReturn
+    }
+
+    func currentWeekByCategory(for date: Date) -> [BlocklistCategory: Int] {
+        currentWeekByCategoryDates.append(date)
+        return currentWeekByCategoryToReturn
+    }
+
+    func trackingStartDate() -> Date? { return trackingStartDateToReturn }
+    func reset() {}
+    func highestReportedFigures() -> Int { return highestReportedFiguresToReturn }
+    func setHighestReportedFigures(_ figures: Int) { highestReportedFiguresToReturn = figures }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TrackerBlockerSheetStateProviderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TrackerBlockerSheetStateProviderTests.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Shared
 import XCTest
 
 @testable import Client
@@ -122,13 +121,8 @@ final class TrackerBlockerSheetStateProviderTests: XCTestCase {
     }
 
     private func createSubject(store: MockTrackerBlockStatsStore) -> TrackerBlockerSheetStateProvider {
-        return TrackerBlockerSheetStateProvider(statsStore: store, dateProvider: MockDateProvider(date: now))
+        return TrackerBlockerSheetStateProvider(statsStore: store, dateProvider: MockDateProvider(fixedDate: now))
     }
-}
-
-private struct MockDateProvider: DateProvider {
-    let date: Date
-    func now() -> Date { return date }
 }
 
 private final class MockTrackerBlockStatsStore: TrackerBlockStatsStore {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TrackerBlockerSheetViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TrackerBlockerSheetViewControllerTests.swift
@@ -304,7 +304,7 @@ final class TrackerBlockerSheetViewControllerTests: XCTestCase {
     func test_categoryRow_placesCountInlineWithProgressBar() throws {
         let row = laidOutRow(count: 12)
 
-        let titleFrame = try frame(of: XCTUnwrap(label(in: row, withText: "Fingerprinters")), in: row)
+        let titleFrame = try frame(of: XCTUnwrap(label(in: row, withText: .PrivacyDashboard.Fingerprinters)), in: row)
         let countFrame = try frame(of: XCTUnwrap(label(in: row, withText: 12.formatted(.number))), in: row)
         let barFrame = try frame(
             of: XCTUnwrap(allSubviews(in: row).first { $0 is TrackerBlockerProgressBarView }),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TrackerBlockerSheetViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TrackerBlockerSheetViewControllerTests.swift
@@ -256,6 +256,20 @@ final class TrackerBlockerSheetViewControllerTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(icon(in: row)).tintColor, theme.colors.iconSecondary)
     }
 
+    // MARK: - Weekly Count Accessibility
+
+    func test_configureFilledState_readsOutTheCountAndHeaderAsOneSentence() throws {
+        let subject = createSubject()
+        subject.loadViewIfNeeded()
+        subject.configure(with: .filled)
+        let weeklyCount = try XCTUnwrap(TrackerBlockerSheetState.filled.weeklyCount)
+        XCTAssertEqual(view(subject, withID: A11y.weeklyCountLabel)?.accessibilityLabel,
+                       String(format: .PrivacyDashboard.HeaderLabelAccessibilityLabel,
+                              weeklyCount.formatted(.number)))
+        // The count already reads the header's copy, so the header isn't read a second time.
+        XCTAssertEqual(view(subject, withID: A11y.headerLabel)?.isAccessibilityElement, false)
+    }
+
     // MARK: - Category row accessibility
 
     func test_categoryRow_withCount_readsOutTheCategoryAndItsCount() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TrackerBlockerSheetViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/TrackerBlockerSheetViewControllerTests.swift
@@ -256,6 +256,24 @@ final class TrackerBlockerSheetViewControllerTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(icon(in: row)).tintColor, theme.colors.iconSecondary)
     }
 
+    // MARK: - Category row accessibility
+
+    func test_categoryRow_withCount_readsOutTheCategoryAndItsCount() {
+        let row = makeRow(count: 1234)
+
+        XCTAssertEqual(row.accessibilityLabel,
+                       String(format: .PrivacyDashboard.CategoryAccessibilityLabel,
+                              String.PrivacyDashboard.Fingerprinters,
+                              1234.formatted(.number)))
+    }
+
+    /// The empty state has no count to read out, so the row is just its category.
+    func test_categoryRow_withoutCount_readsOutTheCategoryOnly() {
+        let row = makeRow(count: nil)
+
+        XCTAssertEqual(row.accessibilityLabel, .PrivacyDashboard.Fingerprinters)
+    }
+
     // MARK: - Category row layout
 
     func test_categoryRow_withoutCount_collapsesProgressBarHeight() {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16429)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/34901)

## :bulb: Description
- change from hardcoded strings to l10n strings
- hook up and add state for the Privacy Dashboard

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

