### PR TITLE
Add FXIOS-15887 [Tabs] Keep only one home page tab at a time

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -1258,6 +1258,7 @@ final class TabManagerImplementation: NSObject,
                 if let url = newTabChoice.url {
                     tab.loadRequest(PrivilegedRequest(url: url) as URLRequest)
                     tab.url = url
+                    closeOtherHomepageTabs(excluding: tab)
                 }
             }
         }
@@ -1267,6 +1268,31 @@ final class TabManagerImplementation: NSObject,
 
         if flushToDisk {
             commitChanges()
+        }
+    }
+
+    /// Keeps a single homepage tab per browsing mode by closing every other tab currently showing about:home.
+    /// Called when a newly added tab loads about:home, so the user doesn't accumulate duplicate homepages.
+    /// - Parameter newTab: the tab that just loaded about:home, which is kept open.
+    private func closeOtherHomepageTabs(excluding newTab: Tab) {
+        // Restoring a session routes every tab through `configureTab` before its persisted URL is applied,
+        // so sweeping here would close homepages that are being restored.
+        guard tabRestoreHasFinished else { return }
+
+        let homepageTabs = tabs.filter { $0 !== newTab && $0.isPrivate == newTab.isPrivate && $0.isFxHomeTab }
+        guard !homepageTabs.isEmpty else { return }
+
+        // `selectedIndex` is positional, so removals shift it onto an unrelated tab. Re-anchor it before
+        // returning to the caller, which may not select `newTab` itself.
+        let previouslySelectedTab = selectedTab
+        for homepageTab in homepageTabs {
+            removeTab(homepageTab, flushToDisk: false)
+        }
+
+        if let previouslySelectedTab, let index = tabs.firstIndex(of: previouslySelectedTab) {
+            selectedIndex = index
+        } else {
+            selectedIndex = tabs.firstIndex(of: newTab) ?? -1
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerRemoveTabTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerRemoveTabTests.swift
@@ -623,4 +623,130 @@ final class TabManagerRemoveTabTests: TabManagerTestsBase {
         XCTAssertNotEqual(tabManager.selectedTab, secondTab, "This tab should have been removed")
         XCTAssertEqual(tabManager.selectedIndex, 0, "Index of new normal tab")
     }
+    // MARK: - Remove Tab (closing duplicate homepage tabs)
+
+    @MainActor
+    func testAddTab_whenNewTabLoadsHomepage_closesOtherHomepageTabs() {
+        let subject = createSubject(tabs: generateHomepageTabs(count: 3))
+        subject.tabRestoreHasFinished = true
+
+        let newTab = subject.addTab()
+
+        XCTAssertEqual(subject.tabs.count, 1)
+        XCTAssertEqual(subject.tabs.first, newTab)
+    }
+
+    @MainActor
+    func testAddTab_whenNewTabLoadsHomepage_keepsTabsShowingOtherURLs() {
+        let subject = createSubject(tabs: generateTabs(count: 3) + generateHomepageTabs(count: 2))
+        subject.tabRestoreHasFinished = true
+
+        let newTab = subject.addTab()
+
+        XCTAssertEqual(subject.tabs.count, 4)
+        XCTAssertEqual(subject.tabs.filter { $0.isFxHomeTab }, [newTab])
+    }
+
+    @MainActor
+    func testAddTab_whenNewTabLoadsHomepage_keepsHomepageTabsFromTheOtherBrowsingMode() {
+        let subject = createSubject(tabs: generateHomepageTabs(count: 2, isPrivate: true)
+                                    + generateHomepageTabs(count: 2))
+        subject.tabRestoreHasFinished = true
+
+        _ = subject.addTab()
+
+        XCTAssertEqual(subject.privateTabs.count, 2)
+        XCTAssertEqual(subject.normalTabs.count, 1)
+    }
+
+    @MainActor
+    func testAddPrivateTab_whenNewTabLoadsHomepage_closesOtherPrivateHomepageTabs() {
+        let subject = createSubject(tabs: generateHomepageTabs(count: 2, isPrivate: true)
+                                    + generateHomepageTabs(count: 2))
+        subject.tabRestoreHasFinished = true
+
+        _ = subject.addTab(isPrivate: true)
+
+        XCTAssertEqual(subject.privateTabs.count, 1)
+        XCTAssertEqual(subject.normalTabs.count, 2)
+    }
+
+    @MainActor
+    func testAddTab_whenNewTabPageIsBlank_keepsOtherHomepageTabs() {
+        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.KeyNewTab] = NewTabPage.blankPage.rawValue
+        let subject = createSubject(tabs: generateHomepageTabs(count: 2))
+        subject.tabRestoreHasFinished = true
+
+        _ = subject.addTab()
+
+        XCTAssertEqual(subject.tabs.count, 3)
+    }
+
+    @MainActor
+    func testAddTab_whenNewTabPageIsACustomHomepage_keepsOtherHomepageTabs() {
+        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.KeyNewTab] = NewTabPage.homePage.rawValue
+        (mockProfile.prefs as? MockProfilePrefs)?.things[PrefsKeys.NewTabCustomUrlPrefKey] = "https://mozilla.com"
+        let subject = createSubject(tabs: generateHomepageTabs(count: 2))
+        subject.tabRestoreHasFinished = true
+
+        _ = subject.addTab()
+
+        XCTAssertEqual(subject.tabs.count, 3)
+    }
+
+    @MainActor
+    func testAddTab_withARequest_keepsOtherHomepageTabs() {
+        let subject = createSubject(tabs: generateHomepageTabs(count: 2))
+        subject.tabRestoreHasFinished = true
+
+        _ = subject.addTab(URLRequest(url: URL(string: "https://mozilla.com")!), afterTab: nil, isPrivate: false)
+
+        XCTAssertEqual(subject.tabs.count, 3)
+    }
+
+    @MainActor
+    func testAddTab_whenTabRestoreHasNotFinished_keepsOtherHomepageTabs() {
+        let subject = createSubject(tabs: generateHomepageTabs(count: 2))
+
+        _ = subject.addTab()
+
+        XCTAssertEqual(subject.tabs.count, 3)
+    }
+
+    @MainActor
+    func testAddTab_whenSelectedTabIsNotAHomepage_keepsThatTabSelected() {
+        let contentTabs = generateTabs(count: 1)
+        let subject = createSubject(tabs: generateHomepageTabs(count: 2) + contentTabs)
+        subject.tabRestoreHasFinished = true
+        subject.selectTab(contentTabs[0])
+
+        _ = subject.addTab()
+
+        XCTAssertEqual(subject.selectedTab, contentTabs[0])
+        XCTAssertEqual(subject.selectedIndex, 0, "The selected tab index should have shifted left")
+    }
+
+    @MainActor
+    func testAddTab_whenSelectedTabIsClosedBySweep_selectsTheNewTab() {
+        let homepageTabs = generateHomepageTabs(count: 2)
+        let subject = createSubject(tabs: homepageTabs)
+        subject.tabRestoreHasFinished = true
+        subject.selectTab(homepageTabs[0])
+
+        let newTab = subject.addTab()
+
+        XCTAssertEqual(subject.selectedTab, newTab)
+        XCTAssertEqual(subject.selectedIndex, 0, "Index of the only remaining tab")
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func generateHomepageTabs(count: Int, isPrivate: Bool = false) -> [Tab] {
+        return (0..<count).map { _ in
+            let tab = Tab(profile: mockProfile, isPrivate: isPrivate, windowUUID: tabWindowUUID)
+            tab.url = HomePanelType.topSites.internalUrl
+            return tab
+        }
+    }
 }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15887)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/33963)

## :bulb: Description
Every time a new home page is created, loop through all tabs and remove any other homepages. 

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

