### PR TITLE
Bugfix FXIOS-16726 Allow Siri Shortcut to Open New Tab Even if on Homepage

### DIFF
--- a/firefox-ios/Client/Coordinators/Router/Route.swift
+++ b/firefox-ios/Client/Coordinators/Router/Route.swift
@@ -136,5 +136,7 @@ enum Route {
     enum SearchOptions: Equatable {
         /// An option to focus the user's attention on the location field of the search interface.
         case focusLocationField
+        /// An option to force open a new tab even when on homepage
+        case forceNewTab
     }
 }

--- a/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
+++ b/firefox-ios/Client/Coordinators/Router/RouteBuilder.swift
@@ -188,7 +188,7 @@ final class RouteBuilder {
                 try? await Task.sleep(nanoseconds: NSEC_PER_SEC)
                 self?.siriOpenTabThrottleIsActive = false
             }
-            return .search(url: nil, isPrivate: false)
+            return .search(url: nil, isPrivate: false, options: [.forceNewTab])
         }
 
         // If the user activity has a webpageURL, it's a deep link or an old history item.

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3462,7 +3462,7 @@ class BrowserViewController: UIViewController,
             switchToTabForURLOrOpen(url, isPrivate: isPrivate)
         } else {
             let isFocusLocationTextFieldOption = options?.contains(.focusLocationField) == true
-
+            let isForceNewTabOption = options?.contains(.forceNewTab) == true
             // Avoid race condition; if we're restoring tabs, wait to process URL until completed. [FXIOS-14406]
             // Wait for tabs restoration because we need the `selectedTab`.
             // The `selectedTab` is `nil` when open firefox from a widget.
@@ -3470,17 +3470,22 @@ class BrowserViewController: UIViewController,
                 AppEventQueue.wait(for: [.tabRestoration(tabManager.windowUUID)]) { [weak self] in
                     ensureMainThread { [weak self] in
                         guard let self, let selectedTab = self.tabManager.selectedTab else { return }
-                        self.handle(selectedTab, isPrivate, isFocusLocationTextFieldOption)
+                        self.handle(selectedTab, isPrivate, isFocusLocationTextFieldOption, isForceNewTabOption)
                     }
                 }
                 return
             }
-            handle(selectedTab, isPrivate, isFocusLocationTextFieldOption)
+            handle(selectedTab, isPrivate, isFocusLocationTextFieldOption, isForceNewTabOption)
         }
     }
 
-    private func handle(_ selectedTab: Tab, _ isPrivate: Bool, _ isFocusLocationTextFieldOption: Bool) {
-        if shouldFocusLocationTextField(for: selectedTab, isPrivate: isPrivate) {
+    private func handle(
+        _ selectedTab: Tab,
+        _ isPrivate: Bool,
+        _ isFocusLocationTextFieldOption: Bool,
+        _ isForceNewTabOption: Bool
+    ) {
+        if !isForceNewTabOption && shouldFocusLocationTextField(for: selectedTab, isPrivate: isPrivate) {
             focusLocationTextField(forTab: selectedTab)
         } else {
             openBlankNewTab(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16726)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35528)

## :bulb: Description
This PR allows the Open New Tab Siri Shortcut to open a new tab even if on the homepage by adding an option to force open a new tab which is used to bypass the homepage check.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

