### PR TITLE
BugFix FXIOS-16796 [WebEngine] Stop WKEngineWebViewTests hanging on network loads

### DIFF
--- a/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
+++ b/BrowserKit/Sources/WebEngine/WKWebview/WKEngineWebView.swift
@@ -289,7 +289,8 @@ final class DefaultWKEngineWebView: WKWebView,
         refresh.configure(with: scrollView) { [weak self] in
             self?.delegate?.webViewNeedsReload()
         }
-        guard pullRefreshViewType != UIRefreshControl.self else { return }
+
+        guard !(refresh is UIRefreshControl) else { return }
         scrollView.addSubview(refresh)
         refresh.translatesAutoresizingMaskIntoConstraints = false
         pullRefreshViewHeightConstraint = refresh.heightAnchor.constraint(equalToConstant: scrollView.frame.height)
@@ -304,6 +305,9 @@ final class DefaultWKEngineWebView: WKWebView,
     }
 
     private func removePullRefresh() {
+        if pullRefreshView is UIRefreshControl {
+            scrollView.refreshControl = nil
+        }
         pullRefreshView?.removeFromSuperview()
         pullRefreshViewWidthConstraint = nil
         pullRefreshViewHeightConstraint = nil

--- a/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
+++ b/BrowserKit/Tests/WebEngineTests/WKEngineWebViewTests.swift
@@ -10,6 +10,10 @@ import WebKit
 final class WKEngineWebViewTests: XCTestCase, @unchecked Sendable {
     private var delegate: MockWKEngineWebViewDelegate!
     private let testURL = URL(string: "https://www.example.com/")!
+    /// Served locally via `loadSimulatedRequest` so the load tests don't depend on network or DNS.
+    private static let testPageHTML = """
+    <html><head><title>Test Page</title></head><body><h1>Test Page</h1><p>Content</p></body></html>
+    """
 
     override func setUp() async throws {
         try await super.setUp()
@@ -55,7 +59,7 @@ final class WKEngineWebViewTests: XCTestCase, @unchecked Sendable {
         }
         let hasOnlySecureContentExpectation = expectation(that: \WKWebView.hasOnlySecureContent, on: subject)
 
-        subject.load(URLRequest(url: testURL))
+        _ = subject.loadSimulatedRequest(URLRequest(url: testURL), responseHTML: Self.testPageHTML)
 
         wait(
             for: [
@@ -67,7 +71,8 @@ final class WKEngineWebViewTests: XCTestCase, @unchecked Sendable {
                 canGoForwardExpectation,
                 contentSizeExpectation,
                 hasOnlySecureContentExpectation
-            ]
+            ],
+            timeout: 30
         )
 
         XCTAssertGreaterThan(delegate.webViewPropertyChangedCalled, 0)
@@ -79,7 +84,7 @@ final class WKEngineWebViewTests: XCTestCase, @unchecked Sendable {
         let subject = createSubject(pullRefreshViewType: MockUIRefreshControl.self)
         let pullRefresh = try XCTUnwrap(subject.scrollView.refreshControl as? MockUIRefreshControl)
 
-        subject.load(URLRequest(url: testURL))
+        _ = subject.loadSimulatedRequest(URLRequest(url: testURL), responseHTML: Self.testPageHTML)
 
         XCTAssertEqual(pullRefresh.beginRefreshingCalled, 1)
         XCTAssertEqual(pullRefresh.endRefreshingCalled, 0)
@@ -103,6 +108,23 @@ final class WKEngineWebViewTests: XCTestCase, @unchecked Sendable {
         let subject = createSubject(pullRefreshViewType: UIRefreshControl.self)
 
         XCTAssertNotNil(subject.scrollView.refreshControl)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+    }
+
+    func testInit_withUIRefreshControlSubclass_doesntConstrainPullRefreshAsSubview() throws {
+        let subject = createSubject(pullRefreshViewType: MockUIRefreshControl.self)
+
+        let pullRefresh = try XCTUnwrap(subject.scrollView.refreshControl as? MockUIRefreshControl)
+        XCTAssertTrue(pullRefresh.translatesAutoresizingMaskIntoConstraints)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+    }
+
+    func testScrollWillBeginZooming_withUIRefreshControl_removesRefreshControl() {
+        let subject = createSubject(pullRefreshViewType: MockUIRefreshControl.self)
+
+        subject.scrollViewWillBeginZooming(UIScrollView(), with: nil)
+
+        XCTAssertNil(subject.scrollView.refreshControl)
         RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
 


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16796)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35609)

## :bulb: Description
`WKEngineWebViewTests.testLoad_callsObservers` loaded `https://www.example.com/` over the real network and waited on KVO expectations with `wait(for:)` and no timeout, which defaults to `.infinity`. When DNS cannot resolve the host, `estimatedProgress` never reaches 1 and the test hangs indefinitely rather than failing. The `UnitTest` test plan sets no `defaultTestExecutionTimeAllowance`, so nothing cuts it off.

Both load tests now serve the page locally via `loadSimulatedRequest`, so the file no longer depends on network or DNS, plus an explicit `timeout:` as a backstop.

Also included: `setupPullRefresh` compared exact types, so a `UIRefreshControl` **subclass** was both installed as the scroll view's `refreshControl` and constrained as a subview, and `removePullRefresh` left a stale `refreshControl` behind. Now subclass-aware, matching the `as?` check already used in `handleWebsiteLoadingChanged`, with two regression tests. Happy to split this into its own PR if preferred.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
