### PR TITLE
Bugfix FXIOS-16632 [Nova] Top address bar buttons are too white

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -745,9 +745,13 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let isLoading = isLoadingChangeAction ? toolbarAction?.isLoading : addressBarState.isLoading
         let hasAlternativeLocationColor: Bool
         if let toolbarAction {
-            hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: toolbarAction)
+            hasAlternativeLocationColor = shouldUseAlternativeLocationColor(
+                action: toolbarAction,
+                isNovaDesignEnabled: addressBarState.isNovaDesignEnabled
+            )
         } else {
-            hasAlternativeLocationColor = toolbarState.toolbarPosition == .top
+            hasAlternativeLocationColor = !addressBarState.isNovaDesignEnabled
+                && toolbarState.toolbarPosition == .top
                 && !toolbarState.isShowingTopTabs
                 && toolbarState.isShowingNavigationToolbar
         }
@@ -815,7 +819,10 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let readerModeState = isReaderModeAction ? action.readerModeState : addressBarState.readerModeState
         let canSummarize = isSummarizeModeAction || isReaderModeAction ? action.canSummarize : addressBarState.canSummarize
         let hasEmptySearchField = isEmptySearch ?? addressBarState.isEmptySearch
-        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(action: action)
+        let hasAlternativeLocationColor = shouldUseAlternativeLocationColor(
+            action: action,
+            isNovaDesignEnabled: addressBarState.isNovaDesignEnabled
+        )
 
         guard !hasEmptySearchField, // When the search field is empty we show no actions
               !isEditing
@@ -956,7 +963,9 @@ struct AddressBarState: StateType, Sendable, Equatable {
     }
 
     @MainActor
-    private static func shouldUseAlternativeLocationColor(action: ToolbarAction) -> Bool {
+    private static func shouldUseAlternativeLocationColor(action: ToolbarAction, isNovaDesignEnabled: Bool) -> Bool {
+        guard !isNovaDesignEnabled else { return false }
+
         guard let toolbarState = store.state.componentState(ToolbarState.self, for: .toolbar, window: action.windowUUID)
         else { return false }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16632)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/TODO)

## :bulb: Description
This PR updates color for URL bar page action icons (share, reader/summarizer, reload, translate) to use iconSecondary on Nova, as requested by design. Old themes are not impacted, there the icons color change based on toolbar position.

<img width="499" height="535" alt="Screenshot 2026-09-03 at 16 04 53" src="https://github.com/user-attachments/assets/b2fb4a5d-4bfb-46f9-9c99-9b289f102037" />

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

