### PR TITLE
Add FXIOS-16782 [Quick Answers] Secret setting to override the model

### DIFF
--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersModel.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersModel.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 /// The provider model that backs the Quick Answers feature.
-public enum QuickAnswersModel: String, Sendable {
+public enum QuickAnswersModel: String, CaseIterable, Sendable {
     case exa
     case liner
 

--- a/BrowserKit/Sources/Shared/Prefs.swift
+++ b/BrowserKit/Sources/Shared/Prefs.swift
@@ -139,6 +139,7 @@ public struct PrefsKeys {
 
     public struct QuickAnswers {
         public static let optInCompleted = "quickAnswers.optInCompleted"
+        public static let modelOverride = "quickAnswers.modelOverride"
     }
 
     public struct Tips {

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1465,6 +1465,7 @@
 		AA459F872F630F3500D05D04 /* QuickAnswersKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA459F862F630F3500D05D04 /* QuickAnswersKit */; };
 		AA4D99432E857AF300BB039D /* MockRecentSearchProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4D99422E857AEE00BB039D /* MockRecentSearchProvider.swift */; };
 		AA5001492F912F610065A279 /* ChangeMLPAEndpointSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5001482F912F530065A279 /* ChangeMLPAEndpointSetting.swift */; };
+		AA5001512FFC000100AD1FBD /* QuickAnswersModelSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5001502FFC000100AD1FBD /* QuickAnswersModelSetting.swift */; };
 		AA5E81472EB12BDC00919E60 /* TranslationsMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5E81462EB12BD800919E60 /* TranslationsMiddleware.swift */; };
 		AA5E81482EF5000000000001 /* PreferredTranslationLanguagesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA5E81492EF5000000000001 /* PreferredTranslationLanguagesManager.swift */; };
 		AA62FA6A2EF2F49A009785D9 /* LocaleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD3B67B2CF65DE300AFA1FE /* LocaleProvider.swift */; };
@@ -10561,6 +10562,7 @@
 		AA3CEBAC2ECB853400DDEFEF /* SearchTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTelemetryTests.swift; sourceTree = "<group>"; };
 		AA4D99422E857AEE00BB039D /* MockRecentSearchProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRecentSearchProvider.swift; sourceTree = "<group>"; };
 		AA5001482F912F530065A279 /* ChangeMLPAEndpointSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeMLPAEndpointSetting.swift; sourceTree = "<group>"; };
+		AA5001502FFC000100AD1FBD /* QuickAnswersModelSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickAnswersModelSetting.swift; sourceTree = "<group>"; };
 		AA5E81462EB12BD800919E60 /* TranslationsMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationsMiddleware.swift; sourceTree = "<group>"; };
 		AA5E81492EF5000000000001 /* PreferredTranslationLanguagesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferredTranslationLanguagesManager.swift; sourceTree = "<group>"; };
 		AA6A6F372EF57EB800D1912D /* SystemLocaleProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemLocaleProviderTests.swift; sourceTree = "<group>"; };
@@ -14393,6 +14395,7 @@
 				1DA710062AE7106B00677F6B /* AppDataUsageReportSetting.swift */,
 				1D1418772DC92DFC004BBFAD /* ChangeRSServerSetting.swift */,
 				AA5001482F912F530065A279 /* ChangeMLPAEndpointSetting.swift */,
+				AA5001502FFC000100AD1FBD /* QuickAnswersModelSetting.swift */,
 				8A3EF7FE2A2FCFBB00796E3A /* ChangeToChinaSetting.swift */,
 				8A093D7C2A4B3E4F0099ABA5 /* DebugSettingsDelegate.swift */,
 				8A3EF7F12A2FCF4000796E3A /* DeleteExportedDataSetting.swift */,
@@ -19902,6 +19905,7 @@
 				21618A8A2A4389F700A5189E /* PresentedComponentsState.swift in Sources */,
 				8CC617092C35463B001C7688 /* AddressModifiedStatus.swift in Sources */,
 				AA5001492F912F610065A279 /* ChangeMLPAEndpointSetting.swift in Sources */,
+				AA5001512FFC000100AD1FBD /* QuickAnswersModelSetting.swift in Sources */,
 				EB1C84BF212EFFBF001489DF /* BrowserViewController+ReaderMode.swift in Sources */,
 				96D95016270238500079D39D /* MainThreadThrottler.swift in Sources */,
 				8A4593C92BF7BECA002758DE /* MicrosurveyTableHeaderView.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/QuickAnswersCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/QuickAnswersCoordinator.swift
@@ -47,10 +47,20 @@ final class QuickAnswersCoordinator: BaseCoordinator, QuickAnswersNavigationHand
             windowUUID: windowUUID,
             themeManager: themeManager,
             telemetry: DefaultQuickAnswersTelemetry(),
-            configFetcher: RemoteQuickAnswersConfigFetcher(model: nimbusModel()),
+            configFetcher: RemoteQuickAnswersConfigFetcher(model: resolvedModel()),
             learnMoreURL: Self.learnMoreURL,
         )
         router.present(controller, animated: shouldAnimateTransition)
+    }
+
+    /// The model backing Quick Answers: the debug override set from the hidden settings when
+    /// present, the Nimbus configured one otherwise.
+    func resolvedModel() -> QuickAnswersKit.QuickAnswersModel {
+        guard let rawValue = prefs.stringForKey(PrefsKeys.QuickAnswers.modelOverride),
+              let overriddenModel = QuickAnswersKit.QuickAnswersModel(rawValue: rawValue) else {
+            return nimbusModel()
+        }
+        return overriddenModel
     }
 
     /// Reads the Nimbus-configured Quick Answers model and maps it to the `QuickAnswersKit` enum,

--- a/firefox-ios/Client/Coordinators/QuickAnswersCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/QuickAnswersCoordinator.swift
@@ -53,7 +53,7 @@ final class QuickAnswersCoordinator: BaseCoordinator, QuickAnswersNavigationHand
         router.present(controller, animated: shouldAnimateTransition)
     }
 
-    /// The model backing Quick Answers: the zdebug override set from the hidden settings when
+    /// The model backing Quick Answers: the debug override set from the hidden settings when
     /// present, the Nimbus configured one otherwise.
     func resolvedModel() -> QuickAnswersKit.QuickAnswersModel {
         guard let rawValue = prefs.stringForKey(PrefsKeys.QuickAnswers.modelOverride),

--- a/firefox-ios/Client/Coordinators/QuickAnswersCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/QuickAnswersCoordinator.swift
@@ -53,7 +53,7 @@ final class QuickAnswersCoordinator: BaseCoordinator, QuickAnswersNavigationHand
         router.present(controller, animated: shouldAnimateTransition)
     }
 
-    /// The model backing Quick Answers: the debug override set from the hidden settings when
+    /// The model backing Quick Answers: the zdebug override set from the hidden settings when
     /// present, the Nimbus configured one otherwise.
     func resolvedModel() -> QuickAnswersKit.QuickAnswersModel {
         guard let rawValue = prefs.stringForKey(PrefsKeys.QuickAnswers.modelOverride),

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -552,6 +552,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         #if MOZ_CHANNEL_beta || MOZ_CHANNEL_developer
         hiddenDebugOptions.append(ResetTipsSetting(settings: self))
         hiddenDebugOptions.append(ChangeMLPAEndpointSetting(settings: self))
+        hiddenDebugOptions.append(QuickAnswersModelSetting(settings: self))
         hiddenDebugOptions.append(DeleteAppAttestKeySetting(settings: self))
         hiddenDebugOptions.append(PrivacyNoticeUpdate(settings: self))
         hiddenDebugOptions.append(FeatureFlagsSettings(settings: self, settingsDelegate: self))

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/QuickAnswersModelSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/QuickAnswersModelSetting.swift
@@ -10,7 +10,6 @@ import Shared
 /// Debug setting that overrides which provider model backs Quick Answers,
 /// taking precedence over the Nimbus configured model until it is cleared.
 final class QuickAnswersModelSetting: HiddenSetting {
-    private static let nimbusOptionTitle = "Nimbus"
     private let prefsKey = PrefsKeys.QuickAnswers.modelOverride
     private var prefs: Prefs? { return settings.profile?.prefs }
     private var overriddenModel: QuickAnswersKit.QuickAnswersModel? {
@@ -20,7 +19,7 @@ final class QuickAnswersModelSetting: HiddenSetting {
 
     override var title: NSAttributedString? {
         guard let theme else { return nil }
-        let current = overriddenModel?.displayName ?? Self.nimbusOptionTitle
+        let current = overriddenModel?.displayName ?? "Nimbus"
         return NSAttributedString(
             string: "Quick Answers Model: \(current)",
             attributes: [.foregroundColor: theme.colors.textPrimary]
@@ -36,7 +35,7 @@ final class QuickAnswersModelSetting: HiddenSetting {
                 self?.select(model)
             })
         }
-        alert.addAction(UIAlertAction(title: "Use \(Self.nimbusOptionTitle) value", style: .destructive) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: "Use Nimbus value", style: .destructive) { [weak self] _ in
             self?.select(nil)
         })
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/QuickAnswersModelSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/QuickAnswersModelSetting.swift
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+import QuickAnswersKit
+import Shared
+
+/// Debug setting that overrides which provider model backs Quick Answers,
+/// taking precedence over the Nimbus configured model until it is cleared.
+final class QuickAnswersModelSetting: HiddenSetting {
+    private static let nimbusOptionTitle = "Nimbus"
+    private let prefsKey = PrefsKeys.QuickAnswers.modelOverride
+    private var prefs: Prefs? { return settings.profile?.prefs }
+    private var overriddenModel: QuickAnswersKit.QuickAnswersModel? {
+        guard let rawValue = prefs?.stringForKey(prefsKey) else { return nil }
+        return QuickAnswersKit.QuickAnswersModel(rawValue: rawValue)
+    }
+
+    override var title: NSAttributedString? {
+        guard let theme else { return nil }
+        let current = overriddenModel?.displayName ?? Self.nimbusOptionTitle
+        return NSAttributedString(
+            string: "Quick Answers Model: \(current)",
+            attributes: [.foregroundColor: theme.colors.textPrimary]
+        )
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let alert = UIAlertController(title: "Quick Answers Model",
+                                      message: "Overrides the model configured by Nimbus.",
+                                      preferredStyle: .alert)
+        for model in QuickAnswersKit.QuickAnswersModel.allCases {
+            alert.addAction(UIAlertAction(title: model.displayName, style: .default) { [weak self] _ in
+                self?.select(model)
+            })
+        }
+        alert.addAction(UIAlertAction(title: "Use \(Self.nimbusOptionTitle) value", style: .destructive) { [weak self] _ in
+            self?.select(nil)
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        settings.present(alert, animated: true)
+    }
+
+    /// Stores the override, or clears it when `model` is nil so the Nimbus value applies again.
+    private func select(_ model: QuickAnswersKit.QuickAnswersModel?) {
+        if let model {
+            prefs?.setString(model.rawValue, forKey: prefsKey)
+        } else {
+            prefs?.removeObjectForKey(prefsKey)
+        }
+        settings.tableView.reloadData()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QuickAnswersCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QuickAnswersCoordinatorTests.swift
@@ -29,9 +29,6 @@ final class QuickAnswersCoordinatorTests: XCTestCase {
         router = nil
         parentCoordinator = nil
         themeManager = nil
-        FxNimbus.shared.features.quickAnswersFeature.with { variables, prefs in
-            QuickAnswersFeature(variables, prefs)
-        }
         DependencyHelperMock().reset()
         try await super.tearDown()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QuickAnswersCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/QuickAnswersCoordinatorTests.swift
@@ -29,6 +29,9 @@ final class QuickAnswersCoordinatorTests: XCTestCase {
         router = nil
         parentCoordinator = nil
         themeManager = nil
+        FxNimbus.shared.features.quickAnswersFeature.with { variables, prefs in
+            QuickAnswersFeature(variables, prefs)
+        }
         DependencyHelperMock().reset()
         try await super.tearDown()
     }
@@ -90,15 +93,48 @@ final class QuickAnswersCoordinatorTests: XCTestCase {
         XCTAssertEqual(router.dismissCalled, 1)
     }
 
+    func test_resolvedModel_withoutOverride_returnsNimbusModel() {
+        setupNimbus(model: .liner)
+        let subject = createSubject()
+
+        XCTAssertEqual(subject.resolvedModel(), QuickAnswersKit.QuickAnswersModel.liner)
+    }
+
+    func test_resolvedModel_withOverride_returnsOverriddenModel() {
+        setupNimbus(model: .liner)
+        let prefs = MockProfilePrefs()
+        prefs.setString(QuickAnswersKit.QuickAnswersModel.exa.rawValue,
+                        forKey: PrefsKeys.QuickAnswers.modelOverride)
+        let subject = createSubject(prefs: prefs)
+
+        XCTAssertEqual(subject.resolvedModel(), QuickAnswersKit.QuickAnswersModel.exa)
+    }
+
+    func test_resolvedModel_withUnknownOverride_returnsNimbusModel() {
+        setupNimbus(model: .liner)
+        let prefs = MockProfilePrefs()
+        prefs.setString("unknown-model", forKey: PrefsKeys.QuickAnswers.modelOverride)
+        let subject = createSubject(prefs: prefs)
+
+        XCTAssertEqual(subject.resolvedModel(), QuickAnswersKit.QuickAnswersModel.liner)
+    }
+
     // MARK: - Helper Methods
+    private func setupNimbus(model: Client.QuickAnswersModel) {
+        FxNimbus.shared.features.quickAnswersFeature.with { _, _ in
+            QuickAnswersFeature(enabled: true, model: model)
+        }
+    }
+
     private func createSubject(
+        prefs: Prefs = MockProfilePrefs(),
         onNavigate: @escaping (QuickAnswersNavigationType) -> Void = { _ in },
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> QuickAnswersCoordinator {
         let subject = QuickAnswersCoordinator(
             parentCoordinatorDelegate: parentCoordinator,
-            prefs: MockProfilePrefs(),
+            prefs: prefs,
             windowUUID: .XCTestDefaultUUID,
             themeManager: themeManager,
             router: router,


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16782)

## :bulb: Description
Adds a hidden debug setting that forces the model backing Quick Answers (Exa or Liner), taking precedence over the Nimbus configured value until it is cleared.

## :movie_camera: Demos

https://github.com/user-attachments/assets/42301a33-a289-4c94-a2a5-ae72574bb297



## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
