### PR TITLE
Bugfix FXIOS-16764 [Quick Answers] Fix SpeechTranscriber not being available on some devices that support iOS 26

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/ErrorExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/ErrorExtension.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+extension Error {
+    /// A telemetry-safe descriptor for an arbitrary error, built from the bridged `NSError` domain and code.
+    public var telemetryDescription: String {
+        let nsError = self as NSError
+        return "domain: \(nsError.domain), code: \(nsError.code)"
+    }
+}

--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -14,8 +14,8 @@ public enum LoggerCategory: String {
     /// Related to setting an alternative app icon and resetting to the default app icon.
     case appIcon
 
-    /// Related to our authentication services, like MLPA.
-    case authentication
+    /// Related to our MLPA authentication service.
+    case mlpa
 
     /// Related to address, credit card and password autofill
     case autofill

--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -14,6 +14,9 @@ public enum LoggerCategory: String {
     /// Related to setting an alternative app icon and resetting to the default app icon.
     case appIcon
 
+    /// Related to our authentication services, like MLPA.
+    case authentication
+
     /// Related to address, credit card and password autofill
     case autofill
 

--- a/BrowserKit/Sources/MLPAKit/AppAttestRequestAuth.swift
+++ b/BrowserKit/Sources/MLPAKit/AppAttestRequestAuth.swift
@@ -56,7 +56,7 @@ public struct AppAttestRequestAuth: RequestAuthProtocol {
         } catch {
             logger.log("Failed to authenticate the request with App Attest",
                        level: .fatal,
-                       category: .authentication,
+                       category: .mlpa,
                        extra: ["error": "\(error.telemetryDescription)",
                                "service": "\(serviceType.rawValue)"])
             throw error

--- a/BrowserKit/Sources/MLPAKit/AppAttestRequestAuth.swift
+++ b/BrowserKit/Sources/MLPAKit/AppAttestRequestAuth.swift
@@ -16,38 +16,50 @@ public struct AppAttestRequestAuth: RequestAuthProtocol {
     private let appAttestClient: AppAttestClient
     private let bundleIdentifier: String
     private let serviceType: MLPAServiceType
+    private let logger: Logger
 
     public init(
         appAttestClient: AppAttestClient,
         bundleIdentifier: String,
-        serviceType: MLPAServiceType
+        serviceType: MLPAServiceType,
+        logger: Logger = DefaultLogger.shared
     ) {
         self.appAttestClient = appAttestClient
         self.bundleIdentifier = bundleIdentifier
         self.serviceType = serviceType
+        self.logger = logger
     }
 
     public func authenticate(request: inout URLRequest) async throws {
-        // Make sure the server trust is established before sending any requests.
-        // This should only be needed for the first request, subsequent requests will reuse the same attestation.
-        _ = try await appAttestClient.performAttestation()
+        do {
+            // Make sure the server trust is established before sending any requests.
+            // This should only be needed for the first request, subsequent requests will reuse the same attestation.
+            _ = try await appAttestClient.performAttestation()
 
-        let body = request.httpBody ?? Data()
-        let payload = try JSONSerialization.jsonObject(with: body) as? [String: Any] ?? [:]
+            let body = request.httpBody ?? Data()
+            let payload = try JSONSerialization.jsonObject(with: body) as? [String: Any] ?? [:]
 
-        let result = try await appAttestClient.generateAssertion(payload: payload)
+            let result = try await appAttestClient.generateAssertion(payload: payload)
 
-        let jwt = try MLPAJWTPayload(
-            keyId: result.keyId,
-            challenge: result.challenge,
-            objectKey: MLPAConstants.assertionObjParam,
-            objectData: result.assertion,
-            bundleIdentifier: bundleIdentifier
-        ).encode()
+            let jwt = try MLPAJWTPayload(
+                keyId: result.keyId,
+                challenge: result.challenge,
+                objectKey: MLPAConstants.assertionObjParam,
+                objectData: result.assertion,
+                bundleIdentifier: bundleIdentifier
+            ).encode()
 
-        request.setValue(MLPAConstants.bearerPrefix + jwt, forHTTPHeaderField: MLPAConstants.authorizationHeader)
-        request.setValue(serviceType.rawValue, forHTTPHeaderField: MLPAConstants.serviceTypeHeader)
-        request.setValue("true", forHTTPHeaderField: MLPAConstants.useAppAttestHeader)
-        request.httpBody = result.payload
+            request.setValue(MLPAConstants.bearerPrefix + jwt, forHTTPHeaderField: MLPAConstants.authorizationHeader)
+            request.setValue(serviceType.rawValue, forHTTPHeaderField: MLPAConstants.serviceTypeHeader)
+            request.setValue("true", forHTTPHeaderField: MLPAConstants.useAppAttestHeader)
+            request.httpBody = result.payload
+        } catch {
+            logger.log("Failed to authenticate the request with App Attest",
+                       level: .fatal,
+                       category: .authentication,
+                       extra: ["error": "\(error.telemetryDescription)",
+                               "service": "\(serviceType.rawValue)"])
+            throw error
+        }
     }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/DefaultQuickAnswersService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/DefaultQuickAnswersService.swift
@@ -66,7 +66,7 @@ final class DefaultQuickAnswersService: QuickAnswersService {
             let result = try await resultsService.fetchResults(for: text)
             return .success(result)
         } catch {
-            let error = (error as? ResultsServiceError) ?? ResultsServiceError.unknown(error.localizedDescription)
+            let error = (error as? ResultsServiceError) ?? ResultsServiceError.unknown(error.telemetryDescription)
             // TODO: FXIOS-15579 Possibly add telemetry
             return .failure(error)
         }
@@ -105,7 +105,7 @@ final class DefaultQuickAnswersService: QuickAnswersService {
         let audioManager = AudioManager()
         let authorizer = AuthorizationHandler()
 
-        if #available(iOS 26.0, *) {
+        if #available(iOS 26.0, *), SpeechAnalyzerEngine.isTranscriberModuleAvailable() {
             return SpeechAnalyzerEngine(
                 audioManager: audioManager,
                 authorizer: authorizer

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/DefaultResultsService.swift
@@ -86,8 +86,8 @@ final class DefaultResultsService: ResultsService {
             return .invalidResponse(statusCode: statusCode)
         case LiteLLMClientError.noContent:
             return .noMessage
-        case let e as LiteLLMClientError: return .unknown(e.localizedDescription)
-        default: return .unknown(error.localizedDescription)
+        case let e as LiteLLMClientError: return .unknown(e.telemetryDescription)
+        default: return .unknown(error.telemetryDescription)
         }
     }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceError.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceError.swift
@@ -30,7 +30,7 @@ enum ResultsServiceError: Error, Equatable {
         case .maxUsers: return "max_users"
         case .payloadTooLarge: return "payload_too_large"
         case .unableToCreateService: return "unable_to_create_service"
-        case .unknown: return "unknown"
+        case .unknown(let description): return "unknown(\(description))"
         }
     }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/SpeechAnalyzerEngine.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/SpeechAnalyzerEngine.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-// TODO: FXIOS-14934 - remove preconcurrency
 import AVFoundation
 import Speech
 import Common
@@ -36,6 +35,11 @@ final class SpeechAnalyzerEngine: TranscriptionEngine {
         self.audioManager = audioManager
         self.authorizer = authorizer
         self.locale = locale
+    }
+
+    /// Wether the transcriber module is available on this device.
+    static func isTranscriberModuleAvailable() -> Bool {
+        return SpeechTranscriber.isAvailable
     }
 
     func prepare() async throws {

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/SpeechError.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/SpeechService/SpeechError.swift
@@ -25,7 +25,7 @@ enum SpeechError: Error, Equatable {
         case .serviceNotInitialized: return "service_not_initialized"
         case .speechRecognitionPermissionDenied: return "speech_recognition_permission_denied"
         case .unableToSupportLocale: return "unable_to_support_locale"
-        case .unknown: return "unknown"
+        case .unknown(let description): return "unknown(\(description))"
         }
     }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewModel.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewModel.swift
@@ -111,7 +111,7 @@ final class QuickAnswersViewModel {
             }
         } catch {
             try? await service.stopRecording()
-            let error = (error as? SpeechError) ?? SpeechError.unknown(error.localizedDescription)
+            let error = (error as? SpeechError) ?? SpeechError.unknown(error.telemetryDescription)
             telemetry.recordingCompleted(outcome: false, errorType: error.telemetryLabel)
             onStateChange?(.speechResult(.empty(), error))
         }

--- a/BrowserKit/Tests/MLPAKitTests/AppAttestRequestAuthTests.swift
+++ b/BrowserKit/Tests/MLPAKitTests/AppAttestRequestAuthTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 @testable import AppAttestKit
+import Common
 import TestKit
 import XCTest
 
@@ -82,17 +83,35 @@ final class AppAttestRequestAuthTests: XCTestCase {
         XCTAssertNotNil(fields[MLPAConstants.bundleIDParam])
     }
 
+    func test_authenticate_logsFatalError_whenAttestationFails() async throws {
+        let logger = MockLogger()
+        let subject = try createSubject(
+            storedKeyID: nil,
+            sendAttestationError: AppAttestServiceError.invalidPayload,
+            logger: logger
+        )
+        var request = try makeRequest()
+
+        try? await subject.authenticate(request: &request)
+
+        XCTAssertEqual(logger.savedLevel, .fatal)
+        XCTAssertEqual(logger.savedExtra?["error"], "\(AppAttestServiceError.invalidPayload)")
+    }
+
     // MARK: - Helpers
 
     private func createSubject(
         storedKeyID: String? = AppAttestTestData.keyID,
         challenge: String = AppAttestTestData.challenge,
         assertionBlob: Data = AppAttestTestData.assertionBlob,
-        bundleIdentifier: String = AppAttestTestData.bundleID
+        bundleIdentifier: String = AppAttestTestData.bundleID,
+        sendAttestationError: Error? = nil,
+        logger: Logger = MockLogger()
     ) throws -> AppAttestRequestAuth {
         let keyStore = MockAppAttestKeyIDStore(initial: storedKeyID)
         let server = MockAppAttestRemoteServer()
         server.challengeToReturn = challenge
+        server.sendAttestationError = sendAttestationError
         let service = MockAppAttestService(isSupported: true)
         service.assertionToReturn = assertionBlob
 
@@ -105,7 +124,8 @@ final class AppAttestRequestAuthTests: XCTestCase {
         return AppAttestRequestAuth(
             appAttestClient: client,
             bundleIdentifier: bundleIdentifier,
-            serviceType: .s2s
+            serviceType: .s2s,
+            logger: logger
         )
     }
 

--- a/BrowserKit/Tests/MLPAKitTests/AppAttestRequestAuthTests.swift
+++ b/BrowserKit/Tests/MLPAKitTests/AppAttestRequestAuthTests.swift
@@ -95,7 +95,8 @@ final class AppAttestRequestAuthTests: XCTestCase {
         try? await subject.authenticate(request: &request)
 
         XCTAssertEqual(logger.savedLevel, .fatal)
-        XCTAssertEqual(logger.savedExtra?["error"], "\(AppAttestServiceError.invalidPayload)")
+        XCTAssertEqual(logger.savedExtra?["error"], AppAttestServiceError.invalidPayload.telemetryDescription)
+        XCTAssertEqual(logger.savedExtra?["service"], MLPAServiceType.s2s.rawValue)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16764)

## :bulb: Description
Some devices run iOS 26 but do not ship the on-device `SpeechTranscriber` module, so gating the engine choice on the OS version alone left voice input broken on them. `SpeechAnalyzerEngine` is now only picked when `SpeechTranscriber.isAvailable` is true, otherwise we fall back to `SFSpeechRecognizerEngine`.

Added richer diagnostic to `SpeechError`, `ResultServiceError` and `AppAttestAuthRequest`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
