### PR TITLE
[MTE-6147] - Fix address bar context menu selectors and iPad MDN sear…

### DIFF
--- a/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+++ b/firefox-ios/Client/Application/AccessibilityIdentifiers.swift
@@ -918,6 +918,7 @@ struct AccessibilityIdentifiers {
         static let tableView = "Context Menu"
         static let pasteAction = "pasteAction"
         static let pasteAndGoAction = "pasteAndGoAction"
+        static let copyAddressAction = "copyAddressAction"
     }
 
     struct Alert {

--- a/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -67,13 +67,15 @@ extension PhotonActionSheetProtocol {
 
         let copyAddressAction = SingleActionViewModel(
             title: .CopyAddressTitle,
-            iconString: StandardImageIdentifiers.Large.link
-        ) { [tabManager] _ in
-            let currentURL = tabManager.selectedTab?.currentURL()
-            if let url = tabManager.selectedTab?.canonicalURL?.displayURL ?? currentURL {
-                UIPasteboard.general.url = url
-            }
-        }
+            iconString: StandardImageIdentifiers.Large.link,
+            tapHandler: { [tabManager] _ in
+                let currentURL = tabManager.selectedTab?.currentURL()
+                if let url = tabManager.selectedTab?.canonicalURL?.displayURL ?? currentURL {
+                    UIPasteboard.general.url = url
+                }
+            },
+            accessibilityId: AccessibilityIdentifiers.Photon.copyAddressAction
+        )
 
         var actionItems: [PhotonRowActions] = []
         if UIPasteboard.general.hasStrings {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DragAndDropTests.swift
@@ -294,7 +294,7 @@ class DragAndDropTestIpad: IpadOnlyTestCase {
 
         navigator.openURL("developer.mozilla.org/en-US")
         waitUntilPageLoad()
-        let searchField = app.webViews["Web content"].searchFields.firstMatch
+        let searchField = app.webViews["Web content"].textFields.firstMatch
         app.webViews["Web content"].buttons["Search"].waitAndTap()
 
         // DragAndDrop the url for only one second so that the TP menu is not shown and the search box is not covered

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NavigationTest.swift
@@ -39,6 +39,7 @@ class NavigationTest: FeatureFlaggedTestSuite {
     override func setUp() async throws {
         try await super.setUp()
 
+        browserScreen = BrowserScreen(app: app)
         launchApp()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/BrowserSelectors.swift
@@ -74,9 +74,7 @@ struct BrowserSelectors: BrowserSelectorsSet {
         static let addressBarContextMenu = AccessibilityIdentifiers.Photon.tableView
         static let contextMenuPasteAndGo = AccessibilityIdentifiers.Photon.pasteAndGoAction
         static let contextMenuPaste = AccessibilityIdentifiers.Photon.pasteAction
-        // "Copy Address" (String.CopyAddressTitle) carries no accessibility identifier, so it is
-        // matched by its title.
-        static let contextMenuCopyAddress = "Copy Address"
+        static let contextMenuCopyAddress = AccessibilityIdentifiers.Photon.copyAddressAction
         static let contextMenuCloseButton = AccessibilityIdentifiers.Photon.closeButton
     }
 
@@ -258,19 +256,19 @@ struct BrowserSelectors: BrowserSelectorsSet {
         groups: ["browser", "addressBarContextMenu"]
     )
 
-    let CONTEXT_MENU_PASTE_AND_GO = Selector.tableCellById(
+    let CONTEXT_MENU_PASTE_AND_GO = Selector.tableCellButtonById(
         IDs.contextMenuPasteAndGo,
         description: "'Paste & Go' option in the address bar long press menu",
         groups: ["browser", "addressBarContextMenu"]
     )
 
-    let CONTEXT_MENU_PASTE = Selector.tableCellById(
+    let CONTEXT_MENU_PASTE = Selector.tableCellButtonById(
         IDs.contextMenuPaste,
         description: "'Paste' option in the address bar long press menu",
         groups: ["browser", "addressBarContextMenu"]
     )
 
-    let CONTEXT_MENU_COPY_ADDRESS = Selector.staticTextInTablesByLabel(
+    let CONTEXT_MENU_COPY_ADDRESS = Selector.tableCellButtonById(
         IDs.contextMenuCopyAddress,
         description: "'Copy Address' option in the address bar long press menu",
         groups: ["browser", "addressBarContextMenu"]


### PR DESCRIPTION
…ch field

## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-6147

## :bulb: Description
Fixes three failing XCUITests. Both causes were test-side — no product bugs were found.

**Address bar long-press menu (3 selectors, follow-up to #35525).** The menu rows were being
looked up as text labels and table cells, but they show up in the accessibility tree as
buttons, so the lookups could never match. Updated all three to query buttons.

While there, `Copy Address` was the only option in that menu without an accessibility
identifier, so the test had to match it by its icon name. Two production files change to fix
that, and they are the only production changes in the PR:

- `AccessibilityIdentifiers.swift` — adds a `Photon.copyAddressAction` identifier, alongside
  the existing `pasteAction` and `pasteAndGoAction`.
- `PhotonActionSheetProtocol.swift` — attaches that identifier to the `Copy Address` menu
  action in `getLongPressLocationBarActions`. Its tap handler also had to move from a trailing
  closure to a named `tapHandler:` argument, because the identifier parameter comes after it in
  `SingleActionViewModel`'s initialiser. The handler's logic is unchanged — only its position
  and indentation.

`testLongPressOnAddressBar` was also crashing rather than failing,
declared a screen object it never created. Fixed by creating it in `setUp`.

**iPad drag-and-drop test.** `testDragAddressBarIntoSearchBox` drops the URL into a search box
on developer.mozilla.org. MDN redesigned that page, and its search
different element type, so the test couldn't find it. One-word fix. With it passing again, the
drag assertion confirms iPad drag-and-drop is working — the broken lookup had been hiding that.

