### PR TITLE
Refactor FXIOS-16751 [Swiftlint] balanced_xctest_lifecycle

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,8 +10,10 @@ only_rules: # Only enforce these rules, ignore all others
   - closure_end_indentation
   - closure_parameter_position
   - closure_spacing
+  # - collection_alignment
   - colon
   - comma
+  # - comma_inheritance
   - comment_spacing
   - compiler_protocol_init
   - computed_accessors_order
@@ -20,7 +22,17 @@ only_rules: # Only enforce these rules, ignore all others
   - contains_over_first_not_nil
   - contains_over_range_nil_comparison
   - control_statement
+  # - convenience_type
+  # - cyclomatic_complexity
+  # - deployment_target
+  # - direct_return
+  # - discarded_notification_center_observer
   - discouraged_assert
+  # - discouraged_default_parameter
+  # - discouraged_direct_init
+  # - discouraged_none_name
+  # - discouraged_object_literal
+  # - discouraged_optional_collection
   - duplicate_conditions
   - duplicate_enum_cases
   - duplicate_imports
@@ -32,19 +44,36 @@ only_rules: # Only enforce these rules, ignore all others
   - empty_parentheses_with_trailing_closure
   - empty_string
   - empty_xctest_method
+  # - enum_case_associated_values_count
   - explicit_init
+  # - fallthrough
+  # - fatal_error_message
   - file_header
+  # - file_name
+  # - file_name_no_space
+  # - file_types_order
+  # - final_test_case
   - first_where
+  # - flatmap_over_map_reduce
   - for_where
   - force_cast
   - force_try
+  # - force_unwrapping
   - function_body_length
+  # - function_default_parameter_at_end
   - function_name_whitespace
+  # - function_parameter_count
+  # - generic_type_name
+  # - ibinspectable_in_extension
+  # - identical_operands
   - implicit_getter
   - implicit_optional_initialization
   - implicitly_unwrapped_optional
   - inclusive_language
   - invalid_swiftlint_command
+  # - invisible_character
+  # - is_disjoint
+  # - joined_default_parameter
   - large_tuple
   - last_where
   - leading_whitespace
@@ -52,94 +81,23 @@ only_rules: # Only enforce these rules, ignore all others
   - legacy_constant
   - legacy_constructor
   - legacy_hashing
-  - legacy_nsgeometry_functions
-  - line_length
-  - mark
-  - modifier_order
-  - multiline_arguments
-  - multiline_parameters
-  - no_space_in_method_call
-  - ns_number_init_as_function_reference
-  - opening_brace
-  - orphaned_doc_comment
-  - overridden_super_call
-  - prefer_type_checking
-  - private_over_fileprivate
-  - protocol_property_accessors_order
-  - redundant_discardable_let
-  - redundant_objc_attribute
-  - redundant_string_enum_value
-  - redundant_type_annotation
-  - redundant_void_return
-  - return_arrow_whitespace
-  - statement_position
-  - switch_case_alignment
-  - syntactic_sugar
-  - trailing_newline
-  - trailing_semicolon
-  - trailing_whitespace
-  - unavailable_condition
-  - unneeded_break_in_switch
-  - unneeded_override
-  - unneeded_synthesized_initializer
-  - unused_optional_binding
-  - unused_setter_value
-  - vertical_parameter_alignment
-  - vertical_parameter_alignment_on_call
-  - vertical_whitespace
-  - vertical_whitespace_closing_braces
-  - vertical_whitespace_opening_braces
-  - void_function_in_ternary
-  - void_return
-  - yoda_condition
-  # - blanket_disable_command
-  # - collection_alignment
-  # - comma_inheritance
-  # - convenience_type
-  # - cyclomatic_complexity
-  # - deployment_target
-  # - direct_return
-  # - discarded_notification_center_observer
-  # - discouraged_default_parameter
-  # - discouraged_direct_init
-  # - discouraged_none_name
-  # - discouraged_object_literal
-  # - duplicate_conditions
-  # - enum_case_associated_values_count
-  # - fallthrough
-  # - fatal_error_message
-  # - file_header
-  # - file_name_no_space
-  # - file_name
-  # - file_types_order
-  # - final_test_case
-  # - flatmap_over_map_reduce
-  # - for_where
-  # - force_cast
-  # - force_try
-  # - force_unwrapping
-  # - function_default_parameter_at_end
-  # - function_name_whitespace
-  # - function_parameter_count
-  # - generic_type_name
-  # - ibinspectable_in_extension
-  # - identical_operands
-  # - invalid_swiftlint_command
-  # - invisible_character
-  # - is_disjoint
-  # - joined_default_parameter
   # - legacy_multiple
+  - legacy_nsgeometry_functions
   # - legacy_objc_type
   # - legacy_random
   # - legacy_uigraphics_function
   # - let_var_whitespace
+  - line_length
   # - literal_expression_end_indentation
   # - local_doc_comment
   # - lower_acl_than_parent
+  - mark
+  - modifier_order
+  - multiline_arguments
   # - multiline_function_chains
   # - multiline_literal_brackets
+  - multiline_parameters
   # - multiline_parameters_brackets
-  # - multiline_parameters
   # - multiple_closures_with_trailing_closure
   # - nesting
   # - nimble_operator
@@ -147,39 +105,49 @@ only_rules: # Only enforce these rules, ignore all others
   # - no_fallthrough_only
   # - no_grouping_extension
   # - no_magic_numbers
+  - no_space_in_method_call
   # - non_optional_string_data_conversion
   # - notification_center_detachment
-  # - ns_number_init_as_function_reference
+  - ns_number_init_as_function_reference
   # - nslocalizedstring_key
   # - nsobject_prefer_isequal
   # - number_separator
+  - opening_brace
   # - operator_usage_whitespace
   # - optional_data_string_conversion
+  - orphaned_doc_comment
+  - overridden_super_call
   # - override_in_extension
   # - period_spacing
   # - prefer_asset_symbols
   # - prefer_condition_list
   # - prefer_self_in_static_references
   # - prefer_self_type_over_type_of_self
-  # - prefer_type_checking
+  - prefer_type_checking
   # - prefer_zero_over_explicit_init
   # - private_action
   # - private_outlet
+  - private_over_fileprivate
   # - private_subject
   # - private_swiftui_state
   # - private_unit_test
   # - prohibited_interface_builder
   # - prohibited_super_call
+  - protocol_property_accessors_order
   # - reduce_boolean
   # - reduce_into
+  - redundant_discardable_let
   # - redundant_final
   # - redundant_nil_coalescing
+  - redundant_objc_attribute
   # - redundant_self
   # - redundant_sendable
   # - redundant_set_access_control
-  # - redundant_string_enum_value
-  # - redundant_type_annotation
+  - redundant_string_enum_value
+  - redundant_type_annotation
+  - redundant_void_return
   # - required_enum_case
+  - return_arrow_whitespace
   # - return_value_from_void_function
   # - self_binding
   # - self_in_property_initialization
@@ -188,24 +156,30 @@ only_rules: # Only enforce these rules, ignore all others
   # - shorthand_optional_binding
   # - sorted_enum_cases
   # - sorted_first_last
+  - statement_position
   # - static_operator
   # - static_over_final_class
   # - strict_fileprivate
   # - strong_iboutlet
+  - switch_case_alignment
+  - syntactic_sugar
   # - toggle_bool
   # - trailing_closure
+  - trailing_newline
+  - trailing_semicolon
+  - trailing_whitespace
   # - type_body_length
   # - type_contents_order
   # - type_name
   # - typesafe_array_init
-  # - unavailable_condition
+  - unavailable_condition
   # - unavailable_function
   # - unhandled_throwing_task
-  # - unneeded_break_in_switch
+  - unneeded_break_in_switch
   # - unneeded_escaping
-  # - unneeded_override
+  - unneeded_override
   # - unneeded_parentheses_in_closure_argument
-  # - unneeded_synthesized_initializer
+  - unneeded_synthesized_initializer
   # - unneeded_throws_rethrows
   # - unowned_variable_capture
   # - untyped_error_in_catch
@@ -213,22 +187,22 @@ only_rules: # Only enforce these rules, ignore all others
   # - unused_control_flow_label
   # - unused_declaration
   # - unused_enumerated
+  - unused_optional_binding
   # - unused_parameter
+  - unused_setter_value
   # - valid_ibinspectable
   # - variable_shadowing
-  # - void_function_in_ternary
+  - vertical_parameter_alignment
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+  - void_function_in_ternary
+  - void_return
   # - weak_delegate
   # - xct_specific_matcher
   # - xctfail_message
-
-# These rules were originally opted into. Disabling for now to get
-# Swiftlint up and running.
-
-# - deployment_target
-# - discouraged_optional_collection
-# - prohibited_interface_builder
-# - prohibited_super_call
-# - protocol_property_accessors_order
+  - yoda_condition
 
 line_length:
   warning: 125

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -226,6 +226,16 @@ file_header:
 redundant_type_annotation:
   consider_default_literal_types_redundant: true
 
+# `balanced_xctest_lifecycle` requires a `tearDown` for every `setUp` (and vice versa), which
+# means one half of the pair is sometimes an empty passthrough to super. Exempt the XCTest
+# life cycle methods so the two rules don't contradict each other.
+unneeded_override:
+  excluded_methods:
+    - setUp
+    - setUpWithError
+    - tearDown
+    - tearDownWithError
+
 analyzer_rules: # Rules run by `swiftlint analyze`
   - unused_import
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,43 +1,75 @@
 only_rules: # Only enforce these rules, ignore all others
-  - line_length
+  - accessibility_label_for_image
+  - accessibility_trait_for_button
+  - attribute_name_spacing
+  - balanced_xctest_lifecycle
   - blanket_disable_command
   - class_delegate_protocol
-  - closure_spacing
+  - closing_brace
+  - closure_body_length
+  - closure_end_indentation
   - closure_parameter_position
+  - closure_spacing
   - colon
   - comma
   - comment_spacing
   - compiler_protocol_init
   - computed_accessors_order
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
   - control_statement
+  - discouraged_assert
   - duplicate_conditions
+  - duplicate_enum_cases
+  - duplicate_imports
   - dynamic_inline
+  - empty_collection_literal
+  - empty_count
   - empty_enum_arguments
   - empty_parameters
   - empty_parentheses_with_trailing_closure
+  - empty_string
+  - empty_xctest_method
+  - explicit_init
+  - file_header
+  - first_where
   - for_where
+  - force_cast
   - force_try
+  - function_body_length
+  - function_name_whitespace
   - implicit_getter
+  - implicit_optional_initialization
+  - implicitly_unwrapped_optional
   - inclusive_language
   - invalid_swiftlint_command
   - large_tuple
+  - last_where
   - leading_whitespace
   - legacy_cggeometry_functions
   - legacy_constant
   - legacy_constructor
   - legacy_hashing
   - legacy_nsgeometry_functions
+  - line_length
   - mark
+  - modifier_order
+  - multiline_arguments
+  - multiline_parameters
   - no_space_in_method_call
   - ns_number_init_as_function_reference
-  - function_name_whitespace
+  - opening_brace
   - orphaned_doc_comment
+  - overridden_super_call
+  - prefer_type_checking
   - private_over_fileprivate
   - protocol_property_accessors_order
   - redundant_discardable_let
   - redundant_objc_attribute
-  - implicit_optional_initialization
   - redundant_string_enum_value
+  - redundant_type_annotation
   - redundant_void_return
   - return_arrow_whitespace
   - statement_position
@@ -47,60 +79,156 @@ only_rules: # Only enforce these rules, ignore all others
   - trailing_semicolon
   - trailing_whitespace
   - unavailable_condition
+  - unneeded_break_in_switch
   - unneeded_override
   - unneeded_synthesized_initializer
   - unused_optional_binding
   - unused_setter_value
   - vertical_parameter_alignment
-  - vertical_whitespace
-  - void_function_in_ternary
-  - void_return
-  - file_header
-  - redundant_type_annotation
-  - closing_brace
-  - closure_end_indentation
-  - contains_over_filter_count
-  - contains_over_filter_is_empty
-  - contains_over_first_not_nil
-  - contains_over_range_nil_comparison
-  - empty_collection_literal
-  - empty_count
-  - empty_string
-  - empty_xctest_method
-  - explicit_init
-  - first_where
-  - discouraged_assert
-  - duplicate_imports
-  - duplicate_enum_cases
-  - last_where
-  - modifier_order
-  - multiline_arguments
-  - opening_brace
-  - overridden_super_call
   - vertical_parameter_alignment_on_call
+  - vertical_whitespace
   - vertical_whitespace_closing_braces
   - vertical_whitespace_opening_braces
+  - void_function_in_ternary
+  - void_return
   - yoda_condition
-  - accessibility_label_for_image
-  - accessibility_trait_for_button
-  - force_cast
-  - closure_body_length
-  - function_body_length
-  - implicitly_unwrapped_optional
-  - prefer_type_checking
-  - attribute_name_spacing
-  - unneeded_break_in_switch
-  - multiline_parameters
+  # - blanket_disable_command
+  # - collection_alignment
+  # - comma_inheritance
+  # - convenience_type
+  # - cyclomatic_complexity
+  # - deployment_target
+  # - direct_return
+  # - discarded_notification_center_observer
+  # - discouraged_default_parameter
+  # - discouraged_direct_init
+  # - discouraged_none_name
+  # - discouraged_object_literal
+  # - duplicate_conditions
+  # - enum_case_associated_values_count
+  # - fallthrough
+  # - fatal_error_message
+  # - file_header
+  # - file_name_no_space
+  # - file_name
+  # - file_types_order
+  # - final_test_case
+  # - flatmap_over_map_reduce
+  # - for_where
+  # - force_cast
+  # - force_try
+  # - force_unwrapping
+  # - function_default_parameter_at_end
+  # - function_name_whitespace
+  # - function_parameter_count
+  # - generic_type_name
+  # - ibinspectable_in_extension
+  # - identical_operands
+  # - invalid_swiftlint_command
+  # - invisible_character
+  # - is_disjoint
+  # - joined_default_parameter
+  # - legacy_multiple
+  # - legacy_objc_type
+  # - legacy_random
+  # - legacy_uigraphics_function
+  # - let_var_whitespace
+  # - literal_expression_end_indentation
+  # - local_doc_comment
+  # - lower_acl_than_parent
+  # - multiline_function_chains
+  # - multiline_literal_brackets
+  # - multiline_parameters_brackets
+  # - multiline_parameters
+  # - multiple_closures_with_trailing_closure
+  # - nesting
+  # - nimble_operator
+  # - no_empty_block
+  # - no_fallthrough_only
+  # - no_grouping_extension
+  # - no_magic_numbers
+  # - non_optional_string_data_conversion
+  # - notification_center_detachment
+  # - ns_number_init_as_function_reference
+  # - nslocalizedstring_key
+  # - nsobject_prefer_isequal
+  # - number_separator
+  # - operator_usage_whitespace
+  # - optional_data_string_conversion
+  # - override_in_extension
+  # - period_spacing
+  # - prefer_asset_symbols
+  # - prefer_condition_list
+  # - prefer_self_in_static_references
+  # - prefer_self_type_over_type_of_self
+  # - prefer_type_checking
+  # - prefer_zero_over_explicit_init
+  # - private_action
+  # - private_outlet
+  # - private_subject
+  # - private_swiftui_state
+  # - private_unit_test
+  # - prohibited_interface_builder
+  # - prohibited_super_call
+  # - reduce_boolean
+  # - reduce_into
+  # - redundant_final
+  # - redundant_nil_coalescing
+  # - redundant_self
+  # - redundant_sendable
+  # - redundant_set_access_control
+  # - redundant_string_enum_value
+  # - redundant_type_annotation
+  # - required_enum_case
+  # - return_value_from_void_function
+  # - self_binding
+  # - self_in_property_initialization
+  # - shorthand_argument
+  # - shorthand_operator
+  # - shorthand_optional_binding
+  # - sorted_enum_cases
+  # - sorted_first_last
+  # - static_operator
+  # - static_over_final_class
+  # - strict_fileprivate
+  # - strong_iboutlet
+  # - toggle_bool
+  # - trailing_closure
+  # - type_body_length
+  # - type_contents_order
+  # - type_name
+  # - typesafe_array_init
+  # - unavailable_condition
+  # - unavailable_function
+  # - unhandled_throwing_task
+  # - unneeded_break_in_switch
+  # - unneeded_escaping
+  # - unneeded_override
+  # - unneeded_parentheses_in_closure_argument
+  # - unneeded_synthesized_initializer
+  # - unneeded_throws_rethrows
+  # - unowned_variable_capture
+  # - untyped_error_in_catch
+  # - unused_closure_parameter
+  # - unused_control_flow_label
+  # - unused_declaration
+  # - unused_enumerated
+  # - unused_parameter
+  # - valid_ibinspectable
+  # - variable_shadowing
+  # - void_function_in_ternary
+  # - weak_delegate
+  # - xct_specific_matcher
+  # - xctfail_message
 
 # These rules were originally opted into. Disabling for now to get
 # Swiftlint up and running.
 
-  # - deployment_target
-  # - discouraged_optional_collection
-  # - prohibited_interface_builder
-  # - prohibited_super_call
-  # - protocol_property_accessors_order
-
+# - deployment_target
+# - discouraged_optional_collection
+# - prohibited_interface_builder
+# - prohibited_super_call
+# - protocol_property_accessors_order
 
 line_length:
   warning: 125
@@ -117,9 +245,9 @@ function_body_length:
 
 file_header:
   required_string: |
-                    // This Source Code Form is subject to the terms of the Mozilla Public
-                    // License, v. 2.0. If a copy of the MPL was not distributed with this
-                    // file, You can obtain one at http://mozilla.org/MPL/2.0/
+    // This Source Code Form is subject to the terms of the Mozilla Public
+    // License, v. 2.0. If a copy of the MPL was not distributed with this
+    // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 redundant_type_annotation:
   consider_default_literal_types_redundant: true
@@ -165,7 +293,6 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
 included:
   - /Users/vagrant/git
   - .
-
 
 # reporter: "json" # reporter type (xcode, json, csv, checkstyle)
 reporter: "xcode" # reporter type (xcode, json, csv, checkstyle)

--- a/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
+++ b/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
@@ -161,7 +161,9 @@ final class URLExtensionTests: XCTestCase {
         let testCases = [
             ("https://www.google.com", (nil, "google.com")),
             ("https://blog.engineering.company.com", ("blog.engineering.", "blog.engineering.company.com")),
-            ("https://long-extended-subdomain-name-containing-many-letters-and-dashes.badssl.com", ("long-extended-subdomain-name-containing-many-letters-and-dashes.", "long-extended-subdomain-name-containing-many-letters-and-dashes.badssl.com")),
+            ("https://long-extended-subdomain-name-containing-many-letters-and-dashes.badssl.com",
+             ("long-extended-subdomain-name-containing-many-letters-and-dashes.",
+              "long-extended-subdomain-name-containing-many-letters-and-dashes.badssl.com")),
             ("http://com:org@m.canadacomputers.co.uk", (nil, "canadacomputers.co.uk")),
             ("https://www.wix.com/blog/what-is-a-subdomain", (nil, "wix.com")),
             ("nothing", (nil, "nothing")),

--- a/BrowserKit/Tests/CommonTests/Theming/NovaMissingTokenTests.swift
+++ b/BrowserKit/Tests/CommonTests/Theming/NovaMissingTokenTests.swift
@@ -7,6 +7,10 @@ import XCTest
 @testable import Common
 
 class NovaMissingTokenTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
     override func tearDown() {
         NovaMissingToken.reportMisuse = { assertionFailure($0) }
         super.tearDown()

--- a/BrowserKit/Tests/ReduxTests/ReduxIntegrationTests.swift
+++ b/BrowserKit/Tests/ReduxTests/ReduxIntegrationTests.swift
@@ -35,6 +35,14 @@ final class ReduxIntegrationTests: XCTestCase {
         fakeReduxViewController = createAndLoadViewController()
     }
 
+    override func tearDown() async throws {
+        fakeReduxViewController = nil
+        mockMiddleware = nil
+        mockState = nil
+        store = nil
+        try await super.tearDown()
+    }
+
     // MARK: Test Legacy Actions
 
     // This test will fail if actions are not completely processed before the next action is fired (i.e. action queuing).

--- a/BrowserKit/Tests/ReduxTests/StoreTests.swift
+++ b/BrowserKit/Tests/ReduxTests/StoreTests.swift
@@ -14,6 +14,14 @@ final class StoreTests: XCTestCase {
         mockState = MockState()
     }
 
+    override func tearDown() async throws {
+        MockState.midReducerActions = nil
+        MockState.runMidReducerActions = false
+        MockState.actionsReduced = []
+        MockState.modernActionsReduced = []
+        try await super.tearDown()
+    }
+
     func testDispatchBasicAction_mainThread() {
         let store = Store(state: mockState,
                           reducer: MockState.reducer,

--- a/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLHandlerTests.swift
+++ b/BrowserKit/Tests/SiteImageViewTests/FaviconURLProcessing/FaviconURLHandlerTests.swift
@@ -18,6 +18,12 @@ class FaviconURLHandlerTests: XCTestCase {
         mockCache = MockFaviconURLCache()
     }
 
+    override func tearDown() {
+        mockFetcher = nil
+        mockCache = nil
+        super.tearDown()
+    }
+
     func testGetFaviconURL_inCache() async throws {
         await mockCache.setTestResult(url: faviconURL)
         let model = createSiteImageModel(siteURL: siteURL)

--- a/BrowserKit/Tests/SummarizeKitTests/FoundationModelsSummarizerTests.swift
+++ b/BrowserKit/Tests/SummarizeKitTests/FoundationModelsSummarizerTests.swift
@@ -29,6 +29,10 @@ final class FoundationModelsSummarizerTests: XCTestCase {
         }
     }
 
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+    }
+
     @available(iOS 26, *)
     func testSummarizerRespondNonStreaming() async throws {
         let subject = createSubject(respondWith: ["hello", "world"])

--- a/BrowserKit/Tests/TabDataStoreTests/TabFileManagerTests.swift
+++ b/BrowserKit/Tests/TabDataStoreTests/TabFileManagerTests.swift
@@ -16,6 +16,10 @@ final class TabFileManagerTests: XCTestCase {
                                                sharedContainerIdentifier: "id")
     }
 
+    override func tearDown() {
+        super.tearDown()
+    }
+
     func testWriteWindowDataThenRetrieve() throws {
         let subject = DefaultTabFileManager()
         let windowData = createMockWindow()

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
@@ -188,7 +188,10 @@ final class TopSitesMiddleware {
         }
 
         guard telemetryMetadata.topSiteConfiguration.site.isSponsoredSite else { return }
-        unifiedAdsTelemetry.sendImpressionTelemetry(tileSite: telemetryMetadata.topSiteConfiguration.site, position: telemetryMetadata.position)
+        unifiedAdsTelemetry.sendImpressionTelemetry(
+            tileSite: telemetryMetadata.topSiteConfiguration.site,
+            position: telemetryMetadata.position
+        )
     }
 
     private func sendSponsoredTappedTracking(with topSiteConfig: TopSiteConfiguration, and position: Int) {

--- a/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/HistoryPanel/HistoryPanel.swift
@@ -496,8 +496,9 @@ class HistoryPanel: UIViewController,
                     assertionFailure("FXIOS-11563 We should never have duplicates! Log how you made this crash happen.")
                 }
 
+                // FXIOS-10996 Force unique while we investigate history panel crashes
                 snapshot.appendItems(
-                    sectionDataUniqued.map { HistoryItem.site($0) }, // FXIOS-10996 Force unique while we investigate history panel crashes
+                    sectionDataUniqued.map { HistoryItem.site($0) },
                     toSection: section
                 )
             }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/AppIconSelection/AppIconSelectionTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/AppIconSelection/AppIconSelectionTelemetryTests.swift
@@ -19,6 +19,11 @@ final class AppIconSelectionTelemetryTests: XCTestCase {
         mockGleanWrapper = MockGleanWrapper()
     }
 
+    override func tearDown() {
+        mockGleanWrapper = nil
+        super.tearDown()
+    }
+
     func testSelectedIcon_firesSelected() throws {
         // The event and event extras type under test
         let event = GleanMetrics.SettingsAppIcon.selected

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/RouteBuilderTests.swift
@@ -19,6 +19,13 @@ final class RouteBuilderTests: XCTestCase {
         randomActivity.webpageURL = testURL
     }
 
+    override func tearDown() async throws {
+        handoffUserActivity.webpageURL = nil
+        universalLinkUserActivity.webpageURL = nil
+        randomActivity.webpageURL = nil
+        try await super.tearDown()
+    }
+
     func test_makeRoute_HandlesAnyActivityType() {
         let routeBuilder = createSubject()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SearchEngineSelectionCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/SearchEngineSelectionCoordinatorTests.swift
@@ -19,6 +19,13 @@ final class SearchEngineSelectionCoordinatorTests: XCTestCase {
         mockParentCoordinator = MockParentCoordinator()
     }
 
+    override func tearDown() async throws {
+        mockRouter = nil
+        mockParentCoordinator = nil
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
     func testInitialState() {
         _ = createSubject()
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/CuratedRecommendationCacheUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/CuratedRecommendationCacheUtilityTests.swift
@@ -11,6 +11,10 @@ import MozillaAppServices
 final class CuratedRecommendationCacheUtilityTests: XCTestCase {
     var testFileURL: URL!
 
+    override func setUp() async throws {
+        try await super.setUp()
+    }
+
     override func tearDown() async throws {
         try? FileManager.default.removeItem(at: testFileURL)
         testFileURL = nil

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/EventQueueTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/EventQueueTests.swift
@@ -31,6 +31,11 @@ final class EventQueueTests: XCTestCase {
         self.queue = EventQueue()
     }
 
+    override func tearDown() {
+        self.queue = nil
+        super.tearDown()
+    }
+
     func testBasicEventFiredCheck() {
         XCTAssertFalse(queue.hasSignalled(.startingEvent))
         queue.signal(event: .startingEvent)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/URLMailTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Extensions/URLMailTests.swift
@@ -41,7 +41,8 @@ class URLMailTests: XCTestCase {
     }
 
     func testMailToMetadata_noToAddress() {
-        let url = URL(string: "mailto:?to=&subject=mailto%20with%20examples&body=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FMailto")
+        let mailto = "mailto:?to=&subject=mailto%20with%20examples&body=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FMailto"
+        let url = URL(string: mailto)
         let metadata = url!.mailToMetadata()
         XCTAssertNotNil(metadata, "Metadata should not be nil")
         XCTAssertEqual(metadata?.to, "", "Should have empty to value")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FxAWebViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FxAWebViewModelTests.swift
@@ -57,7 +57,10 @@ class FxAWebViewModelTests: XCTestCase {
         if let blobURL = URL(string: "blob://some/blob/url"),
            let webViewURL = URL(string: "https://accounts.firefox.com") {
             let result = viewModel.isMozillaAccountPDF(blobURL: blobURL, webViewURL: webViewURL)
-            XCTAssertTrue(result, "Should return true for a valid blob URL and a webView URL with the host accounts.firefox.com.")
+            XCTAssertTrue(
+                result,
+                "Should return true for a valid blob URL and a webView URL with the host accounts.firefox.com."
+            )
         }
     }
 
@@ -65,7 +68,10 @@ class FxAWebViewModelTests: XCTestCase {
         if let blobURL = URL(string: "blob://some/blob/url"),
            let webViewURL = URL(string: "https://example.com") {
             let result = viewModel.isMozillaAccountPDF(blobURL: blobURL, webViewURL: webViewURL)
-            XCTAssertFalse(result, "Should return false for a valid blob URL and a webView URL with a different host then accounts.firefox.com")
+            XCTAssertFalse(
+                result,
+                "Should return false for a valid blob URL and a webView URL with a different host then accounts.firefox.com"
+            )
         }
     }
 
@@ -73,7 +79,10 @@ class FxAWebViewModelTests: XCTestCase {
         if let blobURL = URL(string: "https://example.com/blob"),
            let webViewURL = URL(string: "https://accounts.firefox.com") {
             let result = viewModel.isMozillaAccountPDF(blobURL: blobURL, webViewURL: webViewURL)
-            XCTAssertFalse(result, "Should return false for a wrong blob URL and a webView URL with the host accounts.firefox.com.")
+            XCTAssertFalse(
+                result,
+                "Should return false for a wrong blob URL and a webView URL with the host accounts.firefox.com."
+            )
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/GleanUsageReportingLifecycleObserverTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/GleanUsageReportingLifecycleObserverTest.swift
@@ -13,6 +13,11 @@ class GleanUsageReportingLifecycleObserverTest: XCTestCase {
         fakeGleanUsageReportingApi = MockGleanUsageReportingApi()
     }
 
+    override func tearDown() {
+        fakeGleanUsageReportingApi = nil
+        super.tearDown()
+    }
+
     func testNoPingsSubmittedBeforeLifecycleChanges() {
         _ = createObserver()
         XCTAssertEqual(fakeGleanUsageReportingApi.pingSubmitCount, 0)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/KeyChainAppAttestKeyIDStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/KeyChainAppAttestKeyIDStoreTests.swift
@@ -12,6 +12,10 @@ final class KeychainAppAttestKeyIDStoreTests: XCTestCase {
     private static let testService = "org.mozilla.browserkit.appattest.keyid.test"
     private static let testAccount = "test"
 
+    override func setUp() {
+        super.setUp()
+    }
+
     override func tearDown() {
         // Clean up after each test so keychain state doesn't leak between tests.
         let subject = createSubject()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Nimbus/RecordedNimbusContextTests.swift
@@ -11,8 +11,13 @@ import XCTest
 
 class RecordedNimbusContextTests: XCTestCase {
     override func setUp() {
+        super.setUp()
         Glean.shared.enableTestingMode()
         Glean.shared.resetGlean(clearStores: true)
+    }
+
+    override func tearDown() {
+        super.tearDown()
     }
 
     /**

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SettingsTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/SettingsTelemetryTests.swift
@@ -19,6 +19,11 @@ final class SettingsTelemetryTests: XCTestCase {
         mockGleanWrapper = MockGleanWrapper()
     }
 
+    override func tearDown() {
+        mockGleanWrapper = nil
+        super.tearDown()
+    }
+
     func testOptionSelected_recordsData() throws {
         // The event and event extras type under test
         let event = GleanMetrics.Settings.optionSelected

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/WebsiteDataManagementViewModelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/WebsiteDataManagementViewModelTests.swift
@@ -19,6 +19,12 @@ final class WebsiteDataManagementViewModelTests: XCTestCase {
         selectionChangedCallCount = 0
     }
 
+    override func tearDown() async throws {
+        viewModelChangedCallCount = 0
+        selectionChangedCallCount = 0
+        try await super.tearDown()
+    }
+
     func test_selectItem_notifiesSelectionChangedOnly() {
         let subject = createSubject()
         let record = MockWebsiteDataRecord(displayName: "mozilla.org")

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/HistoryDeletionUtilityTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/HistoryDeletionUtilityTelemetryTests.swift
@@ -16,6 +16,11 @@ final class HistoryDeletionUtilityTelemetryTests: XCTestCase {
         mockGleanWrapper = MockGleanWrapper()
     }
 
+    override func tearDown() {
+        mockGleanWrapper = nil
+        super.tearDown()
+    }
+
     func testHistoryDeletedTelemetry() throws {
         // The event and event extras type under test
         let event = GleanMetrics.LibraryHistoryPanel.clearedHistory

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/UserTelemetryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Telemetry/UserTelemetryTests.swift
@@ -17,6 +17,11 @@ final class UserTelemetryTests: XCTestCase {
         mockGleanWrapper = MockGleanWrapper()
     }
 
+    override func tearDown() {
+        mockGleanWrapper = nil
+        super.tearDown()
+    }
+
     func testSetFirefoxAccountID_recordsData() throws {
         let metric = GleanMetrics.UserClientAssociation.uid
         let expectedValue = mockFirefoxAccountId

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/CertificatesFetcherTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TrackingProtectionTests/CertificatesFetcherTests.swift
@@ -9,6 +9,10 @@ import Common
 @testable import Client
 
 final class CertificatesFetcherTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
     override func tearDown() {
         MockCertificateURLProtocol.requestHandler = nil
         super.tearDown()

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nBaseSnapshotTests.swift
@@ -39,6 +39,14 @@ class L10nBaseSnapshotTests: XCTestCase {
         navigator.synchronizeWithUserState()
     }
 
+    @MainActor
+    override func tearDown() async throws {
+        navigator = nil
+        userState = nil
+        app = nil
+        try await super.tearDown()
+    }
+
     func springboardStart(_ app: XCUIApplication, args: [String] = []) {
         XCUIDevice.shared.press(.home)
         app.launchArguments += [LaunchArguments.Test] + args

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/DiskImageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/DiskImageStoreTests.swift
@@ -18,6 +18,12 @@ class DiskImageStoreTests: XCTestCase {
         await clearStore()
     }
 
+    override func tearDown() async throws {
+        await clearStore()
+        store = nil
+        try await super.tearDown()
+    }
+
     func testSaveImageForKey() async throws {
         let testKey = "testImageKey"
         let testImage = makeImageWithColor(UIColor.red, size: CGSize(width: 100, height: 100))

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustAutofillTests.swift
@@ -54,6 +54,14 @@ class RustAutofillTests: XCTestCase {
         }
     }
 
+    override func tearDown() {
+        _ = autofill?.forceClose()
+        autofill = nil
+        encryptionKey = nil
+        files = nil
+        super.tearDown()
+    }
+
     func addCreditCard() async throws -> CreditCard {
         return try await withCheckedThrowingContinuation { continuation in
             autofill.addCreditCard(creditCard: mockCreditCard) { card, error in

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustLoginsTests.swift
@@ -42,6 +42,14 @@ class RustLoginsTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+    override func tearDown() {
+        _ = logins?.forceClose()
+        logins = nil
+        files = nil
+        MockRustKeychain.shared.removeAllKeys()
+        super.tearDown()
+    }
+
     func testListLogins() {
         let expectation = XCTestExpectation(description: "addLogin")
         logins.addLogin(login: login) { result in

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustRemoteTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/RustRemoteTabsTests.swift
@@ -79,6 +79,15 @@ class RustRemoteTabsTests: XCTestCase {
         }
     }
 
+    override func tearDown() {
+        _ = tabs?.forceClose()
+        _ = mockTabs?.forceClose()
+        tabs = nil
+        mockTabs = nil
+        files = nil
+        super.tearDown()
+    }
+
     func testSetLocalTabs() {
         let url = "https://example.com"
         let title = "example"

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestBrowserDB.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestBrowserDB.swift
@@ -17,14 +17,23 @@ class TestBrowserDB: XCTestCase, @unchecked Sendable {
         }
     }
 
-    override func setUp() {
-        super.setUp()
+    fileprivate func removeTestDatabaseFiles() {
         rm("foo.db")
         rm("foo.db-shm")
         rm("foo.db-wal")
         rm("foo.db.bak.1")
         rm("foo.db.bak.1-shm")
         rm("foo.db.bak.1-wal")
+    }
+
+    override func setUp() {
+        super.setUp()
+        removeTestDatabaseFiles()
+    }
+
+    override func tearDown() {
+        removeTestDatabaseFiles()
+        super.tearDown()
     }
 
     class MockFailingSchema: Schema {

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSQLiteReadingList.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSQLiteReadingList.swift
@@ -18,6 +18,12 @@ class TestSQLiteReadingList: XCTestCase {
         self.readingList = SQLiteReadingList(db: db)
     }
 
+    override func tearDown() {
+        self.readingList = nil
+        self.db = nil
+        super.tearDown()
+    }
+
     func testCreateRecord() {
         let result = readingList.createRecordWithURL(
             "http://www.anandtech.com/show/9117/analyzing-intel-core-m-performance",

--- a/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSwiftData.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/StorageTests/TestSwiftData.swift
@@ -28,6 +28,13 @@ class TestSwiftData: XCTestCase {
         XCTAssertNil(addSite(table, url: "http://url0", title: "title0"), "Added url0.")
     }
 
+    override func tearDownWithError() throws {
+        swiftData = nil
+        testDB = nil
+        urlCounter = 1
+        try super.tearDownWithError()
+    }
+
     func testDefaultSettings() {
         let error = writeDuringRead()
         XCTAssertNil(error, "Insertion succeeded")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
@@ -45,6 +45,12 @@ class ScreenGraphTest: XCTestCase {
                                LaunchArguments.DisableAnimations]
         app.activate()
     }
+
+    override func tearDown() async throws {
+        navigator = nil
+        app = nil
+        try await super.tearDown()
+    }
 }
 
 extension XCTestCase {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ThirdPartySearchTest.swift
@@ -32,7 +32,11 @@ class ThirdPartySearchTest: BaseTestCase {
             XCTFail("Failed to retrieve the URL value from the browser's URL bar")
             return
         }
-        XCTAssertEqual(url, "developer.mozilla.org", "The URL should indicate that the search was performed on MDN and not the default")
+        XCTAssertEqual(
+            url,
+            "developer.mozilla.org",
+            "The URL should indicate that the search was performed on MDN and not the default"
+        )
         mozWaitForElementToExist(app.staticTexts["MDN"])
     }
 
@@ -59,7 +63,10 @@ class ThirdPartySearchTest: BaseTestCase {
             XCTFail("Failed to retrieve the URL value from the browser's URL bar")
             return
         }
-        XCTAssert(url.hasPrefix("developer.mozilla.org"), "The URL should indicate that the search was performed on MDN and not the default")
+        XCTAssert(
+            url.hasPrefix("developer.mozilla.org"),
+            "The URL should indicate that the search was performed on MDN and not the default"
+        )
         mozWaitForElementToExist(app.staticTexts["MDN"])
     }
 

--- a/focus-ios/focus-ios-tests/ClientTests/SearchEngineManagerTests.swift
+++ b/focus-ios/focus-ios-tests/ClientTests/SearchEngineManagerTests.swift
@@ -21,6 +21,11 @@ class SearchEngineManagerTests: XCTestCase {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
 
+    override func tearDown() {
+        mockUserDefaults.clear()
+        super.tearDown()
+    }
+
     func testAddEngine() {
         let manager = SearchEngineManager(prefs: mockUserDefaults)
         let engine = manager.addEngine(name: CUSTOM_ENGINE_NAME, template: CUSTOM_ENGINE_TEMPLATE)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16752)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35522)

## :bulb: Description
`.swiftlint.yaml` has three main changes:
1. added `balanced_xctest_lifecycle` (with the PR being the resulting swiftlint work)
2. alphabetized things because CHAOS!
3. To allow myself to be lazy down the the line, I also added rules that we're gonna enable for sure, but kept them commented out so anybody can really tackle them in any order without having to check the spreadsheet :)

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

