### PR TITLE
[MTE-5789] - automate Search settings menu UI with Firefox Suggest en…

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -615,6 +615,13 @@ struct AccessibilityIdentifiers {
             // This is based on `PrefsKeys.SearchSettings.showRecentSearches`
             static let showRecentSearchesSwitch = "recentSearchesFeatureKey"
             static let showSearchSuggestions = "FirefoxSuggestShowSearchSuggestions"
+            // These are based on the matching `PrefsKeys.SearchSettings` keys
+            static let showPrivateModeSearchSuggestionsSwitch = "ShowPrivateModeSearchSuggestionsKey"
+            static let showBrowsingHistorySuggestionsSwitch = "FirefoxSuggestBrowsingHistorySuggestions"
+            static let showBookmarksSuggestionsSwitch = "FirefoxSuggestBookmarksSuggestions"
+            static let showSyncedTabsSuggestionsSwitch = "FirefoxSuggestSyncedTabsSuggestions"
+            static let showNonSponsoredSuggestionsSwitch = "FirefoxSuggestShowNonSponsoredSuggestions"
+            static let showSponsoredSuggestionsSwitch = "FirefoxSuggestShowSponsoredSuggestions"
             static let backButtoniOS26 = "BackButton"
             static let backButton = "Settings"
         }

--- a/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
@@ -354,6 +354,7 @@
         "ScreenGraphTest",
         "ScreenGraphTest\/testSimpleToggleAction()",
         "ScreenGraphTest\/testUserStateChanges()",
+        "SearchSettingsSuggestUITests",
         "SearchSettingsUITests",
         "SearchSettingsUITests\/testCustomSearchEngineAsDefaultIsNotEditable()",
         "SearchSettingsUITests\/testCustomSearchEngineIsEditable()",

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -158,6 +158,7 @@
         "PrivateBrowsingTestIpad",
         "ReportSiteTests",
         "ScreenGraphTest",
+        "SearchSettingsSuggestUITests",
         "SearchSettingsUITests",
         "SearchTests\/testDefaultSearchEngines()",
         "SearchTests\/testRecentSearchesSettingsToggleOff_recentSearchesExperimentOn()",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -135,6 +135,7 @@
         "ReadingListTests",
         "ReportSiteTests",
         "ScreenGraphTest",
+        "SearchSettingsSuggestUITests",
         "SearchSettingsUITests",
         "SearchTests",
         "SecurityTests",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -480,6 +480,7 @@
         "ReadingListTests\/testRemoveSavedForReadingLongPress()",
         "ReportSiteTests",
         "ScreenGraphTest",
+        "SearchSettingsSuggestUITests",
         "SearchSettingsUITests",
         "SearchTests\/testCopyPasteComplete()",
         "SearchTests\/testDefaultSearchEngine()",

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
@@ -153,6 +153,7 @@
         "ReadingListTests",
         "ReportSiteTests",
         "ScreenGraphTest",
+        "SearchSettingsSuggestUITests",
         "SearchSettingsUITests",
         "SearchTests",
         "SecurityTests",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -32,6 +32,10 @@ let TRANSLATION_TIMEOUT: TimeInterval = 90
 // Probe for optional UI that shows up immediately or not at all
 let TIMEOUT_PICKER_PROBE: TimeInterval = 3
 let MAX_SWIPE = 5
+let IngestSuggestionsCell = "Ingest new suggestions now"
+// Nimbus applies fetched recipes on the launch after the fetch, so two attempts is the floor.
+let SuggestRolloutLaunchAttempts = 5
+let SuggestRolloutProbeTimeout: TimeInterval = 5
 
 @MainActor
 class BaseTestCase: XCTestCase {
@@ -118,6 +122,41 @@ class BaseTestCase: XCTestCase {
         mozWaitForElementToExist(app.windows.otherElements.firstMatch)
         // The navigator state does not survive a relaunch
         setUpScreenGraph()
+    }
+
+    /// The Nimbus database lives inside the test profile, so clearing it would discard the fetched rollout.
+    func relaunchKeepingProfile() {
+        app.terminate()
+        _ = app.wait(for: .notRunning, timeout: TIMEOUT)
+        app.launchArguments = app.launchArguments.filter { $0 != LaunchArguments.ClearProfile }
+        app.launch()
+        waitForTabsButtonHittable()
+        navigator.nowAt(NewTabScreen)
+    }
+
+    /// Enrolls the running app in the live Firefox Suggest rollout, leaving it on the home screen. On
+    /// release builds the feature is enabled by a Nimbus rollout rather than a channel default, and
+    /// Nimbus only applies fetched recipes on the launch that follows the fetch, hence the relaunches.
+    /// - Parameter ingestingSuggestions: also downloads suggestions, which only tests that assert on
+    /// suggestion results need.
+    func enrollInFirefoxSuggestRollout(ingestingSuggestions: Bool = true) {
+        for _ in 1...SuggestRolloutLaunchAttempts {
+            relaunchKeepingProfile()
+            navigator.goto(SettingsScreen)
+            navigator.performAction(Action.OpenSecretSettings)
+            navigator.goto(FirefoxSuggestSettings)
+            // The ingest row only exists while the feature is enabled, so it doubles as the enrollment probe.
+            guard mozWaitForElementToExist(app.cells[IngestSuggestionsCell],
+                                           timeout: SuggestRolloutProbeTimeout,
+                                           failOnTimeout: false) else { continue }
+            if ingestingSuggestions {
+                navigator.performAction(Action.IngestNewSuggestionsNow)
+            }
+            navigator.goto(HomePanelsScreen)
+            return
+        }
+
+        XCTFail("Firefox Suggest was not enabled after \(SuggestRolloutLaunchAttempts) launches")
     }
 
     func removeApp() {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SearchSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SearchSettingsScreen.swift
@@ -94,4 +94,62 @@ final class SearchSettingsScreen {
     func assertSearchEngineExists(named engineName: String) {
         BaseTestCase().mozWaitForElementToExist(sel.searchEngineRow(named: engineName).element(in: app))
     }
+
+    func assertAddSearchEngineRowExists() {
+        assertRowExists(sel.ADD_SEARCH_ENGINE_ROW)
+    }
+
+    func assertShowSearchSuggestionsSwitchIsOn() {
+        assertSwitch(sel.SHOW_SEARCH_SUGGESTIONS_SWITCH, isOn: true)
+    }
+
+    func assertShowInPrivateSessionsSwitchIsOff() {
+        assertSwitch(sel.SHOW_IN_PRIVATE_SESSIONS_SWITCH, isOn: false)
+    }
+
+    func assertSearchBrowsingHistorySwitchIsOn() {
+        assertSwitch(sel.SEARCH_BROWSING_HISTORY_SWITCH, isOn: true)
+    }
+
+    func assertSearchBookmarksSwitchIsOn() {
+        assertSwitch(sel.SEARCH_BOOKMARKS_SWITCH, isOn: true)
+    }
+
+    func assertSearchSyncedTabsSwitchIsOn() {
+        assertSwitch(sel.SEARCH_SYNCED_TABS_SWITCH, isOn: true)
+    }
+
+    func assertSuggestionsFromTheWebSwitchIsOn() {
+        assertSwitch(sel.SUGGESTIONS_FROM_THE_WEB_SWITCH, isOn: true)
+    }
+
+    func assertSuggestionsFromSponsorsSwitchIsOn() {
+        assertSwitch(sel.SUGGESTIONS_FROM_SPONSORS_SWITCH, isOn: true)
+    }
+
+    func assertLearnMoreAboutFirefoxSuggestRowExists() {
+        assertRowExists(sel.LEARN_MORE_ABOUT_FIREFOX_SUGGEST_ROW)
+    }
+
+    /// Rows further down the search settings table are only added to the accessibility tree once the
+    /// table view has scrolled them into range, hence the scroll before every assertion.
+    private func assertRowExists(_ selector: Selector) {
+        let element = selector.element(in: app)
+        BaseTestCase().scrollToElement(element)
+        BaseTestCase().mozWaitForElementToExist(element)
+    }
+
+    private func assertSwitch(_ selector: Selector, isOn: Bool) {
+        let element = selector.element(in: app)
+        BaseTestCase().scrollToElement(element)
+        BaseTestCase().mozWaitForElementToExist(element)
+
+        let expectedValue = isOn ? "1" : "0"
+        let value = element.value as? String
+        XCTAssertEqual(
+            value,
+            expectedValue,
+            "Expected '\(selector.description)' to be \(isOn ? "ON" : "OFF"), but got \(String(describing: value))"
+        )
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchSettingsUITest.swift
@@ -134,3 +134,41 @@ class SearchSettingsUITests: BaseTestCase {
         XCTAssertFalse(app.buttons["Edit"].isEnabled)
     }
 }
+
+class SearchSettingsSuggestUITests: BaseTestCase {
+    private var toolbarScreen: ToolbarScreen!
+    private var mainMenuScreen: MainMenuScreen!
+    private var settingScreen: SettingScreen!
+    private var searchSettingsScreen: SearchSettingsScreen!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        toolbarScreen = ToolbarScreen(app: app)
+        mainMenuScreen = MainMenuScreen(app: app)
+        settingScreen = SettingScreen(app: app)
+        searchSettingsScreen = SearchSettingsScreen(app: app)
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/2753086
+    // Regression
+    func testSearchSettingsMenuUIWithFirefoxSuggestEnabled() {
+        enrollInFirefoxSuggestRollout(ingestingSuggestions: false)
+
+        toolbarScreen.tapSettingsMenuButton()
+        mainMenuScreen.tapSettings()
+        settingScreen.navigateToSearchSettings()
+        searchSettingsScreen.assertNavBarVisible()
+
+        searchSettingsScreen.assertDefaultSearchEngineSectionExists()
+        searchSettingsScreen.assertAlternativeSearchEnginesSectionExists()
+        searchSettingsScreen.assertAddSearchEngineRowExists()
+        searchSettingsScreen.assertShowSearchSuggestionsSwitchIsOn()
+        searchSettingsScreen.assertShowInPrivateSessionsSwitchIsOff()
+        searchSettingsScreen.assertSearchBrowsingHistorySwitchIsOn()
+        searchSettingsScreen.assertSearchBookmarksSwitchIsOn()
+        searchSettingsScreen.assertSearchSyncedTabsSwitchIsOn()
+        searchSettingsScreen.assertSuggestionsFromTheWebSwitchIsOn()
+        searchSettingsScreen.assertSuggestionsFromSponsorsSwitchIsOn()
+        searchSettingsScreen.assertLearnMoreAboutFirefoxSuggestRowExists()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -14,11 +14,6 @@ private let SuggestedSite4 = "foobar buffer length"
 private let SuggestedSite5 = "foobar burn cd"
 private let SuggestedSite6 = "foobar/ b"
 
-private let IngestSuggestionsCell = "Ingest new suggestions now"
-// Nimbus applies fetched recipes on the launch after the fetch, so two attempts is the floor.
-private let SuggestRolloutLaunchAttempts = 5
-private let SuggestRolloutProbeTimeout: TimeInterval = 5
-
 class SearchTests: FeatureFlaggedTestBase {
     var toolbarScreen: ToolbarScreen!
     var browserScreen: BrowserScreen!
@@ -578,37 +573,10 @@ class SearchTests: FeatureFlaggedTestBase {
         }
     }
 
-    /// On release builds Firefox Suggest is enabled by a Nimbus rollout rather than a channel default, and
-    /// Nimbus only applies fetched recipes on the launch that follows the fetch, hence the relaunches.
     private func launchWithFirefoxSuggestRollout() {
         app.launch()
         waitForTabsButtonHittable()
-
-        for _ in 1...SuggestRolloutLaunchAttempts {
-            relaunchKeepingProfile()
-            navigator.goto(SettingsScreen)
-            navigator.performAction(Action.OpenSecretSettings)
-            navigator.goto(FirefoxSuggestSettings)
-            // The ingest row only exists while the feature is enabled, so it doubles as the enrollment probe.
-            guard mozWaitForElementToExist(app.cells[IngestSuggestionsCell],
-                                           timeout: SuggestRolloutProbeTimeout,
-                                           failOnTimeout: false) else { continue }
-            navigator.performAction(Action.IngestNewSuggestionsNow)
-            navigator.goto(HomePanelsScreen)
-            return
-        }
-
-        XCTFail("Firefox Suggest was not enabled after \(SuggestRolloutLaunchAttempts) launches")
-    }
-
-    /// The Nimbus database lives inside the test profile, so clearing it would discard the fetched rollout.
-    private func relaunchKeepingProfile() {
-        app.terminate()
-        _ = app.wait(for: .notRunning, timeout: TIMEOUT)
-        app.launchArguments = app.launchArguments.filter { $0 != LaunchArguments.ClearProfile }
-        app.launch()
-        waitForTabsButtonHittable()
-        navigator.nowAt(NewTabScreen)
+        enrollInFirefoxSuggestRollout()
     }
 
     /// Clears the address bar before typing, so the term can be retyped without appending to itself.

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SearchSettingsSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SearchSettingsSelectors.swift
@@ -13,6 +13,15 @@ protocol SearchSettingsSelectorsSet {
     var DEFAULT_SEARCH_ENGINE_NAVBAR: Selector { get }
     var DEFAULT_SEARCH_ENGINE_SECTION_TITLE: Selector { get }
     var ALTERNATIVE_SEARCH_ENGINES_SECTION_TITLE: Selector { get }
+    var ADD_SEARCH_ENGINE_ROW: Selector { get }
+    var SHOW_SEARCH_SUGGESTIONS_SWITCH: Selector { get }
+    var SHOW_IN_PRIVATE_SESSIONS_SWITCH: Selector { get }
+    var SEARCH_BROWSING_HISTORY_SWITCH: Selector { get }
+    var SEARCH_BOOKMARKS_SWITCH: Selector { get }
+    var SEARCH_SYNCED_TABS_SWITCH: Selector { get }
+    var SUGGESTIONS_FROM_THE_WEB_SWITCH: Selector { get }
+    var SUGGESTIONS_FROM_SPONSORS_SWITCH: Selector { get }
+    var LEARN_MORE_ABOUT_FIREFOX_SUGGEST_ROW: Selector { get }
     func searchEngineRow(named engineName: String) -> Selector
     var all: [Selector] { get }
 }
@@ -27,6 +36,19 @@ struct SearchSettingsSelectors: SearchSettingsSelectorsSet {
         static let defaultSearchEngineNavBar = "Default Search Engine"
         static let defaultSearchEngineSectionTitle = "Default Search Engine"
         static let alternativeSearchEnginesSectionTitle = "Alternative Search Engines"
+        static let addSearchEngineRow          = AccessibilityIdentifiers.Settings.Search.customEngineViewButton
+        static let showSearchSuggestionsSwitch = AccessibilityIdentifiers.Settings.Search.showSearchSuggestions
+        static let showInPrivateSessionsSwitch =
+            AccessibilityIdentifiers.Settings.Search.showPrivateModeSearchSuggestionsSwitch
+        static let searchBrowsingHistorySwitch =
+            AccessibilityIdentifiers.Settings.Search.showBrowsingHistorySuggestionsSwitch
+        static let searchBookmarksSwitch       = AccessibilityIdentifiers.Settings.Search.showBookmarksSuggestionsSwitch
+        static let searchSyncedTabsSwitch      = AccessibilityIdentifiers.Settings.Search.showSyncedTabsSuggestionsSwitch
+        static let suggestionsFromTheWebSwitch =
+            AccessibilityIdentifiers.Settings.Search.showNonSponsoredSuggestionsSwitch
+        static let suggestionsFromSponsorsSwitch =
+            AccessibilityIdentifiers.Settings.Search.showSponsoredSuggestionsSwitch
+        static let learnMoreAboutFirefoxSuggestRow = "Learn more about Firefox Suggest"
     }
 
     let NAVBAR = Selector.navigationBarId(
@@ -77,6 +99,60 @@ struct SearchSettingsSelectors: SearchSettingsSelectorsSet {
         groups: ["settings", "search"]
     )
 
+    let ADD_SEARCH_ENGINE_ROW = Selector.tableCellById(
+        IDs.addSearchEngineRow,
+        description: "Add Search Engine row on Settings → Search",
+        groups: ["settings", "search"]
+    )
+
+    let SHOW_SEARCH_SUGGESTIONS_SWITCH = Selector.switchById(
+        IDs.showSearchSuggestionsSwitch,
+        description: "Switch for 'Show Search Suggestions' on Settings → Search",
+        groups: ["settings", "search"]
+    )
+
+    let SHOW_IN_PRIVATE_SESSIONS_SWITCH = Selector.switchById(
+        IDs.showInPrivateSessionsSwitch,
+        description: "Switch for 'Show in Private Sessions' on Settings → Search",
+        groups: ["settings", "search"]
+    )
+
+    let SEARCH_BROWSING_HISTORY_SWITCH = Selector.switchById(
+        IDs.searchBrowsingHistorySwitch,
+        description: "Switch for 'Search Browsing History' on Settings → Search",
+        groups: ["settings", "search", "firefox suggest"]
+    )
+
+    let SEARCH_BOOKMARKS_SWITCH = Selector.switchById(
+        IDs.searchBookmarksSwitch,
+        description: "Switch for 'Search Bookmarks' on Settings → Search",
+        groups: ["settings", "search", "firefox suggest"]
+    )
+
+    let SEARCH_SYNCED_TABS_SWITCH = Selector.switchById(
+        IDs.searchSyncedTabsSwitch,
+        description: "Switch for 'Search Synced Tabs' on Settings → Search",
+        groups: ["settings", "search", "firefox suggest"]
+    )
+
+    let SUGGESTIONS_FROM_THE_WEB_SWITCH = Selector.switchById(
+        IDs.suggestionsFromTheWebSwitch,
+        description: "Switch for 'Suggestions from the Web' on Settings → Search",
+        groups: ["settings", "search", "firefox suggest"]
+    )
+
+    let SUGGESTIONS_FROM_SPONSORS_SWITCH = Selector.switchById(
+        IDs.suggestionsFromSponsorsSwitch,
+        description: "Switch for 'Suggestions from Sponsors' on Settings → Search",
+        groups: ["settings", "search", "firefox suggest"]
+    )
+
+    let LEARN_MORE_ABOUT_FIREFOX_SUGGEST_ROW = Selector.staticTextInTablesByLabel(
+        IDs.learnMoreAboutFirefoxSuggestRow,
+        description: "'Learn more about Firefox Suggest' row on Settings → Search",
+        groups: ["settings", "search", "firefox suggest"]
+    )
+
     func searchEngineRow(named engineName: String) -> Selector {
         Selector.staticTextInTablesByLabel(
             engineName,
@@ -88,7 +164,10 @@ struct SearchSettingsSelectors: SearchSettingsSelectorsSet {
     var all: [Selector] {
         [
             NAVBAR, BACK_BUTTON_iOS26, BACK_BUTTON, TRENDING_SEARCH_SWITCH, RECENT_SEARCH_SWITCH,
-            DEFAULT_SEARCH_ENGINE_NAVBAR, DEFAULT_SEARCH_ENGINE_SECTION_TITLE, ALTERNATIVE_SEARCH_ENGINES_SECTION_TITLE
+            DEFAULT_SEARCH_ENGINE_NAVBAR, DEFAULT_SEARCH_ENGINE_SECTION_TITLE, ALTERNATIVE_SEARCH_ENGINES_SECTION_TITLE,
+            ADD_SEARCH_ENGINE_ROW, SHOW_SEARCH_SUGGESTIONS_SWITCH, SHOW_IN_PRIVATE_SESSIONS_SWITCH,
+            SEARCH_BROWSING_HISTORY_SWITCH, SEARCH_BOOKMARKS_SWITCH, SEARCH_SYNCED_TABS_SWITCH,
+            SUGGESTIONS_FROM_THE_WEB_SWITCH, SUGGESTIONS_FROM_SPONSORS_SWITCH, LEARN_MORE_ABOUT_FIREFOX_SUGGEST_ROW
         ]
     }
 }


### PR DESCRIPTION
…abled

## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-5789

## :bulb: Description
New test
- SearchSettingsSuggestUITests/testSearchSettingsMenuUIWithFirefoxSuggestEnabled (SearchSettingsUITest.swift) — enrolls the app in the live Firefox Suggest rollout, navigates Toolbar → Main menu → Settings → Search, and asserts the full screen layout: Default Search Engine and Alternative Search Engines sections, the Add Search Engine row, and the default state of every toggle (Show Search Suggestions ON, Show in Private Sessions OFF, Search Browsing History / Bookmarks / Synced Tabs ON, Suggestions from the Web / from Sponsors ON) plus the "Learn more about Firefox Suggest" row.
- It's a new class rather than a case in SearchSettingsUITests because the Suggest enrollment relaunch sequence needs its own setup and shouldn't slow down the existing cases.

Shared Suggest enrollment helper
- Moved relaunchKeepingProfile() and the rollout-enrollment loop out of SearchTest.swift into BaseTestCase, now enrollInFirefoxSuggestRollout(ingestingSuggestions:). On release builds Firefox Suggest comes from a Nimbus rollout, not a channel default, and Nimbus only applies a fetched recipe on the following launch — hence the relaunch loop and the "Ingest new suggestions now" row used as the enrollment probe.
- The new ingestingSuggestions flag lets this test skip the ingest step; it only asserts on settings UI, not on suggestion results. SearchTests.launchWithFirefoxSuggestRollout() keeps the default (true) so its behaviour is unchanged.

Page-object / selector work (keeps assertions out of the test body)
- SearchSettingsSelectors: 9 new selectors for the rows and switches above.
- SearchSettingsScreen: matching assert* methods, backed by private assertRowExists / assertSwitch(_:isOn:) helpers that scroll first — rows further down the table only enter the accessibility tree once scrolled into range.
- AccessibilityIdentifiers.Settings.Search: added the 6 missing switch identifiers, mirroring the existing PrefsKeys.SearchSettings keys.

Test plans
- SearchSettingsSuggestUITests added to the class-level skippedTests of AccessibilityTestPlan, ExperimentIntegrationTests, PerformanceTestPlan, Smoketest and SyncIntegrationTestPlan, so it runs in FullFunctionalTestPlan only.

Known limitation — landscape not automated
C2753086 also covers the same verification in landscape. That step is not automated: on the iPhone / iOS 26.5 simulator, device rotation from XCUITest doesn't take effect — waitForRotation always times out and the app stays in portrait, so a landscape pass would fail for environmental reasons rather than product ones. The portrait coverage above is the automated scope; landscape stays manual until rotation works on that simulator runtime.
