### PR TITLE
Refactor FXIOS-13097 [Swift 6 Migration] [Tech Debt] Adopt isolated deinits now that we are on Swift 6.2 - Sept 2026 Attempt

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -179,16 +179,8 @@ final class DefaultWKEngineWebView: WKWebView,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("DevicePickerViewController was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            close()
-        }
+    isolated deinit {
+        close()
     }
 
     func close() {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -499,21 +499,13 @@ class BrowserViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("TabSwipeGestureHandler was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            logger.log("BVC deallocating (window: \(windowUUID))", level: .info, category: .lifecycle)
-            unsubscribeFromRedux()
-            stopObservingAllWebViews()
-            googleLensTipObservationTask?.cancel()
-            if let pairingWaitToken {
-                AppEventQueue.cancelAction(token: pairingWaitToken)
-            }
+    isolated deinit {
+        logger.log("BVC deallocating (window: \(windowUUID))", level: .info, category: .lifecycle)
+        unsubscribeFromRedux()
+        stopObservingAllWebViews()
+        googleLensTipObservationTask?.cancel()
+        if let pairingWaitToken {
+            AppEventQueue.cancelAction(token: pairingWaitToken)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -209,21 +209,8 @@ class MainMenuViewController: UIViewController,
         hintView.removeFromSuperview()
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            logger.log(
-                "MainMenuViewController was not deallocated on the main thread. Redux was not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("The view controller was not deallocated on the main thread. Redux was not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     private func updateBlur() {

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/Views/SearchEngineSelectionViewController.swift
@@ -49,16 +49,8 @@ class SearchEngineSelectionViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("TabSwipeGestureHandler was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -242,24 +242,9 @@ final class LegacyTabScrollController: NSObject,
             contentSize.height
     }
 
-    deinit {
+    isolated deinit {
         logger.log("TabScrollController deallocating", level: .info, category: .lifecycle)
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        // KVO observation removal directly requires self so we can not use the apple
-        // recommended work around here.
-        guard Thread.isMainThread else {
-            logger.log(
-                "TabScrollController was not deallocated on the main thread. KVOs were not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("TabScrollController was not deallocated on the main thread. KVOs were not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            stopObservingAllScrollViews()
-        }
+        stopObservingAllScrollViews()
     }
 
     init(windowUUID: WindowUUID,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -76,16 +76,8 @@ final class RemoteTabsPanel: UIViewController,
 
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("TabSwipeGestureHandler was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     var currentWindowUUID: UUID? { return windowUUID }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayPanelViewController.swift
@@ -98,16 +98,8 @@ final class TabDisplayPanelViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("TabDisplayPanelViewController was not deallocated on the main thread. Redux was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     // MARK: - Lifecycle methods

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -162,21 +162,8 @@ final class AddressToolbarContainer: UIView,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            DefaultLogger.shared.log(
-                "AddressToolbarContainer was not deallocated on the main thread. Redux was not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("The view was not deallocated on the main thread. Redux was not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     func configure(

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/NavigationToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/NavigationToolbarContainer.swift
@@ -44,21 +44,8 @@ final class NavigationToolbarContainer: UIView, ThemeApplicable, StoreSubscriber
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            DefaultLogger.shared.log(
-                "NavigationToolbarContainer was not deallocated on the main thread. Redux was not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("The view was not deallocated on the main thread. Redux was not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     override func layoutSubviews() {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/SwipeUpTabPreviewGestureHandler.swift
@@ -63,19 +63,8 @@ final class SwipeUpTabPreviewGestureHandler: NSObject, UIGestureRecognizerDelega
         subscribeToRedux()
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("""
-                             SwipeUpTabPreviewGestureHandler was not deallocated on the main thread.
-                             Observer was not removed
-                             """)
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     // MARK: - Redux

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/TabSwipeGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/TabSwipeGestureHandler.swift
@@ -91,16 +91,8 @@ final class TabSwipeGestureHandler: NSObject, UIGestureRecognizerDelegate, Store
         setupGesture()
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("TabSwipeGestureHandler was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     private func setupGesture() {

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -147,6 +147,7 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
     }
 
     isolated deinit {
+        // FIXME: FXIOS-14609 We should remove Tab Manager Delegates
         tabManager.removeDelegate(topTabDisplayManager, completion: nil)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -146,22 +146,8 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
         topTabDisplayManager.refreshStore(forceReload: true)
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits.
-        // Also we will remove Tab Manager Delegates as part of FXIOS-13097
-        guard Thread.isMainThread else {
-            assertionFailure(
-            """
-            TopTabsViewController was not deallocated on the main thread.
-            Tab manager delegate was not removed.
-            """
-            )
-            return
-        }
-
-        MainActor.assumeIsolated {
-            tabManager.removeDelegate(topTabDisplayManager, completion: nil)
-        }
+    isolated deinit {
+        tabManager.removeDelegate(topTabDisplayManager, completion: nil)
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
+++ b/firefox-ios/Client/Frontend/Extensions/DevicePickerViewController.swift
@@ -145,17 +145,9 @@ class DevicePickerViewController: UITableViewController {
         pickerDelegate?.devicePickerViewControllerDidCancel(self)
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("DevicePickerViewController was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            if let notification = notification {
-                NotificationCenter.default.removeObserver(notification)
-            }
+    isolated deinit {
+        if let notification = notification {
+            NotificationCenter.default.removeObserver(notification)
         }
     }
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -141,16 +141,8 @@ final class HomepageViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("TabSwipeGestureHandler was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     func stopCFRsTimer() {

--- a/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/PrivateHome/PrivateHomepageViewController.swift
@@ -126,22 +126,9 @@ final class PrivateHomepageViewController: UIViewController,
         }
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            DefaultLogger.shared.log(
-                "AddressToolbarContainer was not deallocated on the main thread. Redux was not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("The view was not deallocated on the main thread. Redux was not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            // TODO: FXIOS-11187 - Investigate further on privateMessageCardCell memory leaking during viewing private tab.
-            scrollView.removeFromSuperview()
-        }
+    isolated deinit {
+        // TODO: FXIOS-11187 - Investigate further on privateMessageCardCell memory leaking during viewing private tab.
+        scrollView.removeFromSuperview()
     }
 
     private func setupLayout() {

--- a/firefox-ios/Client/Frontend/HostingTableViewCell.swift
+++ b/firefox-ios/Client/Frontend/HostingTableViewCell.swift
@@ -18,22 +18,9 @@ final class HostingTableViewCell<Content: View>: UITableViewCell, ReusableCell {
         hostingController.removeFromParent()
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            DefaultLogger.shared.log(
-                "AddressToolbarContainer was not deallocated on the main thread. Redux was not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("The view was not deallocated on the main thread. Redux was not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            // FIXME: FXIOS-14153 This doesn't seem like it should be necessary, investigate later
-            removeHostingControllerFromParent()
-        }
+    isolated deinit {
+        // FIXME: FXIOS-14153 This doesn't seem like it should be necessary, investigate later
+        removeHostingControllerFromParent()
     }
 
     @available(*, unavailable)

--- a/firefox-ios/Client/Frontend/HostingTableViewSectionHeader.swift
+++ b/firefox-ios/Client/Frontend/HostingTableViewSectionHeader.swift
@@ -19,22 +19,9 @@ final class HostingTableViewSectionHeader<Content: View>: UITableViewHeaderFoote
         hostingController.removeFromParent()
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            DefaultLogger.shared.log(
-                "AddressToolbarContainer was not deallocated on the main thread. Redux was not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("The view was not deallocated on the main thread. Redux was not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            // FIXME: FXIOS-14153 This doesn't seem like it should be necessary, investigate later
-            removeHostingControllerFromParent()
-        }
+    isolated deinit {
+        // FIXME: FXIOS-14153 This doesn't seem like it should be necessary, investigate later
+        removeHostingControllerFromParent()
     }
 
     @available(*, unavailable)

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -162,22 +162,9 @@ final class BookmarksViewController: SiteTableViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            DefaultLogger.shared.log(
-                "AddressToolbarContainer was not deallocated on the main thread. Redux was not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("The view was not deallocated on the main thread. Redux was not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            // FXIOS-11315: Necessary to prevent BookmarksFolderEmptyStateView from being retained in memory
-            a11yEmptyStateScrollView.removeFromSuperview()
-        }
+    isolated deinit {
+        // FXIOS-11315: Necessary to prevent BookmarksFolderEmptyStateView from being retained in memory
+        a11yEmptyStateScrollView.removeFromSuperview()
     }
 
     // MARK: - Lifecycle

--- a/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
+++ b/firefox-ios/Client/Frontend/Microsurvey/Survey/View/MicrosurveyViewController.swift
@@ -197,16 +197,8 @@ final class MicrosurveyViewController: UIViewController,
         )
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("tabSwipeGestureHandler was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     private func configureUI() {

--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorPageViewController.swift
@@ -279,16 +279,8 @@ final class NativeErrorPageViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("TabSwipeGestureHandler was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     override func viewDidLoad() {

--- a/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
+++ b/firefox-ios/Client/Frontend/PasswordGenerator/PasswordGeneratorViewController.swift
@@ -95,16 +95,8 @@ class PasswordGeneratorViewController: UIViewController, StoreSubscriber, Themea
         )
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("TabSwipeGestureHandler was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     required init?(coder: NSCoder) {

--- a/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/SyncContentSettingsViewController.swift
@@ -52,17 +52,9 @@ final class ManageFxAccountSetting: Setting {
         navigationController?.pushViewController(viewController, animated: true)
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("ManageFxAccountSetting was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            if let notification = notification {
-                NotificationCenter.default.removeObserver(notification)
-            }
+    isolated deinit {
+        if let notification = notification {
+            NotificationCenter.default.removeObserver(notification)
         }
     }
 }
@@ -170,17 +162,9 @@ class DeviceNameSetting: StringSetting {
         alignTextFieldToNatural()
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("DeviceNameSetting was not deallocated on the main thread. Observer was not removed")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            if let notification = notification {
-                NotificationCenter.default.removeObserver(notification)
-            }
+    isolated deinit {
+        if let notification = notification {
+            NotificationCenter.default.removeObserver(notification)
         }
     }
 }

--- a/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
+++ b/firefox-ios/Client/Frontend/ShortcutsLibrary/ShortcutsLibraryViewController.swift
@@ -65,21 +65,8 @@ class ShortcutsLibraryViewController: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            logger.log(
-                "MainMenuViewController was not deallocated on the main thread. Redux was not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("The view controller was not deallocated on the main thread. Redux was not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     // MARK: View lifecycle

--- a/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
+++ b/firefox-ios/Client/Frontend/TrackingProtection/TrackingProtectionViewController.swift
@@ -145,21 +145,8 @@ class TrackingProtectionViewController: UIViewController,
         subscribeToRedux()
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            logger.log(
-                "TrackingProtectionViewController was not deallocated on the main thread. Redux was not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("The view controller was not deallocated on the main thread. Redux was not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            unsubscribeFromRedux()
-        }
+    isolated deinit {
+        unsubscribeFromRedux()
     }
 
     @available(*, unavailable)

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheet.swift
@@ -78,25 +78,12 @@ class PhotonActionSheet: UIViewController,
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            DefaultLogger.shared.log(
-                "AddressToolbarContainer was not deallocated on the main thread. Redux was not cleaned up.",
-                level: .fatal,
-                category: .lifecycle
-            )
-            assertionFailure("The view was not deallocated on the main thread. Redux was not cleaned up.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            // Not sure that we need to do this clean up in the deinit but leaving this in place since
-            // this class should be going away soon
-            tableView.dataSource = nil
-            tableView.delegate = nil
-            tableView.removeFromSuperview()
-        }
+    isolated deinit {
+        // Not sure that we need to do this clean up in the deinit but leaving this in place since
+        // this class should be going away soon
+        tableView.dataSource = nil
+        tableView.delegate = nil
+        tableView.removeFromSuperview()
     }
 
     // MARK: - View cycle

--- a/firefox-ios/Client/TabManagement/TabWebView.swift
+++ b/firefox-ios/Client/TabManagement/TabWebView.swift
@@ -31,18 +31,10 @@ class TabWebView: WKWebView, MenuHelperWebViewInterface, ThemeApplicable {
     private var uiTestLeakView: UIView? // Used for automation
     private var certStore: CertStore
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits
-        guard Thread.isMainThread else {
-            assertionFailure("TabWebView not deallocated on the main thread.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            // Note: this has no effect in production. This view is only
-            // created during automation testing as a sentinel UI element.
-            uiTestLeakView?.removeFromSuperview()
-        }
+    isolated deinit {
+        // Note: this has no effect in production. This view is only
+        // created during automation testing as a sentinel UI element.
+        uiTestLeakView?.removeFromSuperview()
     }
 
     override var hasOnlySecureContent: Bool {

--- a/firefox-ios/Extensions/ShareTo/EmbeddedNavController.swift
+++ b/firefox-ios/Extensions/ShareTo/EmbeddedNavController.swift
@@ -72,7 +72,7 @@ class EmbeddedNavController {
     }
 
     isolated deinit {
-        // EmbeddedNavController probably should be a real nav controller...
+        // FIXME: FXIOS-14608 EmbeddedNavController probably should be a real nav controller...
         navigationController.view.removeFromSuperview()
         navigationController.removeFromParent()
     }

--- a/firefox-ios/Extensions/ShareTo/EmbeddedNavController.swift
+++ b/firefox-ios/Extensions/ShareTo/EmbeddedNavController.swift
@@ -71,17 +71,9 @@ class EmbeddedNavController {
         heightConstraint.isActive = true
     }
 
-    deinit {
-        // TODO: FXIOS-13097 This is a work around until we can leverage isolated deinits. EmbeddedNavController probably
-        // should be a real nav controller...
-        guard Thread.isMainThread else {
-            assertionFailure("EmbeddedNavController was not deallocated on the main thread.")
-            return
-        }
-
-        MainActor.assumeIsolated {
-            navigationController.view.removeFromSuperview()
-            navigationController.removeFromParent()
-        }
+    isolated deinit {
+        // EmbeddedNavController probably should be a real nav controller...
+        navigationController.view.removeFromSuperview()
+        navigationController.removeFromParent()
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13097)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/28516)

## :bulb: Description
This is my second attempt at using `isolated deinit`s so we can clean up ~300 lines of code and a pile of FIXMEs.

I originally tried this back in January 2026, but had to reject the changes because of a Swift bug (see https://github.com/mozilla-mobile/firefox-ios/pull/31604 for the details).

CI passed cleanly when I tested running last night, so now I'm opening this for review!

### Details
- Adopt isolated deinits now that we are on Swift 6.x+ 
- Clean up FIXMEs and assumeIsolated calls

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

