### PR TITLE
Refactor FXIOS-14550 - [Tab Tray] -  Remove calling of layoutIfNeeded in runPresenationAnimation method

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -379,6 +379,7 @@
 		21EA33812EC67FCA00D20D90 /* ToolbarAnimatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EA33802EC67FCA00D20D90 /* ToolbarAnimatorTest.swift */; };
 		21EA466A2B04130500AAAB2D /* TabsPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EA46692B04130500AAAB2D /* TabsPanelState.swift */; };
 		21ED80B32AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ED80B22AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift */; };
+		A1B2C3D12F0000010000AA01 /* TabDisplayViewGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D02F0000010000AA01 /* TabDisplayViewGeometryTests.swift */; };
 		21EEAA192D3852B300595119 /* BookmarksTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EEAA182D3852B300595119 /* BookmarksTelemetry.swift */; };
 		21EEAA1B2D3AE3B300595119 /* BookmarksTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EEAA1A2D3AE3B300595119 /* BookmarksTelemetryTests.swift */; };
 		21EEAA1D2D4005DE00595119 /* NativeErrorPageFeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21EEAA1C2D4005DE00595119 /* NativeErrorPageFeatureFlag.swift */; };
@@ -1073,6 +1074,7 @@
 		8A6B799D2CDBDAE4003C3077 /* MockSponsoredTileData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B799C2CDBDAE4003C3077 /* MockSponsoredTileData.swift */; };
 		8A6B79A02CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6B799F2CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift */; };
 		8A6CDB472DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6CDB462DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift */; };
+		A1B2C3D32F0000010000AA02 /* MockTabTrayUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D22F0000010000AA02 /* MockTabTrayUtils.swift */; };
 		8A6E13982A71BA4E00A88FA8 /* TabWebViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */; };
 		8A6E63C72D4946B90040D355 /* JumpBackInSectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63C62D4946B40040D355 /* JumpBackInSectionState.swift */; };
 		8A6E63C92D4948BE0040D355 /* JumpBackInTabConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6E63C82D4948BE0040D355 /* JumpBackInTabConfiguration.swift */; };
@@ -3278,6 +3280,7 @@
 		21EA33802EC67FCA00D20D90 /* ToolbarAnimatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarAnimatorTest.swift; sourceTree = "<group>"; };
 		21EA46692B04130500AAAB2D /* TabsPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPanelState.swift; sourceTree = "<group>"; };
 		21ED80B22AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayDiffableDataSourceTests.swift; sourceTree = "<group>"; };
+		A1B2C3D02F0000010000AA01 /* TabDisplayViewGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDisplayViewGeometryTests.swift; sourceTree = "<group>"; };
 		21EEAA182D3852B300595119 /* BookmarksTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksTelemetry.swift; sourceTree = "<group>"; };
 		21EEAA1A2D3AE3B300595119 /* BookmarksTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksTelemetryTests.swift; sourceTree = "<group>"; };
 		21EEAA1C2D4005DE00595119 /* NativeErrorPageFeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeErrorPageFeatureFlag.swift; sourceTree = "<group>"; };
@@ -9859,6 +9862,7 @@
 		8A6B799C2CDBDAE4003C3077 /* MockSponsoredTileData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSponsoredTileData.swift; sourceTree = "<group>"; };
 		8A6B799F2CDBDB0C003C3077 /* MockGoogleTopSiteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGoogleTopSiteManager.swift; sourceTree = "<group>"; };
 		8A6CDB462DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabDisplayViewDragAndDropInteraction.swift; sourceTree = "<group>"; };
+		A1B2C3D22F0000010000AA02 /* MockTabTrayUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabTrayUtils.swift; sourceTree = "<group>"; };
 		8A6E13972A71BA4E00A88FA8 /* TabWebViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabWebViewTests.swift; sourceTree = "<group>"; };
 		8A6E63C62D4946B40040D355 /* JumpBackInSectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInSectionState.swift; sourceTree = "<group>"; };
 		8A6E63C82D4948BE0040D355 /* JumpBackInTabConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpBackInTabConfiguration.swift; sourceTree = "<group>"; };
@@ -13036,6 +13040,7 @@
 				8ABB15C82D5A4E3900A4635C /* RemoteTabsMiddlewareTests.swift */,
 				219935F02B07DFA200E5966F /* TabDisplayPanelTests.swift */,
 				21ED80B22AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift */,
+				A1B2C3D02F0000010000AA01 /* TabDisplayViewGeometryTests.swift */,
 				21D8EA922ABE04F7003FF16E /* TabTrayViewControllerTests.swift */,
 				8A3EAFE42D5F9AA40060AB87 /* TabManagerMiddlewareTests.swift */,
 			);
@@ -16076,6 +16081,7 @@
 				216424D32E56174400A3AF40 /* MockTabScrollHandlerDelegate.swift */,
 				0B5CAF0C2E40DA89008B5D5A /* MockSummarizationChecker.swift */,
 				8A6CDB462DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift */,
+				A1B2C3D22F0000010000AA02 /* MockTabTrayUtils.swift */,
 				8A01FE3F2DF0CE49002C483B /* MockDateProvider.swift */,
 				FF0005AC2F000003000BBBBB /* MockQuickAnswersStore.swift */,
 				8A9F4F042DC8F4ED004644B9 /* MockRemoteTabs.swift */,
@@ -20843,6 +20849,7 @@
 				8AFCE50729DE0CD500B1B253 /* LaunchCoordinatorTests.swift in Sources */,
 				961D6B832995AF84001B9CF1 /* GeneralizedImageFetcherTests.swift in Sources */,
 				21ED80B32AF2E43A0065D4C7 /* TabDisplayDiffableDataSourceTests.swift in Sources */,
+				A1B2C3D12F0000010000AA01 /* TabDisplayViewGeometryTests.swift in Sources */,
 				8C3A17792E68390000341A01 /* OnboardingLaunchScreenViewControllerTests.swift in Sources */,
 				C29B64872AD69D0200F3244B /* QRCodeCoordinatorTests.swift in Sources */,
 				8A4880802E68AF8400AD43D5 /* GleanHttpUploaderTests.swift in Sources */,
@@ -21366,6 +21373,7 @@
 				C8699152289177F5007ACC5C /* WallpaperNetworkingTests.swift in Sources */,
 				EC407900300AA7FA0003DE07 /* GroupedDefaultFolderHierarchyFetcherTests.swift in Sources */,
 				8A6CDB472DF9E78400F11139 /* MockTabDisplayViewDragAndDropInteraction.swift in Sources */,
+				A1B2C3D32F0000010000AA02 /* MockTabTrayUtils.swift in Sources */,
 				8CFBBFDC2ECE17AA00E5B22B /* NimbusOnboardingKitFeatureLayerTests.swift in Sources */,
 				0B6153E22E24ECCA000D2FBD /* SummarizeCoordinatorTests.swift in Sources */,
 				8A4EA0D42C01100200E4E4F1 /* MicrosurveySurfaceManagerTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -217,21 +217,21 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         return backgroundView
     }
 
-    /// Finds the selected tab's cell, scales the grid and starts the shared presentation animation.
+    /// Finds the selected tab's destination frame, scales the grid and starts the shared presentation animation.
     private func presentSelectedTab(
         context: UIViewControllerContextTransitioning,
         destinationController: UIViewController,
         bvcSnapshot: UIImageView,
         backgroundView: UIView,
-        collectionView: UICollectionView,
+        tabDisplayView: TabDisplayView,
         selectedTab: Tab,
-        tabDisplayView: TabDisplayView?, // needed for interactive path only
         isInteractive: Bool
     ) {
+        let collectionView = tabDisplayView.collectionView
         guard let dataSource = collectionView.dataSource as? TabDisplayDiffableDataSource,
               let item = self.findItem(by: selectedTab.tabUUID, dataSource: dataSource)
         else {
-            tabDisplayView?.minimizingTabUUID = nil
+            tabDisplayView.minimizingTabUUID = nil
             context.containerView.addSubview(destinationController.view)
             context.completeTransition(true)
             return
@@ -239,28 +239,16 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
 
         let theme = self.retrieveTheme()
         var cellFrame: CGRect?
-        var tabCell: ExperimentTabCell?
 
         if let indexPath = dataSource.indexPath(for: item) {
             collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
-            // TODO: FXIOS-14550 Look into if we can find an alternative to calling layoutIfNeeded() here
-            collectionView.layoutIfNeeded()
-            if let cell = collectionView.cellForItem(at: indexPath) as? ExperimentTabCell {
-                cellFrame = cell.convert(cell.backgroundHolder.bounds, to: nil)
-                cell.isHidden = true
-                if !isInteractive {
-                    tabCell = cell
-                    cell.setUnselectedState(theme: theme)
-                    cell.alpha = UX.clearAlpha
-                }
-            }
+            cellFrame = destinationFrame(for: indexPath, in: collectionView)
         }
         // Animate
         collectionView.transform = CGAffineTransform(scaleX: UX.cvScalingFactor, y: UX.cvScalingFactor)
         collectionView.alpha = UX.halfAlpha
         self.performPresentationAnimation(
             cellFrame: cellFrame,
-            tabCell: tabCell,
             bvcSnapshot: bvcSnapshot,
             collectionView: collectionView,
             backgroundView: backgroundView,
@@ -272,16 +260,26 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         )
     }
 
+    /// Window frame the browser snapshot animates into.
+    ///
+    /// Taken from the layout attributes rather than a realized cell, so the transition doesn't have to force a
+    /// synchronous layout pass to realize the cell it scrolls to.
+    private func destinationFrame(for indexPath: IndexPath, in collectionView: UICollectionView) -> CGRect? {
+        guard let attributes = collectionView.collectionViewLayout.layoutAttributesForItem(at: indexPath)
+        else { return nil }
+
+        return collectionView.convert(attributes.frame, to: nil)
+    }
+
     private func performPresentationAnimation(
         cellFrame: CGRect?,
-        tabCell: ExperimentTabCell?,
         bvcSnapshot: UIImageView,
         collectionView: UICollectionView,
         backgroundView: UIView,
         context: UIViewControllerContextTransitioning,
         selectedTab: Tab,
         theme: Theme,
-        tabDisplayView: TabDisplayView?,
+        tabDisplayView: TabDisplayView,
         isInteractive: Bool
     ) {
         let animator = UIViewPropertyAnimator(duration: UX.presentDuration, curve: .easeOut) {
@@ -301,7 +299,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
                 let settledImage = bvcSnapshot.image
                 backgroundView.removeFromSuperview()
                 bvcSnapshot.removeFromSuperview()
-                tabDisplayView?.minimizingTabUUID = nil
+                tabDisplayView.minimizingTabUUID = nil
                 self.revealSelectedCell(
                     in: collectionView,
                     selectedTab: selectedTab,
@@ -310,12 +308,15 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
                 )
                 context.completeTransition(true)
             }
-            animator.startAnimation()
         } else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak tabCell] in
-                tabCell?.isHidden = false
+            DispatchQueue.main.async {
+                tabDisplayView.minimizingTabUUID = nil
+                guard let cell = self.selectedCell(in: collectionView, selectedTab: selectedTab) else { return }
+                cell.setUnselectedState(theme: theme)
+                cell.alpha = UX.clearAlpha
+                cell.isHidden = false
                 UIView.animate(withDuration: 0.1) {
-                    tabCell?.alpha = UX.opaqueAlpha
+                    cell.alpha = UX.opaqueAlpha
                 }
             }
 
@@ -323,15 +324,15 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
                 backgroundView.removeFromSuperview()
                 bvcSnapshot.removeFromSuperview()
                 context.completeTransition(true)
-                self.unhideCellBorder(tabCell: tabCell, isPrivate: selectedTab.isPrivate, theme: theme)
+                self.unhideCellBorder(in: collectionView, selectedTab: selectedTab, theme: theme)
             }
-            animator.startAnimation()
         }
+        animator.startAnimation()
     }
 
-    private func unhideCellBorder(tabCell: ExperimentTabCell?, isPrivate: Bool, theme: Theme) {
-        guard let tab = tabCell else { return }
-        tab.setSelectedState(isPrivate: isPrivate, theme: theme)
+    private func unhideCellBorder(in collectionView: UICollectionView, selectedTab: Tab, theme: Theme) {
+        guard let cell = selectedCell(in: collectionView, selectedTab: selectedTab) else { return }
+        cell.setSelectedState(isPrivate: selectedTab.isPrivate, theme: theme)
     }
 
     private func revealSelectedCell(
@@ -340,14 +341,20 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         settledImage: UIImage?,
         theme: Theme
     ) {
-        guard let dataSource = collectionView.dataSource as? TabDisplayDiffableDataSource,
-              let item = findItem(by: selectedTab.tabUUID, dataSource: dataSource),
-              let indexPath = dataSource.indexPath(for: item),
-              let cell = collectionView.cellForItem(at: indexPath) as? ExperimentTabCell
-        else { return }
+        guard let cell = selectedCell(in: collectionView, selectedTab: selectedTab) else { return }
         cell.syncScreenshotForAnimation(settledImage)
         cell.isHidden = false
         cell.setSelectedState(isPrivate: selectedTab.isPrivate, theme: theme)
+    }
+
+    /// The selected tab's cell, when it is currently realized by the collection view.
+    private func selectedCell(in collectionView: UICollectionView, selectedTab: Tab) -> ExperimentTabCell? {
+        guard let dataSource = collectionView.dataSource as? TabDisplayDiffableDataSource,
+              let item = findItem(by: selectedTab.tabUUID, dataSource: dataSource),
+              let indexPath = dataSource.indexPath(for: item)
+        else { return nil }
+
+        return collectionView.cellForItem(at: indexPath) as? ExperimentTabCell
     }
 
     // MARK: - Presentations
@@ -383,9 +390,8 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
             destinationController: destinationController,
             bvcSnapshot: bvcSnapshot,
             backgroundView: backgroundView,
-            collectionView: tabDisplayView.collectionView,
-            selectedTab: selectedTab,
             tabDisplayView: tabDisplayView,
+            selectedTab: selectedTab,
             isInteractive: true
         )
     }
@@ -398,7 +404,13 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         finalFrame: CGRect,
         selectedTab: Tab
     ) {
-        let browserVCScreenshot = browserVC.view.screenshot(quality: UX.bvcScreenshotQuality)
+        // Keep the selected tab cell hidden for the whole animation. Going through `minimizingTabUUID`
+        // rather than the realized cell means cells that only get dequeued once the grid scrolls to the
+        // selected tab also come back hidden.
+        let tabDisplayView = panelViewController.tabDisplayView
+        tabDisplayView.minimizingTabUUID = selectedTab.tabUUID
+
+        let browserVCScreenshot = selectedTab.screenshot ?? browserVC.view.screenshot(quality: UX.bvcScreenshotQuality)
         let bvcSnapshot = makePresentationSnapshot(
             image: browserVCScreenshot,
             frame: browserVC.view.frame,
@@ -419,9 +431,8 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
                 destinationController: destinationController,
                 bvcSnapshot: bvcSnapshot,
                 backgroundView: backgroundView,
-                collectionView: panelViewController.tabDisplayView.collectionView,
+                tabDisplayView: tabDisplayView,
                 selectedTab: selectedTab,
-                tabDisplayView: nil,
                 isInteractive: false
             )
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/Animation/TabAnimation.swift
@@ -260,10 +260,6 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         )
     }
 
-    /// Window frame the browser snapshot animates into.
-    ///
-    /// Taken from the layout attributes rather than a realized cell, so the transition doesn't have to force a
-    /// synchronous layout pass to realize the cell it scrolls to.
     private func destinationFrame(for indexPath: IndexPath, in collectionView: UICollectionView) -> CGRect? {
         guard let attributes = collectionView.collectionViewLayout.layoutAttributesForItem(at: indexPath)
         else { return nil }
@@ -300,7 +296,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
                 backgroundView.removeFromSuperview()
                 bvcSnapshot.removeFromSuperview()
                 tabDisplayView.minimizingTabUUID = nil
-                self.revealSelectedCell(
+                self.unhideSelectedCell(
                     in: collectionView,
                     selectedTab: selectedTab,
                     settledImage: settledImage,
@@ -335,7 +331,7 @@ extension TabTrayViewController: BasicAnimationControllerDelegate {
         cell.setSelectedState(isPrivate: selectedTab.isPrivate, theme: theme)
     }
 
-    private func revealSelectedCell(
+    private func unhideSelectedCell(
         in collectionView: UICollectionView,
         selectedTab: Tab,
         settledImage: UIImage?,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabTrayUtils.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabTrayUtils.swift
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@testable import Client
+
+/// Lets tests pick a tab tray UI without going through Nimbus or the device idiom.
+@MainActor
+struct MockTabTrayUtils: TabTrayUtils {
+    var isTabTrayUIExperimentsEnabled = true
+    var isTabTrayIpadUIExperimentsEnabled = true
+    var isTabTrayTranslucencyEnabled = false
+    var isReduceTransparencyEnabled = false
+    var segmentedControlHeight: CGFloat = 0
+    var displaysExperimentUI = true
+    var blurs = false
+    var backgroundAlphaValue: CGFloat = 1.0
+
+    func shouldDisplayExperimentUI() -> Bool { return displaysExperimentUI }
+
+    func shouldBlur() -> Bool { return blurs }
+
+    func backgroundAlpha() -> CGFloat { return backgroundAlphaValue }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewGeometryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabDisplayViewGeometryTests.swift
@@ -1,0 +1,108 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+
+@testable import Client
+
+/// Checks that an item's layout attributes frame matches the rect its cell occupies, including for cells the
+/// collection view has not realized yet. `TabAnimation` reads that frame to size the browser snapshot
+/// instead of forcing a layout pass.
+@MainActor
+final class TabDisplayViewGeometryTests: XCTestCase {
+    let viewSize = CGSize(width: 390, height: 844)
+    let tabCount = 20
+
+    override func setUp() async throws {
+        try await super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() async throws {
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    func testLayoutAttributesFrame_matchesRealizedCellFrame() throws {
+        let subject = createSubject()
+        let collectionView = subject.collectionView
+        let indexPath = IndexPath(item: 0, section: 0)
+
+        let cell = try XCTUnwrap(collectionView.cellForItem(at: indexPath) as? ExperimentTabCell)
+        let attributes = try XCTUnwrap(collectionView.collectionViewLayout.layoutAttributesForItem(at: indexPath))
+
+        XCTAssertEqual(collectionView.convert(attributes.frame, to: subject),
+                       cell.convert(cell.backgroundHolder.bounds, to: subject))
+    }
+
+    func testLayoutAttributesFrame_matchesRealizedCellFrame_forOffscreenTabAfterScrolling() throws {
+        let subject = createSubject()
+        let collectionView = subject.collectionView
+        let indexPath = IndexPath(item: tabCount - 1, section: 0)
+        XCTAssertNil(collectionView.cellForItem(at: indexPath),
+                     "The last tab is expected to start off screen, otherwise this isn't testing anything.")
+
+        collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+        let attributes = try XCTUnwrap(collectionView.collectionViewLayout.layoutAttributesForItem(at: indexPath))
+        let frameBeforeLayout = collectionView.convert(attributes.frame, to: subject)
+
+        collectionView.layoutIfNeeded()
+
+        let cell = try XCTUnwrap(collectionView.cellForItem(at: indexPath) as? ExperimentTabCell)
+        XCTAssertEqual(frameBeforeLayout, cell.convert(cell.backgroundHolder.bounds, to: subject))
+    }
+
+    func testMinimizingTabUUID_hidesOnlyTheMatchingCell() throws {
+        // The subject has to stay alive: it owns the diffable data source the collection view only holds weakly.
+        let subject = createSubject(minimizingTabUUID: tabUUID(for: 0))
+        let collectionView = subject.collectionView
+
+        let minimizedCell = try XCTUnwrap(collectionView.cellForItem(at: IndexPath(item: 0, section: 0)))
+        let otherCell = try XCTUnwrap(collectionView.cellForItem(at: IndexPath(item: 1, section: 0)))
+
+        XCTAssertTrue(minimizedCell.isHidden)
+        XCTAssertFalse(otherCell.isHidden)
+    }
+
+    /// The animation sets `minimizingTabUUID` before scrolling so that cells dequeued on the way to the
+    /// selected tab also come back hidden.
+    func testMinimizingTabUUID_hidesMatchingCellDequeuedWhileScrolling() throws {
+        let indexPath = IndexPath(item: tabCount - 1, section: 0)
+        let subject = createSubject(minimizingTabUUID: tabUUID(for: indexPath.item))
+        let collectionView = subject.collectionView
+        XCTAssertNil(collectionView.cellForItem(at: indexPath),
+                     "The last tab is expected to start off screen, otherwise this isn't testing anything.")
+
+        collectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
+        collectionView.layoutIfNeeded()
+
+        let cell = try XCTUnwrap(collectionView.cellForItem(at: indexPath))
+        XCTAssertTrue(cell.isHidden)
+    }
+
+    // MARK: - Private
+    private func createSubject(minimizingTabUUID: TabUUID? = nil,
+                               file: StaticString = #filePath,
+                               line: UInt = #line) -> TabDisplayView {
+        let tabs = (0..<tabCount).map {
+            TabModel.emptyState(tabUUID: tabUUID(for: $0), title: "Tab \($0)")
+        }
+        let state = TabsPanelState(windowUUID: .XCTestDefaultUUID).copy(tabs: tabs)
+
+        let subject = TabDisplayView(panelType: .tabs,
+                                     state: state,
+                                     windowUUID: .XCTestDefaultUUID,
+                                     tabTrayUtils: MockTabTrayUtils())
+        subject.minimizingTabUUID = minimizingTabUUID
+        subject.frame = CGRect(origin: .zero, size: viewSize)
+        subject.newState(state: state)
+        subject.layoutIfNeeded()
+
+        trackForMemoryLeaks(subject, file: file, line: line)
+        return subject
+    }
+
+    private func tabUUID(for index: Int) -> TabUUID { return "tab-\(index)" }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14550)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31475)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR aims to improve the performance related to Tab Tray animation with the scope of reducing one of our top hangs related to the animation.

These are the most important changes:
- The snapshot's destination frame now comes from the collection view's layout attributes (`destinationFrame(for:in:)`) instead of a realized cell, which removes the forced `collectionView.layoutIfNeeded()` after `scrollToItem`.
- The non-interactive path reuses the cached tab screenshot when one exists (`selectedTab.screenshot ?? browserVC.view.screenshot(...)`) rather than always rendering a fresh full-screen capture, matching what the interactive path already did.
- Adds `TabDisplayViewGeometryTests`: (4 tests) covering that an item's layout attributes frame matches the `rect` its cell occupies, including for a cell the collection view hasn't realized yet and the `minimizingTabUUID` hiding behavior.

### I also tested many many times manually to make sure no regressions are introduced. I will ask QA team to have a regression test regarding Tab Tray animation.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

