### PR TITLE
Bugfix FXIOS-16583 [Nova] Improve top address bar contrast over wallpapers

### DIFF
--- a/BrowserKit/Sources/Common/Theming/NovaDarkTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaDarkTheme.swift
@@ -35,6 +35,7 @@ private struct NovaDarkColourPalette: ThemeColourPalette {
     var layer4: UIColor = NovaColors.Gray65
     var layerSurfaceLow = NovaColors.Gray75
     var layerSurfaceMedium = NovaColors.Gray65
+    var layerSurfaceMediumAlt: UIColor = NovaColors.Gray60
     var layerSurfaceMediumAlpha = NovaColors.Gray65.withAlphaComponent(0.4)
     var layerAccentSubtle: UIColor = NovaColors.VioletDesaturated70
     var layerInverse: UIColor = NovaColors.Gray30
@@ -143,7 +144,6 @@ private struct NovaDarkColourPalette: ThemeColourPalette {
     var layerCriticalSubdued: UIColor = DarkTheme().colors.layerCriticalSubdued
     var layerEmphasis: UIColor = DarkTheme().colors.layerEmphasis
     var layer5Hover: UIColor = DarkTheme().colors.layer5Hover
-    var layerSurfaceMediumAlt: UIColor = DarkTheme().colors.layerSurfaceMediumAlt
     var indicatorActive: UIColor = DarkTheme().colors.indicatorActive
     var indicatorInactive: UIColor = DarkTheme().colors.indicatorInactive
     var iconAccentViolet: UIColor = DarkTheme().colors.iconAccentViolet

--- a/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaLightTheme.swift
@@ -22,6 +22,7 @@ private struct NovaLightColourPalette: ThemeColourPalette {
     var layer4: UIColor = NovaColors.Gray15
     var layerSurfaceLow = NovaColors.Gray10
     var layerSurfaceMedium = NovaColors.White
+    var layerSurfaceMediumAlt: UIColor = NovaColors.White
     var layerSurfaceMediumAlpha = NovaColors.White.withAlphaComponent(0.4)
     var layerAccentSubtle: UIColor = NovaColors.VioletDesaturated10
     var layerInverse: UIColor = NovaColors.Gray70
@@ -130,7 +131,6 @@ private struct NovaLightColourPalette: ThemeColourPalette {
     var layerCriticalSubdued: UIColor = LightTheme().colors.layerCriticalSubdued
     var layerEmphasis: UIColor = LightTheme().colors.layerEmphasis
     var layer5Hover: UIColor = LightTheme().colors.layer5Hover
-    var layerSurfaceMediumAlt: UIColor = LightTheme().colors.layerSurfaceMediumAlt
     var indicatorActive: UIColor = LightTheme().colors.indicatorActive
     var indicatorInactive: UIColor = LightTheme().colors.indicatorInactive
     var iconAccentViolet: UIColor = LightTheme().colors.iconAccentViolet

--- a/BrowserKit/Sources/Common/Theming/NovaPrivateTheme.swift
+++ b/BrowserKit/Sources/Common/Theming/NovaPrivateTheme.swift
@@ -23,6 +23,7 @@ private struct NovaPrivateColourPalette: ThemeColourPalette {
     var layer5Hover: UIColor = NovaColors.VioletDesaturated70
     var layerSurfaceLow = NovaColors.VioletDesaturated90
     var layerSurfaceMedium = NovaColors.VioletDesaturated80
+    var layerSurfaceMediumAlt: UIColor = NovaColors.VioletDesaturated70
     var layerSurfaceMediumAlpha = NovaColors.VioletDesaturated80.withAlphaComponent(0.4)
     var layerAccentSubtle: UIColor = NovaColors.Violet70
     var layerInverse: UIColor = NovaColors.Gray30
@@ -130,7 +131,6 @@ private struct NovaPrivateColourPalette: ThemeColourPalette {
     var layerScrim: UIColor = PrivateModeTheme().colors.layerScrim
     var layerCriticalSubdued: UIColor = PrivateModeTheme().colors.layerCriticalSubdued
     var layerEmphasis: UIColor = PrivateModeTheme().colors.layerEmphasis
-    var layerSurfaceMediumAlt: UIColor = PrivateModeTheme().colors.layerSurfaceMediumAlt
     var indicatorActive: UIColor = PrivateModeTheme().colors.indicatorActive
     var indicatorInactive: UIColor = PrivateModeTheme().colors.indicatorInactive
     var iconAccentViolet: UIColor = PrivateModeTheme().colors.iconAccentViolet

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
@@ -60,10 +60,8 @@ public struct AddressToolbarUXConfiguration {
     func locationContainerBackgroundColor(theme: some Theme) -> UIColor {
         guard !isAddressBarMinimized else { return .clear }
 
-        let alternativeLocationColor = theme.isNova ? theme.colors.layerSurfaceMedium : theme.colors.layerSurfaceMediumAlt
-
         if hasAlternativeLocationColor {
-            return isLocationTextCentered ? alternativeLocationColor : theme.colors.layerEmphasis
+            return isLocationTextCentered ? theme.colors.layerSurfaceMediumAlt : theme.colors.layerEmphasis
         } else {
             return isLocationTextCentered ? theme.colors.layerSurfaceMedium : theme.colors.layerEmphasis
         }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/AddressToolbarUXConfiguration.swift
@@ -62,8 +62,12 @@ public struct AddressToolbarUXConfiguration {
 
         if hasAlternativeLocationColor {
             return isLocationTextCentered ? theme.colors.layerSurfaceMediumAlt : theme.colors.layerEmphasis
-        } else {
+        } else if #available(iOS 26, *) {
             return isLocationTextCentered ? theme.colors.layerSurfaceMedium : theme.colors.layerEmphasis
+        } else {
+            // for Nova themes on iOS 18 we want to use the alternative color for both top and bottom toolbar
+            let useAlternativeLocationColor = theme.isNova && isLocationTextCentered
+            return useAlternativeLocationColor ? theme.colors.layerSurfaceMediumAlt : theme.colors.layerEmphasis
         }
     }
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -774,8 +774,7 @@ final class LocationView: UIView,
     func applyTheme(theme: Theme) {
         self.theme = theme
         let colors = theme.colors
-        let usesAlternativeLocationColor = !theme.isNova && hasAlternativeLocationColor
-        let mainBackgroundColor = usesAlternativeLocationColor ? colors.layerSurfaceMediumAlt : colors.layerSurfaceMedium
+        let mainBackgroundColor = hasAlternativeLocationColor ? colors.layerSurfaceMediumAlt : colors.layerSurfaceMedium
         let (primaryColor, secondaryColor) = getPrimaryAndSecondaryColors()
 
         gradientLayer.colors = Gradient(

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -774,7 +774,13 @@ final class LocationView: UIView,
     func applyTheme(theme: Theme) {
         self.theme = theme
         let colors = theme.colors
-        let mainBackgroundColor = hasAlternativeLocationColor ? colors.layerSurfaceMediumAlt : colors.layerSurfaceMedium
+
+        var useAlternativeLocationColor = hasAlternativeLocationColor
+        if #unavailable(iOS 26) {
+            // for Nova themes on iOS 18 we want to use the alternative color for both top and bottom toolbar
+            useAlternativeLocationColor = theme.isNova
+        }
+        let mainBackgroundColor = useAlternativeLocationColor ? colors.layerSurfaceMediumAlt : colors.layerSurfaceMedium
         let (primaryColor, secondaryColor) = getPrimaryAndSecondaryColors()
 
         gradientLayer.colors = Gradient(

--- a/BrowserKit/Tests/ToolbarKitTests/AddressToolbarUXConfigurationTests.swift
+++ b/BrowserKit/Tests/ToolbarKitTests/AddressToolbarUXConfigurationTests.swift
@@ -37,4 +37,12 @@ final class AddressToolbarUXConfigurationTests: XCTestCase {
         XCTAssertEqual(subject.addressToolbarBackgroundColor(theme: theme),
                        theme.colors.layer1.withAlphaComponent(0.5))
     }
+
+    func testLocationContainerBackgroundColorWithAlternativeColorUsesAlternativeNovaToken() {
+        let theme = NovaLightTheme()
+        let subject = AddressToolbarUXConfiguration.experiment(hasAlternativeLocationColor: true)
+
+        XCTAssertEqual(subject.locationContainerBackgroundColor(theme: theme),
+                       theme.colors.layerSurfaceMediumAlt)
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -22,7 +22,7 @@ protocol ToolbarHelperInterface {
     var glassEffectAlpha: CGFloat { get }
 
     @MainActor
-    func toolbarBackgroundAlpha(isTopToolbar: Bool) -> CGFloat
+    var novaToolbarGlassEffectAlpha: CGFloat { get }
 
     func shouldShowNavigationToolbar(for traitCollection: UITraitCollection) -> Bool
     func shouldShowTopTabs(for traitCollection: UITraitCollection) -> Bool
@@ -33,10 +33,10 @@ protocol ToolbarHelperInterface {
     func getLockIconState(hasOnlySecureContent: Bool, isWebsiteMode: Bool) -> LockIconState
 }
 
-final class ToolbarHelper: ToolbarHelperInterface {
+final class ToolbarHelper: ToolbarHelperInterface, FeatureFlaggable {
     private enum UX {
         static let backgroundAlphaForBlur: CGFloat = 0.85
-        static let topToolbarBackgroundAlpha: CGFloat = 0.90
+        static let novaToolbarBackgroundAlphaForBlur: CGFloat = 0.90
     }
 
     var isSwipingTabsEnabled: Bool {
@@ -58,11 +58,12 @@ final class ToolbarHelper: ToolbarHelperInterface {
     }
 
     @MainActor
-    func toolbarBackgroundAlpha(isTopToolbar: Bool) -> CGFloat {
-        if #available(iOS 26, *) {
+    var novaToolbarGlassEffectAlpha: CGFloat {
+        if featureFlagsProvider.isEnabled(.novaDesign), #available(iOS 26, *) {
             return glassEffectAlpha
         }
-        return isTopToolbar && shouldBlur() ? UX.topToolbarBackgroundAlpha : glassEffectAlpha
+        // for Nova themes on iOS 18 we want to use a different alpha for both top and bottom toolbar
+        return shouldBlur() ? UX.novaToolbarBackgroundAlphaForBlur : glassEffectAlpha
     }
 
     func shouldShowNavigationToolbar(for traitCollection: UITraitCollection) -> Bool {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -59,7 +59,7 @@ final class ToolbarHelper: ToolbarHelperInterface, FeatureFlaggable {
 
     @MainActor
     var novaToolbarGlassEffectAlpha: CGFloat {
-        if featureFlagsProvider.isEnabled(.novaDesign), #available(iOS 26, *) {
+        guard featureFlagsProvider.isEnabled(.novaDesign), #unavailable(iOS 26) else {
             return glassEffectAlpha
         }
         // for Nova themes on iOS 18 we want to use a different alpha for both top and bottom toolbar

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/ToolbarHelper.swift
@@ -21,6 +21,9 @@ protocol ToolbarHelperInterface {
     @MainActor
     var glassEffectAlpha: CGFloat { get }
 
+    @MainActor
+    func toolbarBackgroundAlpha(isTopToolbar: Bool) -> CGFloat
+
     func shouldShowNavigationToolbar(for traitCollection: UITraitCollection) -> Bool
     func shouldShowTopTabs(for traitCollection: UITraitCollection) -> Bool
 
@@ -33,6 +36,7 @@ protocol ToolbarHelperInterface {
 final class ToolbarHelper: ToolbarHelperInterface {
     private enum UX {
         static let backgroundAlphaForBlur: CGFloat = 0.85
+        static let topToolbarBackgroundAlpha: CGFloat = 0.90
     }
 
     var isSwipingTabsEnabled: Bool {
@@ -51,6 +55,14 @@ final class ToolbarHelper: ToolbarHelperInterface {
     var glassEffectAlpha: CGFloat {
         guard shouldBlur() else { return 1 }
         if #available(iOS 26, *) { return .zero } else { return UX.backgroundAlphaForBlur }
+    }
+
+    @MainActor
+    func toolbarBackgroundAlpha(isTopToolbar: Bool) -> CGFloat {
+        if #available(iOS 26, *) {
+            return glassEffectAlpha
+        }
+        return isTopToolbar && shouldBlur() ? UX.topToolbarBackgroundAlpha : glassEffectAlpha
     }
 
     func shouldShowNavigationToolbar(for traitCollection: UITraitCollection) -> Bool {

--- a/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
@@ -27,6 +27,7 @@ final class StatusBarOverlay: UIView,
                         Notifiable {
     private struct UX {
         static let overlayAppearanceAnimationDuration: TimeInterval = 0.2
+        static let topToolbarBackgroundAlpha: CGFloat = 0.90
     }
 
     private var savedBackgroundColor: UIColor?
@@ -88,7 +89,7 @@ final class StatusBarOverlay: UIView,
     func showOverlay(animated: Bool) {
         guard animated else {
             scrollDelegate?.homepageScrollViewDidScroll(scrollOffset: 1.0)
-            backgroundColor = savedBackgroundColor?.withAlphaComponent(toolbarHelper.glassEffectAlpha)
+            backgroundColor = savedBackgroundColor?.withAlphaComponent(backgroundAlpha)
             return
         }
         UIView.animate(
@@ -97,7 +98,7 @@ final class StatusBarOverlay: UIView,
             options: .curveEaseIn
         ) {
             self.scrollDelegate?.homepageScrollViewDidScroll(scrollOffset: 1.0)
-            self.backgroundColor = self.savedBackgroundColor?.withAlphaComponent(self.toolbarHelper.glassEffectAlpha)
+            self.backgroundColor = self.savedBackgroundColor?.withAlphaComponent(self.backgroundAlpha)
         }
     }
 
@@ -130,14 +131,20 @@ final class StatusBarOverlay: UIView,
     }
 
     private func updateStatusBarAlpha(isHomepage: Bool, needsNoStatusBar: Bool) {
-        let translucencyBackgroundAlpha = toolbarHelper.glassEffectAlpha
-
         if needsNoStatusBar {
-            let alpha = scrollOffset > translucencyBackgroundAlpha ? translucencyBackgroundAlpha : scrollOffset
+            let alpha = scrollOffset > backgroundAlpha ? backgroundAlpha : scrollOffset
             backgroundColor = savedBackgroundColor?.withAlphaComponent(alpha)
         } else {
-            backgroundColor = savedBackgroundColor?.withAlphaComponent(translucencyBackgroundAlpha)
+            backgroundColor = savedBackgroundColor?.withAlphaComponent(backgroundAlpha)
         }
+    }
+
+    private var backgroundAlpha: CGFloat {
+        if #available(iOS 26, *) {
+            return toolbarHelper.glassEffectAlpha
+        }
+        return !isBottomSearchBar && toolbarHelper.shouldBlur() ?
+            UX.topToolbarBackgroundAlpha : toolbarHelper.glassEffectAlpha
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
@@ -27,7 +27,6 @@ final class StatusBarOverlay: UIView,
                         Notifiable {
     private struct UX {
         static let overlayAppearanceAnimationDuration: TimeInterval = 0.2
-        static let topToolbarBackgroundAlpha: CGFloat = 0.90
     }
 
     private var savedBackgroundColor: UIColor?
@@ -140,11 +139,7 @@ final class StatusBarOverlay: UIView,
     }
 
     private var backgroundAlpha: CGFloat {
-        if #available(iOS 26, *) {
-            return toolbarHelper.glassEffectAlpha
-        }
-        return !isBottomSearchBar && toolbarHelper.shouldBlur() ?
-            UX.topToolbarBackgroundAlpha : toolbarHelper.glassEffectAlpha
+        return toolbarHelper.toolbarBackgroundAlpha(isTopToolbar: !isBottomSearchBar)
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
+++ b/firefox-ios/Client/Frontend/Components/StatusBarOverlay.swift
@@ -86,6 +86,8 @@ final class StatusBarOverlay: UIView,
     }
 
     func showOverlay(animated: Bool) {
+        let backgroundAlpha = toolbarHelper.novaToolbarGlassEffectAlpha
+
         guard animated else {
             scrollDelegate?.homepageScrollViewDidScroll(scrollOffset: 1.0)
             backgroundColor = savedBackgroundColor?.withAlphaComponent(backgroundAlpha)
@@ -97,7 +99,7 @@ final class StatusBarOverlay: UIView,
             options: .curveEaseIn
         ) {
             self.scrollDelegate?.homepageScrollViewDidScroll(scrollOffset: 1.0)
-            self.backgroundColor = self.savedBackgroundColor?.withAlphaComponent(self.backgroundAlpha)
+            self.backgroundColor = self.savedBackgroundColor?.withAlphaComponent(backgroundAlpha)
         }
     }
 
@@ -130,16 +132,13 @@ final class StatusBarOverlay: UIView,
     }
 
     private func updateStatusBarAlpha(isHomepage: Bool, needsNoStatusBar: Bool) {
+        let backgroundAlpha = toolbarHelper.novaToolbarGlassEffectAlpha
         if needsNoStatusBar {
             let alpha = scrollOffset > backgroundAlpha ? backgroundAlpha : scrollOffset
             backgroundColor = savedBackgroundColor?.withAlphaComponent(alpha)
         } else {
             backgroundColor = savedBackgroundColor?.withAlphaComponent(backgroundAlpha)
         }
-    }
-
-    private var backgroundAlpha: CGFloat {
-        return toolbarHelper.toolbarBackgroundAlpha(isTopToolbar: !isBottomSearchBar)
     }
 
     // MARK: - ThemeApplicable

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockToolbarHelper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockToolbarHelper.swift
@@ -31,7 +31,7 @@ class MockToolbarHelper: ToolbarHelperInterface, FeatureFlaggable {
 
     @MainActor
     var novaToolbarGlassEffectAlpha: CGFloat {
-        if featureFlagsProvider.isEnabled(.novaDesign), #available(iOS 26, *) {
+        guard featureFlagsProvider.isEnabled(.novaDesign), #unavailable(iOS 26) else {
             return glassEffectAlpha
         }
         // for Nova themes on iOS 18 we want to use a different alpha for both top and bottom toolbar

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockToolbarHelper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockToolbarHelper.swift
@@ -8,10 +8,10 @@ import UIKit
 
 @testable import Client
 
-class MockToolbarHelper: ToolbarHelperInterface {
+class MockToolbarHelper: ToolbarHelperInterface, FeatureFlaggable {
     private enum UX {
         static let backgroundAlphaForBlur: CGFloat = 0.85
-        static let topToolbarBackgroundAlpha: CGFloat = 0.90
+        static let novaToolbarBackgroundAlphaForBlur: CGFloat = 0.90
     }
 
     var reduceTransparencyEnabled = false
@@ -30,11 +30,12 @@ class MockToolbarHelper: ToolbarHelperInterface {
     }
 
     @MainActor
-    func toolbarBackgroundAlpha(isTopToolbar: Bool) -> CGFloat {
-        if #available(iOS 26, *) {
+    var novaToolbarGlassEffectAlpha: CGFloat {
+        if featureFlagsProvider.isEnabled(.novaDesign), #available(iOS 26, *) {
             return glassEffectAlpha
         }
-        return isTopToolbar && shouldBlur() ? UX.topToolbarBackgroundAlpha : glassEffectAlpha
+        // for Nova themes on iOS 18 we want to use a different alpha for both top and bottom toolbar
+        return shouldBlur() ? UX.novaToolbarBackgroundAlphaForBlur : glassEffectAlpha
     }
 
     func shouldShowNavigationToolbar(for traitCollection: UITraitCollection) -> Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockToolbarHelper.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockToolbarHelper.swift
@@ -11,6 +11,7 @@ import UIKit
 class MockToolbarHelper: ToolbarHelperInterface {
     private enum UX {
         static let backgroundAlphaForBlur: CGFloat = 0.85
+        static let topToolbarBackgroundAlpha: CGFloat = 0.90
     }
 
     var reduceTransparencyEnabled = false
@@ -26,6 +27,14 @@ class MockToolbarHelper: ToolbarHelperInterface {
     var glassEffectAlpha: CGFloat {
         guard shouldBlur() else { return 1 }
         if #available(iOS 26, *) { return .zero } else { return UX.backgroundAlphaForBlur }
+    }
+
+    @MainActor
+    func toolbarBackgroundAlpha(isTopToolbar: Bool) -> CGFloat {
+        if #available(iOS 26, *) {
+            return glassEffectAlpha
+        }
+        return isTopToolbar && shouldBlur() ? UX.topToolbarBackgroundAlpha : glassEffectAlpha
     }
 
     func shouldShowNavigationToolbar(for traitCollection: UITraitCollection) -> Bool {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StatusBarOverlayTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StatusBarOverlayTests.swift
@@ -14,22 +14,26 @@ final class StatusBarOverlayTests: XCTestCase {
     private var wallpaperManager: WallpaperManagerMock!
     private var notificationCenter: MockNotificationCenter!
     private var toolbarHelper: ToolbarHelperInterface!
+    private var featureFlags: MockNimbusFeatureFlags!
 
-    private var expectedAlpha: CGFloat = if #available(iOS 26, *) { .zero } else { 0.90 }
-    private var expectedBottomAlpha: CGFloat = if #available(iOS 26, *) { .zero } else { 0.85 }
+    private var expectedAlpha: CGFloat = if #available(iOS 26, *) { .zero } else { 0.85 }
+    private var expectedNovaAlpha: CGFloat = if #available(iOS 26, *) { .zero } else { 0.90 }
 
     override func setUp() async throws {
         try await super.setUp()
         self.profile = MockProfile()
         self.wallpaperManager = WallpaperManagerMock()
         self.notificationCenter = MockNotificationCenter()
-        DependencyHelperMock().bootstrapDependencies(injectedProfile: profile)
+        self.featureFlags = MockNimbusFeatureFlags()
+        DependencyHelperMock().bootstrapDependencies(injectedProfile: profile,
+                                                     injectedFeatureFlagProvider: featureFlags)
     }
 
     override func tearDown() async throws {
         self.profile = nil
         self.wallpaperManager = nil
         self.notificationCenter = nil
+        self.featureFlags = nil
         DependencyHelperMock().reset()
         try await super.tearDown()
     }
@@ -100,6 +104,20 @@ final class StatusBarOverlayTests: XCTestCase {
                        LightTheme().colors.layerSurfaceLow.withAlphaComponent(expectedAlpha).cgColor)
     }
 
+    func testOnHomepage_withNovaThemeTopURLBar_translucencyOn_usesNovaAlpha() throws {
+        featureFlags.enabledFlags = [.novaDesign]
+        let toolbarHelper = createToolbarMock()
+        let subject = createSubject(toolbarHelper: toolbarHelper)
+        profile.prefs.setString("top", forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+        subject.applyTheme(theme: NovaLightTheme())
+
+        subject.resetState(isHomepage: true)
+
+        let backgroundColor = try XCTUnwrap(subject.backgroundColor)
+        XCTAssertEqual(backgroundColor.cgColor,
+                       NovaLightTheme().colors.layerSurfaceLow.withAlphaComponent(expectedNovaAlpha).cgColor)
+    }
+
     func testOnWebpage_withoutWallpaperWithBottomURLBar_translucencyOn_isTranslucent() throws {
         let toolbarHelper = createToolbarMock()
         let subject = createSubject(toolbarHelper: toolbarHelper)
@@ -109,7 +127,7 @@ final class StatusBarOverlayTests: XCTestCase {
 
         let backgroundColor = try XCTUnwrap(subject.backgroundColor)
         XCTAssertEqual(backgroundColor.cgColor,
-                       LightTheme().colors.layerSurfaceLow.withAlphaComponent(expectedBottomAlpha).cgColor)
+                       LightTheme().colors.layerSurfaceLow.withAlphaComponent(expectedAlpha).cgColor)
     }
 
     func testOnWebpage_withoutWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {
@@ -137,7 +155,7 @@ final class StatusBarOverlayTests: XCTestCase {
 
         let backgroundColor = try XCTUnwrap(subject.backgroundColor)
         XCTAssertEqual(backgroundColor.cgColor,
-                       LightTheme().colors.layerSurfaceLow.withAlphaComponent(expectedBottomAlpha).cgColor)
+                       LightTheme().colors.layerSurfaceLow.withAlphaComponent(expectedAlpha).cgColor)
     }
 
     func testOnWebpage_withWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/StatusBarOverlayTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/StatusBarOverlayTests.swift
@@ -15,7 +15,8 @@ final class StatusBarOverlayTests: XCTestCase {
     private var notificationCenter: MockNotificationCenter!
     private var toolbarHelper: ToolbarHelperInterface!
 
-    private var expectedAlpha: CGFloat = if #available(iOS 26, *) { .zero } else { 0.85 }
+    private var expectedAlpha: CGFloat = if #available(iOS 26, *) { .zero } else { 0.90 }
+    private var expectedBottomAlpha: CGFloat = if #available(iOS 26, *) { .zero } else { 0.85 }
 
     override func setUp() async throws {
         try await super.setUp()
@@ -108,7 +109,7 @@ final class StatusBarOverlayTests: XCTestCase {
 
         let backgroundColor = try XCTUnwrap(subject.backgroundColor)
         XCTAssertEqual(backgroundColor.cgColor,
-                       LightTheme().colors.layerSurfaceLow.withAlphaComponent(expectedAlpha).cgColor)
+                       LightTheme().colors.layerSurfaceLow.withAlphaComponent(expectedBottomAlpha).cgColor)
     }
 
     func testOnWebpage_withoutWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {
@@ -136,7 +137,7 @@ final class StatusBarOverlayTests: XCTestCase {
 
         let backgroundColor = try XCTUnwrap(subject.backgroundColor)
         XCTAssertEqual(backgroundColor.cgColor,
-                       LightTheme().colors.layerSurfaceLow.withAlphaComponent(expectedAlpha).cgColor)
+                       LightTheme().colors.layerSurfaceLow.withAlphaComponent(expectedBottomAlpha).cgColor)
     }
 
     func testOnWebpage_withWallpaperWithTopURLBar_translucencyOn_isTranslucent() throws {


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16583)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35260)

## :bulb: Description
Improves top address bar visibility against wallpapers by using layerSurfaceMediumAlt and increasing the iOS 18 toolbar overlay alpha to 0.90

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
|<img width="1290" height="2796" alt="image-20260814-132046" src="https://github.com/user-attachments/assets/54ec3cff-8434-48a7-9743-79d14e2e3c8a" />| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-09-10 at 07 52 46" src="https://github.com/user-attachments/assets/ec692aa1-371f-4f80-b551-81ebe26dfed5" /> |


## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

