### PR TITLE
Bugfix FXIOS-16577 Add proper url routing for the browsing settings hyperlinks

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -682,6 +682,19 @@ final class BrowserCoordinator: BaseCoordinator,
         nav.pushViewController(viewController, animated: true)
     }
 
+    func pressedOpenSupportPage(url: URL) {
+        askedToOpen(url: url, withTitle: nil)
+    }
+
+    func askedToOpen(url: URL?, withTitle title: NSAttributedString?) {
+        guard let url,
+              let nav = router.navigationController.presentedViewController as? UINavigationController else { return }
+        let viewController = SettingsContentViewController(windowUUID: windowUUID)
+        viewController.settingsTitle = title
+        viewController.url = url
+        nav.pushViewController(viewController, animated: true)
+    }
+
     func presentSavePDFController() {
         guard let selectedTab = browserViewController.tabManager.selectedTab else { return }
 

--- a/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/BrowsingSettingsViewController.swift
@@ -6,7 +6,7 @@ import Common
 import Shared
 
 /// Child settings pages browsing actions
-protocol BrowsingSettingsDelegate: AnyObject {
+protocol BrowsingSettingsDelegate: AnyObject, SupportSettingsDelegate {
     @MainActor
     func pressedMailApp()
 
@@ -85,7 +85,7 @@ class BrowsingSettingsViewController: SettingsTableViewController, FeatureFlagga
             if featureFlagsProvider.isEnabled(.adBlocker) {
                 contentSection.append(AdBlockerSetting(
                     prefs: profile.prefs,
-                    supportDelegate: parentCoordinator as? SupportSettingsDelegate,
+                    supportDelegate: parentCoordinator,
                     settingDidChange: { isEnabled in
                         if isEnabled {
                             Task {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -781,6 +781,23 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertEqual(mockRouter.presentCalled, 1)
     }
 
+    func testAskedToOpen_pushesSettingsContentViewController() throws {
+        let subject = createSubject()
+        let navigationController = UINavigationController()
+        let mockNavigationController = try XCTUnwrap(mockRouter.navigationController as? MockNavigationController)
+        mockNavigationController.presentedViewController = navigationController
+        let url = try XCTUnwrap(URL(string: "https://support.mozilla.org"))
+        let title = NSAttributedString(string: "Support")
+
+        subject.askedToOpen(url: url, withTitle: title)
+
+        let contentViewController = try XCTUnwrap(
+            navigationController.topViewController as? SettingsContentViewController
+        )
+        XCTAssertEqual(contentViewController.url, url)
+        XCTAssertEqual(contentViewController.settingsTitle, title)
+    }
+
     func testPopToBVC_popsViewControllers() {
         let subject = createSubject()
 


### PR DESCRIPTION

## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16577)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35506)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
There was a cast which always resulted in nil, which made the app never open hyperlinks when accessed from the adblock browser settings modal.
I added the missing protocol to the main browser settings protocol, this way we will never miss casting it properly.
The other approach would be to add this support settings protocol directly to BrowserCoordinator

## :movie_camera: Demos


https://github.com/user-attachments/assets/a5ae9b10-a7bc-4f3e-86d6-cde31e79159b



<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

