### PR TITLE
Bugfix MTE-6144 [Tests] Fix the iOS 15 paste flows and mark the remaining known failures

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
@@ -603,9 +603,17 @@ class BaseTestCase: XCTestCase {
         let urlBar = app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField]
         let pasteAction = app.tables.buttons[AccessibilityIdentifiers.Photon.pasteAction]
         urlBar.waitAndTap()
-        urlBar.pressWithRetry(duration: 2.0, element: pasteAction)
-        mozWaitForElementToExist(app.tables["Context Menu"])
-        pasteAction.waitAndTap()
+        if #unavailable(iOS 16) {
+            // EXPERIMENT: focusing the bar puts it in editing mode, where iOS offers the system
+            // edit menu rather than Firefox's Photon sheet, and a 2s press starts a drag lift.
+            let pasteMenuItem = app.menuItems["Paste"]
+            urlBar.pressWithRetry(duration: 0.8, element: pasteMenuItem)
+            pasteMenuItem.waitAndTap()
+        } else {
+            urlBar.pressWithRetry(duration: 2.0, element: pasteAction)
+            mozWaitForElementToExist(app.tables["Context Menu"])
+            pasteAction.waitAndTap()
+        }
         mozWaitForElementToExist(urlBar)
         waitForPastedValue(in: urlBar, contains: url)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/DomainAutocompleteTests.swift
@@ -88,9 +88,11 @@ class DomainAutocompleteTests: BaseTestCase {
         urlBarAddress.waitAndTap()
         mozWaitForElementToExist(urlBarAddress)
         urlBarAddress.typeText("moz")
+        mozWaitForValueContains(urlBarAddress, value: "mozilla.org")
 
         // First delete the autocompleted part
         urlBarAddress.typeText("\u{0008}")
+        mozWaitForValueContains(urlBarAddress, value: "moz")
         // Then remove an extra char and check that the autocompletion stops working
         urlBarAddress.typeText("\u{0008}")
         mozWaitForValueContains(urlBarAddress, value: "mo")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -678,6 +678,7 @@ class LoginTest: BaseTestCase {
             mozWaitForElementToNotExist(app.keyboards.buttons["Continue"])
             mozWaitForElementToExist(app.keyboards.keys.firstMatch)
         }
+        mozWaitElementHittable(element: app.keyboards.keys.firstMatch, timeout: TIMEOUT)
         for letter in typedText {
             print("\(letter)")
             app.keyboards.keys["\(letter)"].waitAndTap()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/BrowserScreen.swift
@@ -283,16 +283,26 @@ final class BrowserScreen {
     // Pastes the clipboard contents into the (already focused) address bar and asserts the resulting
     // value. Used to verify clipboard content in-app, avoiding the iOS 16+ cross-process paste prompt.
     func pasteAndAssertAddressBarContains(_ value: String) {
-        let pasteButton = sel.PASTE_BUTTON.element(in: app)
         if BaseTestCase().iPad() {
             addressBar.waitAndTap()
         } else {
             addressBar.press(forDuration: 1)
         }
-        if !pasteButton.exists {
-            addressBar.press(forDuration: 1)
+        if #unavailable(iOS 16) {
+            // The edit callout is a system menu item on iOS 15 rather than an otherElements
+            // button, and a longer press starts a drag lift instead of showing the callout.
+            let pasteMenuItem = app.menuItems["Paste"]
+            if !pasteMenuItem.exists {
+                addressBar.press(forDuration: 0.8)
+            }
+            pasteMenuItem.waitAndTap()
+        } else {
+            let pasteButton = sel.PASTE_BUTTON.element(in: app)
+            if !pasteButton.exists {
+                addressBar.press(forDuration: 1)
+            }
+            pasteButton.waitAndTap()
         }
-        pasteButton.waitAndTap()
         BaseTestCase().mozWaitForValueContains(addressBar, value: value)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/StoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/StoryTests.swift
@@ -48,6 +48,8 @@ class StoryTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306924
+    // Expected failure: iOS 15
+    // https://github.com/mozilla-mobile/firefox-ios/issues/35616
     func testNewsStoriesEnabledByDefault() {
         app.launch()
 
@@ -77,6 +79,8 @@ class StoryTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2855360
+    // Expected failure: iOS 15
+    // https://github.com/mozilla-mobile/firefox-ios/issues/35616
     func testValidateNewsContextMenu() {
         app.launch()
 
@@ -100,6 +104,8 @@ class StoryTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/XXXXXXX
+    // Expected failure: iOS 15
+    // https://github.com/mozilla-mobile/firefox-ios/issues/35616
     func testNewsStoryCategoriesFilterStories() throws {
         if !isFennec {
             throw XCTSkip("Skipping testNewsStoryCategoriesFilterStories on Firefox or FirefoxBeta schemas")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/StoryTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/StoryTests.swift
@@ -49,7 +49,7 @@ class StoryTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2306924
     // Expected failure: iOS 15
-    // https://github.com/mozilla-mobile/firefox-ios/issues/35616
+    // https://github.com/mozilla-mobile/firefox-ios/issues/35618
     func testNewsStoriesEnabledByDefault() {
         app.launch()
 
@@ -80,7 +80,7 @@ class StoryTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/2855360
     // Expected failure: iOS 15
-    // https://github.com/mozilla-mobile/firefox-ios/issues/35616
+    // https://github.com/mozilla-mobile/firefox-ios/issues/35618
     func testValidateNewsContextMenu() {
         app.launch()
 
@@ -105,7 +105,7 @@ class StoryTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/XXXXXXX
     // Expected failure: iOS 15
-    // https://github.com/mozilla-mobile/firefox-ios/issues/35616
+    // https://github.com/mozilla-mobile/firefox-ios/issues/35618
     func testNewsStoryCategoriesFilterStories() throws {
         if !isFennec {
             throw XCTSkip("Skipping testNewsStoryCategoriesFilterStories on Firefox or FirefoxBeta schemas")

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
@@ -24,6 +24,8 @@ final class TranslationsTests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/3211480
+    // Expected failure: iOS 15
+    // https://github.com/mozilla-mobile/firefox-ios/issues/35615
     func testTranslationFlow_withDifferentStates_translationExperimentOn() {
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "translations-feature")
         app.launch()

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/TranslationTests.swift
@@ -25,7 +25,7 @@ final class TranslationsTests: FeatureFlaggedTestBase {
 
     // https://mozilla.testrail.io/index.php?/cases/view/3211480
     // Expected failure: iOS 15
-    // https://github.com/mozilla-mobile/firefox-ios/issues/35615
+    // https://github.com/mozilla-mobile/firefox-ios/issues/35608
     func testTranslationFlow_withDifferentStates_translationExperimentOn() {
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "translations-feature")
         app.launch()


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/MTE-6144)

## :bulb: Description

Investigation of the XCUITest failures specific to iOS 15, ahead of the Xcode/iOS 27 upgrade. Every failure the CI job reported on iOS 15 was rerun locally on iPhone 13 / iOS 15.5 against current `main`, one test at a time, and each was traced to either a test defect we can fix or an app defect that needs a bug.

**CI reported 52 failures on iOS 15; 19 reproduce.** Of those, this PR fixes 9 and files issues for 4.

### :white_check_mark: Fixed here — the paste button, 9 tests

The paste helpers were looking for the wrong affordance on iOS 15.

Once the address bar is focused, iOS presents its **own edit menu**, not Firefox's Photon action sheet — so `app.tables.buttons["pasteAction"]` and `otherElements.buttons["Paste"]` can never match there. On top of that, the 2-second long press starts a **drag lift** on the text field rather than showing any callout at all; the screenshot below shows the lifted preview floating above the real address bar.

Both helpers now use `app.menuItems["Paste"]` with a 0.8 s press, below the drag-lift threshold, gated to iOS 15 so 16 and later keep the existing path:

| Helper | File |
| - | - |
| `openNewTabAndValidateURLisPaste` | `BaseTestCase.swift` |
| `BrowserScreen.pasteAndAssertAddressBarContains` | `PageScreens/BrowserScreen.swift` |

Tests fixed on iPhone 13 / iOS 15.5:

- `ShareLongPressTests.testBookmarksShareNormalWebsiteCopyURL`
- `ShareLongPressTests.testHistoryShareNormalWebsiteCopyURL`
- `ShareLongPressTests.testReaderModeShareNormalWebsiteCopy`
- `ShareLongPressTests.testShareViaLongPressLinkCopy`
- `ShareMenuTests.testShareNormalWebsiteCopyUrl`
- `ShareMenuTests.testShareWebsiteReaderModeCopy`
- `ShareToolbarTests.testShareNormalWebsiteCopyUrl`
- `ShareToolbarTests.testShareWebsiteReaderModeCopy`
- `TabsTests.testLongTapOnTabInTabsTray`

Verified beyond the individual tests: **all 13 `ShareMenuTests` and all 14 `TabsTests` pass on iOS 15.5**, and the nine paste-path tests were rerun on 16.4, 17.5 and 18.6 with no change, since those versions take the untouched branch.

### :beetle: Issues tracking app defects, not test defects

| Issue | Tests | Symptom |
| - | - | - |
| [#35608](https://github.com/mozilla-mobile/firefox-ios/issues/35608) | `TranslationsTests.testTranslationFlow_withDifferentStates_translationExperimentOn` | Translation fails with a **"Couldn't Translate Page"** banner; the translate button never reaches its active state. Filed by @dragosb01 as affecting every iOS version below 17.4, which matches the platform requirement for the Translation framework. Passes on 26.5. |
| [#35618](https://github.com/mozilla-mobile/firefox-ios/issues/35618) | `StoryTests.testNewsStoriesEnabledByDefault`, `testValidateNewsContextMenu`, `testNewsStoryCategoriesFilterStories` | The **Stories/News section does not render** on iOS 15 and 16 under the UI test configuration, though it renders on the same simulator outside the harness. Passes on 17.5, 18.6 and 26.5. Filed by @dragosb01 for 16.4; the iOS 15 evidence is the same defect. |

Those four tests are marked `// Expected failure: iOS 15` with the issue link directly beneath, so the failure explains itself in the source.

### Still open, not addressed here

Six iOS 15.5 failures remain and are not touched by this PR: `ThirdPartySearchTest.testCustomSearchEngines` and `testCustomSearchEngineDeletion`, `DomainAutocompleteTests.test3AutocompleteDeletingChars`, `LoginTest.testAddDuplicateLogin`, `ModernKitOnboardingTests.testModernKitOnboardingToolbarPlacementBottom`, and `SearchTests.testCopyPasteComplete`.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] I updated the documentation if needed
