### PR TITLE
Refactor FXIOS-16718 - [Tab Tray] - Fix Memory Leak related to TabsCoordinator

### DIFF
--- a/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/TabTray/TabTrayCoordinator.swift
@@ -14,7 +14,7 @@ protocol TabTrayNavigationHandler: AnyObject {
     func start(panelType: TabTrayPanelType, navigationController: UINavigationController)
 }
 
-class TabTrayCoordinator: BaseCoordinator,
+final class TabTrayCoordinator: BaseCoordinator,
                           ParentCoordinatorDelegate,
                           TabTrayViewControllerDelegate,
                           TabTrayNavigationHandler {
@@ -100,10 +100,21 @@ class TabTrayCoordinator: BaseCoordinator,
     }
 
     private func makeTabsCoordinator(navigationController: UINavigationController) {
+        // A panel can be selected any number of times while the tab tray stays open, so reuse the
+        // coordinator already owning that navigation controller instead of appending a new
+        // coordinator and router on every switch.
+        guard !hasTabsCoordinator(for: navigationController) else { return }
         let router = DefaultRouter(navigationController: navigationController)
         let tabCoordinator = TabsCoordinator(router: router)
         add(child: tabCoordinator)
         tabCoordinator.parentCoordinator = self
+    }
+
+    private func hasTabsCoordinator(for navigationController: UINavigationController) -> Bool {
+        return childCoordinators.contains { child in
+            guard let tabsCoordinator = child as? TabsCoordinator else { return false }
+            return (tabsCoordinator.router.navigationController as? UINavigationController) === navigationController
+        }
     }
 
     private func makeRemoteTabsCoordinator(navigationController: UINavigationController, for window: WindowUUID) {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/TabTrayCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/TabTray/TabTrayCoordinatorTests.swift
@@ -61,6 +61,30 @@ final class TabTrayCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 1)
     }
 
+    func testStart_reselectingSamePanel_reusesTabsCoordinator() {
+        let subject = createSubject()
+        let navigationController = UINavigationController()
+
+        subject.start(panelType: .tabs, navigationController: navigationController)
+        subject.start(panelType: .tabs, navigationController: navigationController)
+        subject.start(panelType: .tabs, navigationController: navigationController)
+
+        XCTAssertEqual(subject.childCoordinators.count, 1)
+    }
+
+    func testStart_switchingBetweenPanels_createsOneCoordinatorPerPanel() {
+        let subject = createSubject()
+        let regularNavigationController = UINavigationController()
+        let privateNavigationController = UINavigationController()
+
+        for _ in 0..<3 {
+            subject.start(panelType: .tabs, navigationController: regularNavigationController)
+            subject.start(panelType: .privateTabs, navigationController: privateNavigationController)
+        }
+
+        XCTAssertEqual(subject.childCoordinators.count, 2)
+    }
+
     func testDidFinishCalled() {
         let subject = createSubject()
         subject.start(panelType: .tabs, navigationController: UINavigationController())


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16718)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35457)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### The Problem

Switching between the regular and private panels in the tab tray leaked a `TabsCoordinator` and a `DefaultRouter` on every switch. Memory grew for as long as the tray stayed open and was only reclaimed once the tray was dismissed.

### The Fix

So this adds a guard keyed on the navigation controller rather than just the type. The regular and private panels are two separate `ThemedNavigationController`s from `makeChildPanels`, and each one needs its own coordinator, a type-only check would leave the second panel without one. `childCoordinators` now sits at three entries (regular, private, synced) and stays there no matter how much you flip between panels.

It also adds 2 unit tests to make sure it works as expected.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

