### PR TITLE
Bugfix FXIOS-16741 [Toolbar] - Weird behavior of the toolbar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -728,14 +728,17 @@ final class LocationView: UIView,
     }
 
     func locationTextFieldDidBeginEditing(_ textField: UITextField) {
-        guard !isEditing else { return }
-        updateUIForSearchEngineDisplay(isURLTextFieldCentered: isURLTextFieldCentered)
         let searchText = searchTerm != nil ? searchTerm : urlAbsolutePath
+        if !isEditing {
+            updateUIForSearchEngineDisplay(isURLTextFieldCentered: isURLTextFieldCentered)
 
-        // `attributedText` property is set to nil to remove all formatting and truncation set before.
-        textField.attributedText = nil
-        textField.text = searchText
-
+            // `attributedText` property is set to nil to remove all formatting and truncation set before.
+            textField.attributedText = nil
+            textField.text = searchText
+        }
+        // Always notify, even if `isEditing` was already true, this fires when the text field
+        // regains first responder after the keyboard was dismissed (e.g. scrolling the
+        // homepage), which is the only path that restores `shouldShowKeyboard` in that case.
         delegate?.locationViewDidBeginEditing(searchText ?? "", shouldShowSuggestions: searchTerm != nil)
     }
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -728,17 +728,15 @@ final class LocationView: UIView,
     }
 
     func locationTextFieldDidBeginEditing(_ textField: UITextField) {
-        let searchText = searchTerm != nil ? searchTerm : urlAbsolutePath
-        if !isEditing {
-            updateUIForSearchEngineDisplay(isURLTextFieldCentered: isURLTextFieldCentered)
+        guard !isEditing else { return }
 
-            // `attributedText` property is set to nil to remove all formatting and truncation set before.
-            textField.attributedText = nil
-            textField.text = searchText
-        }
-        // Always notify, even if `isEditing` was already true, this fires when the text field
-        // regains first responder after the keyboard was dismissed (e.g. scrolling the
-        // homepage), which is the only path that restores `shouldShowKeyboard` in that case.
+        updateUIForSearchEngineDisplay(isURLTextFieldCentered: isURLTextFieldCentered)
+        let searchText = searchTerm != nil ? searchTerm : urlAbsolutePath
+
+        // `attributedText` property is set to nil to remove all formatting and truncation set before.
+        textField.attributedText = nil
+        textField.text = searchText
+
         delegate?.locationViewDidBeginEditing(searchText ?? "", shouldShowSuggestions: searchTerm != nil)
     }
 

--- a/BrowserKit/Tests/ToolbarKitTests/LocationViewTests.swift
+++ b/BrowserKit/Tests/ToolbarKitTests/LocationViewTests.swift
@@ -100,18 +100,6 @@ final class LocationViewTests: XCTestCase {
         XCTAssertEqual(subject.searchEngineContentView.alpha, 1, message)
     }
 
-    // MARK: - Resuming Editing
-    /// Regression test for FXIOS-16590: retapping the location view while it's already editing
-    /// (e.g. the keyboard was dismissed by scrolling the homepage) must still notify the delegate.
-    func testLocationTextFieldDidBeginEditing_whenAlreadyEditing_stillNotifiesDelegate() {
-        let subject = createSubject()
-        subject.configure(makeConfig(url: nil, isEditing: true), delegate: delegate)
-
-        subject.locationTextFieldDidBeginEditing(UITextField())
-
-        XCTAssertEqual(delegate.didBeginEditingCallCount, 1)
-    }
-
     func testLocationTextFieldDidBeginEditing_whenNotEditing_notifiesDelegate() {
         let subject = createSubject()
         subject.configure(makeConfig(url: nil, isEditing: false), delegate: delegate)

--- a/BrowserKit/Tests/ToolbarKitTests/LocationViewTests.swift
+++ b/BrowserKit/Tests/ToolbarKitTests/LocationViewTests.swift
@@ -100,6 +100,27 @@ final class LocationViewTests: XCTestCase {
         XCTAssertEqual(subject.searchEngineContentView.alpha, 1, message)
     }
 
+    // MARK: - Resuming Editing
+    /// Regression test for FXIOS-16590: retapping the location view while it's already editing
+    /// (e.g. the keyboard was dismissed by scrolling the homepage) must still notify the delegate.
+    func testLocationTextFieldDidBeginEditing_whenAlreadyEditing_stillNotifiesDelegate() {
+        let subject = createSubject()
+        subject.configure(makeConfig(url: nil, isEditing: true), delegate: delegate)
+
+        subject.locationTextFieldDidBeginEditing(UITextField())
+
+        XCTAssertEqual(delegate.didBeginEditingCallCount, 1)
+    }
+
+    func testLocationTextFieldDidBeginEditing_whenNotEditing_notifiesDelegate() {
+        let subject = createSubject()
+        subject.configure(makeConfig(url: nil, isEditing: false), delegate: delegate)
+
+        subject.locationTextFieldDidBeginEditing(UITextField())
+
+        XCTAssertEqual(delegate.didBeginEditingCallCount, 1)
+    }
+
     // MARK: - Helpers
     /// Puts both icons at an alpha no expected value matches, so the assertions fail unless the
     /// code under test actually writes them.
@@ -149,9 +170,13 @@ private extension LocationView {
 
 @MainActor
 private final class MockLocationViewDelegate: LocationViewDelegate {
+    var didBeginEditingCallCount = 0
+
     func locationViewDidEnterText(_ text: String) {}
     func locationViewDidClearText() {}
-    func locationViewDidBeginEditing(_ text: String, shouldShowSuggestions: Bool) {}
+    func locationViewDidBeginEditing(_ text: String, shouldShowSuggestions: Bool) {
+        didBeginEditingCallCount += 1
+    }
     func locationViewDidSubmitText(_ text: String) {}
     func locationViewDidTapSearchEngine<T: SearchEngineView>(_ searchEngine: T) {}
     func locationViewAccessibilityActions() -> [UIAccessibilityCustomAction]? { return nil }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -765,7 +765,7 @@ final class BrowserCoordinator: BaseCoordinator,
             navigationController.sheetPresentationController?.detents = [.medium(), .large()]
             navigationController.sheetPresentationController?.prefersGrabberVisible = true
             if isEditing {
-                store.dispatch(ToolbarModernAction.didCancelKeyboardRequest, forWindowUUID: windowUUID)
+                store.dispatch(ToolbarModernAction.didKeyboardRequestChange(shouldShow: false), forWindowUUID: windowUUID)
             }
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5094,7 +5094,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
         let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: windowUUID)
         let isEditing = toolbarState?.addressToolbar.isEditing == true
         if !isEditing {
-            store.dispatch(ToolbarModernAction.didCancelKeyboardRequest, forWindowUUID: windowUUID)
+            store.dispatch(ToolbarModernAction.didKeyboardRequestChange(shouldShow: false), forWindowUUID: windowUUID)
         }
         tabManager.selectedTab?.setFindInPage(isBottomSearchBar: isBottomSearchBar,
                                               doesFindInPageBarExist: iOS15FindInPageBar != nil)
@@ -5113,6 +5113,11 @@ extension BrowserViewController: KeyboardHelperDelegate {
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidShowWithState state: KeyboardState) {
         keyboardState = state
+
+        let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: windowUUID)
+        if toolbarState?.addressToolbar.isEditing == true {
+            store.dispatch(ToolbarModernAction.didKeyboardRequestChange(shouldShow: true), forWindowUUID: windowUUID)
+        }
 
         UIView.animate(
             withDuration: state.animationDuration,

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -166,8 +166,8 @@ struct AddressBarState: StateType, Sendable, Equatable {
     static let modernReducer: ReducerMethod<Self> = { state, action, actionWindowUUID in
         guard let action = action as? ToolbarModernAction else { return defaultState(from: state) }
         switch action {
-        case .didCancelKeyboardRequest:
-            return state.copy(shouldShowKeyboard: false)
+        case .didKeyboardRequestChange(let shouldShow):
+            return state.copy(shouldShowKeyboard: shouldShow)
         default:
             return defaultState(from: state)
         }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -118,8 +118,12 @@ enum ToolbarModernAction: ModernAction {
     /// `accessoryViewVisibilityChanged`.
     case keyboardDidHide
 
-    // When the keyboard hides, or a search engine is selected while isEditing, update shouldShowKeyboard
-    case didCancelKeyboardRequest
+    /// Whether the address bar's own keyboard should be shown while editing. `false` when the
+    /// keyboard hides (or a search engine is selected) while isEditing. `true` when the keyboard
+    /// genuinely finishes presenting while still editing. Also restores `shouldShowKeyboard` after it
+    /// was set to `false` by a path that doesn't fully leave overlay mode (e.g. scrolling the
+    /// homepage mid-edit via `cancelEditOnHomepage`)
+    case didKeyboardRequestChange(shouldShow: Bool)
 }
 
 enum ToolbarActionType: ActionType {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarAction.swift
@@ -118,10 +118,11 @@ enum ToolbarModernAction: ModernAction {
     /// `accessoryViewVisibilityChanged`.
     case keyboardDidHide
 
-    /// Whether the address bar's own keyboard should be shown while editing. `false` when the
+    /// Action fired when the keyboard state changes specifically whether
+    /// the address bar's keyboard should be shown while editing. shouldShow is `false` when the
     /// keyboard hides (or a search engine is selected) while isEditing. `true` when the keyboard
     /// genuinely finishes presenting while still editing. Also restores `shouldShowKeyboard` after it
-    /// was set to `false` by a path that doesn't fully leave overlay mode (e.g. scrolling the
+    /// was set to `false` by a path that doesn't fully leave overlay mode (like scrolling the
     /// homepage mid-edit via `cancelEditOnHomepage`)
     case didKeyboardRequestChange(shouldShow: Bool)
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/ToolbarState.swift
@@ -162,7 +162,7 @@ struct ToolbarState: ScreenState, Sendable {
                 .copy(isAddressBarMinimized: false)
                 .copy(isAccessoryViewVisible: false)
 
-        case .didCancelKeyboardRequest:
+        case .didKeyboardRequestChange:
             // AddressBarState is a nested sub-state, forwards modern call to AddressBarState
             return state.copy(addressToolbar: AddressBarState.reducer.modernReducer(state.addressToolbar,
                                                                                     action,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -1154,6 +1154,41 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(newState.shouldShowKeyboard)
     }
 
+    /// Regression test for FXIOS-16590: scrolling the homepage while still editing hides the
+    /// keyboard (`cancelEditOnHomepage`) but must not permanently leave `shouldShowKeyboard` at `false`
+    func test_cancelEditOnHomepageThenResumeEditing_restoresShouldShowKeyboard() {
+        setupStore()
+        let initialState = createSubject()
+        let reducer = addressBarReducer()
+
+        let urlDidChangeState = loadWebsiteAction(state: initialState, reducer: reducer)
+        let didStartEditingAction = ToolbarAction(
+            searchTerm: nil,
+            windowUUID: windowUUID,
+            actionType: ToolbarActionType.didStartEditingUrl
+        )
+        let editingState = reducer.legacyReducer(urlDidChangeState, didStartEditingAction)
+        XCTAssertTrue(editingState.isEditing)
+        XCTAssertTrue(editingState.shouldShowKeyboard)
+
+        let scrolledState = reducer.legacyReducer(
+            editingState,
+            ToolbarAction(
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.cancelEditOnHomepage
+            )
+        )
+        XCTAssertTrue(scrolledState.isEditing)
+        XCTAssertFalse(scrolledState.shouldShowKeyboard)
+
+        // Resuming: the text field regains first responder while `isEditing` is already true,
+        // which re-dispatches `didStartEditingUrl`.
+        let resumedState = reducer.legacyReducer(scrolledState, didStartEditingAction)
+
+        XCTAssertTrue(resumedState.isEditing)
+        XCTAssertTrue(resumedState.shouldShowKeyboard)
+    }
+
     func test_clearSearchAction_returnsExpectedState() {
         let initialState = createSubject()
         let reducer = addressBarReducer()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -1137,7 +1137,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(newState.isEmptySearch)
 }
 
-    func test_keyboardStateDidChangeAction_returnsExpectedState() {
+    func test_keyboardRequestChangeAction_whenHiding_returnsExpectedState() {
         setupStore()
         let initialState = createSubject().copy(shouldShowKeyboard: true)
         let reducer = addressBarReducer()
@@ -1146,7 +1146,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
 
         let newState = reducer.modernReducer(
             initialState,
-            ToolbarModernAction.didCancelKeyboardRequest,
+            ToolbarModernAction.didKeyboardRequestChange(shouldShow: false),
             windowUUID
         )
 
@@ -1154,20 +1154,42 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertFalse(newState.shouldShowKeyboard)
     }
 
+    func test_keyboardRequestChangeAction_whenShowing_returnsExpectedState() {
+        setupStore()
+        let initialState = createSubject().copy(shouldShowKeyboard: false)
+        let reducer = addressBarReducer()
+
+        XCTAssertFalse(initialState.shouldShowKeyboard)
+
+        let newState = reducer.modernReducer(
+            initialState,
+            ToolbarModernAction.didKeyboardRequestChange(shouldShow: true),
+            windowUUID
+        )
+
+        XCTAssertEqual(newState.windowUUID, windowUUID)
+        XCTAssertTrue(newState.shouldShowKeyboard)
+    }
+
     /// Regression test for FXIOS-16590: scrolling the homepage while still editing hides the
-    /// keyboard (`cancelEditOnHomepage`) but must not permanently leave `shouldShowKeyboard` at `false`
-    func test_cancelEditOnHomepageThenResumeEditing_restoresShouldShowKeyboard() {
+    /// keyboard (`cancelEditOnHomepage`) but must not permanently leave `shouldShowKeyboard` at
+    /// `false`, once the keyboard genuinely finishes presenting again while still editing
+    /// (`BrowserViewController.keyboardHelper(_:keyboardDidShowWithState:)` dispatches
+    /// `didKeyboardRequestChange(shouldShow: true)`), it must be restored.
+    func test_cancelEditOnHomepageThenKeyboardDidShow_restoresShouldShowKeyboard() {
         setupStore()
         let initialState = createSubject()
         let reducer = addressBarReducer()
 
         let urlDidChangeState = loadWebsiteAction(state: initialState, reducer: reducer)
-        let didStartEditingAction = ToolbarAction(
-            searchTerm: nil,
-            windowUUID: windowUUID,
-            actionType: ToolbarActionType.didStartEditingUrl
+        let editingState = reducer.legacyReducer(
+            urlDidChangeState,
+            ToolbarAction(
+                searchTerm: nil,
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.didStartEditingUrl
+            )
         )
-        let editingState = reducer.legacyReducer(urlDidChangeState, didStartEditingAction)
         XCTAssertTrue(editingState.isEditing)
         XCTAssertTrue(editingState.shouldShowKeyboard)
 
@@ -1181,9 +1203,11 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(scrolledState.isEditing)
         XCTAssertFalse(scrolledState.shouldShowKeyboard)
 
-        // Resuming: the text field regains first responder while `isEditing` is already true,
-        // which re-dispatches `didStartEditingUrl`.
-        let resumedState = reducer.legacyReducer(scrolledState, didStartEditingAction)
+        let resumedState = reducer.modernReducer(
+            scrolledState,
+            ToolbarModernAction.didKeyboardRequestChange(shouldShow: true),
+            windowUUID
+        )
 
         XCTAssertTrue(resumedState.isEditing)
         XCTAssertTrue(resumedState.shouldShowKeyboard)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -1171,7 +1171,7 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(newState.shouldShowKeyboard)
     }
 
-    /// Regression test for FXIOS-16590: scrolling the homepage while still editing hides the
+    /// Regression test for FXIOS-16741: scrolling the homepage while still editing hides the
     /// keyboard (`cancelEditOnHomepage`) but must not permanently leave `shouldShowKeyboard` at
     /// `false`, once the keyboard genuinely finishes presenting again while still editing
     /// (`BrowserViewController.keyboardHelper(_:keyboardDidShowWithState:)` dispatches

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/ToolbarStateTests.swift
@@ -202,19 +202,35 @@ final class ToolbarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.navigationToolbar, initialState.navigationToolbar)
     }
 
-    func test_keyboardStateDidChangeAction_returnsExpectedState() {
+    func test_keyboardRequestChangeAction_whenHiding_returnsExpectedState() {
         let baseState = createSubject()
         let initialState = baseState.copy(addressToolbar: baseState.addressToolbar.copy(shouldShowKeyboard: true))
         let reducer = toolbarReducer()
 
         let newState = reducer.modernReducer(
             initialState,
-            ToolbarModernAction.didCancelKeyboardRequest,
+            ToolbarModernAction.didKeyboardRequestChange(shouldShow: false),
             windowUUID
         )
 
         XCTAssertNotEqual(newState.addressToolbar, initialState.addressToolbar)
         XCTAssertFalse(newState.addressToolbar.shouldShowKeyboard)
+        XCTAssertEqual(newState.navigationToolbar, initialState.navigationToolbar)
+    }
+
+    func test_keyboardRequestChangeAction_whenShowing_returnsExpectedState() {
+        let baseState = createSubject()
+        let initialState = baseState.copy(addressToolbar: baseState.addressToolbar.copy(shouldShowKeyboard: false))
+        let reducer = toolbarReducer()
+
+        let newState = reducer.modernReducer(
+            initialState,
+            ToolbarModernAction.didKeyboardRequestChange(shouldShow: true),
+            windowUUID
+        )
+
+        XCTAssertNotEqual(newState.addressToolbar, initialState.addressToolbar)
+        XCTAssertTrue(newState.addressToolbar.shouldShowKeyboard)
         XCTAssertEqual(newState.navigationToolbar, initialState.navigationToolbar)
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16741)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35490)

## :bulb: Description
Cause: PR #35292 (FXIOS-16590, "Migrate keyboardStateDidChange to ToolbarModernAction") replaced a single generic, bidirectional legacy action: `keyboardStateDidChange`, which any call site could dispatch with shouldShowKeyboard: true or false, with several narrower, one-directional modern actions (`didCancelKeyboardRequest`, `accessoryViewVisibilityChanged`) that only ever set it to false, and hardcoded `cancelEditOnHomepage`'s branch to unconditionally false too. That was a reasonable simplification for the cases the refactor targeted, but it quietly removed the only remaining path that could set shouldShowKeyboard back to true outside of a genuinely fresh begin-edit (`didStartEditingUrl/didPasteSearchTerm`).

Resuming an edit after the keyboard was dismissed mid-session (e.g. scrolling the homepage while the Cancel button is still showing) is neither a fresh begin-edit nor one of the new actions' triggers — so once the generic restore-to-true mechanism was gone, there was no path left for that specific transition. It surfaced because `LocationView.locationTextFieldDidBeginEditing `already early-returns when isEditing is already true (to skip redundant setup), silently swallowing the one call that would have re-dispatched didStartEditingUrl. That guard itself is old and untouched by the refactor, it just went from "harmless, because something else could still restore the keyboard" to "the single point of failure," once the refactor deleted the other path.

Fix: `locationTextFieldDidBeginEditing` now always notifies the delegate, reusing the existing `didStartEditingUrl` dispatch (which already sets shouldShowKeyboard: true) instead of adding a new action or delegate method. It still skips the cosmetic text/attributedText reset when already editing, so nothing about the normal fresh-edit flow changes.

Add unit test 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

