### PR TITLE
Refactor FXIOS-16769 [Technical Debt] [Redux] [Modern Action Migration] Migrate `TabPanelViewActionType.addNewTab` to `TabPanelViewModernAction` as per ADR #0012

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2341,6 +2341,7 @@
 		EDF2C05C2D6CDB6F00723609 /* AppIcons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDF2C05B2D6CDB6F00723609 /* AppIcons.xcassets */; };
 		EDF567A02C8B51DC00FDB09D /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = EDF5679F2C8B51DC00FDB09D /* SiteImageView */; };
 		EDF567A22C8B51E100FDB09D /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = EDF567A12C8B51E100FDB09D /* Kingfisher */; };
+		EDFC356E304B72840036079E /* TabsDisplayViewPanelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFC356D304B72840036079E /* TabsDisplayViewPanelType.swift */; };
 		EDFEE3F42DE670B8005ADE03 /* gleanProbes.xcfilelist in Resources */ = {isa = PBXBuildFile; fileRef = EDFEE3F32DE670B8005ADE03 /* gleanProbes.xcfilelist */; };
 		EE046A75300A75D7004E3D80 /* SwipeUpTabWebViewPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE046A74300A75D7004E3D80 /* SwipeUpTabWebViewPreviewTests.swift */; };
 		EE046A77300A75F4004E3D80 /* SwipeUpTabPreviewGestureHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE046A76300A75F4004E3D80 /* SwipeUpTabPreviewGestureHandlerTests.swift */; };
@@ -12131,6 +12132,7 @@
 		EDF2C0552D693A7300723609 /* AppIconSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconSetting.swift; sourceTree = "<group>"; };
 		EDF2C0572D693B7C00723609 /* AppIconSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconSelectionView.swift; sourceTree = "<group>"; };
 		EDF2C05B2D6CDB6F00723609 /* AppIcons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AppIcons.xcassets; sourceTree = "<group>"; };
+		EDFC356D304B72840036079E /* TabsDisplayViewPanelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsDisplayViewPanelType.swift; sourceTree = "<group>"; };
 		EDFEE3F32DE670B8005ADE03 /* gleanProbes.xcfilelist */ = {isa = PBXFileReference; lastKnownFileType = text.xcfilelist; path = gleanProbes.xcfilelist; sourceTree = "<group>"; };
 		EE046A74300A75D7004E3D80 /* SwipeUpTabWebViewPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeUpTabWebViewPreviewTests.swift; sourceTree = "<group>"; };
 		EE046A76300A75F4004E3D80 /* SwipeUpTabPreviewGestureHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeUpTabPreviewGestureHandlerTests.swift; sourceTree = "<group>"; };
@@ -13100,6 +13102,7 @@
 				21EA46692B04130500AAAB2D /* TabsPanelState.swift */,
 				21E77E4F2AA8BAEC00FABA10 /* TabTrayState.swift */,
 				21996BAA2AE95AFC00E0D55F /* TabTrayPanelType.swift */,
+				EDFC356D304B72840036079E /* TabsDisplayViewPanelType.swift */,
 				5A9F83412B2B796800272819 /* TabPeekState.swift */,
 			);
 			path = State;
@@ -20459,6 +20462,7 @@
 				C8DC90C52A066B6A0008832B /* MarkupTokenizingUtility.swift in Sources */,
 				367C100A7ABD4B4585D029D5 /* AutoTranslatePromptView.swift in Sources */,
 				31286F788EBE4BDE9BB9FF21 /* AutoTranslatePromptState.swift in Sources */,
+				EDFC356E304B72840036079E /* TabsDisplayViewPanelType.swift in Sources */,
 				AA02D5EB2EB3D83200814F4C /* TranslationsAction.swift in Sources */,
 				C79CEE5E2EDF3C4B004C4EB8 /* JumpBackInCell.swift in Sources */,
 				C2F700A22FBC000100112233 /* TrackerBlockerModuleCell.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3383,10 +3383,10 @@ class BrowserViewController: UIViewController,
         else { return }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500), execute: {
-            let action = TabPanelViewAction(panelType: .tabs,
-                                            windowUUID: self.windowUUID,
-                                            actionType: TabPanelViewActionType.addNewTab)
-            store.dispatch(action)
+            store.dispatch(
+                TabPanelViewModernAction.addNewTab(.tabs),
+                forWindowUUID: self.windowUUID
+            )
 
             self.debugOpen(numberOfNewTabs: numberOfNewTabs - 1, at: url)
         })

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3384,7 +3384,7 @@ class BrowserViewController: UIViewController,
 
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500), execute: {
             store.dispatch(
-                TabPanelViewModernAction.addNewTab(.tabs),
+                TabPanelViewModernAction.addNewTab(ofType: .normal),
                 forWindowUUID: self.windowUUID
             )
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -52,7 +52,6 @@ struct TabPanelViewAction: Action {
 enum TabPanelViewActionType: ActionType {
     case tabPanelDidLoad
     case tabPanelWillAppear
-    case addNewTab
     case closeTab
     case closeAllTabs
     case cancelCloseAllTabs
@@ -107,4 +106,9 @@ struct ScreenshotAction: Action {
 enum ScreenshotActionType: ActionType {
     case screenshotTaken
     case screenshotRestored
+}
+
+// MARK: Modernizing actions
+enum TabPanelViewModernAction: ModernAction {
+    case addNewTab(TabTrayPanelType)
 }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Action/TabPanelAction.swift
@@ -110,5 +110,7 @@ enum ScreenshotActionType: ActionType {
 
 // MARK: Modernizing actions
 enum TabPanelViewModernAction: ModernAction {
-    case addNewTab(TabTrayPanelType)
+    case addNewTab(ofType: TabsDisplayViewPanelType)
 }
+
+// MARK: ModernAction Payload Types

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -62,9 +62,9 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
     lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
         if let action = action as? TabPanelViewModernAction {
             switch action {
-            case .addNewTab(let panelType):
-                tabsPanelTelemetry.newTabButtonTapped(mode: panelType.modeForTelemetry)
-                addNewTab(withRequest: nil, isPrivate: panelType.isPrivateMode, showOverlay: true, for: windowUUID)
+            case .addNewTab(let type):
+                tabsPanelTelemetry.newTabButtonTapped(mode: type.modeForTelemetry)
+                addNewTab(withRequest: nil, isPrivate: type == .private, showOverlay: true, for: windowUUID)
                 dispatchRecentlyAccessedTabsAction(forWindowUUID: windowUUID)
             }
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -60,7 +60,14 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
     lazy var tabsPanelProvider: Middleware<AppState> = (legacyProvider, modernProvider)
 
     lazy var modernProvider: MiddlewareClosure<AppState> = { [self] state, action, windowUUID in
-        // Does not test any modern actions
+        if let action = action as? TabPanelViewModernAction {
+            switch action {
+            case .addNewTab(let panelType):
+                tabsPanelTelemetry.newTabButtonTapped(mode: panelType.modeForTelemetry)
+                addNewTab(withRequest: nil, isPrivate: panelType.isPrivateMode, showOverlay: true, for: windowUUID)
+                dispatchRecentlyAccessedTabsAction(forWindowUUID: windowUUID)
+            }
+        }
     }
 
     lazy var legacyProvider: LegacyMiddlewareClosure<AppState> = { [self] state, action in
@@ -186,10 +193,10 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
         // FXIOS-11740 - This is relate to homepage actions, so if we want to break up this middleware
         // then this action should go to the homepage specific middleware.
         case TabTrayActionType.dismissTabTray, TabTrayActionType.modalSwipedToClose:
-            dispatchRecentlyAccessedTabs(action: action)
+            dispatchRecentlyAccessedTabsAction(forWindowUUID: action.windowUUID)
         case TabTrayActionType.doneButtonTapped:
             tabsPanelTelemetry.doneButtonTapped(mode: action.panelType?.modeForTelemetry ?? .normal)
-            dispatchRecentlyAccessedTabs(action: action)
+            dispatchRecentlyAccessedTabsAction(forWindowUUID: action.windowUUID)
         default:
             break
         }
@@ -220,11 +227,6 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
                                                   actionType: TabPanelMiddlewareActionType.willAppearTabPanel)
             store.dispatch(action)
 
-        case TabPanelViewActionType.addNewTab:
-            let isPrivateMode = action.panelType == .privateTabs
-            tabsPanelTelemetry.newTabButtonTapped(mode: action.panelType?.modeForTelemetry ?? .normal)
-            addNewTab(with: action.urlRequest, isPrivate: isPrivateMode, showOverlay: true, for: action.windowUUID)
-            dispatchRecentlyAccessedTabs(action: action)
         case TabPanelViewActionType.moveTab:
             guard let moveTabData = action.moveTabData else { return }
             moveTab(state: state, moveTabData: moveTabData, uuid: action.windowUUID)
@@ -314,7 +316,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
                                      method: .open,
                                      object: .syncTab)
         let urlRequest = URLRequest(url: url)
-        self.addNewTab(with: urlRequest, isPrivate: false, showOverlay: showOverlay, for: windowUUID)
+        self.addNewTab(withRequest: urlRequest, isPrivate: false, showOverlay: showOverlay, for: windowUUID)
     }
 
     private func closeSelectedRemoteTab(deviceId: String, url: URL, windowUUID: WindowUUID) {
@@ -385,7 +387,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
     /// - Parameters:
     ///   - urlRequest: URL request to load
     ///   - isPrivate: if the tab should be created in private mode or not
-    private func addNewTab(with urlRequest: URLRequest?, isPrivate: Bool, showOverlay: Bool, for uuid: WindowUUID) {
+    private func addNewTab(withRequest urlRequest: URLRequest?, isPrivate: Bool, showOverlay: Bool, for uuid: WindowUUID) {
         MainActor.assertIsolated("Expected to be called only on main actor.")
         // TODO: Legacy class has a guard to cancel adding new tab if dragging was enabled,
         // check if change is still needed
@@ -537,7 +539,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
     }
 
     private func didTapLearnMoreAboutPrivate(with urlRequest: URLRequest, uuid: WindowUUID) {
-        addNewTab(with: urlRequest, isPrivate: true, showOverlay: false, for: uuid)
+        addNewTab(withRequest: urlRequest, isPrivate: true, showOverlay: false, for: uuid)
     }
 
     private func selectTab(
@@ -990,7 +992,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
             HomepageMiddlewareActionType.jumpBackInLocalTabsUpdated,
             TopTabsActionType.didTapNewTab,
             TopTabsActionType.didTapCloseTab:
-            dispatchRecentlyAccessedTabs(action: action)
+            dispatchRecentlyAccessedTabsAction(forWindowUUID: action.windowUUID)
         case JumpBackInActionType.tapOnCell:
             guard let jumpBackInAction = action as? JumpBackInAction,
                   let tab = jumpBackInAction.tab else { return }
@@ -1089,13 +1091,13 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
     }
 
     /// Sends out updated recent tabs which is currently used for the homepage jumpBackIn section
-    private func dispatchRecentlyAccessedTabs(action: Action) {
-        guard let tabManager = tabManager(for: action.windowUUID) else { return }
+    private func dispatchRecentlyAccessedTabsAction(forWindowUUID windowUUID: WindowUUID) {
+        guard let tabManager = tabManager(for: windowUUID) else { return }
         let recentTabs = tabManager.recentlyAccessedNormalTabs
         store.dispatch(
             TabManagerAction(
                 recentTabs: recentTabs,
-                windowUUID: action.windowUUID,
+                windowUUID: windowUUID,
                 actionType: TabManagerMiddlewareActionType.fetchedRecentTabs
             )
         )

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Common
 
+/// Within the app's Tabs Panel, visually there are three panels: private tabs, normal tabs, and synced tabs.
 enum TabTrayPanelType: Int, CaseIterable {
     case tabs
     case privateTabs

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabTrayPanelType.swift
@@ -10,6 +10,15 @@ enum TabTrayPanelType: Int, CaseIterable {
     case privateTabs
     case syncedTabs
 
+    var isPrivateMode: Bool {
+        switch self {
+        case .privateTabs:
+            return true
+        case .tabs, .syncedTabs:
+            return false
+        }
+    }
+
     var navTitle: String {
         switch self {
         case .tabs:

--- a/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsDisplayViewPanelType.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/State/TabsDisplayViewPanelType.swift
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// This enum is a subset of `TabTrayPanelType`. It is only possible for the user to manually create either `normal` or
+/// `private` tabs in the `TabsDisplayView`, not synced tabs.
+///
+/// Eventually it would be nice for `TabTrayPanelType` to inherit from `TabsDisplayViewPanelType`, but because of the
+/// `tabTrayUIExperiments` experiment, we can't alter the `TabTrayPanelType` rawValue indices right now.
+enum TabsDisplayViewPanelType {
+    case normal
+    case `private`
+
+    init?(fromTabTrayPanelType panelType: TabTrayPanelType) {
+        switch panelType {
+        case .tabs:
+            self = .normal
+        case .privateTabs:
+            self = .private
+        case .syncedTabs:
+            return nil
+        }
+    }
+
+    var modeForTelemetry: TabsPanelTelemetry.Mode {
+        switch self {
+        case .normal:
+            return .normal
+        case .private:
+            return .private
+        }
+    }
+}

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -170,9 +170,10 @@ final class TabDisplayView: UIView,
             scrollToTab(scrollState)
         }
 
-        if state.didTapAddTab {
+        // Users can only create tabs for normal and private tab panel types, but not synced tab panel type
+        if state.didTapAddTab, let type = TabsDisplayViewPanelType(fromTabTrayPanelType: panelType) {
             store.dispatch(
-                TabPanelViewModernAction.addNewTab(panelType),
+                TabPanelViewModernAction.addNewTab(ofType: type),
                 forWindowUUID: self.windowUUID
             )
         }

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabDisplayView.swift
@@ -171,10 +171,10 @@ final class TabDisplayView: UIView,
         }
 
         if state.didTapAddTab {
-            let action = TabPanelViewAction(panelType: self.panelType,
-                                            windowUUID: self.windowUUID,
-                                            actionType: TabPanelViewActionType.addNewTab)
-            store.dispatch(action)
+            store.dispatch(
+                TabPanelViewModernAction.addNewTab(panelType),
+                forWindowUUID: self.windowUUID
+            )
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -1053,10 +1053,10 @@ final class TabTrayViewController: UIViewController,
 
     @objc
     private func newTabButtonTapped() {
-        let action = TabPanelViewAction(panelType: tabTrayState.selectedPanel,
-                                        windowUUID: windowUUID,
-                                        actionType: TabPanelViewActionType.addNewTab)
-        store.dispatch(action)
+        store.dispatch(
+            TabPanelViewModernAction.addNewTab(tabTrayState.selectedPanel),
+            forWindowUUID: self.windowUUID
+        )
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -1053,8 +1053,9 @@ final class TabTrayViewController: UIViewController,
 
     @objc
     private func newTabButtonTapped() {
+        guard let type = TabsDisplayViewPanelType(fromTabTrayPanelType: tabTrayState.selectedPanel) else { return }
         store.dispatch(
-            TabPanelViewModernAction.addNewTab(tabTrayState.selectedPanel),
+            TabPanelViewModernAction.addNewTab(ofType: type),
             forWindowUUID: self.windowUUID
         )
     }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16769)
GitHub ticket hasn't synced yet

## :bulb: Description

First PR in a stack.

- No functionality changes
- Migrates the legacy `TabPanelViewActionType.addNewTab` struct and enum pair to `TabPanelViewModernAction.addNewTab enum`
- Adds a new `TabsDisplayViewPanelType`, which is a subset of `TabTrayPanelType`.
    - This allows us to harden code paths that use the action payload. It only makes sense to "add a new tab" when we're talking about normal and private tabs panels, not the synced tabs panel.

[ADR 12: Redux Action Guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/adr/0012-redux-action-guidelines.md) 

The last PR in this stack has new added test coverage (https://github.com/mozilla-mobile/firefox-ios/pull/35558). Just breaking this out into 4 PRs since I've had to add a lot of test utilities.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

