### PR TITLE
Refactor FXIOS-16769 [Technical Debt] [Redux] [Modern Action Migration] Add `MockTabsPanelTelemetry` and make `TabsPanelTelemetry` injectable into `TabsPanelMiddleware`

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2336,6 +2336,7 @@
 		EDDEB52D2D35C1A300517783 /* SiteType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDEB52C2D35C1A300517783 /* SiteType.swift */; };
 		EDDF340A2CDD159F008BB6A4 /* SearchEngineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */; };
 		EDDF340B2CDD1B7C008BB6A4 /* SearchEngineModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */; };
+		EDE77479304B4D250082408E /* MockTabsPanelTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE77478304B4D250082408E /* MockTabsPanelTelemetry.swift */; };
 		EDF2C0562D693A7300723609 /* AppIconSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF2C0552D693A7300723609 /* AppIconSetting.swift */; };
 		EDF2C0582D693B7D00723609 /* AppIconSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF2C0572D693B7C00723609 /* AppIconSelectionView.swift */; };
 		EDF2C05C2D6CDB6F00723609 /* AppIcons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EDF2C05B2D6CDB6F00723609 /* AppIcons.xcassets */; };
@@ -12128,6 +12129,7 @@
 		EDDC4F722F68697E00E0B8FA /* ModernKitOnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernKitOnboardingTests.swift; sourceTree = "<group>"; };
 		EDDEB52C2D35C1A300517783 /* SiteType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteType.swift; sourceTree = "<group>"; };
 		EDDF34092CDD159F008BB6A4 /* SearchEngineModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEngineModel.swift; sourceTree = "<group>"; };
+		EDE77478304B4D250082408E /* MockTabsPanelTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabsPanelTelemetry.swift; sourceTree = "<group>"; };
 		EDEE4CC7BD65892525632A4E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Today.strings; sourceTree = "<group>"; };
 		EDF2C0552D693A7300723609 /* AppIconSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconSetting.swift; sourceTree = "<group>"; };
 		EDF2C0572D693B7C00723609 /* AppIconSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconSelectionView.swift; sourceTree = "<group>"; };
@@ -13120,6 +13122,7 @@
 				21D8EA922ABE04F7003FF16E /* TabTrayViewControllerTests.swift */,
 				8A3EAFE42D5F9AA40060AB87 /* TabManagerMiddlewareTests.swift */,
 				A54F6A36304B02780040449A /* TabModelTests.swift */,
+				EDE77478304B4D250082408E /* MockTabsPanelTelemetry.swift */,
 			);
 			path = TabTray;
 			sourceTree = "<group>";
@@ -21025,6 +21028,7 @@
 				8AFC095B2FA54A240070CA11 /* TabManagerRestoreTabsTests.swift in Sources */,
 				B63BC8CF34524B98B781AE4D /* TranslationSettingsMiddlewareTests.swift in Sources */,
 				B63BC8D034524B98B781AE4E /* TranslationSettingsViewControllerTests.swift in Sources */,
+				EDE77479304B4D250082408E /* MockTabsPanelTelemetry.swift in Sources */,
 				B63BC8D134524B98B781AE4F /* TranslationPickerSettingsViewControllerTests.swift in Sources */,
 				8C3B0B8A2F72767000E2C370 /* TranslationLanguagePickerViewControllerTests.swift in Sources */,
 				8C5E7E932F6B3C3F00A3DD27 /* TranslationSettingsDiffableDataSourceTests.swift in Sources */,

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Middleware/TabManagerMiddleware.swift
@@ -22,7 +22,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
     private let bookmarksSaver: BookmarksSaver
     private let summarizerNimbusUtils: SummarizerNimbusUtils
     private let summarizerConfigFactory: SummarizerConfigFactory
-    private let tabsPanelTelemetry: TabsPanelTelemetry
+    private let tabsPanelTelemetry: TabsPanelTelemetryProtocol
     var bookmarksHandler: BookmarksHandler
 
     private var isTabTrayUIExperimentsEnabled: Bool {
@@ -45,7 +45,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
          summarizerNimbusUtility: SummarizerNimbusUtils = DefaultSummarizerNimbusUtils(),
          summarizerConfigFactory: SummarizerConfigFactory = SummarizerMiddleware(),
          bookmarksSaver: BookmarksSaver? = nil,
-         gleanWrapper: GleanWrapper = DefaultGleanWrapper()
+         tabsPanelTelemetry: TabsPanelTelemetryProtocol = TabsPanelTelemetry()
     ) {
         self.summarizerNimbusUtils = summarizerNimbusUtility
         self.summarizerConfigFactory = summarizerConfigFactory
@@ -54,7 +54,7 @@ final class TabManagerMiddleware: FeatureFlaggable, CanRemoveQuickActionBookmark
         self.logger = logger
         self.windowManager = windowManager
         self.bookmarksSaver = bookmarksSaver ?? DefaultBookmarksSaver(profile: profile)
-        self.tabsPanelTelemetry = TabsPanelTelemetry(gleanWrapper: gleanWrapper, logger: logger)
+        self.tabsPanelTelemetry = tabsPanelTelemetry
     }
 
     lazy var tabsPanelProvider: Middleware<AppState> = (legacyProvider, modernProvider)

--- a/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
+++ b/firefox-ios/Client/Telemetry/TabsPanelTelemetry.swift
@@ -6,7 +6,20 @@ import Foundation
 import Glean
 import Common
 
-struct TabsPanelTelemetry {
+protocol TabsPanelTelemetryProtocol {
+    typealias Mode = TabsPanelTelemetry.Mode
+    typealias CloseAllPanelOption = TabsPanelTelemetry.CloseAllPanelOption
+
+    func newTabButtonTapped(mode: Mode)
+    func tabModeSelected(mode: Mode)
+    func tabSelected(at index: Int?, mode: Mode)
+    func closeAllTabsSheetOptionSelected(option: CloseAllPanelOption, mode: Mode)
+    func tabClosed(mode: Mode)
+    func doneButtonTapped(mode: Mode)
+    func deleteNormalTabsSheetOptionSelected(period: TabsDeletionPeriod)
+}
+
+struct TabsPanelTelemetry: TabsPanelTelemetryProtocol {
     enum Mode: String {
         case normal
         case `private`

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/MockTabsPanelTelemetry.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/MockTabsPanelTelemetry.swift
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import Client
+
+class MockTabsPanelTelemetry: TabsPanelTelemetryProtocol {
+    var newTabButtonCalled: (callCount: Int, withMode: Mode?) = (0, nil)
+
+    func newTabButtonTapped(mode: Mode) {
+        newTabButtonCalled = (newTabButtonCalled.callCount + 1, mode)
+    }
+
+    func tabModeSelected(mode: Mode) {}
+    func tabSelected(at index: Int?, mode: Mode) {}
+    func closeAllTabsSheetOptionSelected(option: CloseAllPanelOption, mode: Mode) {}
+    func tabClosed(mode: Mode) {}
+    func doneButtonTapped(mode: Mode) {}
+    func deleteNormalTabsSheetOptionSelected(period: TabsDeletionPeriod) {}
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -5,32 +5,46 @@
 import Common
 import Redux
 import XCTest
+import TestKit
 
 @testable import Client
 
 final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
     private var mockProfile: MockProfile!
     private var mockWindowManager: MockWindowManager!
+    private var mockTabsPanelTelemetry: MockTabsPanelTelemetry!
     private var mockStore: MockStoreForMiddleware<AppState>!
     private var mockTabManager: MockTabManager!
-    private var summarizerConfigFactory: MockSummarizerConfigFactory!
+    private var mockSummarizerConfigFactory: MockSummarizerConfigFactory!
     private var appState: AppState!
     private let homepageURLString = "internal://local/about/home"
+    private var mockNimbusLayer: MockNimbusFeatureFlagLayer!
 
     @MainActor
     override func setUp() async throws {
         try await super.setUp()
         DependencyHelperMock().bootstrapDependencies()
+
         setIsHostedSummaryEnabled(false)
+        mockSummarizerConfigFactory = MockSummarizerConfigFactory()
+
         mockProfile = MockProfile()
-        summarizerConfigFactory = MockSummarizerConfigFactory()
+        mockNimbusLayer = MockNimbusFeatureFlagLayer()
         mockTabManager = MockTabManager()
         mockTabManager.recentlyAccessedNormalTabs = [createTab(profile: mockProfile)]
         mockWindowManager = MockWindowManager(
             wrappedManager: WindowManagerImplementation(),
             tabManager: mockTabManager
         )
-        DependencyHelperMock().bootstrapDependencies(injectedWindowManager: mockWindowManager)
+        mockTabsPanelTelemetry = MockTabsPanelTelemetry()
+
+        let featureFlagProvider = FeatureFlagsProvider(prefs: mockProfile.prefs, backendLayer: mockNimbusLayer)
+
+        DependencyHelperMock().bootstrapDependencies(
+            injectedWindowManager: mockWindowManager,
+            injectedFeatureFlagProvider: featureFlagProvider
+        )
+
         setupStore()
         appState = setupAppState()
     }
@@ -39,7 +53,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         mockProfile = nil
         mockWindowManager = nil
         mockTabManager = nil
-        summarizerConfigFactory = nil
+        mockSummarizerConfigFactory = nil
         DependencyHelperMock().reset()
         resetStore()
         try await super.tearDown()
@@ -68,6 +82,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, TabPanelMiddlewareActionType.refreshTabs)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_screenshotAction_returnsEarlyIfTabManagerDoesNotExistForWindow() {
@@ -88,6 +104,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.tabsPanelProvider.legacyMiddleware(appState, action)
         wait(for: [expectation], timeout: 0.1)
         XCTAssertTrue(mockWindowManager.windowsWereAccessed)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_screenshotRestoredAction_triggersRefresh_withoutSavingToDisk() throws {
@@ -118,6 +136,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             0,
             "screenshotRestored should not write the loaded image back to disk."
         )
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_prefetchScreenshotsAction_callsPreloadScreenshotForTab() {
@@ -138,6 +158,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
             mockTabManager.restoreScreenshotCalls.map { $0.tabUUID },
             [tabA.tabUUID]
         )
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_prefetchScreenshotsAction_skipsUnknownUUID() {
@@ -154,6 +176,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         XCTAssertTrue(mockTabManager.restoreScreenshotCalls.isEmpty)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Recent Tabs
@@ -180,6 +204,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_homepageAction_returnsRecentTabs() throws {
@@ -205,6 +231,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_tabTrayDismissAction_returnsRecentTabs() throws {
@@ -230,6 +258,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_tabTrayModalSwipedToCloseAction_returnsRecentTabs() throws {
@@ -255,6 +285,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_tabTrayDoneButtonTappedAction_returnsRecentTabs() throws {
@@ -280,6 +312,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_topTabsNewTabAction_returnsRecentTabs() throws {
@@ -305,6 +339,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_topTabsCloseTabAction_returnsRecentTabs() throws {
@@ -330,6 +366,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertEqual(actionType, TabManagerMiddlewareActionType.fetchedRecentTabs)
         XCTAssertEqual(actionCalled.recentTabs?.first?.tabState.title, "www.mozilla.org")
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_tapOnCell_fromJumpBackInAction_selectsCorrectTabs() {
@@ -352,6 +390,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let selectedTab = mockWindowManager.tabManager(for: .XCTestDefaultUUID)!.selectedTab
         XCTAssertEqual(selectedTab?.displayTitle, "www.mozilla.org")
         XCTAssertEqual(selectedTab?.url?.absoluteString, "www.mozilla.org")
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesMainMenuAction_withSummaryIsAvailableTrue() throws {
@@ -363,7 +403,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let tab = MockTab(profile: MockProfile(databasePrefix: ""), windowUUID: .XCTestDefaultUUID)
         tab.webView = MockTabWebView(tab: tab)
         mockTabManager?.selectedTab = tab
-        summarizerConfigFactory.returnedConfig = .defaultConfig
+        mockSummarizerConfigFactory.returnedConfig = .defaultConfig
 
         mockStore.dispatchCalled = { [weak self] in
             // requestTabInfo dispatches 2 actions, fulfill only when the second action is dispatched.
@@ -381,6 +421,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let action = try XCTUnwrap(mockStore.dispatchedActions[1] as? MainMenuAction)
         XCTAssertEqual(action.currentTabInfo?.summaryIsAvailable, true)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesMainMenuAction_withSummaryIsAvailableFalse_whenWebViewNil() throws {
@@ -406,6 +448,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let action = try XCTUnwrap(mockStore.dispatchedActions.first as? MainMenuAction)
         XCTAssertEqual(action.currentTabInfo?.summaryIsAvailable, false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesMainMenuAction_withSummaryIsAvailableFalse_whenSummarizeFeatureOff() throws {
@@ -430,6 +474,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let action = try XCTUnwrap(mockStore.dispatchedActions.first as? MainMenuAction)
         XCTAssertEqual(action.currentTabInfo?.summaryIsAvailable, false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_withSummaryIsAvailableFalse_whenSummarizeFeatureOn_andIsHomepage() throws {
@@ -454,6 +500,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         let action = try XCTUnwrap(mockStore.dispatchedActions.first as? MainMenuAction)
         XCTAssertEqual(action.currentTabInfo?.summaryIsAvailable, false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesMainMenuAction_withReaderModeIsEnabledFalse_byDefault() throws {
@@ -479,6 +527,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = try XCTUnwrap(mockStore.dispatchedActions.first as? MainMenuAction)
         XCTAssertEqual(action.currentTabInfo?.readerModeConfiguration.isAvailable, false)
         XCTAssertEqual(action.currentTabInfo?.readerModeConfiguration.isActive, false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesMainMenuAction_withReaderModeIsActive() throws {
@@ -505,6 +555,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let action = try XCTUnwrap(mockStore.dispatchedActions.first as? MainMenuAction)
         XCTAssertEqual(action.currentTabInfo?.readerModeConfiguration.isAvailable, true)
         XCTAssertEqual(action.currentTabInfo?.readerModeConfiguration.isActive, true)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testRequestTabInfo_dispatchesMainMenuAction_withAccountData() throws {
@@ -530,6 +582,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let accountData = try XCTUnwrap(action.currentTabInfo?.accountData)
         // With no signed-in account in the test environment, the menu shows the signed-out header.
         XCTAssertEqual(accountData.title, String.MainMenu.Account.SignedOutTitle)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_shortcutsLibraryAction_switchTabToastButtonPressed_selectsTab() throws {
@@ -545,6 +599,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let selectedTab = mockWindowManager.tabManager(for: .XCTestDefaultUUID)!.selectedTab
 
         XCTAssertEqual(selectedTab, tab)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_shortcutsLibraryAction_withNonSwitchTabActionType_doesNotSelectTab() throws {
@@ -560,6 +616,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let selectedTab = mockWindowManager.tabManager(for: .XCTestDefaultUUID)!.selectedTab
 
         XCTAssertNotEqual(selectedTab, tab)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_mainMenuAddToShortcutsAction_dispatchesShortcutPinnedTelemetryAction() throws {
@@ -579,6 +637,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(actionType, .shortcutPinned)
         XCTAssertEqual(dispatchedAction.shortcutPinnedSource, .appMenu)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_mainMenuAddToShortcutsAction_withoutTab_doesNotDispatchShortcutPinnedTelemetryAction() {
@@ -591,6 +651,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         XCTAssertTrue(mockStore.dispatchedActions.isEmpty)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_mainMenuRemoveFromShortcutsAction_dispatchesShortcutUnpinnedTelemetryAction() throws {
@@ -610,6 +672,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(actionType, .shortcutUnpinned)
         XCTAssertEqual(dispatchedAction.shortcutUnpinnedSource, .appMenu)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func test_mainMenuRemoveFromShortcutsAction_withoutTab_doesNotDispatchShortcutUnpinnedTelemetryAction() {
@@ -622,6 +686,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         subject.tabsPanelProvider.legacyMiddleware(appState, action)
 
         XCTAssertTrue(mockStore.dispatchedActions.isEmpty)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Tab Peek Actions
@@ -648,6 +714,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabPeekAction)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertTrue(actionCalled.tabPeekModel?.canTabBeSaved ?? false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesTabPeekDidLoadAction_NoBookmarks_withNilTab() throws {
@@ -674,6 +742,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         // Expected to fail because tab is nil
         XCTAssertFalse(actionCalled.tabPeekModel?.canTabBeSaved ?? false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesTabPeekDidLoadAction_NoBookmarks_URLToLong() throws {
@@ -703,6 +773,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabPeekAction)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertFalse(actionCalled.tabPeekModel?.canTabBeSaved ?? false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesTabPeekDidLoadAction_NoBookmarks_Homepage() throws {
@@ -728,6 +800,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabPeekAction)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertFalse(actionCalled.tabPeekModel?.canTabBeSaved ?? false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesTabPeekDidLoadAction_NoBookmarks_BlankURL() throws {
@@ -753,6 +827,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabPeekAction)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertFalse(actionCalled.tabPeekModel?.canTabBeSaved ?? false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesTabPeekDidLoadAction_CopyOption() throws {
@@ -778,6 +854,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabPeekAction)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertTrue(actionCalled.tabPeekModel?.canCopyURL ?? false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesTabPeekDidLoadAction_NoCopy_Homepage() throws {
@@ -803,6 +881,8 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabPeekAction)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertFalse(actionCalled.tabPeekModel?.canCopyURL ?? false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     func testTabPanelProvider_dispatchesTabPeekDidLoadAction_NoCopy_BlankURL() throws {
@@ -828,15 +908,33 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? TabPeekAction)
         XCTAssertEqual(mockStore.dispatchedActions.count, 1)
         XCTAssertFalse(actionCalled.tabPeekModel?.canCopyURL ?? false)
+
+        releaseMiddlewareProvidersFromMemory(subject)
     }
 
     // MARK: - Helpers
     private func createSubject() -> TabManagerMiddleware {
-        return TabManagerMiddleware(
+        let subject = TabManagerMiddleware(
             profile: mockProfile,
             windowManager: mockWindowManager,
-            summarizerConfigFactory: summarizerConfigFactory
+            summarizerConfigFactory: mockSummarizerConfigFactory,
+            tabsPanelTelemetry: mockTabsPanelTelemetry
         )
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+
+    /// Our middleware providers always retain a strong reference to `self` for ease of use. Thus, `trackForMemoryLeaks` will
+    /// fail in our unit tests due to a strong circular reference to the middleware retained by its provider closures. In
+    /// practice, this is not a memory leak issue, as we permanently allocate and retain our middleware providers for the
+    /// entire app lifecycle.
+    ///
+    /// As a work around for unit tests, we should release each middleware's provider closures from memory by assigning an
+    /// empty closure, which does not strongly retain `self`.
+    private func releaseMiddlewareProvidersFromMemory(_ subject: TabManagerMiddleware) {
+        subject.tabsPanelProvider = emptyMiddlewareProviderFactory()
+        subject.legacyProvider = emptyLegacyMiddlewareFactory()
+        subject.modernProvider = emptyMiddlewareFactory()
     }
 
     private func createTab(
@@ -881,5 +979,13 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
     func resetStore() {
         StoreTestUtilityHelper.resetStore()
+    }
+
+    private func setFeatureFlag(_ flag: FeatureFlagID, isEnabled: Bool) {
+        if isEnabled {
+            mockNimbusLayer.enabledFlags.insert(flag)
+        } else {
+            mockNimbusLayer.enabledFlags.remove(flag)
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16769)
GitHub ticket never synced

## :bulb: Description

This is part 2 of a set of stacked PRs. New unit tests to follow later ([PR 4 in stack](https://github.com/mozilla-mobile/firefox-ios/pull/35558)) after I've added all the test utilities I need to clean this area up. This `TabManagerMiddleware` tests will eventually need some feature flag branching and telemetry checks, hence adding those helpers.

- Make tabs panel telemetry injectable [as per Confluence glean testing guidelines](https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2485026853/Unit+Testing+Glean+Telemetry). 
- Add MockTabsPanelTelemetry type.
- Add proper checks for middleware memory leaks to existing `TabManagerMiddlewareTests`

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

