### PR TITLE
Refactor FXIOS-16780 [Build] Rename Fennec build configuration to Debug to enable non-optimized Swift package builds

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -29810,7 +29810,7 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		282731771ABC9BE800AA1954 /* Fennec */ = {
+		282731771ABC9BE800AA1954 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
@@ -29825,9 +29825,9 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				SWIFT_VERSION = 6.0;
 			};
-			name = Fennec;
+			name = Debug;
 		};
-		2827317A1ABC9BE800AA1954 /* Fennec */ = {
+		2827317A1ABC9BE800AA1954 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -29837,9 +29837,9 @@
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
-			name = Fennec;
+			name = Debug;
 		};
-		288A2DA01AB8B3260023ABC3 /* Fennec */ = {
+		288A2DA01AB8B3260023ABC3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
@@ -29865,9 +29865,9 @@
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 			};
-			name = Fennec;
+			name = Debug;
 		};
-		2FA436151ABB83B4008031D1 /* Fennec */ = {
+		2FA436151ABB83B4008031D1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
@@ -29890,9 +29890,9 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
 				SWIFT_VERSION = 6.0;
 			};
-			name = Fennec;
+			name = Debug;
 		};
-		2FA436191ABB83B4008031D1 /* Fennec */ = {
+		2FA436191ABB83B4008031D1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -29902,9 +29902,9 @@
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
-			name = Fennec;
+			name = Debug;
 		};
-		2FCAE2341ABB51F900877008 /* Fennec */ = {
+		2FCAE2341ABB51F900877008 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEFINES_MODULE = YES;
@@ -29915,9 +29915,9 @@
 				SWIFT_VERSION = 6.0;
 				VALIDATE_WORKSPACE = YES;
 			};
-			name = Fennec;
+			name = Debug;
 		};
-		2FCAE2381ABB51F900877008 /* Fennec */ = {
+		2FCAE2381ABB51F900877008 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -29927,7 +29927,7 @@
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		3958DAB01ED98DCB0054AA27 /* Fennec_Enterprise */ = {
 			isa = XCBuildConfiguration;
@@ -29955,7 +29955,7 @@
 			};
 			name = Fennec_Enterprise;
 		};
-		397848E31ED86605004C0C0B /* Fennec */ = {
+		397848E31ED86605004C0C0B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "$(inherit)Extensions/Entitlements/Fennec.entitlements";
@@ -29970,7 +29970,7 @@
 				SKIP_INSTALL = NO;
 				SWIFT_VERSION = 6.0;
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		397848E51ED86605004C0C0B /* Firefox */ = {
 			isa = XCBuildConfiguration;
@@ -30007,7 +30007,7 @@
 			};
 			name = FirefoxBeta;
 		};
-		3B43E3D71D95C48E00BBA9DB /* Fennec */ = {
+		3B43E3D71D95C48E00BBA9DB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -30017,7 +30017,7 @@
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		3B43E3D81D95C48E00BBA9DB /* Firefox */ = {
 			isa = XCBuildConfiguration;
@@ -30041,7 +30041,7 @@
 			};
 			name = FirefoxBeta;
 		};
-		3BFE4B0E1D342FB900DDF53F /* Fennec */ = {
+		3BFE4B0E1D342FB900DDF53F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -30056,7 +30056,7 @@
 				SWIFT_VERSION = 6.0;
 				TEST_TARGET_NAME = Client;
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		3BFE4B0F1D342FB900DDF53F /* Firefox */ = {
 			isa = XCBuildConfiguration;
@@ -30092,7 +30092,7 @@
 			};
 			name = FirefoxBeta;
 		};
-		4354D3E124EEEEC5001184F6 /* Fennec */ = {
+		4354D3E124EEEEC5001184F6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Extensions/Entitlements/Fennec.entitlements;
@@ -30108,7 +30108,7 @@
 				SKIP_INSTALL = NO;
 				SWIFT_VERSION = 6.0;
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		4354D3E224EEEEC5001184F6 /* Fennec_Enterprise */ = {
 			isa = XCBuildConfiguration;
@@ -30172,7 +30172,7 @@
 			};
 			name = FirefoxBeta;
 		};
-		43BE5786278BA4D900491291 /* Fennec */ = {
+		43BE5786278BA4D900491291 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
@@ -30199,7 +30199,7 @@
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		43BE5787278BA4D900491291 /* Fennec_Enterprise */ = {
 			isa = XCBuildConfiguration;
@@ -31280,7 +31280,7 @@
 			};
 			name = Fennec_Testing;
 		};
-		8CF609332EA8D46F00F069B6 /* Fennec */ = {
+		8CF609332EA8D46F00F069B6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -31366,7 +31366,7 @@
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		8CF609342EA8D46F00F069B6 /* Fennec_Testing */ = {
 			isa = XCBuildConfiguration;
@@ -31776,14 +31776,14 @@
 			};
 			name = FirefoxStaging;
 		};
-		C2A1EA0E2F4383F100DD202A /* Fennec */ = {
+		C2A1EA0E2F4383F100DD202A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		C2A1EA0F2F4383F100DD202A /* Fennec_Testing */ = {
 			isa = XCBuildConfiguration;
@@ -31830,7 +31830,7 @@
 			};
 			name = FirefoxStaging;
 		};
-		D39FA1681A83E0EC00EE869C /* Fennec */ = {
+		D39FA1681A83E0EC00EE869C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -31840,7 +31840,7 @@
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 				VALIDATE_WORKSPACE = YES;
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		D39FA1691A83E0EC00EE869C /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -31852,7 +31852,7 @@
 			};
 			name = Release;
 		};
-		E17EFC352CD16F5B00169A1F /* Fennec */ = {
+		E17EFC352CD16F5B00169A1F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -31924,7 +31924,7 @@
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		E17EFC362CD16F5B00169A1F /* Fennec_Testing */ = {
 			isa = XCBuildConfiguration;
@@ -32434,7 +32434,7 @@
 			};
 			name = Firefox;
 		};
-		E601384C1C89EAE600DF9756 /* Fennec */ = {
+		E601384C1C89EAE600DF9756 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -32449,7 +32449,7 @@
 				TEST_TARGET_NAME = Client;
 				USES_XCTRUNNER = YES;
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		E601384D1C89EAE600DF9756 /* Firefox */ = {
 			isa = XCBuildConfiguration;
@@ -32485,7 +32485,7 @@
 			};
 			name = FirefoxBeta;
 		};
-		E69DB0931E97DEAA008A67E6 /* Fennec */ = {
+		E69DB0931E97DEAA008A67E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -32494,7 +32494,7 @@
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		E69DB0941E97DEAA008A67E6 /* Fennec_Enterprise */ = {
 			isa = XCBuildConfiguration;
@@ -32830,7 +32830,7 @@
 			};
 			name = Fennec_Enterprise;
 		};
-		E6F965151B2F1CF20034B023 /* Fennec */ = {
+		E6F965151B2F1CF20034B023 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -32840,7 +32840,7 @@
 				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		E6F965171B2F1CF20034B023 /* Firefox */ = {
 			isa = XCBuildConfiguration;
@@ -33098,7 +33098,7 @@
 			};
 			name = FirefoxBeta;
 		};
-		F8324A132649A189007E4BFA /* Fennec */ = {
+		F8324A132649A189007E4BFA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -33175,7 +33175,7 @@
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Fennec;
+			name = Debug;
 		};
 		F8324A142649A189007E4BFA /* Fennec_Enterprise */ = {
 			isa = XCBuildConfiguration;
@@ -33399,7 +33399,7 @@
 			};
 			name = FirefoxBeta;
 		};
-		F84B21DB1A090F8100AAB793 /* Fennec */ = {
+		F84B21DB1A090F8100AAB793 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E60961861B62B8A700DD640F /* Fennec.xcconfig */;
 			buildSettings = {
@@ -33425,9 +33425,9 @@
 				SWIFT_VERSION = 6.0;
 				VALIDATE_WORKSPACE = YES;
 			};
-			name = Fennec;
+			name = Debug;
 		};
-		F84B21DE1A090F8100AAB793 /* Fennec */ = {
+		F84B21DE1A090F8100AAB793 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES = "AppIcon_Alt_Color_Blue AppIcon_Alt_Color_Cyan AppIcon_Alt_Color_Green AppIcon_Alt_Color_Orange AppIcon_Alt_Color_Pink AppIcon_Alt_Color_Purple AppIcon_Alt_Color_Red AppIcon_Alt_Color_Yellow AppIcon_Alt_Gradient_BlueHour AppIcon_Alt_Gradient_GoldenHour AppIcon_Alt_Gradient_Twilight AppIcon_Alt_Gradient_Sunset AppIcon_Alt_Gradient_Sunrise AppIcon_Alt_Gradient_NorthernLights AppIcon_Alt_Gradient_Midnight AppIcon_Alt_Gradient_Midday AppIcon_Alt_DarkPurple";
@@ -33457,9 +33457,9 @@
 				SWIFT_UPCOMING_FEATURE_ISOLATED_DEFAULT_VALUES = YES;
 				VALIDATE_WORKSPACE = YES;
 			};
-			name = Fennec;
+			name = Debug;
 		};
-		F84B21E11A090F8100AAB793 /* Fennec */ = {
+		F84B21E11A090F8100AAB793 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "";
@@ -33469,9 +33469,9 @@
 				PRODUCT_NAME = ClientTests;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
 			};
-			name = Fennec;
+			name = Debug;
 		};
-		F84B22561A0920C600AAB793 /* Fennec */ = {
+		F84B22561A0920C600AAB793 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "$(inherit)Extensions/Entitlements/Fennec.entitlements";
@@ -33486,7 +33486,7 @@
 				SKIP_INSTALL = NO;
 				SWIFT_VERSION = 6.0;
 			};
-			name = Fennec;
+			name = Debug;
 		};
 /* End XCBuildConfiguration section */
 
@@ -33494,7 +33494,7 @@
 		047F9B3824E1FE1F00CD7DF7 /* Build configuration list for PBXNativeTarget "WidgetKitExtension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4354D3E124EEEEC5001184F6 /* Fennec */,
+				4354D3E124EEEEC5001184F6 /* Debug */,
 				8A1993712C9B5A63001F4D57 /* Fennec_Testing */,
 				4354D3E224EEEEC5001184F6 /* Fennec_Enterprise */,
 				4354D3E324EEEEC5001184F6 /* Firefox */,
@@ -33502,12 +33502,12 @@
 				5A9F8FD22D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		282731971ABC9BE800AA1954 /* Build configuration list for PBXNativeTarget "Sync" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				282731771ABC9BE800AA1954 /* Fennec */,
+				282731771ABC9BE800AA1954 /* Debug */,
 				8A1993812C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC20E1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA81AEE7A6000869B6C /* Firefox */,
@@ -33515,12 +33515,12 @@
 				5A9F8FE32D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		282731981ABC9BE800AA1954 /* Build configuration list for PBXNativeTarget "SyncTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2827317A1ABC9BE800AA1954 /* Fennec */,
+				2827317A1ABC9BE800AA1954 /* Debug */,
 				8A19937B2C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC2151DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA91AEE7A6000869B6C /* Firefox */,
@@ -33528,12 +33528,12 @@
 				5A9F8FDD2D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		288A2D9F1AB8B3260023ABC3 /* Build configuration list for PBXNativeTarget "Localizations" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				288A2DA01AB8B3260023ABC3 /* Fennec */,
+				288A2DA01AB8B3260023ABC3 /* Debug */,
 				8A1993802C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC20B1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA31AEE7A6000869B6C /* Firefox */,
@@ -33541,12 +33541,12 @@
 				5A9F8FE22D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		2FA436141ABB83B4008031D1 /* Build configuration list for PBXNativeTarget "Account" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2FA436151ABB83B4008031D1 /* Fennec */,
+				2FA436151ABB83B4008031D1 /* Debug */,
 				8A1993732C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC20D1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA61AEE7A6000869B6C /* Firefox */,
@@ -33554,12 +33554,12 @@
 				5A9F8FD52D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		2FA436181ABB83B4008031D1 /* Build configuration list for PBXNativeTarget "AccountTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2FA436191ABB83B4008031D1 /* Fennec */,
+				2FA436191ABB83B4008031D1 /* Debug */,
 				8A1993752C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC2141DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA71AEE7A6000869B6C /* Firefox */,
@@ -33567,12 +33567,12 @@
 				5A9F8FD72D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		2FCAE2331ABB51F900877008 /* Build configuration list for PBXNativeTarget "Storage" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2FCAE2341ABB51F900877008 /* Fennec */,
+				2FCAE2341ABB51F900877008 /* Debug */,
 				8A1993742C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC20C1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA41AEE7A6000869B6C /* Firefox */,
@@ -33580,12 +33580,12 @@
 				5A9F8FD62D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		2FCAE2371ABB51F900877008 /* Build configuration list for PBXNativeTarget "StorageTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2FCAE2381ABB51F900877008 /* Fennec */,
+				2FCAE2381ABB51F900877008 /* Debug */,
 				8A1993782C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC2131DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA51AEE7A6000869B6C /* Firefox */,
@@ -33593,12 +33593,12 @@
 				5A9F8FDA2D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		397848F51ED86605004C0C0B /* Build configuration list for PBXNativeTarget "NotificationService" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				397848E31ED86605004C0C0B /* Fennec */,
+				397848E31ED86605004C0C0B /* Debug */,
 				8A19936F2C9B5A63001F4D57 /* Fennec_Testing */,
 				397848E51ED86605004C0C0B /* Firefox */,
 				397848E61ED86605004C0C0B /* FirefoxBeta */,
@@ -33606,12 +33606,12 @@
 				3958DAB01ED98DCB0054AA27 /* Fennec_Enterprise */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		3B43E3E91D95C48E00BBA9DB /* Build configuration list for PBXNativeTarget "StoragePerfTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3B43E3D71D95C48E00BBA9DB /* Fennec */,
+				3B43E3D71D95C48E00BBA9DB /* Debug */,
 				8A1993772C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC21B1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				3B43E3D81D95C48E00BBA9DB /* Firefox */,
@@ -33619,12 +33619,12 @@
 				5A9F8FD92D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		3BFE4B201D342FB900DDF53F /* Build configuration list for PBXNativeTarget "XCUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3BFE4B0E1D342FB900DDF53F /* Fennec */,
+				3BFE4B0E1D342FB900DDF53F /* Debug */,
 				8A19937E2C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC21A1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				3BFE4B0F1D342FB900DDF53F /* Firefox */,
@@ -33632,12 +33632,12 @@
 				5A9F8FE02D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		43BE5785278BA4D900491291 /* Build configuration list for PBXNativeTarget "RustMozillaAppServices" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				43BE5786278BA4D900491291 /* Fennec */,
+				43BE5786278BA4D900491291 /* Debug */,
 				8A19937F2C9B5A63001F4D57 /* Fennec_Testing */,
 				43BE5787278BA4D900491291 /* Fennec_Enterprise */,
 				43BE5788278BA4D900491291 /* Firefox */,
@@ -33645,12 +33645,12 @@
 				5A9F8FE12D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		8CF6093A2EA8D46F00F069B6 /* Build configuration list for PBXNativeTarget "ActionExtension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				8CF609332EA8D46F00F069B6 /* Fennec */,
+				8CF609332EA8D46F00F069B6 /* Debug */,
 				8CF609342EA8D46F00F069B6 /* Fennec_Testing */,
 				8CF609352EA8D46F00F069B6 /* Fennec_Enterprise */,
 				8CF609362EA8D46F00F069B6 /* Firefox */,
@@ -33658,12 +33658,12 @@
 				8CF609382EA8D46F00F069B6 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		C2A1EA142F4383F100DD202A /* Build configuration list for PBXAggregateTarget "Periphery" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C2A1EA0E2F4383F100DD202A /* Fennec */,
+				C2A1EA0E2F4383F100DD202A /* Debug */,
 				C2A1EA0F2F4383F100DD202A /* Fennec_Testing */,
 				C2A1EA102F4383F100DD202A /* Fennec_Enterprise */,
 				C2A1EA112F4383F100DD202A /* Firefox */,
@@ -33671,12 +33671,12 @@
 				C2A1EA132F4383F100DD202A /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		D39FA1671A83E0EC00EE869C /* Build configuration list for PBXNativeTarget "UITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D39FA1681A83E0EC00EE869C /* Fennec */,
+				D39FA1681A83E0EC00EE869C /* Debug */,
 				8A19937C2C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC2111DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				D39FA1691A83E0EC00EE869C /* Release */,
@@ -33685,12 +33685,12 @@
 				5A9F8FDE2D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		E17EFC3A2CD16F5B00169A1F /* Build configuration list for PBXNativeTarget "Sticker" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E17EFC352CD16F5B00169A1F /* Fennec */,
+				E17EFC352CD16F5B00169A1F /* Debug */,
 				E17EFC362CD16F5B00169A1F /* Fennec_Testing */,
 				E17EFC372CD16F5B00169A1F /* Fennec_Enterprise */,
 				E17EFC382CD16F5B00169A1F /* Firefox */,
@@ -33698,12 +33698,12 @@
 				5A9F8FD42D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		E60138631C89EAE700DF9756 /* Build configuration list for PBXNativeTarget "L10nSnapshotTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E601384C1C89EAE600DF9756 /* Fennec */,
+				E601384C1C89EAE600DF9756 /* Debug */,
 				8A19937D2C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC2181DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E601384D1C89EAE600DF9756 /* Firefox */,
@@ -33711,12 +33711,12 @@
 				5A9F8FDF2D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		E69DB0921E97DEAA008A67E6 /* Build configuration list for PBXNativeTarget "SyncTelemetryTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E69DB0931E97DEAA008A67E6 /* Fennec */,
+				E69DB0931E97DEAA008A67E6 /* Debug */,
 				8A19937A2C9B5A63001F4D57 /* Fennec_Testing */,
 				E69DB0941E97DEAA008A67E6 /* Fennec_Enterprise */,
 				E69DB0951E97DEAA008A67E6 /* Firefox */,
@@ -33724,12 +33724,12 @@
 				5A9F8FDC2D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		E6F965381B2F1CF20034B023 /* Build configuration list for PBXNativeTarget "SharedTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E6F965151B2F1CF20034B023 /* Fennec */,
+				E6F965151B2F1CF20034B023 /* Debug */,
 				8A1993792C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC2171DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E6F965171B2F1CF20034B023 /* Firefox */,
@@ -33737,12 +33737,12 @@
 				5A9F8FDB2D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		F8324A172649A189007E4BFA /* Build configuration list for PBXNativeTarget "CredentialProvider" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F8324A132649A189007E4BFA /* Fennec */,
+				F8324A132649A189007E4BFA /* Debug */,
 				8A1993722C9B5A63001F4D57 /* Fennec_Testing */,
 				F8324A142649A189007E4BFA /* Fennec_Enterprise */,
 				F8324A152649A189007E4BFA /* Firefox */,
@@ -33750,12 +33750,12 @@
 				5A9F8FD32D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		F84B21B91A090F8100AAB793 /* Build configuration list for PBXProject "Client" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F84B21DB1A090F8100AAB793 /* Fennec */,
+				F84B21DB1A090F8100AAB793 /* Debug */,
 				8A19936D2C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC2051DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FC9D1AEE7A6000869B6C /* Firefox */,
@@ -33763,12 +33763,12 @@
 				5A9F8FCE2D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		F84B21DD1A090F8100AAB793 /* Build configuration list for PBXNativeTarget "Client" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F84B21DE1A090F8100AAB793 /* Fennec */,
+				F84B21DE1A090F8100AAB793 /* Debug */,
 				8A19936E2C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC2061DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FC9E1AEE7A6000869B6C /* Firefox */,
@@ -33776,12 +33776,12 @@
 				5A9F8FCF2D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		F84B21E01A090F8100AAB793 /* Build configuration list for PBXNativeTarget "ClientTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F84B21E11A090F8100AAB793 /* Fennec */,
+				F84B21E11A090F8100AAB793 /* Debug */,
 				8A1993762C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC2101DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FC9F1AEE7A6000869B6C /* Firefox */,
@@ -33789,12 +33789,12 @@
 				5A9F8FD82D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 		F84B22551A0920C600AAB793 /* Build configuration list for PBXNativeTarget "ShareTo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F84B22561A0920C600AAB793 /* Fennec */,
+				F84B22561A0920C600AAB793 /* Debug */,
 				8A1993702C9B5A63001F4D57 /* Fennec_Testing */,
 				E6DCC2081DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA01AEE7A6000869B6C /* Firefox */,
@@ -33802,7 +33802,7 @@
 				5A9F8FD12D91C3A60019C311 /* FirefoxStaging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Fennec;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -850,7 +850,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Fennec"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/firefox-ios/bin/nimbus-fml-configuration.sh
+++ b/firefox-ios/bin/nimbus-fml-configuration.sh
@@ -10,7 +10,7 @@
 ## The `CONFIGURATION` to derive the channel used in the feature manifest.
 CHANNEL=
 case "${CONFIGURATION}" in
-    Fennec)
+    Debug)
         CHANNEL="developer"
         ;;
     Fennec_Testing)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16780)

## :bulb: Description
Renames the `Fennec` build configuration to `Debug`. The scheme is still named `Fennec` and still maps to the `developer` Nimbus channel, only the configuration name changes.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
