### PR TITLE
Bugfix FXIOS-16737 Stop the daily usage ping from following the technical data opt-out

### DIFF
--- a/BrowserKit/Sources/Common/Constants/AppConstants.swift
+++ b/BrowserKit/Sources/Common/Constants/AppConstants.swift
@@ -49,6 +49,8 @@ public final class AppConstants {
     public static let prefStudiesToggle = "settings.studiesToggle"
     public static let prefRolloutsToggle = "settings.rolloutsToggle"
 
+    public static let defaultSendDailyUsagePing = true
+
     /// Build Channel.
     public static let buildChannel: AppBuildChannel = {
         let channelRaw = Bundle.main.infoDictionary?["CHANNEL"] as? String ?? "other"

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -281,7 +281,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         let sendDailyUsagePingSettings = SendDataSetting(
             prefs: profile.prefs,
             prefKey: AppConstants.prefSendDailyUsagePing,
-            defaultValue: true,
+            defaultValue: AppConstants.defaultSendDailyUsagePing,
             titleText: .SendDailyUsagePingSettingTitle,
             subtitleText: String(format: .SendDailyUsagePingSettingMessage, MozillaName.shortName.rawValue),
             learnMoreText: .SendDailyUsagePingSettingLinkV2,

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -278,7 +278,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         }
         sendTechnicalDataSetting = sendTechnicalDataSettings
 
-        // Technical data is the only setting that may drive experiment participation
+        // Technical data is the only setting that drives the Nimbus telemetry setting
         Experiments.setTelemetrySetting(profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true)
 
         let sendDailyUsagePingSettings = SendDataSetting(

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -278,6 +278,9 @@ class AppSettingsTableViewController: SettingsTableViewController,
         }
         sendTechnicalDataSetting = sendTechnicalDataSettings
 
+        // Technical data is the only setting that may drive experiment participation
+        Experiments.setTelemetrySetting(profile.prefs.boolForKey(AppConstants.prefSendUsageData) ?? true)
+
         let sendDailyUsagePingSettings = SendDataSetting(
             prefs: profile.prefs,
             prefKey: AppConstants.prefSendDailyUsagePing,

--- a/firefox-ios/Client/Frontend/Settings/Main/Support/SendDataSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Support/SendDataSetting.swift
@@ -52,11 +52,6 @@ final class SendDataSetting: BoolSetting {
             // Special Case (EXP-4780, FXIOS-10534) disable studies if usage data is disabled
             // and studies should be toggled back on after re-enabling Telemetry
             self.enabled = sendUsageDataPref
-        } else {
-            // We make sure to set this on initialization, in case the setting is turned off
-            // in which case, we would to make sure that users are opted out of experiments
-            guard let key = prefKey else { return }
-            Experiments.setTelemetrySetting(prefs?.boolForKey(key) ?? true)
         }
     }
 

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -99,16 +99,9 @@ class TelemetryWrapper: TelemetryWrapperProtocol,
         initGlean(profile, sendUsageData: sendUsageData)
     }
 
-    /// Resolves the daily usage ping setting, defaulting to on and persisting it so the value is
-    /// explicit on later launches. It never follows `prefSendUsageData`: the `usage-reporting` ping is
-    /// declared `follows_collection_enabled: false`, so opting out of technical data must not silence it.
-    static func resolveSendDailyUsagePing(prefs: Prefs) -> Bool {
-        if let dailyUsagePing = prefs.boolForKey(AppConstants.prefSendDailyUsagePing) {
-            return dailyUsagePing
-        }
-
-        prefs.setBool(true, forKey: AppConstants.prefSendDailyUsagePing)
-        return true
+    /// Never follows `prefSendUsageData`: `usage-reporting` is `follows_collection_enabled: false`.
+    static func shouldSendDailyUsagePing(prefs: Prefs) -> Bool {
+        return prefs.boolForKey(AppConstants.prefSendDailyUsagePing) ?? AppConstants.defaultSendDailyUsagePing
     }
 
     @MainActor
@@ -140,9 +133,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol,
         GleanMetrics.Pings.shared.usageDeletionRequest.setEnabled(enabled: true)
         GleanMetrics.Pings.shared.onboardingOptOut.setEnabled(enabled: true)
 
-        let shouldSendUsagePing = Self.resolveSendDailyUsagePing(prefs: profile.prefs)
-
-        if shouldSendUsagePing {
+        if Self.shouldSendDailyUsagePing(prefs: profile.prefs) {
             gleanUsageReportingMetricsService.start()
         } else {
             gleanUsageReportingMetricsService.unsetUsageProfileId()

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -100,7 +100,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol,
     }
 
     /// Never follows `prefSendUsageData`: `usage-reporting` is `follows_collection_enabled: false`.
-    static func shouldSendDailyUsagePing(prefs: Prefs) -> Bool {
+    func shouldSendDailyUsagePing(prefs: Prefs) -> Bool {
         return prefs.boolForKey(AppConstants.prefSendDailyUsagePing) ?? AppConstants.defaultSendDailyUsagePing
     }
 
@@ -133,7 +133,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol,
         GleanMetrics.Pings.shared.usageDeletionRequest.setEnabled(enabled: true)
         GleanMetrics.Pings.shared.onboardingOptOut.setEnabled(enabled: true)
 
-        if Self.shouldSendDailyUsagePing(prefs: profile.prefs) {
+        if shouldSendDailyUsagePing(prefs: profile.prefs) {
             gleanUsageReportingMetricsService.start()
         } else {
             gleanUsageReportingMetricsService.unsetUsageProfileId()

--- a/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
+++ b/firefox-ios/Client/Telemetry/TelemetryWrapper.swift
@@ -99,6 +99,18 @@ class TelemetryWrapper: TelemetryWrapperProtocol,
         initGlean(profile, sendUsageData: sendUsageData)
     }
 
+    /// Resolves the daily usage ping setting, defaulting to on and persisting it so the value is
+    /// explicit on later launches. It never follows `prefSendUsageData`: the `usage-reporting` ping is
+    /// declared `follows_collection_enabled: false`, so opting out of technical data must not silence it.
+    static func resolveSendDailyUsagePing(prefs: Prefs) -> Bool {
+        if let dailyUsagePing = prefs.boolForKey(AppConstants.prefSendDailyUsagePing) {
+            return dailyUsagePing
+        }
+
+        prefs.setBool(true, forKey: AppConstants.prefSendDailyUsagePing)
+        return true
+    }
+
     @MainActor
     func initGlean(
         _ profile: Profile,
@@ -128,24 +140,7 @@ class TelemetryWrapper: TelemetryWrapperProtocol,
         GleanMetrics.Pings.shared.usageDeletionRequest.setEnabled(enabled: true)
         GleanMetrics.Pings.shared.onboardingOptOut.setEnabled(enabled: true)
 
-        let shouldSendUsagePing: Bool
-
-        if let dailyUsagePing = profile.prefs.boolForKey(AppConstants.prefSendDailyUsagePing) {
-            // If SendDailyUsagePing is explicitly set, use its value
-            shouldSendUsagePing = dailyUsagePing
-        } else if let usageData = profile.prefs.boolForKey(AppConstants.prefSendUsageData) {
-            // If SendDailyUsagePing is not set, follow SendUsageData
-            shouldSendUsagePing = usageData
-
-            // Persist the SendDailyUsagePing value to ensure it is explicitly set for future launches
-            profile.prefs.setBool(usageData, forKey: AppConstants.prefSendDailyUsagePing)
-        } else {
-            // Default to true if neither is set
-            shouldSendUsagePing = true
-
-            // Persist the default to ensure consistency on subsequent launches
-            profile.prefs.setBool(true, forKey: AppConstants.prefSendDailyUsagePing)
-        }
+        let shouldSendUsagePing = Self.resolveSendDailyUsagePing(prefs: profile.prefs)
 
         if shouldSendUsagePing {
             gleanUsageReportingMetricsService.start()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -18,8 +18,9 @@ class TelemetryWrapperTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         profile = MockProfile()
-        Experiments.events.clearEvents()
+        // Dependencies must be bootstrapped before touching `Experiments`, which resolves from AppContainer.
         Self.setupTelemetry(with: profile)
+        Experiments.events.clearEvents()
     }
 
     override func tearDown() {
@@ -874,6 +875,32 @@ class TelemetryWrapperTests: XCTestCase {
                                           value: .webviewShowErrorPage,
                                           extras: extra)
         try testEventMetricRecordingSuccess(metric: GleanMetrics.Webview.showErrorPage)
+    }
+
+    // MARK: - Daily usage ping
+
+    func testResolveSendDailyUsagePing_whenTechnicalDataIsOptedOut_staysEnabled() {
+        profile.prefs.setBool(false, forKey: AppConstants.prefSendUsageData)
+
+        let result = TelemetryWrapper.resolveSendDailyUsagePing(prefs: profile.prefs)
+
+        XCTAssertTrue(result, "Opting out of technical data must not disable the daily usage ping")
+        XCTAssertEqual(profile.prefs.boolForKey(AppConstants.prefSendDailyUsagePing), true)
+    }
+
+    func testResolveSendDailyUsagePing_whenUnset_defaultsToEnabledAndPersists() {
+        let result = TelemetryWrapper.resolveSendDailyUsagePing(prefs: profile.prefs)
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(profile.prefs.boolForKey(AppConstants.prefSendDailyUsagePing), true)
+    }
+
+    func testResolveSendDailyUsagePing_whenExplicitlyDisabled_staysDisabled() {
+        profile.prefs.setBool(false, forKey: AppConstants.prefSendDailyUsagePing)
+
+        let result = TelemetryWrapper.resolveSendDailyUsagePing(prefs: profile.prefs)
+
+        XCTAssertFalse(result)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -883,7 +883,7 @@ class TelemetryWrapperTests: XCTestCase {
         let prefs = MockProfilePrefs()
         prefs.setBool(false, forKey: AppConstants.prefSendUsageData)
 
-        let result = TelemetryWrapper.shouldSendDailyUsagePing(prefs: prefs)
+        let result = TelemetryWrapper().shouldSendDailyUsagePing(prefs: prefs)
 
         XCTAssertTrue(result, "Opting out of technical data must not disable the daily usage ping")
     }
@@ -891,7 +891,7 @@ class TelemetryWrapperTests: XCTestCase {
     func testShouldSendDailyUsagePing_whenUnset_defaultsToEnabled() {
         let prefs = MockProfilePrefs()
 
-        let result = TelemetryWrapper.shouldSendDailyUsagePing(prefs: prefs)
+        let result = TelemetryWrapper().shouldSendDailyUsagePing(prefs: prefs)
 
         XCTAssertEqual(result, AppConstants.defaultSendDailyUsagePing)
         XCTAssertNil(prefs.boolForKey(AppConstants.prefSendDailyUsagePing), "Reading must not write a default")
@@ -901,7 +901,7 @@ class TelemetryWrapperTests: XCTestCase {
         let prefs = MockProfilePrefs()
         prefs.setBool(false, forKey: AppConstants.prefSendDailyUsagePing)
 
-        let result = TelemetryWrapper.shouldSendDailyUsagePing(prefs: prefs)
+        let result = TelemetryWrapper().shouldSendDailyUsagePing(prefs: prefs)
 
         XCTAssertFalse(result)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TelemetryWrapperTests.swift
@@ -6,6 +6,7 @@
 
 import Common
 import Glean
+import Shared
 import XCTest
 
 class TelemetryWrapperTests: XCTestCase {
@@ -18,7 +19,6 @@ class TelemetryWrapperTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         profile = MockProfile()
-        // Dependencies must be bootstrapped before touching `Experiments`, which resolves from AppContainer.
         Self.setupTelemetry(with: profile)
         Experiments.events.clearEvents()
     }
@@ -879,26 +879,29 @@ class TelemetryWrapperTests: XCTestCase {
 
     // MARK: - Daily usage ping
 
-    func testResolveSendDailyUsagePing_whenTechnicalDataIsOptedOut_staysEnabled() {
-        profile.prefs.setBool(false, forKey: AppConstants.prefSendUsageData)
+    func testShouldSendDailyUsagePing_whenTechnicalDataIsOptedOut_staysEnabled() {
+        let prefs = MockProfilePrefs()
+        prefs.setBool(false, forKey: AppConstants.prefSendUsageData)
 
-        let result = TelemetryWrapper.resolveSendDailyUsagePing(prefs: profile.prefs)
+        let result = TelemetryWrapper.shouldSendDailyUsagePing(prefs: prefs)
 
         XCTAssertTrue(result, "Opting out of technical data must not disable the daily usage ping")
-        XCTAssertEqual(profile.prefs.boolForKey(AppConstants.prefSendDailyUsagePing), true)
     }
 
-    func testResolveSendDailyUsagePing_whenUnset_defaultsToEnabledAndPersists() {
-        let result = TelemetryWrapper.resolveSendDailyUsagePing(prefs: profile.prefs)
+    func testShouldSendDailyUsagePing_whenUnset_defaultsToEnabled() {
+        let prefs = MockProfilePrefs()
 
-        XCTAssertTrue(result)
-        XCTAssertEqual(profile.prefs.boolForKey(AppConstants.prefSendDailyUsagePing), true)
+        let result = TelemetryWrapper.shouldSendDailyUsagePing(prefs: prefs)
+
+        XCTAssertEqual(result, AppConstants.defaultSendDailyUsagePing)
+        XCTAssertNil(prefs.boolForKey(AppConstants.prefSendDailyUsagePing), "Reading must not write a default")
     }
 
-    func testResolveSendDailyUsagePing_whenExplicitlyDisabled_staysDisabled() {
-        profile.prefs.setBool(false, forKey: AppConstants.prefSendDailyUsagePing)
+    func testShouldSendDailyUsagePing_whenExplicitlyDisabled_staysDisabled() {
+        let prefs = MockProfilePrefs()
+        prefs.setBool(false, forKey: AppConstants.prefSendDailyUsagePing)
 
-        let result = TelemetryWrapper.resolveSendDailyUsagePing(prefs: profile.prefs)
+        let result = TelemetryWrapper.shouldSendDailyUsagePing(prefs: prefs)
 
         XCTAssertFalse(result)
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16737)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35487)

## :bulb: Description
Opting out of "Send technical and interaction data" on the Terms of Use card also turned off the Daily Usage Ping, a setting onboarding never shows.

`initGlean` fell back to `sendUsageData` when `sendDailyUsagePing` was unset, which is exactly the state on a fresh install after the ToU handler writes `sendUsageData = false`. Fallback removed: the ping reads only its own pref and defaults to on, fresh installs and upgrades alike per QA. The default now lives once, in `AppConstants.defaultSendDailyUsagePing`.

Also reorders two lines in `TelemetryWrapperTests.setUp` so dependencies bootstrap before `Experiments`; otherwise the class crashes when it runs first.

Review note: users upgrading from v135 or earlier who opted out of technical data will now get the daily ping on.

## :movie_camera: Demos

Settings > Support, after opting out of technical data on the ToU card.

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="01-before-settings-daily-ping-off" src="https://github.com/user-attachments/assets/135312f3-b4b1-4bba-9577-ae628b784a3a" /> | <img width="1206" height="2622" alt="02-after-settings-daily-ping-on" src="https://github.com/user-attachments/assets/c1cfbe64-71de-4e2e-aeb0-689d84b0f7a5" /> |

<details>
<summary>The Manage sheet the user actually sees during onboarding</summary>

<img width="1206" height="2622" alt="03-tou-manage-sheet-no-daily-ping-control" src="https://github.com/user-attachments/assets/3f84f283-52e9-49b7-b3ef-27bfff952aa1" />


Two toggles, and no daily usage ping control anywhere in the flow.
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

