### PR TITLE
Remove FXIOS-16722 [DeadCode] Remove stale SnapKit attribution from Licenses.html

### DIFF
--- a/firefox-ios/Client/Assets/About/Licenses.html
+++ b/firefox-ios/Client/Assets/About/Licenses.html
@@ -2789,27 +2789,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 </pre>
-        <h2>SnapKit</h2>
-        <pre>Copyright (c) 2011-Present SnapKit Team - https://github.com/SnapKit
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &#x22;Software&#x22;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &#x22;AS IS&#x22;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
         <h2>swift-asn1</h2>
         <pre>
                                  Apache License


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16722)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35462)

## :bulb: Description
**Overview**

Removes the SnapKit section from the generated `Licenses.html`. No current LicensePlist input produces it.

**Details**

- SnapKit appears in no `Package.resolved` pin, `Package.swift`, pbxproj package reference or `license_plist_config.yml` entry.
- Each of the remaining 27 sections maps to a live input, and every input has a section.
- focus-ios, which still uses SnapKit, ships its own `licenses.html`.
- The Lottie section is left for the Lottie PR (#35576), which edits a disjoint region of the file.

**History**

- SnapKit was removed from firefox-ios under FXIOS-16322: #35041 (2026-08-05) dropped the feature flag and the last SnapKit code, and #35057 (2026-08-06) removed the package from `project.pbxproj` and `Package.resolved`. `Licenses.html` was not regenerated afterwards.
- `Licenses.html` is generated by LicensePlist from `license_plist_config.yml` and checked in; the next run would drop SnapKit anyway.
- After the edit the file still parses with 27 matched `<h2>`/`<pre>` pairs.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
