### PR TITLE
[MTE-6145] - fixes on iOS 16 automation

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuMainView.swift
+++ b/BrowserKit/Sources/MenuKit/MenuMainView.swift
@@ -131,9 +131,12 @@ public final class MenuMainView: UIView, ThemeApplicable {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             UIAccessibility.post(notification: .announcement, argument: expandedHint)
 
-            guard let section = self?.menuData.first,
+            // The index is an index into the section options, so it has to be resolved against the
+            // table rows. Indexing `visibleCells` with it traps whenever fewer cells fit on screen.
+            guard let self,
+               let section = menuData.first,
                let optionalElementIndex = section.options.firstIndex(where: { $0.isOptional }),
-               let firstCell = self?.tableView.tableView.visibleCells[optionalElementIndex]
+               let firstCell = tableView.tableView.cellForRow(at: IndexPath(row: optionalElementIndex, section: 0))
             else { return }
 
             UIAccessibility.post(notification: .layoutChanged, argument: firstCell)

--- a/BrowserKit/Tests/MenuKitTests/MenuMainViewTests.swift
+++ b/BrowserKit/Tests/MenuKitTests/MenuMainViewTests.swift
@@ -100,6 +100,33 @@ final class MenuMainViewTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testAnnounceAccessibility_whenOptionalRowIsNotVisible() {
+        menuView.frame = CGRect(x: 0, y: 0, width: 375, height: 100)
+        let options = (0..<10).map { menuElement(a11yId: "option\($0)", isOptional: $0 == 9) }
+        menuView.reloadDataView(with: [MenuSection(isExpanded: true, isHomepage: false, options: options)])
+        menuView.layoutIfNeeded()
+
+        let expectation = XCTestExpectation(description: "Announcement completes without trapping")
+        menuView.announceAccessibility(expandedHint: "expanded")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { expectation.fulfill() }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    private func menuElement(a11yId: String, isOptional: Bool) -> MenuElement {
+        MenuElement(
+            title: a11yId,
+            iconName: "",
+            isEnabled: true,
+            isActive: false,
+            a11yLabel: a11yId,
+            a11yHint: "",
+            a11yId: a11yId,
+            isOptional: isOptional,
+            action: nil
+        )
+    }
+
     private func setupDetails(isBrowserDefault: Bool, bannerShown: Bool) {
         menuView.setupDetails(
             title: "",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/AIControlsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/AIControlsScreen.swift
@@ -71,11 +71,13 @@ final class AIControlsScreen {
 
     // MARK: - Helpers
 
+    /// The matched element spans the whole row, label included. Tapping its centre lands on the label,
+    /// which iOS 16 ignores, so the nested switch control is tapped instead.
     private func setToggle(_ toggle: XCUIElement, on: Bool) {
         BaseTestCase().mozWaitForElementToExist(toggle)
-        if (toggle.value as? String) != (on ? "1" : "0") {
-            toggle.waitAndTap()
-        }
+        guard (toggle.value as? String) != (on ? "1" : "0") else { return }
+        let control = toggle.switches.firstMatch
+        (control.exists ? control : toggle).waitAndTap()
     }
 
     private func assertToggle(_ toggle: XCUIElement, isOn: Bool, name: String) {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
@@ -185,9 +185,7 @@ private func createTestGraph(for test: XCTestCase, with app: XCUIApplication) ->
         screenState.tap(app.tables.cells["Settings"], to: SettingsScreen)
 
         // More Options
-        screenState.tap(
-            app.tables.cells["MainMenu.MoreLess"],
-            to: BrowserTabMenuMore)
+        screenState.gesture(to: BrowserTabMenuMore) { expandTabMenuIfNeeded(in: app) }
 
         screenState.backAction = {
             if isTablet {

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabMenuNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabMenuNavigation.swift
@@ -5,6 +5,21 @@
 import XCTest
 import MappaMundi
 
+/// Taps the main menu's More row to reveal the expanded options. The menu keeps its expanded state
+/// between presentations on iOS 16, where the row is absent because the options are already shown.
+@MainActor
+func expandTabMenuIfNeeded(in app: XCUIApplication) {
+    let moreLess = app.tables.cells[AccessibilityIdentifiers.MainMenu.moreLess]
+    let expandedRow = app.tables.cells[AccessibilityIdentifiers.MainMenu.addToShortcuts]
+    let deadline = Date().addingTimeInterval(TIMEOUT)
+    while !moreLess.exists, !expandedRow.exists, Date() < deadline {
+        usleep(10000)
+    }
+    if moreLess.exists {
+        moreLess.tap()
+    }
+}
+
 @MainActor
 func registerTabMenuNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIApplication) {
     map.addScreenState(BrowserTabMenuMore) { screenState in
@@ -45,8 +60,7 @@ func registerTabMenuNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIAppl
             app.tables.cells.buttons[AccessibilityIdentifiers.MainMenu.downloads], to: LibraryPanel_Downloads
         )
         // More Options
-        screenState.tap(
-            app.tables.cells["MainMenu.MoreLess"], to: BrowserTabMenuMore)
+        screenState.gesture(to: BrowserTabMenuMore) { expandTabMenuIfNeeded(in: app) }
         // Tracking Protections
         screenState.tap(
             app.buttons["Protections are ON"], to: EnhancedTrackingProtection)


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-6145

## :bulb: Description
Addresses failures from the iOS 16.4 CI report

Investigating them surfaced one real product crash, which is fixed here too.

### Product fix: out-of-range crash in `MenuMainView.announceAccessibility`

`MenuMainView.swift` subscripted `tableView.visibleCells` with an index derived from the section's
options array:

```swift
let optionalElementIndex = section.options.firstIndex(where: { $0.isOptional })
let firstCell = self?.tableView.tableView.visibleCells[optionalElementIndex]
```

`visibleCells` only contains the cells currently on screen, so the two collections don't line up.
Whenever fewer cells were visible than the optional element's position in the data, this trapped
with an index-out-of-range — and even when it didn't crash, it posted the accessibility
`layoutChanged` notification against the wrong cell. Replaced with
`cellForRow(at: IndexPath(row: optionalElementIndex, section: 0))`, which resolves the index against
the table's rows and returns `nil` (handled by the existing `guard`) when the row isn't realised.
Also collapsed the repeated `self?` into a single `guard let self`.

`MenuMainViewTests.swift` adds `testAnnounceAccessibility_whenOptionalRowIsNotVisible`, which pins
the view to a 100pt height and supplies 10 options with the optional one last, so the target row is
off-screen — the exact condition that used to crash.

### Automation fix: SwiftUI toggle rows aren't tappable at their centre on iOS 16

`AIControlsScreen.setToggle` tapped the matched element directly. That element spans the whole row,
so the tap lands on the label text rather than the control. iOS 18.6 and 26.5 toggle anyway; iOS 16.4
silently ignores it, and the test then failed further down on a stale value instead of at the tap —
which made it look like a product bug. `setToggle` now taps the nested switch
(`toggle.switches.firstMatch`), falling back to the row if that isn't present, and returns early when
the toggle is already in the requested state.

### Automation fix: the main menu reopens already expanded on iOS 16

Any screengraph edge that unconditionally taps `MainMenu.MoreLess` to reach `BrowserTabMenuMore`
dies on iOS 16 with `Cannot get from BrowserTabMenu to BrowserTabMenuMore`, because that row isn't
there — the menu reopens with the expanded options already showing. The underlying product cause is
that `moreCellTapped` is only reset when `MainMenuViewController.deinit` runs
`unsubscribeFromRedux()`, and on iOS 16 the view controller isn't deallocated before the next
presentation. A separate product ticket is being filed for that inconsistency; this PR only makes
the automation tolerant of it.

`registerTabMenuNavigation.swift` replaces the unconditional tap with a gesture calling a new shared
`expandTabMenuIfNeeded(in:)`, which waits for either the More row or an already-expanded row and taps
More only when it exists. `ScreenGraphTest.swift` defines the same edge in its own local graph, so it
now delegates to the same helper. The hardcoded `"MainMenu.MoreLess"` string is replaced by the
identifier constant.

Full sweep of the affected tests — the 3 `AIControlsTests` plus `testShortcutsToggle`,
`testShortcutsRows`, `testNightModeUI`, `testValidatePrintOption`, `testSimpleToggleAction`:

| Runtime | Device | Result |
| - | - | - |
| iOS 16.4 | iPhone 14 Pro | 8/8 |
| iOS 18.6 | iPhone 16 | 8/8 |
| iOS 26.5 | iPhone 17 | 8/8 |
| MenuKitTests | — | 24/24 |