### PR TITLE
Bugfix FXIOS-16780 [Build] Apply the Fennec to Debug rename to L10nSnapshotTests

### DIFF
--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/L10nSnapshotTests.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/L10nSnapshotTests.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Fennec"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES"
@@ -117,7 +117,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Fennec"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"

--- a/firefox-ios/l10n-screenshots.sh
+++ b/firefox-ios/l10n-screenshots.sh
@@ -46,4 +46,12 @@ for lang in $LOCALES; do
         --xcodebuild_formatter xcbeautify \
         $EXTRA_FAST_LANE_ARGS
     echo "Fastlane exited with code: $?"
+
+    # `fastlane snapshot` catches build and test failures, prints its own summary and still
+    # exits 0, so its status cannot be relied on. Fail on the observable outcome instead:
+    # a locale that produced no screenshots did not succeed.
+    if [ -z "$(find "l10n-screenshots/$lang" -name '*.png' -print -quit)" ]; then
+        echo "ERROR: no screenshots were produced for $lang" >&2
+        exit 1
+    fi
 done


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16780)

## :bulb: Description

**The Fennec → Debug rename needs to be applied to the l10n path as well.**

#35582 renamed the `Fennec` build configuration to `Debug` across `project.pbxproj`, but updated only `Fennec.xcscheme`. `L10nSnapshotTests.xcscheme` still requested `buildConfiguration = "Fennec"` for its `TestAction` and `LaunchAction` — a configuration that no longer exists — so those actions built under a fallback in which `ActionExtensionKit` is never compiled, and `ActionExtension` failed to build:

```
ActionViewController.swift:7:8: error: unable to resolve module dependency: 'ActionExtensionKit'
import ActionExtensionKit
       ^
```

**`L10nBuild` has produced no screenshots since #35582 merged**, while reporting success the whole time. `fastlane snapshot` catches build and test failures, prints its own summary and still exits 0 — the log shows `Caught error... 65` immediately followed by `Fastlane exited with code: 0`. The only visible signal was the run time: **5.5 minutes versus 18–23 for a real run**.

This PR:

1. Points `L10nSnapshotTests.xcscheme` at `Debug`, restoring the pre-rename behaviour.
2. Makes `l10n-screenshots.sh` fail on the observable outcome — a locale that produced no screenshots did not succeed — rather than on an exit code that cannot be trusted.

### Still outstanding

Eight other shared schemes reference the removed `Fennec` configuration and are **not** touched here, since this change is scoped to the l10n path:

`Account`, `Fennec`, `Periphery`, `ShareTo`, `Storage`, `Sync`, `Telemetry`, `Today`

Note `Fennec.xcscheme` is among them — the scheme #35582 did edit is itself only partially updated.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
