### PR TITLE
Bugfix FXIOS-16761 - [Theming] - Toast message background color and text is not displayed properly upon theme change

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toasts/Toast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/Toast.swift
@@ -141,7 +141,7 @@ class Toast: UIView, ThemeApplicable, Notifiable {
         }
     }
 
-    private lazy var glassEffect: some UIVisualEffect? = {
+    private lazy var glassEffect: UIVisualEffect? = {
         guard #available(iOS 26, *) else { return nil }
         return UIGlassEffect()
     }()

--- a/firefox-ios/Client/Frontend/Browser/Toasts/Toast.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toasts/Toast.swift
@@ -141,17 +141,25 @@ class Toast: UIView, ThemeApplicable, Notifiable {
         }
     }
 
+    private lazy var glassEffect: some UIVisualEffect? = {
+        guard #available(iOS 26, *) else { return nil }
+        return UIGlassEffect()
+    }()
+
     @available(iOS 26.0, *)
     private func setupGlassEffect(theme: Theme) {
-        // Only add glass effect if it doesn't already exist
-        guard glassEffectView == nil else { return }
+        if let effect = glassEffect as? UIGlassEffect {
+            effect.tintColor = theme.isNova ? theme.colors.layerInverse : theme.colors.actionPrimary
+        }
+
+        // Only add the effect view once; later calls just refresh the tint
+        if let glassEffectView {
+            glassEffectView.effect = glassEffect
+            return
+        }
 
         let effectView = UIVisualEffectView()
-
-        let glassEffect = UIGlassEffect()
-        glassEffect.tintColor = theme.isNova ? theme.colors.layerInverse : theme.colors.actionPrimary
         effectView.effect = glassEffect
-
         effectView.layer.cornerRadius = UX.toastCornerRadius
         effectView.clipsToBounds = true
         effectView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16761)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35611)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
### The Problem

The `UIGlassEffect` and its theme tint were only configured inline at the moment the effect view was first created. Every subsequent `applyTheme(theme:)` call hit this guard and returned before touching the tint at all.

### The Fix

Separate the one-time view setup from the per-theme styling:

- The `UIGlassEffect` now lives in a cached lazy property instead of  being created inline during view setup.
- `setupGlassEffect(theme:)` updates the effect's `tintColor` on every call and re-assigns the effect to the existing effect view, so each `applyTheme` refreshes the color.
- The `UIVisualEffectView` itself is still created and constrained only once, preserving the original intent of the guard.


<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->

https://github.com/user-attachments/assets/0d84823c-7160-418c-a2d9-5710210bd0de

</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [x] If needed, I updated documentation and added comments to complex code

