### PR TITLE
Refactor FXIOS-16781 - [Hangs] - Reduce hangs when LocationView becomeFirstResponder is called

### DIFF
--- a/firefox-ios/Client/Application/SceneDelegate.swift
+++ b/firefox-ios/Client/Application/SceneDelegate.swift
@@ -95,6 +95,14 @@ class SceneDelegate: UIResponder,
                 self.tabErrorTelemetryHelper.validateTabCountForForegroundedScene(uuid)
             }
         }
+
+        // Re-warm the connection to the pasteboard daemon off the main thread.
+        // UIKit queries the pasteboard synchronously on the main thread every time
+        // a text field becomes first responder, and returning from the background
+        // is when that call is most likely to be slow.
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = UIPasteboard.general.numberOfItems
+        }
     }
 
     // MARK: - Transitioning to Background

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -546,6 +546,15 @@ class BrowserViewController: UIViewController,
         let tabWindowUUID = tabManager.windowUUID
         AppEventQueue.wait(for: [.startupFlowComplete, .tabRestoration(tabWindowUUID)]) { [weak self] in
             ensureMainThread { [weak self] in
+                // Wait an extra beat after startup settles so the prewarm's main-thread work
+                // can't compete with post-restoration rendering, then only run when no
+                // interaction is in flight (default run loop mode).
+                DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
+                    RunLoop.main.perform(inModes: [.default]) { [weak self] in
+                        MainActor.assumeIsolated { self?.prewarmSearchController() }
+                    }
+                }
+
                 // Ensure we call into didBecomeActive at least once during startup flow (if needed)
                 guard !AppEventQueue.activityIsCompleted(.browserUpdatedForAppActivation(tabWindowUUID)) else { return }
                 self?.browserDidBecomeActive()
@@ -2141,10 +2150,16 @@ class BrowserViewController: UIViewController,
 
     // MARK: - SearchViewController
 
-    fileprivate func createSearchControllerIfNeeded() {
-        guard self.searchController == nil else { return }
-
+    private func createSearchControllerIfNeeded() {
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
+
+        // Discard a controller built for the other browsing mode (e.g. prewarmed in normal
+        // mode before the user switched to private browsing) so private state can't leak.
+        if let searchController, searchController.viewModel.isPrivate != isPrivate {
+            destroySearchController()
+        }
+
+        guard self.searchController == nil else { return }
 
         let trendingClient = TrendingSearchClient()
 
@@ -2173,11 +2188,21 @@ class BrowserViewController: UIViewController,
         self.searchLoader = searchLoader
 
         self.searchController = searchController
-        self.searchSessionState = .active
+    }
+
+    /// Builds the search suggestions controller and loads its view ahead of the user's first tap
+    /// on the address bar. Creating SearchViewController and its view hierarchy is the largest
+    /// chunk of work when editing begins.
+    @MainActor
+    func prewarmSearchController() {
+        guard searchController == nil else { return }
+        createSearchControllerIfNeeded()
+        searchController?.loadViewIfNeeded()
     }
 
     func showSearchController() {
         createSearchControllerIfNeeded()
+        searchSessionState = .active
 
         guard let searchController = self.searchController else { return }
 
@@ -2251,6 +2276,14 @@ class BrowserViewController: UIViewController,
         searchLoader = nil
 
         contentContainer.accessibilityElementsHidden = false
+        // Rebuild the controller at idle so the next address bar tap doesn't pay the creation
+        // cost synchronously inside becomeFirstResponder.
+        DispatchQueue.main.async { [weak self] in
+            // Run when no interaction is in flight (default run loop mode).
+            RunLoop.main.perform(inModes: [.default]) { [weak self] in
+                MainActor.assumeIsolated { self?.prewarmSearchController() }
+            }
+        }
     }
 
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -34,7 +34,7 @@ protocol SearchViewControllerDelegate: AnyObject {
     func searchViewControllerWillHide(_ searchViewController: SearchViewController)
 }
 
-class SearchViewController: SiteTableViewController,
+final class SearchViewController: SiteTableViewController,
                             KeyboardHelperDelegate,
                             SearchViewDelegate,
                             FeatureFlaggable,
@@ -60,7 +60,10 @@ class SearchViewController: SiteTableViewController,
         static let AppendButtonSize: CGFloat = 44
     }
 
-    var searchDelegate: SearchViewControllerDelegate?
+    // Weak to avoid a retain cycle with BrowserViewController: now that the controller is
+    // kept alive across search sessions for reuse, a strong delegate would leak the whole
+    // window's BVC when it closes.
+    weak var searchDelegate: SearchViewControllerDelegate?
     let viewModel: SearchViewModel
     private var tabManager: TabManager
     private let logger: Logger

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewModel.swift
@@ -56,7 +56,7 @@ class SearchViewModel: FeatureFlaggable,
 
     private let maxNumOfFirefoxSuggestions: Int32 = 1
     weak var delegate: SearchViewDelegate?
-    private let isPrivate: Bool
+    let isPrivate: Bool
     public private(set) var isBottomSearchBar: Bool
     var savedQuery = ""
     @MainActor

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -435,7 +435,7 @@ final class HomepageViewController: UIViewController,
 
         // TODO: - FXIOS-13346 / FXIOS-13343 - fix collection view being reloaded all the time also when data don't change
         // this is a quick workaround to avoid blocking the main thread by calling apply snapshot many times.
-        if homepageState != state {
+        if !state.hasSameRenderableContent(as: homepageState) {
             let animatingDifferences = state.wallpaperState.availableContentHeight
                                         == homepageState.wallpaperState.availableContentHeight
             self.homepageState = state
@@ -447,6 +447,8 @@ final class HomepageViewController: UIViewController,
                 self?.updateNewsTransitionHeaderProgress()
             }
             updateWallpaperConstraints(availableWallpaperHeight: state.wallpaperState.availableWallpaperHeight)
+        } else {
+            homepageState = state
         }
 
         // FXIOS-11523 - Trigger impression when user opens homepage view new tab + scroll to top

--- a/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Redux/HomepageState.swift
@@ -22,6 +22,21 @@ struct HomepageState: ScreenState, Equatable {
     let wallpaperState: WallpaperState
     let telemetryState: HomepageTelemetryState
 
+    /// Compares the states that drive what the homepage renders, ignoring `telemetryState`,
+    /// which is impression/zero-search bookkeeping with no visual representation.
+    func hasSameRenderableContent(as other: HomepageState) -> Bool {
+        return headerState == other.headerState
+        && privacyNoticeState == other.privacyNoticeState
+        && messageState == other.messageState
+        && topSitesState == other.topSitesState
+        && searchBarState == other.searchBarState
+        && jumpBackInState == other.jumpBackInState
+        && trackerBlockerModuleState == other.trackerBlockerModuleState
+        && bookmarkState == other.bookmarkState
+        && merinoState == other.merinoState
+        && wallpaperState == other.wallpaperState
+    }
+
     init(appState: AppState, uuid: WindowUUID) {
         guard let homepageState = appState.componentState(
             HomepageState.self,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/BrowserViewController/BrowserViewControllerTests.swift
@@ -820,6 +820,58 @@ class BrowserViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertTrue(tab2.tabDelegate === subject)
     }
 
+    // MARK: - Search controller prewarming
+    @MainActor
+    func testPrewarmSearchController_createsControllerOnce_withoutStartingSearchSession() {
+        let subject = createSubject()
+        tabManager.selectedTab = MockTab(profile: profile, windowUUID: .XCTestDefaultUUID)
+        XCTAssertNil(subject.searchController)
+
+        subject.prewarmSearchController()
+
+        let prewarmedController = subject.searchController
+        XCTAssertNotNil(prewarmedController)
+        // Prewarming must not count as the user beginning a search for telemetry.
+        XCTAssertNil(subject.searchSessionState)
+
+        // A second prewarm is a no-op and keeps the same instance.
+        subject.prewarmSearchController()
+        XCTAssertIdentical(subject.searchController, prewarmedController)
+    }
+
+    @MainActor
+    func testShowSearchController_reusesPrewarmedController_andStartsSearchSession() {
+        let subject = createSubject()
+        subject.loadViewIfNeeded()
+        tabManager.selectedTab = MockTab(profile: profile, windowUUID: .XCTestDefaultUUID)
+
+        subject.prewarmSearchController()
+        let prewarmedController = subject.searchController
+
+        subject.showSearchController()
+
+        XCTAssertIdentical(subject.searchController, prewarmedController)
+        XCTAssertEqual(subject.searchSessionState, .active)
+    }
+
+    @MainActor
+    func testShowSearchController_afterSwitchingToPrivateMode_rebuildsControllerForPrivateBrowsing() {
+        let subject = createSubject()
+        subject.loadViewIfNeeded()
+        tabManager.selectedTab = MockTab(profile: profile, windowUUID: .XCTestDefaultUUID)
+
+        subject.prewarmSearchController()
+        let normalModeController = subject.searchController
+        XCTAssertEqual(normalModeController?.viewModel.isPrivate, false)
+
+        // A controller prewarmed in normal mode must not serve a private session.
+        tabManager.selectedTab = MockTab(profile: profile, isPrivate: true, windowUUID: .XCTestDefaultUUID)
+        subject.showSearchController()
+
+        XCTAssertNotIdentical(subject.searchController, normalModeController)
+        XCTAssertEqual(subject.searchController?.viewModel.isPrivate, true)
+    }
+
     // MARK: - Private
 
     private func createSubject(file: StaticString = #filePath,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/HomepageViewControllerTests.swift
@@ -526,6 +526,50 @@ final class HomepageViewControllerTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(wallpaperHeightConstraint.constant, 300)
     }
 
+    func test_newState_withTelemetryOnlyChange_skipsSnapshotApply_butStillTriggersImpression() throws {
+        let subject = createSubject()
+        subject.loadViewIfNeeded()
+
+        // didSelectedTabChangeToHomepage only mutates telemetry state (shouldTriggerImpression).
+        let telemetryOnlyState = HomepageState.reducer.legacyReducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            GeneralBrowserAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: GeneralBrowserActionType.didSelectedTabChangeToHomepage
+            )
+        )
+
+        subject.newState(state: telemetryOnlyState)
+
+        // Applying a snapshot always appends at least the header section, so an empty
+        // snapshot proves the telemetry-only update skipped the apply entirely.
+        let collectionView = try getCollectionView(from: subject)
+        let dataSource = try XCTUnwrap(collectionView.dataSource as? HomepageDiffableDataSource)
+        XCTAssertTrue(dataSource.snapshot().sectionIdentifiers.isEmpty)
+
+        // The state is still adopted, so the impression trigger it carries runs.
+        XCTAssertTrue(mockThrottler.didCallThrottle)
+    }
+
+    func test_newState_withRenderableChange_appliesSnapshot() throws {
+        let subject = createSubject()
+        subject.loadViewIfNeeded()
+
+        let renderableState = HomepageState.reducer.legacyReducer(
+            HomepageState(windowUUID: .XCTestDefaultUUID),
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageMiddlewareActionType.configuredPrivacyNotice
+            )
+        )
+
+        subject.newState(state: renderableState)
+
+        let collectionView = try getCollectionView(from: subject)
+        let dataSource = try XCTUnwrap(collectionView.dataSource as? HomepageDiffableDataSource)
+        XCTAssertFalse(dataSource.snapshot().sectionIdentifiers.isEmpty)
+    }
+
     private func createSubject(
         tabManager: TabManager = MockTabManager(),
         statusBarScrollDelegate: StatusBarScrollDelegate? = nil

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Homepage/Redux/HomepageStateTests.swift
@@ -160,6 +160,53 @@ final class HomepageStateTests: XCTestCase {
         XCTAssertFalse(newState.trackerBlockerModuleState.shouldShowSection)
     }
 
+    // MARK: - hasSameRenderableContent
+    func test_hasSameRenderableContent_withIdenticalStates_returnsTrue() {
+        let initialState = createSubject()
+        let otherState = createSubject()
+
+        XCTAssertTrue(initialState.hasSameRenderableContent(as: otherState))
+    }
+
+    @MainActor
+    func test_hasSameRenderableContent_withTelemetryOnlyChange_returnsTrue() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        // The embeddedHomepage action is dispatched when the address bar gains focus and
+        // only mutates telemetry bookkeeping (isZeroSearch).
+        let newState = reducer.legacyReducer(
+            initialState,
+            HomepageAction(
+                isZeroSearch: true,
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageActionType.embeddedHomepage
+            )
+        )
+
+        // Plain equality sees a difference, but the renderable content is unchanged. This is
+        // what lets HomepageViewController skip re-applying the collection view snapshot
+        // during keyboard bring-up
+        XCTAssertNotEqual(newState, initialState)
+        XCTAssertTrue(newState.hasSameRenderableContent(as: initialState))
+    }
+
+    @MainActor
+    func test_hasSameRenderableContent_withRenderableChange_returnsFalse() {
+        let initialState = createSubject()
+        let reducer = homepageReducer()
+
+        let newState = reducer.legacyReducer(
+            initialState,
+            HomepageAction(
+                windowUUID: .XCTestDefaultUUID,
+                actionType: HomepageMiddlewareActionType.configuredPrivacyNotice
+            )
+        )
+
+        XCTAssertFalse(newState.hasSameRenderableContent(as: initialState))
+    }
+
     // MARK: - Private
     private func createSubject() -> HomepageState {
         return HomepageState(windowUUID: .XCTestDefaultUUID)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16781)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35584)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->

### Changes

`SceneDelegate`: warm the pasteboard daemon connection on every scene activation with a background-queue `UIPasteboard.general.numberOfItems` touch, so `UIKit`'s unavoidable synchronous call hits a warm connection. 
`BrowserViewController`: added `prewarmSearchController()`, which builds the search controller and loads its view off the interaction path. It runs one second after startup settles (enqueued in the default run-loop mode so it can't interrupt a touch or scroll), and again at idle after every `destroySearchController()`. The session lifecycle is unchanged, the controller is still torn down when overlay mode exits, but the next tap finds a pre-built controller instead of paying creation inside `becomeFirstResponder`.
 `createSearchControllerIfNeeded` now discards a controller built for the other browsing mode (`SearchViewModel.isPrivate` exposed for this check), so a controller prewarmed in normal mode can never serve a private session.
 `searchSessionState = .active` moved from creation to `showSearchController()`, so prewarming doesn't start a search session for telemetry.
`SearchViewController: searchDelegate` is now `weak` (and the class final). The strong `delegate` was a latent BVC retain cycle previously masked by destroy-per-session; with a prewarmed controller existing outside sessions it would leak the window's entire BVC. Caught by the new tests memory-leak tracking.
`HomepageState` / `HomepageViewController`: added `hasSameRenderableContent(as:)`, which compares all section states but ignores `telemetryState`. `newState` uses it to skip the snapshot re-apply for telemetry-only updates while still adopting the new state, so impression triggering and interaction-time telemetry reads behave exactly as before. Partial mitigation of FXIOS-13346 / FXIOS-13343.

### Results (Time Profiler)

App-side work inside the tap turn dropped from ~90 ms to ~25 ms (homepage re-apply eliminated, controller creation moved off-path); `becomeFirstResponder` total: ~180 ms on the first tap (dominated by UIKit's one-time keyboard construction), ~70 ms on subsequent taps.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

