### PR TITLE
Bump FXIOS-15086 [Build] Resolve swift-syntax 603.0.2 for macro prebuilts

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -33802,8 +33802,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/WilhelmOks/ModifiedCopyMacro.git";
 			requirement = {
-				kind = exactVersion;
-				version = 2.2.0;
+				kind = revision;
+				revision = d020bf8c6432d0c6aa8428b5ca1c3225a0545b3b;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5e6124f24b4be9fc5e7ff3861008c35efe9f028bb1fa6fa8e0636c1f2664cdac",
+  "originHash" : "0c46f7d8bc92800f2f39fd391cdc4de3909f8e5b8ebb009081d9b3b446efdb84",
   "pins" : [
     {
       "identity" : "a-star",
@@ -87,8 +87,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/WilhelmOks/ModifiedCopyMacro.git",
       "state" : {
-        "revision" : "13dee3de60d4614ac268ec822325a19812e6c6f6",
-        "version" : "2.2.0"
+        "revision" : "d020bf8c6432d0c6aa8428b5ca1c3225a0545b3b"
       }
     },
     {
@@ -132,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-15086)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/32482)

## :bulb: Description

**Overview**

**Cuts clean build time on a developer machine by 44% — 338s to 190s — and build for testing from 346s to 213s** (M3 Pro, Xcode 26.6). These are local developer-loop numbers; CI already serves most compile tasks from its remote build cache, so the saving there is far smaller.

`ModifiedCopyMacro` capped `swift-syntax` below 601, and Apple publishes macro prebuilts only for 602 and later, so every clean build compiled `swift-syntax` from source to run the `@Copyable` plugin. On a developer machine it compiled it twice — arm64 and x86_64 — although the plugin Xcode actually loads is arm64-only, so half that work was discarded at link. Pinning the merged upstream revision resolves `swift-syntax` 603.0.2, for which a prebuilt is published, and SwiftPM links it instead of building it.

**Details**

- `project.pbxproj`: `kind = exactVersion; version = 2.2.0` becomes `kind = revision; revision = d020bf8c64…`, the `ModifiedCopyMacro` commit that widens its range to `..< 604.0.0`. No tag contains that change yet; this should become `kind = exactVersion` once one is cut.
- `Package.resolved`: `swift-syntax` 600.0.1 to 603.0.2. Widening the range alone does not move the pin — SwiftPM keeps any version that still satisfies it — so the update is recorded explicitly here, and nothing needs clearing to pick it up.
- Verified on `swiftlang-6.3.3.1.3`: `BUILD SUCCEEDED`, the macro plugin links the published prebuilt, and DerivedData contains zero `swift-syntax` object files.

**History**

ADR-0011 (#34112) adopted the `@Copyable` macro and already recorded the `swift-syntax` compile cost, naming prebuilts as the mitigation. That mitigation could never engage: `ModifiedCopyMacro` 2.2.0 declares `"509.1.1" ..< "601.0.0"`, and Apple publishes no prebuilt for 600.x on any toolchain. Upstream [ModifiedCopyMacro#15](https://github.com/WilhelmOks/ModifiedCopyMacro/pull/15) widened the range and merged on 2026-09-08 as `d020bf8c64`; the newest tag predates it, which is why this pins the revision. SwiftPM reports the fallback to a source build at `info` level only, so the cost never appeared in the Xcode build log.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code
