### PR TITLE
BugFix FXIOS-16777 [Quick Answers] Pass the source faviconURL as a SiteResource so favicons resolve correctly

### DIFF
--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
@@ -78,7 +78,7 @@ final class QuickAnswersSourceCell: UICollectionViewCell, ReusableCell, ThemeApp
             faviconCornerRadius: UX.faviconCornerRadius,
             faviconBorderWidth: UX.thumbnailBorderWidth,
             heroImageSize: .zero,
-            fallbackFaviconSize: CGSize(width: UX.faviconSize, height: UX.faviconSize),
+            fallbackFaviconSize: CGSize(width: UX.faviconSize, height: UX.faviconSize)
         )
         thumbnailImageView.setHeroImage(heroImageViewModel)
         let faviconSiteResource: SiteResource? = if let url = item.faviconURL {

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
@@ -78,12 +78,18 @@ final class QuickAnswersSourceCell: UICollectionViewCell, ReusableCell, ThemeApp
             faviconCornerRadius: UX.faviconCornerRadius,
             faviconBorderWidth: UX.thumbnailBorderWidth,
             heroImageSize: .zero,
-            fallbackFaviconSize: CGSize(width: UX.faviconSize, height: UX.faviconSize)
+            fallbackFaviconSize: CGSize(width: UX.faviconSize, height: UX.faviconSize),
         )
         thumbnailImageView.setHeroImage(heroImageViewModel)
+        let faviconSiteResource: SiteResource? = if let url = item.faviconURL {
+            SiteResource.remoteURL(url: url)
+        } else {
+            nil
+        }
         faviconImageView.setFavicon(
             FaviconImageViewModel(
-                siteURLString: item.faviconURL?.absoluteString ?? item.url?.absoluteString,
+                siteURLString: item.url?.absoluteString ?? "",
+                siteResource: faviconSiteResource,
                 faviconCornerRadius: UX.faviconCornerRadius
             )
         )


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16777)

## :bulb: Description
Pass the correct `SiteResource` for favicon on QuickAnswers.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
