### PR TITLE
Bugfix FXIOS-16707 [Synced Tabs] Show empty state when no synced tabs are available

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/ExperimentRemoteTabsEmptyView.swift
@@ -83,22 +83,24 @@ class ExperimentRemoteTabsEmptyView: UIView,
         )
         signInButton.configure(viewModel: viewModel)
 
-        if config == .notLoggedIn || config == .failedToSync {
+        signInButton.removeTarget(nil, action: nil, for: .touchUpInside)
+
+        switch config {
+        case .noClients, .noTabs:
+            signInButton.addTarget(self, action: #selector(refreshTabs), for: .touchUpInside)
+        case .notLoggedIn, .failedToSync:
             signInButton.addTarget(self, action: #selector(presentSignIn), for: .touchUpInside)
-        } else if config == .syncDisabledByUser {
+        case .syncDisabledByUser:
             signInButton.addTarget(self, action: #selector(openAccountSettings), for: .touchUpInside)
         }
 
-        signInButton.isHidden = shouldHideButton(config)
+        signInButton.isHidden = false
+        signInButton.isEnabled = !isSyncing
 
         // Recalculate layout after setting text. Labels initialize empty, causing button to clip
         // multi-line text at large Dynamic Type sizes if intrinsic size isn't updated.
         signInButton.invalidateIntrinsicContentSize()
         signInButton.layoutIfNeeded()
-    }
-
-    private func shouldHideButton(_ state: RemoteTabsPanelEmptyStateReason) -> Bool {
-        return state == .noClients && state == .noTabs
     }
 
     private func setupLayout() {
@@ -163,6 +165,11 @@ class ExperimentRemoteTabsEmptyView: UIView,
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .syncSignIn)
             delegate.remotePanelDidRequestToSignIn()
         }
+    }
+
+    @objc
+    private func refreshTabs() {
+        delegate?.remotePanelDidRequestToRefreshTabs()
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsEmptyView.swift
@@ -9,6 +9,9 @@ import Shared
 
 protocol RemoteTabsEmptyViewDelegate: AnyObject {
     @MainActor
+    func remotePanelDidRequestToRefreshTabs()
+
+    @MainActor
     func remotePanelDidRequestToSignIn()
 
     @MainActor
@@ -93,17 +96,19 @@ class RemoteTabsEmptyView: UIView,
         titleLabel.text =  .EmptySyncedTabsPanelStateTitle
         instructionsLabel.text = config.localizedString()
 
-        if config == .notLoggedIn || config == .failedToSync {
+        signInButton.removeTarget(nil, action: nil, for: .touchUpInside)
+
+        switch config {
+        case .noClients, .noTabs:
+            signInButton.addTarget(self, action: #selector(refreshTabs), for: .touchUpInside)
+        case .notLoggedIn, .failedToSync:
             signInButton.addTarget(self, action: #selector(presentSignIn), for: .touchUpInside)
-        } else if config == .syncDisabledByUser {
+        case .syncDisabledByUser:
             signInButton.addTarget(self, action: #selector(openAccountSettings), for: .touchUpInside)
         }
 
-        signInButton.isHidden = shouldHideButton(config)
-    }
-
-    private func shouldHideButton(_ state: RemoteTabsPanelEmptyStateReason) -> Bool {
-        return state == .noClients && state == .noTabs
+        signInButton.isHidden = false
+        signInButton.isEnabled = !isSyncing
     }
 
     private func setupLayout() {
@@ -149,6 +154,11 @@ class RemoteTabsEmptyView: UIView,
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .syncSignIn)
             delegate.remotePanelDidRequestToSignIn()
         }
+    }
+
+    @objc
+    private func refreshTabs() {
+        delegate?.remotePanelDidRequestToRefreshTabs()
     }
 
     @objc

--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/RemoteTabsPanel.swift
@@ -237,6 +237,10 @@ final class RemoteTabsPanel: UIViewController,
     }
 
     // MARK: - RemotePanelDelegate
+    func remotePanelDidRequestToRefreshTabs() {
+        refreshTabs()
+    }
+
     func remotePanelDidRequestToSignIn() {
         remoteTabsDelegate?.presentFirefoxAccountSignIn()
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/RemoteTabsPanelTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/RemoteTabsPanelTests.swift
@@ -144,6 +144,17 @@ final class RemoteTabsPanelTests: XCTestCase, StoreTestUtility {
 
     // MARK: - RemoteTabsEmptyViewDelegate
     @MainActor
+    func testRemotePanelDidRequestToRefreshTabs_dispatchesRefreshTabsAction() throws {
+        let subject = createSubject()
+        subject.remotePanelDidRequestToRefreshTabs()
+
+        let action = try XCTUnwrap(mockStore.dispatchedActions.last)
+        let actionType = try XCTUnwrap(action.actionType as? RemoteTabsPanelActionType)
+
+        XCTAssertEqual(actionType, RemoteTabsPanelActionType.refreshTabs)
+    }
+
+    @MainActor
     func testRemotePanelDidRequestToOpenInNewTab_dispatchesCloseSelectedRemoteURLAction() throws {
         let subject = createSubject()
         subject.remotePanelDidRequestToOpenInNewTab(


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16415)

## :bulb: Description

Display an empty state in the Synced Tabs panel when there are no synced tabs available.

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| --- | --- |
|  |  |

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

