### PR TITLE
Add FXIOS-16774 [WebCompat] Send the ad blocker state in the broken-site-report ping

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportDataCollector.swift
@@ -43,6 +43,16 @@ struct WebCompatExperimentsProvider: WebCompatExperimentsProviding {
     }
 }
 
+protocol WebCompatAdBlockerStateProviding {
+    func isAdBlockerEnabled(prefs: Prefs) -> Bool
+}
+
+struct WebCompatAdBlockerStateProvider: WebCompatAdBlockerStateProviding, FeatureFlaggable {
+    func isAdBlockerEnabled(prefs: Prefs) -> Bool {
+        return featureFlagsProvider.isEnabled(.adBlocker) && (prefs.boolForKey(PrefsKeys.BlockAds) ?? false)
+    }
+}
+
 /// Tab inputs as a plain value, so tests don't need a live `Tab`/`WKWebView`. Nil
 /// `blockingStrength` means no content blocker; `blockedOrigins` is nil once the user unchecks Additional Info.
 struct WebCompatTabSnapshot: Equatable {
@@ -64,14 +74,18 @@ enum WebCompatReportDataCollector {
         includeBlockedList: Bool,
         includeTabSpecificInfo: Bool = true,
         device: WebCompatDeviceInfoProviding = WebCompatDeviceInfoProvider(),
-        experiments: WebCompatExperimentsProviding = WebCompatExperimentsProvider()
+        experiments: WebCompatExperimentsProviding = WebCompatExperimentsProvider(),
+        adBlockerState: WebCompatAdBlockerStateProviding = WebCompatAdBlockerStateProvider()
     ) -> WebCompatReportPayload {
         let snapshot = makeSnapshot(
             from: tab,
             includeBlockedList: includeBlockedList,
             includeTabSpecificInfo: includeTabSpecificInfo
         )
-        return enrich(payload, device: device, tab: snapshot, experiments: experiments)
+        var payload = enrich(payload, device: device, tab: snapshot, experiments: experiments)
+        // An app-wide pref, so it is read from the profile rather than the tab's content blocker.
+        payload.adBlockerEnabled = adBlockerState.isAdBlockerEnabled(prefs: tab.profile.prefs)
+        return payload
     }
 
     /// Pure mapping: no UIKit, no `Tab`, so tests can drive it with fakes.

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportPayload.swift
@@ -62,6 +62,8 @@ struct WebCompatReportPayload: Equatable {
     var mobify: Bool?
     // broken_site_report.browser_info
     var experiments: [WebCompatExperiment]?
+    // broken_site_report.browser_info.prefs
+    var adBlockerEnabled: Bool?
     // broken_site_report.browser_info.app
     var defaultLocales: [String]?
     var defaultUserAgentString: String?
@@ -99,6 +101,7 @@ struct WebCompatReportPayload: Equatable {
             case marfeel
             case mobify
             case experiments
+            case adBlockerEnabled
             case defaultLocales
             case defaultUseragentString
             case isTablet
@@ -118,6 +121,7 @@ struct WebCompatReportPayload: Equatable {
             case antiTracking
             case frameworks
             case browserInfo
+            case prefs
             case app
             case system
             case graphics
@@ -153,6 +157,9 @@ struct WebCompatReportPayload: Equatable {
             ]),
             PreviewGroup(id: .browserInfo, fields: [
                 PreviewField(key: .experiments, value: previewValue(experiments))
+            ]),
+            PreviewGroup(id: .prefs, fields: [
+                PreviewField(key: .adBlockerEnabled, value: previewValue(adBlockerEnabled))
             ]),
             PreviewGroup(id: .app, fields: [
                 PreviewField(key: .defaultLocales, value: previewValue(defaultLocales)),

--- a/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportRecorder.swift
+++ b/firefox-ios/Client/Frontend/Browser/WebCompat/WebCompatReportRecorder.swift
@@ -99,6 +99,10 @@ struct WebCompatReportRecorder {
             gleanWrapper.recordObject(for: GleanMetrics.BrokenSiteReportBrowserInfo.experiments,
                                       value: experiments.map { $0.gleanObjectItem })
         }
+        if let adBlockerEnabled = payload.adBlockerEnabled {
+            gleanWrapper.setBoolean(for: GleanMetrics.BrokenSiteReportBrowserInfoPrefs.adBlockerEnabled,
+                                    value: adBlockerEnabled)
+        }
         if let defaultLocales = payload.defaultLocales {
             gleanWrapper.recordStringList(for: GleanMetrics.BrokenSiteReportBrowserInfoApp.defaultLocales,
                                           value: defaultLocales)

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -334,9 +334,8 @@ broken_site_report.browser_info.prefs:
       - broken-site-report
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16774
-    # TODO: FXIOS-16774 swap for the data-review PR URL before landing.
     data_reviews:
-      - https://mozilla-hub.atlassian.net/browse/FXIOS-16774
+      - https://github.com/mozilla-mobile/firefox-ios/pull/35567
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/Client/Glean/probes/broken_site_report.yaml
+++ b/firefox-ios/Client/Glean/probes/broken_site_report.yaml
@@ -19,15 +19,20 @@ $tags:
 # files an in-app "Report a Website Issue" report. Metric names mirror the
 # cross-platform desktop/Android `broken_site_report.*` schema so iOS data
 # lands in the same family. The set matches the iOS design's "Report Preview"
-# sections: basic / tabInfo / graphics / antiTracking / frameworks /
-# browserInfo / app — restricted to fields a WebKit browser (Firefox iOS) can
+# sections: basic / tabInfo / antiTracking / frameworks / browserInfo / prefs /
+# app / system / graphics — restricted to fields a WebKit browser (Firefox iOS) can
 # populate (page-context values via on-demand JS; tracking-protection state
 # from the content blocker; device/app values natively).
 #
-# OMITTED (Gecko-only, no WebKit equivalent): browser_info.prefs.*,
-# graphics.{devices,drivers,features,monitors}_json, browser_info.security.*,
-# browser_info.addons, app.fission_enabled, and the Gecko-specific antitracking
-# mixed-content / bounce-tracking flags.
+# OMITTED (Gecko-only, no WebKit equivalent): the Gecko prefs under
+# browser_info.prefs.*, graphics.{devices,drivers,features,monitors}_json,
+# browser_info.security.*, browser_info.addons, app.fission_enabled, and the
+# Gecko-specific antitracking mixed-content / bounce-tracking flags.
+#
+# AD BLOCKER: iOS ships ad blocking in the app rather than as an extension, so
+# there is no desktop/Android metric of the same name to mirror. It is reported
+# as a pref under browser_info.prefs, where desktop keeps its own privacy
+# toggles.
 #
 # SCREENSHOT: the iOS design includes a default-on "Include screenshot" option.
 # The image is intentionally NOT carried by this Glean ping — Glean has no
@@ -308,6 +313,30 @@ broken_site_report.browser_info:
       - https://mozilla-hub.atlassian.net/browse/FXIOS-16704
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-ios/pull/35402
+    notification_emails:
+      - fx-ios-data-stewards@mozilla.com
+    expires: never
+
+broken_site_report.browser_info.prefs:
+  ad_blocker_enabled:
+    type: boolean
+    description: |
+      Whether the built-in ad blocker is on: the `blockAds` pref and the
+      `adBlocker` Nimbus feature flag together. iOS-only, since ad blocking is
+      an extension on desktop and Android and shows up in browser_info.addons
+      there. The app-wide setting, sent even when the reported URL is not the
+      current tab's page. Like `block_list` and `etp_category` it reads a pref,
+      so it does not say whether blocking was in force on the page itself.
+    data_sensitivity:
+      - interaction
+    lifetime: ping
+    send_in_pings:
+      - broken-site-report
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16774
+    # TODO: FXIOS-16774 swap for the data-review PR URL before landing.
+    data_reviews:
+      - https://mozilla-hub.atlassian.net/browse/FXIOS-16774
     notification_emails:
       - fx-ios-data-stewards@mozilla.com
     expires: never

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportDataCollectorTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Shared
 import WebKit
 import XCTest
 
@@ -358,6 +359,24 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
         XCTAssertEqual(payload.devicePixelRatio, "2")
     }
 
+    // MARK: - Ad blocker
+
+    func test_enrich_adBlockerOn_reportsTrue() {
+        XCTAssertEqual(adBlockerPayload(isEnabled: true).adBlockerEnabled, true)
+    }
+
+    func test_enrich_adBlockerOff_reportsFalseRatherThanOmittingIt() {
+        XCTAssertEqual(adBlockerPayload(isEnabled: false).adBlockerEnabled, false)
+    }
+
+    // The pref is app-wide, so it survives the tab-specific opt-out that drops the page fields.
+    func test_enrich_withoutTabSpecificInfo_stillReportsTheAdBlockerPref() {
+        let payload = adBlockerPayload(isEnabled: true, includeTabSpecificInfo: false)
+
+        XCTAssertEqual(payload.adBlockerEnabled, true)
+        XCTAssertNil(payload.blockList)
+    }
+
     func test_captureFullPage_withoutWebView_returnsNil() async {
         let tab = Tab(profile: MockProfile(), windowUUID: windowUUID)
 
@@ -409,6 +428,20 @@ final class WebCompatReportDataCollectorTests: XCTestCase {
             blockingStrength: blockingStrength,
             blockedOrigins: blockedOrigins,
             hasTrackingContentBlocked: hasTrackingContentBlocked
+        )
+    }
+
+    private func adBlockerPayload(
+        isEnabled: Bool,
+        includeTabSpecificInfo: Bool = true
+    ) -> WebCompatReportPayload {
+        return WebCompatReportDataCollector.enrich(
+            WebCompatReportPayload(),
+            tab: Tab(profile: MockProfile(), windowUUID: windowUUID),
+            includeBlockedList: false,
+            includeTabSpecificInfo: includeTabSpecificInfo,
+            device: FakeDeviceInfoProvider(),
+            adBlockerState: FakeAdBlockerStateProvider(isEnabled: isEnabled)
         )
     }
 
@@ -467,5 +500,13 @@ private final class NavigationCompletionDelegate: NSObject, WKNavigationDelegate
         let onCompletion = self.onCompletion
         self.onCompletion = nil
         onCompletion?()
+    }
+}
+
+private struct FakeAdBlockerStateProvider: WebCompatAdBlockerStateProviding {
+    let isEnabled: Bool
+
+    func isAdBlockerEnabled(prefs: Prefs) -> Bool {
+        return isEnabled
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportPayloadTests.swift
@@ -54,7 +54,7 @@ final class WebCompatReportPayloadTests: XCTestCase {
         // Labelled with the raw schema keys, so a renamed or reordered group misdescribes the ping.
         XCTAssertEqual(
             WebCompatReportPayload().previewGroups.map(\.id.rawValue),
-            ["basic", "tabInfo", "antiTracking", "frameworks", "browserInfo", "app", "system", "graphics"]
+            ["basic", "tabInfo", "antiTracking", "frameworks", "browserInfo", "prefs", "app", "system", "graphics"]
         )
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportRecorderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReportRecorderTests.swift
@@ -26,11 +26,11 @@ final class WebCompatReportRecorderTests: XCTestCase {
         XCTAssertEqual(gleanWrapper.recordStringCalled, 4)
         XCTAssertEqual(gleanWrapper.recordTextCalled, 3)
         XCTAssertEqual(gleanWrapper.recordStringListCalled, 3)
-        XCTAssertEqual(gleanWrapper.setBooleanCalled, 7)
+        XCTAssertEqual(gleanWrapper.setBooleanCalled, 8)
         XCTAssertEqual(gleanWrapper.recordQuantityCalled, 1)
         XCTAssertEqual(gleanWrapper.recordUrlCalled, 1)
         XCTAssertEqual(gleanWrapper.recordObjectCalled, 1)
-        XCTAssertEqual(gleanWrapper.savedEvents.count, 20)
+        XCTAssertEqual(gleanWrapper.savedEvents.count, 21)
         XCTAssertEqual(gleanWrapper.submitPingCalled, 1)
     }
 
@@ -61,6 +61,28 @@ final class WebCompatReportRecorderTests: XCTestCase {
         createSubject().submit(payload)
 
         XCTAssertEqual(gleanWrapper.savedBooleans, [false, true])
+    }
+
+    // `savedBooleans` alone can't say which metric got the value, so assert the metric too.
+    func testSubmit_recordsTheAdBlockerPrefAgainstItsOwnMetric() {
+        var payload = WebCompatReportPayload()
+        payload.adBlockerEnabled = true
+
+        createSubject().submit(payload)
+
+        XCTAssertIdentical(gleanWrapper.savedEvents.last as AnyObject,
+                           GleanMetrics.BrokenSiteReportBrowserInfoPrefs.adBlockerEnabled)
+        XCTAssertEqual(gleanWrapper.savedBooleans, [true])
+    }
+
+    // `if let` on an optional Bool is one careless edit from dropping `false` as "no data".
+    func testSubmit_adBlockerPrefOff_recordsFalseRatherThanSkippingIt() {
+        var payload = WebCompatReportPayload()
+        payload.adBlockerEnabled = false
+
+        createSubject().submit(payload)
+
+        XCTAssertEqual(gleanWrapper.savedBooleans, [false])
     }
 
     func testSubmit_recordsTheValuesItWasGiven() {
@@ -111,6 +133,7 @@ final class WebCompatReportRecorderTests: XCTestCase {
         payload.etpCategory = "strict"
         payload.isPrivateBrowsing = false
         payload.hasTrackingContentBlocked = true
+        payload.adBlockerEnabled = true
         payload.fastclick = true
         payload.marfeel = false
         payload.mobify = false

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/WebCompatReporter/WebCompatReporterMiddlewareTests.swift
@@ -161,8 +161,9 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
 
-        // is_private_browsing on top of the device's has_touch_screen and is_tablet.
-        XCTAssertEqual(gleanWrapper.setBooleanCalled, 3)
+        // is_private_browsing on top of the device's has_touch_screen and is_tablet,
+        // plus the app-wide ad_blocker_enabled pref.
+        XCTAssertEqual(gleanWrapper.setBooleanCalled, 4)
 
         releaseMiddlewareProvidersFromMemory(subject)
     }
@@ -173,7 +174,7 @@ final class WebCompatReporterMiddlewareTests: XCTestCase, StoreTestUtility {
 
         subject.webCompatReporterProvider.legacyMiddleware(mockStore.state, submitAction())
 
-        XCTAssertEqual(gleanWrapper.setBooleanCalled, 2)
+        XCTAssertEqual(gleanWrapper.setBooleanCalled, 3)
 
         releaseMiddlewareProvidersFromMemory(subject)
     }


### PR DESCRIPTION
## :scroll: Tickets
[FXIOS-16774](https://mozilla-hub.atlassian.net/browse/FXIOS-16774)

## :bulb: Description
The report only carried ETP state, so an ad-blocker-on report looked identical to an off one.

Adds `broken_site_report.browser_info.prefs.ad_blocker_enabled`, the `blockAds` pref and the `.adBlocker` flag together. Under `browser_info.prefs` to match where desktop keeps its privacy toggles. Desktop and Android have no equivalent, ad blocking is an extension there.

`data_reviews` is a placeholder until the data review lands. Part 2 of the ticket, whether the blocker blocked anything, needs a spike.

## Testing
1. Settings, Browsing, turn Block Ads on.
2. Report a broken site, open Technical Data.
3. `prefs.adBlockerEnabled` reads `true`. Turn it off, report again, reads `false`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code


[FXIOS-16774]: https://mozilla-hub.atlassian.net/browse/FXIOS-16774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ