### PR TITLE
Add FXIOS-16784 [Quick Answers] Liner model and service type

### DIFF
--- a/BrowserKit/Sources/LLMKit/ProviderSpecificFields.swift
+++ b/BrowserKit/Sources/LLMKit/ProviderSpecificFields.swift
@@ -22,7 +22,7 @@ public struct QuickAnswersProviderFields: Codable, Sendable {
 }
 
 public struct Citation: Codable, Sendable {
-    public let id: String
+    public let id: String?
     public let title: String?
     public let url: String?
     public let image: String?
@@ -37,7 +37,7 @@ public struct Citation: Codable, Sendable {
     }
 
     public init(
-        id: String,
+        id: String? = nil,
         title: String? = nil,
         url: String? = nil,
         image: String? = nil,

--- a/BrowserKit/Sources/MLPAKit/MLPAJWTPayload.swift
+++ b/BrowserKit/Sources/MLPAKit/MLPAJWTPayload.swift
@@ -11,6 +11,7 @@ import JWTKit
 public enum MLPAServiceType: String, Sendable {
     case s2s = "s2s"
     case quickAnswers = "answer"
+    case quickAnswersLiner = "liner-answer"
 }
 
 public enum MLPAConstants {

--- a/BrowserKit/Sources/MLPAKit/MLPAJWTPayload.swift
+++ b/BrowserKit/Sources/MLPAKit/MLPAJWTPayload.swift
@@ -10,7 +10,7 @@ import JWTKit
 /// request construction and server contract fields.
 public enum MLPAServiceType: String, Sendable {
     case s2s = "s2s"
-    case quickAnswers = "answer"
+    case quickAnswersExa = "answer"
     case quickAnswersLiner = "liner-answer"
 }
 

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersModel.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersModel.swift
@@ -12,17 +12,17 @@ public enum QuickAnswersModel: String, Sendable {
     /// The MLPA service backing the model, sent as the service type of every request so the proxy
     /// routes it to the right provider.
     var serviceType: MLPAServiceType {
-        switch self {
-        case .exa: return .quickAnswersExa
-        case .liner: return .quickAnswersLiner
+        return switch self {
+        case .exa: .quickAnswersExa
+        case .liner: .quickAnswersLiner
         }
     }
 
     /// The user-facing name of the model.
     public var displayName: String {
-        switch self {
-        case .exa: return "Exa"
-        case .liner: return "Liner"
+        return switch self {
+        case .exa: "Exa"
+        case .liner: "Liner"
         }
     }
 }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersModel.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersModel.swift
@@ -2,10 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import MLPAKit
+
 /// The provider model that backs the Quick Answers feature.
 public enum QuickAnswersModel: String, Sendable {
     case exa
     case liner
+
+    /// The MLPA service backing the model, sent as the service type of every request so the proxy
+    /// routes it to the right provider.
+    var serviceType: MLPAServiceType {
+        switch self {
+        case .exa: return .quickAnswers
+        case .liner: return .quickAnswersLiner
+        }
+    }
 
     /// The user-facing name of the model.
     public var displayName: String {

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersModel.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/QuickAnswersModel.swift
@@ -13,7 +13,7 @@ public enum QuickAnswersModel: String, Sendable {
     /// routes it to the right provider.
     var serviceType: MLPAServiceType {
         switch self {
-        case .exa: return .quickAnswers
+        case .exa: return .quickAnswersExa
         case .liner: return .quickAnswersLiner
         }
     }

--- a/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceFactory.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/Backend/ResultsService/ResultsServiceFactory.swift
@@ -25,7 +25,7 @@ public struct DefaultResultsServiceFactory: ResultsServiceFactory {
         prefs: Prefs,
         configFetcher: QuickAnswersConfigFetcher
     ) throws -> ResultsService {
-        guard let client = makeLiteLLMClient(prefs: prefs) else {
+        guard let client = makeLiteLLMClient(prefs: prefs, model: configFetcher.model) else {
             throw ResultsServiceError.unableToCreateService
         }
 
@@ -33,7 +33,7 @@ public struct DefaultResultsServiceFactory: ResultsServiceFactory {
     }
 
     // MARK: - Private Helpers
-    private func makeLiteLLMClient(prefs: Prefs) -> LiteLLMClientProtocol? {
-        return liteLLMCreator.createAppAttestLiteLLM(using: prefs, serviceType: .quickAnswers)
+    private func makeLiteLLMClient(prefs: Prefs, model: QuickAnswersModel) -> LiteLLMClientProtocol? {
+        return liteLLMCreator.createAppAttestLiteLLM(using: prefs, serviceType: model.serviceType)
     }
 }

--- a/BrowserKit/Tests/LLMKitTests/LiteLLMCreatorTests.swift
+++ b/BrowserKit/Tests/LLMKitTests/LiteLLMCreatorTests.swift
@@ -34,7 +34,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with prod environment")
@@ -51,7 +51,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with dev environment")
@@ -68,7 +68,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with stage environment")
@@ -83,7 +83,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with default prod environment")
@@ -100,7 +100,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         let result = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
 
         XCTAssertNotNil(result, "Should create LiteLLM client with default prod environment")
@@ -133,7 +133,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
 
         XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when environment changes")
@@ -152,7 +152,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
 
         XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when environment changes from prod to stage")
@@ -172,7 +172,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
 
         XCTAssertEqual(
@@ -195,7 +195,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
 
         XCTAssertEqual(
@@ -220,15 +220,15 @@ final class LiteLLMCreatorTests: XCTestCase {
         let subject = createSubject()
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
 
         XCTAssertEqual(
@@ -245,14 +245,14 @@ final class LiteLLMCreatorTests: XCTestCase {
         mockPrefs.setString(MLPAEnvironment.prod.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
         try mockKeyStore.saveKeyID(existingKeyID)
 
         mockPrefs.setString(MLPAEnvironment.dev.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
         XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when switching from prod to dev")
         try mockKeyStore.saveKeyID(existingKeyID)
@@ -260,7 +260,7 @@ final class LiteLLMCreatorTests: XCTestCase {
         mockPrefs.setString(MLPAEnvironment.stage.rawValue, forKey: PrefsKeys.MLPASettings.mlpaEndpointEnvironment)
         _ = subject.createAppAttestLiteLLM(
             using: mockPrefs,
-            serviceType: .quickAnswers
+            serviceType: .quickAnswersExa
         )
         XCTAssertNil(mockKeyStore.loadKeyID(), "Should clear key when switching from dev to stage")
     }

--- a/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockLLMClientCreator.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/Mocks/MockLLMClientCreator.swift
@@ -11,12 +11,14 @@ final class MockLLMClientCreator: LiteLLMCreating {
     var clientToReturn: LiteLLMClientProtocol?
     var shouldReturnNil = false
     var createAppAttestLiteLLMCallCount = 0
+    var lastServiceType: MLPAServiceType?
 
     func createAppAttestLiteLLM(
         using prefs: Prefs,
         serviceType: MLPAServiceType
     ) -> LiteLLMClientProtocol? {
         createAppAttestLiteLLMCallCount += 1
+        lastServiceType = serviceType
         return shouldReturnNil ? nil : clientToReturn
     }
 }

--- a/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/QuickAnswersConfigTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/QuickAnswersConfigTests.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Testing
+import MLPAKit
 
 @testable import QuickAnswersKit
 
@@ -34,5 +35,11 @@ struct QuickAnswersConfigTests {
     func test_model_displayName() {
         #expect(QuickAnswersModel.exa.displayName == "Exa")
         #expect(QuickAnswersModel.liner.displayName == "Liner")
+    }
+
+    @Test
+    func test_model_serviceType() {
+        #expect(QuickAnswersModel.exa.serviceType == MLPAServiceType.quickAnswersExa)
+        #expect(QuickAnswersModel.liner.serviceType == MLPAServiceType.quickAnswersLiner)
     }
 }

--- a/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/ResultsServiceFactoryTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/ResultsServiceFactoryTests.swift
@@ -39,6 +39,25 @@ struct ResultsServiceFactoryTests {
         #expect(mockLLMCreator.createAppAttestLiteLLMCallCount == 1, "Should attempt to create LLM client")
     }
 
+    @Test(arguments: [
+        (QuickAnswersModel.exa, MLPAServiceType.quickAnswers),
+        (QuickAnswersModel.liner, MLPAServiceType.quickAnswersLiner)
+    ])
+    func test_make_usesTheServiceTypeOfTheConfiguredModel(
+        model: QuickAnswersModel,
+        expectedServiceType: MLPAServiceType
+    ) throws {
+        let mockLLMCreator = MockLLMClientCreator()
+        mockLLMCreator.clientToReturn = MockLiteLLMClient()
+        let configFetcher = MockQuickAnswersConfigFetcher()
+        configFetcher.model = model
+        let subject = createSubject(liteLLMCreator: mockLLMCreator)
+
+        _ = try subject.make(prefs: MockProfilePrefs(), configFetcher: configFetcher)
+
+        #expect(mockLLMCreator.lastServiceType == expectedServiceType)
+    }
+
     // MARK: - Helper
     private func createSubject(
         liteLLMCreator: LiteLLMCreating = MockLLMClientCreator(),

--- a/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/ResultsServiceFactoryTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/ResultsService/ResultsServiceFactoryTests.swift
@@ -40,7 +40,7 @@ struct ResultsServiceFactoryTests {
     }
 
     @Test(arguments: [
-        (QuickAnswersModel.exa, MLPAServiceType.quickAnswers),
+        (QuickAnswersModel.exa, MLPAServiceType.quickAnswersExa),
         (QuickAnswersModel.liner, MLPAServiceType.quickAnswersLiner)
     ])
     func test_make_usesTheServiceTypeOfTheConfiguredModel(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16784)

## :bulb: Description
- Each request now uses the MLPA service type of the configured model.
- `Citation.id` is optional, since Liner does not send it.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [x] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [x] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code
