### PR TITLE
Bugfix FXIOS-16763 Change Wayback Error Card Icon to Custom Icon

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
@@ -54,7 +54,7 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable, UITextViewDe
     }
 
     private lazy var waybackErrorIcon: UIImageView = .build { imageView in
-        imageView.image = UIImage(systemName: "exclamationmark.triangle.fill")
+        imageView.image = UIImage(named: StandardImageIdentifiers.Large.warning)
         imageView.contentMode = .scaleAspectFit
         imageView.setContentHuggingPriority(.required, for: .horizontal)
         imageView.isAccessibilityElement = false


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16763)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35627)

## :bulb: Description
This PR changes the icon used in the wayback error card to our custom icon.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

