### PR TITLE
Refactor FXIOS-16749 [Nimbus] Set disabled as startAtHome default

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/StartAtHome/StartAtHomeHelper.swift
@@ -42,7 +42,7 @@ class StartAtHomeHelper: UserFeaturePreferenceProvider {
     var startAtHomeSetting: StartAtHomeSetting {
         get {
             let pref = userPreferences.startAtHomeSetting
-            return StartAtHomeSetting(rawValue: pref.rawValue) ?? .afterFourHours
+            return StartAtHomeSetting(rawValue: pref.rawValue) ?? .disabled
         }
         set { prefs.setString(newValue.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome) }
     }

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -227,7 +227,7 @@ class HomePageSettingViewController: SettingsTableViewController,
 
     private func setupStartAtHomeSection() -> SettingSection {
         let pref = userPreferences.startAtHomeSetting
-        currentStartAtHomeSetting = StartAtHomeSetting(rawValue: pref.rawValue) ?? .afterFourHours
+        currentStartAtHomeSetting = StartAtHomeSetting(rawValue: pref.rawValue) ?? .disabled
 
         typealias a11y = AccessibilityIdentifiers.Settings.Homepage.StartAtHome
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -63,8 +63,8 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
 
         // Opening Screen
         XCTAssertFalse(app.tables.cells["StartAtHomeAlways"].isSelected)
-        XCTAssertFalse(app.tables.cells["StartAtHomeDisabled"].isSelected)
-        XCTAssertTrue(app.tables.cells["StartAtHomeAfterFourHours"].isSelected)
+        XCTAssertFalse(app.tables.cells["StartAtHomeAfterFourHours"].isSelected)
+        XCTAssertTrue(app.tables.cells["StartAtHomeDisabled"].isSelected)
 
         // Include on Homepage
         mozWaitForElementToExist(app.tables.cells["TopSitesSettings"].staticTexts["On"])

--- a/firefox-ios/nimbus-features/startAtHomeFeature.yaml
+++ b/firefox-ios/nimbus-features/startAtHomeFeature.yaml
@@ -6,15 +6,8 @@ features:
       setting:
         description: This property provides a default setting for the start at home feature
         type: StartAtHome
-        default: afterFourHours
-    defaults:
-      - channel: beta
-        value:
-          setting: afterFourHours
-      - channel: developer
-        value: 
-          setting: afterFourHours
-        
+        default: disabled
+
 # These different variants must match those of StartAtHomeSetting (including casing) in FlaggableFeatureOptions.swift
 enums:
   StartAtHome:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16749)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35521)

## :bulb: Description
Title

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

