### PR TITLE
Refactor FXIOS-16769 [Technical Debt] [Redux] [Modern Action Migration] Add new unit tests for `TabManagerMiddleware` `.addNewTab` Redux action

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -19,6 +19,7 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility, FeatureFlag
     private var mockSummarizerConfigFactory: MockSummarizerConfigFactory!
     private var appState: AppState!
     private let homepageURLString = "internal://local/about/home"
+    private var mockNimbusLayer: MockNimbusFeatureFlagLayer!
 
     @MainActor
     override func setUp() async throws {
@@ -977,5 +978,13 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility, FeatureFlag
 
     func resetStore() {
         StoreTestUtilityHelper.resetStore()
+    }
+
+    private func setFeatureFlag(_ flag: FeatureFlagID, isEnabled: Bool) {
+        if isEnabled {
+            mockNimbusLayer.enabledFlags.insert(flag)
+        } else {
+            mockNimbusLayer.enabledFlags.remove(flag)
+        }
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -910,6 +910,140 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility, FeatureFlag
         releaseMiddlewareProvidersFromMemory(subject)
     }
 
+    // MARK: Test addNewTab action
+
+    func testAddNewTab_callsAddNewTabTelemetry_forNormalTabs() {
+        let addNewTabAction = TabPanelViewModernAction.addNewTab(ofType: .normal)
+        let subject = createSubject()
+
+        subject.modernProvider(appState, addNewTabAction, .XCTestDefaultUUID)
+
+        XCTAssertEqual(mockTabsPanelTelemetry.newTabButtonCalled.callCount, 1)
+        XCTAssertEqual(mockTabsPanelTelemetry.newTabButtonCalled.withMode, TabsPanelTelemetry.Mode.normal)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func testAddNewTab_callsAddNewTabTelemetry_forPrivateTabs() {
+        let addNewTabAction = TabPanelViewModernAction.addNewTab(ofType: .private)
+        let subject = createSubject()
+
+        subject.modernProvider(appState, addNewTabAction, .XCTestDefaultUUID)
+
+        XCTAssertEqual(mockTabsPanelTelemetry.newTabButtonCalled.callCount, 1)
+        XCTAssertEqual(mockTabsPanelTelemetry.newTabButtonCalled.withMode, TabsPanelTelemetry.Mode.private)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func testAddNewTab_addsNewNormalTab_andSelectsNewNormalTab() throws {
+        let mockTabManager = try XCTUnwrap(mockWindowManager.tabManager(for: .XCTestDefaultUUID) as? MockTabManager)
+        let addNewTabAction = TabPanelViewModernAction.addNewTab(ofType: .normal)
+        let expectation = XCTestExpectation(description: "Tab should be selected")
+        mockTabManager.selectTabExpectation = expectation
+
+        let subject = createSubject()
+
+        XCTAssertEqual(mockTabManager.tabs.count, 0)
+        XCTAssertNil(mockTabManager.selectedTab)
+
+        subject.modernProvider(appState, addNewTabAction, .XCTestDefaultUUID)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(mockTabManager.addTabWasCalled)
+        XCTAssertEqual(mockTabManager.lastSelectedTabs.count, 1)
+        XCTAssertEqual(mockTabManager.lastSelectedTabs.first?.isNormal, true)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func testAddNewTab_addsNewPrivateTab_andSelectsNewPrivateTab() throws {
+        let mockTabManager = try XCTUnwrap(mockWindowManager.tabManager(for: .XCTestDefaultUUID) as? MockTabManager)
+        let addNewTabAction = TabPanelViewModernAction.addNewTab(ofType: .private)
+        let expectation = XCTestExpectation(description: "Tab should be selected")
+        mockTabManager.selectTabExpectation = expectation
+
+        let subject = createSubject()
+
+        XCTAssertEqual(mockTabManager.tabs.count, 0)
+        XCTAssertNil(mockTabManager.selectedTab)
+
+        subject.modernProvider(appState, addNewTabAction, .XCTestDefaultUUID)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(mockTabManager.addTabWasCalled)
+        XCTAssertEqual(mockTabManager.lastSelectedTabs.count, 1)
+        XCTAssertEqual(mockTabManager.lastSelectedTabs.first?.isPrivate, true)
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func testAddNewTab_dispatchesDismissTabTrayAction() throws {
+        let addNewTabAction = TabPanelViewModernAction.addNewTab(ofType: .private)
+        let subject = createSubject()
+        let expectation = XCTestExpectation(description: "General browser action is dispatched")
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.modernProvider(appState, addNewTabAction, .XCTestDefaultUUID)
+        wait(for: [expectation])
+
+        _ = try XCTUnwrap(
+            mockStore.dispatchedActions.first(where: {
+                ($0.actionType as? TabTrayActionType) == .dismissTabTray
+            })
+        )
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func testAddNewTab_doesNotDispatchShowOverlayAction_whenTabTrayUIExperimentsEnabled() {
+        setFeatureFlag(.tabTrayUIExperiments, isEnabled: true)
+
+        let addNewTabAction = TabPanelViewModernAction.addNewTab(ofType: .private)
+        let subject = createSubject()
+        let expectation = XCTestExpectation(description: "showOverlay action dispatched")
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.modernProvider(appState, addNewTabAction, .XCTestDefaultUUID)
+        wait(for: [expectation])
+
+        XCTAssertNil(
+            mockStore.dispatchedActions.first(where: {
+                ($0.actionType as? GeneralBrowserActionType) == .showOverlay
+            })
+        )
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
+    func testAddNewTab_dispatchShowOverlayAction_whenTabTrayUIExperimentsDisabled() throws {
+        setFeatureFlag(.tabTrayUIExperiments, isEnabled: false)
+
+        let addNewTabAction = TabPanelViewModernAction.addNewTab(ofType: .private)
+        let subject = createSubject()
+        let expectation = XCTestExpectation(description: "showOverlay action dispatched")
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.modernProvider(appState, addNewTabAction, .XCTestDefaultUUID)
+        wait(for: [expectation])
+
+        _ = try XCTUnwrap(
+            mockStore.dispatchedActions.first(where: {
+                ($0.actionType as? GeneralBrowserActionType) == .showOverlay
+            })
+        )
+
+        releaseMiddlewareProvidersFromMemory(subject)
+    }
+
     // MARK: - Helpers
     private func createSubject() -> TabManagerMiddleware {
         let subject = TabManagerMiddleware(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabManagerMiddlewareTests.swift
@@ -19,7 +19,6 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility, FeatureFlag
     private var mockSummarizerConfigFactory: MockSummarizerConfigFactory!
     private var appState: AppState!
     private let homepageURLString = "internal://local/about/home"
-    private var mockNimbusLayer: MockNimbusFeatureFlagLayer!
 
     @MainActor
     override func setUp() async throws {
@@ -978,13 +977,5 @@ final class TabManagerMiddlewareTests: XCTestCase, StoreTestUtility, FeatureFlag
 
     func resetStore() {
         StoreTestUtilityHelper.resetStore()
-    }
-
-    private func setFeatureFlag(_ flag: FeatureFlagID, isEnabled: Bool) {
-        if isEnabled {
-            mockNimbusLayer.enabledFlags.insert(flag)
-        } else {
-            mockNimbusLayer.enabledFlags.remove(flag)
-        }
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16769)
 GitHub ticket hasn't synced yet

## :bulb: Description
This PR is the last in the stack.

It adds unit tests which were missing for the addNewTab action which was migrated in the first PR of the stack: https://github.com/mozilla-mobile/firefox-ios/pull/35553

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

