### PR TITLE
Bugfix FXIOS-16765 Fix Repeated VO Readout in Wayback Footer

### DIFF
--- a/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
+++ b/firefox-ios/Client/Frontend/NativeErrorPage/NativeErrorRegularContentView.swift
@@ -203,7 +203,6 @@ final class NativeErrorRegularContentView: UIView, ThemeApplicable, UITextViewDe
         }
 
         waybackFooterTextView.attributedText = attributedString
-        waybackFooterTextView.accessibilityLabel = fullText
     }
 
     /// Updates the wayback area to reflect idle, loading, or failed state.


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16765)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35628)

## :bulb: Description
This PR fixes a bug where in VO the footer would be read out twice.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

