### PR TITLE
Bugfix FXIOS-16633 [Nova] [Addresses/CC] Cursor not purple no matter the theme

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -188,7 +188,7 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         let style = theme.type.getInterfaceStyle()
         self.windows[window]?.overrideUserInterfaceStyle = style
         // Nova only: highlighted text purple tint.
-        let selectedTextTint = theme.isNova ? theme.colors.layerSelectedText : nil
+        let selectedTextTint = theme.isNova ? theme.colors.actionPrimary : nil
         UITextField.appearance().tintColor = selectedTextTint
         UITextView.appearance().tintColor = selectedTextTint
         notifyCurrentThemeDidChange(for: window)

--- a/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
+++ b/firefox-ios/Client/Frontend/Autofill/Address/Edit/EditAddressViewController.swift
@@ -212,7 +212,8 @@ class EditAddressViewController: UIViewController,
         let theme = themeManager.getCurrentTheme(for: currentWindowUUID)
         removeButton.applyTheme(theme: theme)
         let isDarkTheme = theme.type == .dark
-        evaluateJavaScript("setTheme(\(isDarkTheme));")
+        let caretColor = theme.colors.actionPrimary.hexString
+        evaluateJavaScript("setTheme(\(isDarkTheme), '\(caretColor)');")
     }
 
     func presentRemoveAddressAlert() {

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.css
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.css
@@ -56,6 +56,7 @@ label select {
   outline: none;
   background-color: transparent;
   color: var(--text-primary);
+  caret-color: var(--caret-color, auto);
   font: -apple-system-body;
 }
 

--- a/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.mjs
+++ b/firefox-ios/Client/Frontend/UserContent/UserScripts/AddressFormManager/AddressFormManager.mjs
@@ -13,9 +13,13 @@ window.getCurrentFormData = getCurrentFormData;
 /**
  * Sets the theme of the webview.
  * @param {Boolean} isDarkTheme - Set to true if the dark theme should be applied.
+ * @param {string} caretColor - Color applied to the text cursor.
  */
-const setTheme = (isDarkTheme) => {
+const setTheme = (isDarkTheme, caretColor) => {
   document.body.classList.toggle("dark", isDarkTheme);
+  if (caretColor) {
+    document.documentElement.style.setProperty("--caret-color", caretColor);
+  }
 };
 window.setTheme = setTheme;
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16633)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35471)

## :bulb: Description
Passing accent color to html for caret color and using the correct color for appearance tint

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

