### PR TITLE
[MTE-6156] - Fix XCUITest failures on iOS 16

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -255,7 +255,7 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
                 app.buttons[AccessibilityIdentifiers.TabTray.newTabButton].waitAndTap()
             } else {
                 navigator.performAction(Action.GoToHomePage)
-                app.buttons[AccessibilityIdentifiers.Browser.UrlBar.cancelButton].waitAndTap()
+                browserScreen.dismissURLBarOverlay()
             }
             mozWaitForElementToExist(app.staticTexts["Bookmarks"])
             navigator.nowAt(NewTabScreen)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/KeyboardShortcutsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/KeyboardShortcutsTests.swift
@@ -19,6 +19,11 @@ class KeyboardShortcutsTests: BaseTestCase {
     private var tabTrayScreen: TabTrayScreen!
 
     override func setUp() async throws {
+        // Every shortcut fails all its attempts on the iOS 16 simulator, where `typeKey` does not
+        // deliver key events to the app. The same build passes on 17.5, 18.6 and 26.5.
+        if #unavailable(iOS 17) {
+            throw XCTSkip("typeKey does not deliver key events to the app on the iOS 16 simulator")
+        }
         try await super.setUp()
         toolbarScreen = ToolbarScreen(app: app)
         homePageScreen = HomePageScreen(app: app)

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -343,6 +343,19 @@ final class BrowserScreen {
         sel.CANCEL_BUTTON_URL_BAR.element(in: app).tapIfExists()
     }
 
+    /// On iOS 16 the first Cancel tap right after a new tab opens is swallowed, leaving the keyboard up,
+    /// which clips the lower homepage sections out of the accessibility tree.
+    func dismissURLBarOverlay(maxAttempts: Int = 3) {
+        for _ in 0..<maxAttempts {
+            guard cancelButton.mozWaitForElementToExist(timeout: 5.0, failOnTimeout: false) else { return }
+            cancelButton.tap()
+            if BaseTestCase().mozWaitForElementToNotExist(cancelButton, timeout: 3.0, failOnTimeout: false) {
+                return
+            }
+        }
+        XCTFail("The URL bar is still in editing mode after \(maxAttempts) Cancel taps")
+    }
+
     func assertRFCLinkExist(timeout: TimeInterval = TIMEOUT) {
         BaseTestCase().mozWaitForElementToExist(sel.LINK_RFC_2606.element(in: app), timeout: timeout)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/IOSSettingsAppScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/IOSSettingsAppScreen.swift
@@ -21,10 +21,32 @@ final class IOSSettingsAppScreen {
 
     /// The Firefox option in the default-browser picker. Options are buttons whose label is the app's
     /// display name; match either scheme (Fennec "Fennec (user)" or the Firefox release "Firefox").
+    /// iOS 16/17 expose the picker options as table cells labelled with the app name, iOS 18+ as buttons.
+    /// Cells are tried first: they also rule out the back button, labelled with the app name on iOS 16/17.
     private var firefoxBrowserOption: XCUIElement {
-        settingsApp.buttons.matching(
-            NSPredicate(format: "label CONTAINS[c] %@ OR label CONTAINS[c] %@", "Fennec", "Firefox")
-        ).firstMatch
+        let predicate = NSPredicate(
+            format: "label CONTAINS[c] %@ OR label CONTAINS[c] %@",
+            "Fennec",
+            "Firefox"
+        )
+        let optionCell = settingsApp.cells.matching(predicate).firstMatch
+        return optionCell.exists ? optionCell : settingsApp.buttons.matching(predicate).firstMatch
+    }
+
+    /// The default-browser row in the app's own Settings pane, matched on its accessibility identifier so
+    /// the lookup survives localization and cannot hit the picker's identically named title.
+    private var appPaneDefaultBrowserRow: XCUIElement {
+        settingsApp.buttons["DEFAULT_BROWSER_APP"]
+    }
+
+    /// Back button in the Settings navigation bar. Only some iOS versions expose the "BackButton"
+    /// identifier; elsewhere it is labelled with the previous screen's title, so fall back to position.
+    /// Never in split view (iPad): there a leading button can be a sidebar control, and popping is not
+    /// needed anyway since re-selecting a sidebar row resets the detail pane.
+    private var settingsBackButton: XCUIElement {
+        let identified = settingsApp.navigationBars.buttons["BackButton"]
+        guard !identified.exists, settingsApp.navigationBars.count == 1 else { return identified }
+        return settingsApp.navigationBars.buttons.firstMatch
     }
 
     // MARK: - Assertions
@@ -39,8 +61,8 @@ final class IOSSettingsAppScreen {
 
     // MARK: - Actions
 
-    /// Selects Firefox in the "Default Browser App" picker, then re-opens the picker from the root to
-    /// confirm the choice was saved (still checked) — not merely registered on the initial tap.
+    /// Selects Firefox in the "Default Browser App" picker, then leaves and re-opens the picker to confirm
+    /// the choice was saved (still checked) — not merely registered on the initial tap.
     func setFirefoxAsDefaultBrowser() {
         openDefaultBrowserPicker()
         let option = firefoxBrowserOption
@@ -48,15 +70,30 @@ final class IOSSettingsAppScreen {
         option.waitAndTap()
         XCTAssertTrue(option.isSelected, "The Firefox option should be selected after tapping it")
 
+        leaveDefaultBrowserPicker()
         openDefaultBrowserPicker()
         let persisted = firefoxBrowserOption
         BaseTestCase().mozWaitForElementToExist(persisted, timeout: TIMEOUT_LONG)
         XCTAssertTrue(persisted.isSelected, "Firefox should still be the default browser after reopening the picker")
     }
 
-    /// The Settings deep link lands on the root page on Simulator, and iOS 26 nests the default-browser
-    /// choice under Settings > Apps > Default Apps, so navigate there explicitly.
+    /// Up to iOS 18.1 the choice lives in the app's own pane, which is where the Settings deep link lands.
+    /// iOS 18.2+ nests it under Settings > Apps > Default Apps, reached from the root the deep link opens.
     private func openDefaultBrowserPicker() {
+        if appPaneDefaultBrowserRow.mozWaitForElementToExist(
+            timeout: TIMEOUT_PICKER_PROBE,
+            failOnTimeout: false
+        ) {
+            tapSettingsRow(appPaneDefaultBrowserRow)
+            // Settle on the picker before the option is looked up, so a mid-push snapshot cannot decide
+            // between the cell and button shapes on the pane still being dismissed.
+            _ = settingsApp.navigationBars["Default Browser App"].mozWaitForElementToExist(
+                timeout: TIMEOUT,
+                failOnTimeout: false
+            )
+            return
+        }
+
         // Settings resumes where a prior run left it, so pop any pushed screen back to root first (on iPad
         // this pops the detail pane's own nav stack, since its back button survives sidebar re-selection).
         popToSettingsRoot()
@@ -76,12 +113,20 @@ final class IOSSettingsAppScreen {
         tapSettingsRow(browserSetting)
     }
 
+    /// Leaves the open picker so that reopening it is a real round trip rather than a re-read of the
+    /// screen the selection was made on.
+    private func leaveDefaultBrowserPicker() {
+        let backButton = settingsBackButton
+        if backButton.exists {
+            backButton.tap()
+        }
+    }
+
     /// Taps the navigation back button until the root of Settings is reached (no back button left).
     private func popToSettingsRoot() {
-        let backButton = settingsApp.navigationBars.buttons["BackButton"]
         var attempts = 0
-        while backButton.exists && attempts < 8 {
-            backButton.tap()
+        while settingsBackButton.exists && attempts < 8 {
+            settingsBackButton.tap()
             attempts += 1
         }
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LibraryScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/LibraryScreen.swift
@@ -244,7 +244,11 @@ final class LibraryScreen {
     }
 
     func deleteFolder(folderName: String) {
-        app.tables.cells.buttons["Remove \(folderName)"].waitAndTap()
+        if #available(iOS 17, *) {
+            app.tables.cells.buttons["Remove \(folderName)"].waitAndTap()
+        } else {
+            app.tables.cells.buttons["Delete \(folderName)"].waitAndTap()
+        }
         deleteButton.waitAndTap()
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SecurityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SecurityTests.swift
@@ -245,13 +245,15 @@ class SecurityTests: BaseTestCase {
                        "Attacker-controlled URL should not remain displayed after tapping.")
     }
 
+    /// The form fields are matched through their rendered labels: iOS 16 WebKit does not apply the
+    /// `<label for=>` association to the input itself, leaving the field with no accessibility label.
     private func validateURLAndPageContent(URL: String, elementsShouldExists: Bool) {
         browserScreen.assertAddressBarContains(value: URL)
         browserScreen.assertWebElements(
             shouldExist: elementsShouldExists,
             app.webViews.staticTexts[WebStrings.demoText],
-            app.webViews.textFields[WebStrings.usernameField],
-            app.webViews.secureTextFields[WebStrings.passwordField2]
+            app.webViews.staticTexts[WebStrings.usernameField],
+            app.webViews.staticTexts[WebStrings.passwordField2]
         )
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-6156

## :bulb: Description

**`KeyboardShortcutsTests`** — every shortcut fails all its attempts on the iOS 16 simulator because
`typeKey` doesn't deliver key events to the app there, while the same build passes on 17.5, 18.6 and
26.5. The class now throws `XCTSkip` in `setUp` below iOS 17 instead of reporting false failures.

**`HomePageSettingsUITests.testRecentlySaved` (C2307034)** — on iOS 16 the first Cancel tap after a
new tab opens is swallowed, so the keyboard stays up and clips the lower homepage sections out of the
accessibility tree. Added `BrowserScreen.dismissURLBarOverlay()`, which retries the tap until the URL
bar leaves editing mode, and used it in place of the inline cancel-button tap.

**`BookmarksTests.testDeleteEmptyFolderInEditMode` (C3168596)** — the edit-mode remove control is
labelled `Delete <folder>` on iOS 16 and `Remove <folder>`
`LibraryScreen.deleteFolder(folderName:)` now picks the label by availability check.

**`ModernKitOnboardingTests.testModernKitOnboardingSetAsDefaultBrowser` (C4038425)** —
`IOSSettingsAppScreen` assumed the iOS 26 Settings layout; it now handles every runtime we test on:
the picker lives in the app's own pane up to iOS 18.1 (where the deep link lands) and under
Apps > Default Apps from 18.2, options are cells on iOS 16/17 but buttons on iOS 18+, and the back
button only exposes the `BackButton` identifier on some versions. The persistence assertion also now
leaves the picker before reopening it, so it's a real round trip rather than a re-read of the screen
the selection was made on.

**`SecurityTests` (C3395566, C3395567 and the URL-spoofing cases)** — iOS 16 WebKit doesn't apply the
`<label for=>` association to the input element, leaving the username and password fields with no
accessibility label, so the `textFields`/`secureTextFields` lookups never match.
`validateURLAndPageContent` now matches them through theiriews.staticTexts`,
which resolves on all runtimes.

