### PR TITLE
Refactor FXIOS-16769 [Technical Debt] Add `FeatureFlagTestUtility` to more easily follow wiki guidelines around feature flag testing

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -2343,6 +2343,7 @@
 		EDF567A02C8B51DC00FDB09D /* SiteImageView in Frameworks */ = {isa = PBXBuildFile; productRef = EDF5679F2C8B51DC00FDB09D /* SiteImageView */; };
 		EDF567A22C8B51E100FDB09D /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = EDF567A12C8B51E100FDB09D /* Kingfisher */; };
 		EDFC356E304B72840036079E /* TabsDisplayViewPanelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFC356D304B72840036079E /* TabsDisplayViewPanelType.swift */; };
+		EDFC3570304B77540036079E /* FeatureFlagTestUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFC356F304B77540036079E /* FeatureFlagTestUtility.swift */; };
 		EDFEE3F42DE670B8005ADE03 /* gleanProbes.xcfilelist in Resources */ = {isa = PBXBuildFile; fileRef = EDFEE3F32DE670B8005ADE03 /* gleanProbes.xcfilelist */; };
 		EE046A75300A75D7004E3D80 /* SwipeUpTabWebViewPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE046A74300A75D7004E3D80 /* SwipeUpTabWebViewPreviewTests.swift */; };
 		EE046A77300A75F4004E3D80 /* SwipeUpTabPreviewGestureHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE046A76300A75F4004E3D80 /* SwipeUpTabPreviewGestureHandlerTests.swift */; };
@@ -12135,6 +12136,7 @@
 		EDF2C0572D693B7C00723609 /* AppIconSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconSelectionView.swift; sourceTree = "<group>"; };
 		EDF2C05B2D6CDB6F00723609 /* AppIcons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AppIcons.xcassets; sourceTree = "<group>"; };
 		EDFC356D304B72840036079E /* TabsDisplayViewPanelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsDisplayViewPanelType.swift; sourceTree = "<group>"; };
+		EDFC356F304B77540036079E /* FeatureFlagTestUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTestUtility.swift; sourceTree = "<group>"; };
 		EDFEE3F32DE670B8005ADE03 /* gleanProbes.xcfilelist */ = {isa = PBXFileReference; lastKnownFileType = text.xcfilelist; path = gleanProbes.xcfilelist; sourceTree = "<group>"; };
 		EE046A74300A75D7004E3D80 /* SwipeUpTabWebViewPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeUpTabWebViewPreviewTests.swift; sourceTree = "<group>"; };
 		EE046A76300A75F4004E3D80 /* SwipeUpTabPreviewGestureHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeUpTabPreviewGestureHandlerTests.swift; sourceTree = "<group>"; };
@@ -14298,6 +14300,7 @@
 				8ACA8F7529198D6400D3075D /* MainThreadThrottlerTests.swift */,
 				C888A06C303F8325009A09E3 /* MainActorDebouncerTests.swift */,
 				8AA8389C2CA2FEFC003FA256 /* StoreTestUtility.swift */,
+				EDFC356F304B77540036079E /* FeatureFlagTestUtility.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -21127,6 +21130,7 @@
 				4D5041490000000000000004 /* FxAPairingURLParserTests.swift in Sources */,
 				C8EDDBF029DD83FC003A4C07 /* RouteTests.swift in Sources */,
 				0A7693612C7DD19600103A6D /* CertificatesViewModelTests.swift in Sources */,
+				EDFC3570304B77540036079E /* FeatureFlagTestUtility.swift in Sources */,
 				8A454D372CB86B86009436D9 /* MerinoStateTests.swift in Sources */,
 				ED70CD812CE3BD2C0018761B /* MockStoreForMiddleware.swift in Sources */,
 				8AED868328CA3B3400351A50 /* BookmarkPanelViewModelTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageDiffableDataSourceTests.swift
@@ -9,23 +9,21 @@ import MozillaAppServices
 @testable import Client
 
 @MainActor
-final class HomepageDiffableDataSourceTests: XCTestCase {
+final class HomepageDiffableDataSourceTests: XCTestCase, FeatureFlagTestUtility {
     var collectionView: UICollectionView?
     var diffableDataSource: HomepageDiffableDataSource?
-    private var profile: MockProfile!
-    private var mockNimbusLayer: MockNimbusFeatureFlagLayer!
+    internal var mockProfile: MockProfile!
+    internal var mockNimbusLayer: MockNimbusFeatureFlagLayer!
 
     override func setUp() async throws {
         try await super.setUp()
-        profile = MockProfile()
+        mockProfile = MockProfile()
         mockNimbusLayer = MockNimbusFeatureFlagLayer()
-        let featureFlagProvider = FeatureFlagsProvider(prefs: profile.prefs, backendLayer: mockNimbusLayer)
-        let userFeaturePreferences = UserFeaturePreferenceManager(prefs: profile.prefs, backendLayer: mockNimbusLayer)
 
         DependencyHelperMock().bootstrapDependencies(
-            injectedProfile: profile,
-            injectedFeatureFlagProvider: featureFlagProvider,
-            injectedUserFeaturePreferences: userFeaturePreferences
+            injectedProfile: mockProfile,
+            injectedFeatureFlagProvider: featureFlagsProviderFactory(),
+            injectedUserFeaturePreferences: userFeaturePreferenceManagerFactory()
         )
 
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -40,7 +38,7 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
     override func tearDown() async throws {
         diffableDataSource = nil
         collectionView = nil
-        profile = nil
+        mockProfile = nil
         mockNimbusLayer = nil
         DependencyHelperMock().reset()
         try await super.tearDown()
@@ -681,14 +679,6 @@ final class HomepageDiffableDataSourceTests: XCTestCase {
             layoutType: .compact,
             hasSyncedTab: false
         )
-    }
-
-    private func setFeatureFlag(_ flag: FeatureFlagID, isEnabled: Bool) {
-        if isEnabled {
-            mockNimbusLayer.enabledFlags.insert(flag)
-        } else {
-            mockNimbusLayer.enabledFlags.remove(flag)
-        }
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
@@ -7,27 +7,25 @@ import XCTest
 
 @testable import Client
 
-final class HomepageStateTests: XCTestCase {
-    private var profile: MockProfile!
-    private var mockNimbusLayer: MockNimbusFeatureFlagLayer!
+final class HomepageStateTests: XCTestCase, FeatureFlagTestUtility {
+    internal var mockProfile: MockProfile!
+    internal var mockNimbusLayer: MockNimbusFeatureFlagLayer!
 
     override func setUp() async throws {
         try await super.setUp()
-        profile = MockProfile()
+        mockProfile = MockProfile()
         mockNimbusLayer = MockNimbusFeatureFlagLayer()
-        let featureFlagProvider = FeatureFlagsProvider(prefs: profile.prefs, backendLayer: mockNimbusLayer)
-        let userFeaturePreferences = UserFeaturePreferenceManager(prefs: profile.prefs, backendLayer: mockNimbusLayer)
 
-        await DependencyHelperMock().bootstrapDependencies(
-            injectedProfile: profile,
-            injectedFeatureFlagProvider: featureFlagProvider,
-            injectedUserFeaturePreferences: userFeaturePreferences
+        DependencyHelperMock().bootstrapDependencies(
+            injectedProfile: mockProfile,
+            injectedFeatureFlagProvider: featureFlagsProviderFactory(),
+            injectedUserFeaturePreferences: userFeaturePreferenceManagerFactory()
         )
     }
 
     override func tearDown() async throws {
         DependencyHelperMock().reset()
-        profile = nil
+        mockProfile = nil
         mockNimbusLayer = nil
         try await super.tearDown()
     }
@@ -167,13 +165,5 @@ final class HomepageStateTests: XCTestCase {
 
     private func homepageReducer() -> Reducer<HomepageState> {
         return HomepageState.reducer
-    }
-
-    private func setFeatureFlag(_ flag: FeatureFlagID, isEnabled: Bool) {
-        if isEnabled {
-            mockNimbusLayer.enabledFlags.insert(flag)
-        } else {
-            mockNimbusLayer.enabledFlags.remove(flag)
-        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Settings/HomePageSettingViewControllerTests.swift
@@ -8,23 +8,21 @@ import Shared
 @testable import Client
 
 @MainActor
-final class HomePageSettingViewControllerTests: XCTestCase {
-    private var profile: MockProfile!
+final class HomePageSettingViewControllerTests: XCTestCase, FeatureFlagTestUtility {
+    internal var mockProfile: MockProfile!
+    internal var mockNimbusLayer: MockNimbusFeatureFlagLayer!
     private var wallpaperManager: WallpaperManagerMock!
     private var delegate: MockSettingsDelegate!
-    private var mockNimbusLayer: MockNimbusFeatureFlagLayer!
 
     override func setUp() async throws {
         try await super.setUp()
-        profile = MockProfile()
+        mockProfile = MockProfile()
         mockNimbusLayer = MockNimbusFeatureFlagLayer()
-        let featureFlagProvider = FeatureFlagsProvider(prefs: profile.prefs, backendLayer: mockNimbusLayer)
-        let userFeaturePreferences = UserFeaturePreferenceManager(prefs: profile.prefs, backendLayer: mockNimbusLayer)
 
         DependencyHelperMock().bootstrapDependencies(
-            injectedProfile: profile,
-            injectedFeatureFlagProvider: featureFlagProvider,
-            injectedUserFeaturePreferences: userFeaturePreferences
+            injectedProfile: mockProfile,
+            injectedFeatureFlagProvider: featureFlagsProviderFactory(),
+            injectedUserFeaturePreferences: userFeaturePreferenceManagerFactory()
         )
 
         delegate = MockSettingsDelegate()
@@ -33,7 +31,7 @@ final class HomePageSettingViewControllerTests: XCTestCase {
 
     override func tearDown() async throws {
         DependencyHelperMock().reset()
-        profile = nil
+        mockProfile = nil
         delegate = nil
         wallpaperManager = nil
         mockNimbusLayer = nil
@@ -48,7 +46,7 @@ final class HomePageSettingViewControllerTests: XCTestCase {
 
     func testHomepageSettings_generateSettings_jumpBackInSectionDefaultValue_isFalse() throws {
         let subject = createSubject()
-        subject.profile = profile
+        subject.profile = mockProfile
 
         let settingsList = subject.generateSettings()
 
@@ -69,7 +67,7 @@ final class HomePageSettingViewControllerTests: XCTestCase {
 
     func testHomepageSettings_generateSettings_bookmarksSectionDefaultValue_isFalse() throws {
         let subject = createSubject()
-        subject.profile = profile
+        subject.profile = mockProfile
 
         let settingsList = subject.generateSettings()
 
@@ -90,7 +88,7 @@ final class HomePageSettingViewControllerTests: XCTestCase {
 
     func testHomepageSettings_generateSettings_trackerBlockerModule_whenFeatureDisabled_isHidden() throws {
         let subject = createSubject()
-        subject.profile = profile
+        subject.profile = mockProfile
 
         let settingsList = subject.generateSettings()
 
@@ -110,7 +108,7 @@ final class HomePageSettingViewControllerTests: XCTestCase {
     func testHomepageSettings_generateSettings_trackerBlockerModule_whenFeatureEnabledDefaultValue_isTrue() throws {
         setFeatureFlag(.homepageTrackerBlockerModule, isEnabled: true)
         let subject = createSubject()
-        subject.profile = profile
+        subject.profile = mockProfile
 
         let settingsList = subject.generateSettings()
 
@@ -129,17 +127,10 @@ final class HomePageSettingViewControllerTests: XCTestCase {
         XCTAssertTrue(trackerBlockerModuleSettingValue)
     }
 
-    // MARK: - Helper
-    private func setFeatureFlag(_ flag: FeatureFlagID, isEnabled: Bool) {
-        if isEnabled {
-            mockNimbusLayer.enabledFlags.insert(flag)
-        } else {
-            mockNimbusLayer.enabledFlags.remove(flag)
-        }
-    }
+    // MARK: - Helpers
 
     private func createSubject() -> HomePageSettingViewController {
-        let subject = HomePageSettingViewController(prefs: profile.prefs,
+        let subject = HomePageSettingViewController(prefs: mockProfile.prefs,
                                                     wallpaperManager: wallpaperManager,
                                                     settingsDelegate: delegate,
                                                     tabManager: MockTabManager())

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -9,8 +9,9 @@ import TestKit
 
 @testable import Client
 
-final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
-    private var mockProfile: MockProfile!
+final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility, FeatureFlagTestUtility {
+    internal var mockProfile: MockProfile!
+    internal var mockNimbusLayer: MockNimbusFeatureFlagLayer!
     private var mockWindowManager: MockWindowManager!
     private var mockTabsPanelTelemetry: MockTabsPanelTelemetry!
     private var mockStore: MockStoreForMiddleware<AppState>!
@@ -18,7 +19,6 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
     private var mockSummarizerConfigFactory: MockSummarizerConfigFactory!
     private var appState: AppState!
     private let homepageURLString = "internal://local/about/home"
-    private var mockNimbusLayer: MockNimbusFeatureFlagLayer!
 
     @MainActor
     override func setUp() async throws {
@@ -38,11 +38,9 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
         )
         mockTabsPanelTelemetry = MockTabsPanelTelemetry()
 
-        let featureFlagProvider = FeatureFlagsProvider(prefs: mockProfile.prefs, backendLayer: mockNimbusLayer)
-
         DependencyHelperMock().bootstrapDependencies(
             injectedWindowManager: mockWindowManager,
-            injectedFeatureFlagProvider: featureFlagProvider
+            injectedFeatureFlagProvider: featureFlagsProviderFactory()
         )
 
         setupStore()
@@ -979,13 +977,5 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility {
 
     func resetStore() {
         StoreTestUtilityHelper.resetStore()
-    }
-
-    private func setFeatureFlag(_ flag: FeatureFlagID, isEnabled: Bool) {
-        if isEnabled {
-            mockNimbusLayer.enabledFlags.insert(flag)
-        } else {
-            mockNimbusLayer.enabledFlags.remove(flag)
-        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/FeatureFlagTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/FeatureFlagTestUtility.swift
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+
+@testable import Client
+
+@MainActor
+protocol FeatureFlagTestUtility {
+    var mockProfile: MockProfile! { get }
+    var mockNimbusLayer: MockNimbusFeatureFlagLayer! { get }
+}
+
+extension FeatureFlagTestUtility {
+    func featureFlagsProviderFactory() -> FeatureFlagsProvider {
+        return FeatureFlagsProvider(
+            prefs: mockProfile.prefs,
+            backendLayer: mockNimbusLayer
+        )
+    }
+
+    func userFeaturePreferenceManagerFactory() -> UserFeaturePreferenceManager {
+        return UserFeaturePreferenceManager(
+            prefs: mockProfile.prefs,
+            backendLayer: mockNimbusLayer
+        )
+    }
+
+    /// Sets whether a given feature is enabled or disabled for unit tests.
+    func setFeatureFlag(_ flag: FeatureFlagID, isEnabled: Bool) {
+        if isEnabled {
+            mockNimbusLayer.enabledFlags.insert(flag)
+        } else {
+            mockNimbusLayer.enabledFlags.remove(flag)
+        }
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Utils/StoreTestUtility.swift
@@ -4,8 +4,9 @@
 
 import Foundation
 import Redux
-@testable import Client
 import XCTest
+
+@testable import Client
 
 @MainActor
 protocol StoreTestUtility {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16769)
GitHub ticket never synced

## :bulb: Description

This is part 3 of a set of stacked PRs. 

- Add `FeatureFlagTestUtility` to more easily follow [wiki guidelines around feature flag testing](https://github.com/mozilla-mobile/firefox-ios/wiki/Feature-Flags#injecting-via-dependencyhelpermock). 
- Add extension helper methods to avoid code duplication across unit test files.
- Update call sites to use new utility.
- Make mockProfile naming consistent.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

