### PR TITLE
Bugfix FXIOS-16732 Fix Library Segment Control Seeping Into View When Hidden

### DIFF
--- a/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/LibraryViewController/LibraryViewController.swift
@@ -25,6 +25,7 @@ class LibraryViewController: UIViewController, Themeable {
     var logger: Logger
     let windowUUID: WindowUUID
     var currentWindowUUID: UUID? { windowUUID }
+    var isNavBarHidden = false
 
     // Views
     private var controllerContainerView: UIView = .build { view in }
@@ -89,6 +90,8 @@ class LibraryViewController: UIViewController, Themeable {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        guard !isNavBarHidden else { return }
+
         setupSegmentControl()
         librarySegmentControl.selectedSegmentIndex = viewModel.selectedPanel?.rawValue ?? 0
         applyTheme()
@@ -441,6 +444,11 @@ class LibraryViewController: UIViewController, Themeable {
         let controlbarHeight = librarySegmentControl.frame.height
         librarySegmentControl.transform = value ? .init(translationX: 0, y: -controlbarHeight) : .identity
         controllerContainerView.transform = value ? .init(translationX: 0, y: -controlbarHeight) : .identity
+
+        isNavBarHidden = value
+        guard !isNavBarHidden else { return }
+        setupSegmentControl()
+        librarySegmentControl.selectedSegmentIndex = viewModel.selectedPanel?.rawValue ?? 0
 
         // Reload the current panel
         guard let index = viewModel.selectedPanel?.rawValue,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16732)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35477)

## :bulb: Description
This PR fixes an issue where the library segment control would seep through the view even when the navigation bar was hidden.

The bug can be reproduced by opening the library panel, navigating to bookmarks, tapping new folder, and then scrolling. As the dismissable controller moves down slightly during the scroll, it triggers viewWillAppear, which sets up the navigation bar even though it should still be hidden.

To fix this, the navigation bar setup now only runs when the navigation bar is actually being shown. This is controlled through a new flag that tracks whether the navigation bar should be visible.

The initial fix introduced a regression where, after dismissing the new folder controller by dragging it down and then reopening it through bookmarks, tapping the top-left back button would cause the liquid glass bug to reappear. This happens because the library segment control was never set up when the new folder page was initially presented, since the navigation bar was hidden at that point.

To address this, whenever the navigation bar is unhidden, we also trigger the setup again.

It is important to note that this repeated setup is only necessary due to a liquid glass bug on iOS 26.3 and below, where the bug can reappear if the segment control isn't reconfigured when the navigation bar becomes visible. I do not have much knowledge about the liquid glass bug and why it happens just that it seems to happen if we do not setup every time the controller appears.

I personally do not like the fix but it was the only one I could think of without refactoring how the library works, which imo needs a refactor.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

