### PR TITLE
Add FXIOS-9686 [Tab Peek] Tests for TabPeekViewController

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabPeekViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabTray/TabPeekViewControllerTests.swift
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+
+@testable import Client
+
+@MainActor
+final class TabPeekViewControllerTests: XCTestCase {
+    let windowUUID: WindowUUID = .XCTestDefaultUUID
+
+    override func setUp() async throws {
+        try await super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+    }
+
+    override func tearDown() async throws {
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    func testTabPeekViewController_simpleCreation_hasNoLeaks() {
+        let tab = TabModel.emptyState(tabUUID: UUID().uuidString, title: "Test Tab")
+        let tabPeekViewController = TabPeekViewController(tab: tab, windowUUID: windowUUID)
+        trackForMemoryLeaks(tabPeekViewController)
+    }
+}


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-9686)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/21303)

## :bulb: Description
- Add a unit test for `TabPeekViewController` to verify that the view controller is properly deallocated and does not introduce memory leaks

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

