### PR TITLE
Bugfix FXIOS-13424 [Swipe tabs] Hide preview at tab boundary

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Toolbars/TabSwipeGestureHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/TabSwipeGestureHandler.swift
@@ -234,6 +234,7 @@ final class TabSwipeGestureHandler: NSObject, UIGestureRecognizerDelegate, Store
                 webPagePreview.setScreenshot(url: nil)
             }
         } else {
+            webPagePreview.isHidden = nextTab == nil
             webPagePreview.alpha = 1.0
             webPagePreview.setScreenshot(nextTab)
         }


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-13424)
[GitHub issue](https://github.com/mozilla-mobile/firefox-ios/issues/29181)

## :bulb: Description
When swiping toward a missing adjacent tab, `nextTab` is `nil`, but `TabWebViewPreview` remains visible and displays its fallback background and Firefox favicon.

This change hides the preview only when no adjacent tab exists in the non-new-tab path. Valid adjacent-tab previews and the add-new-tab gesture remain unchanged.

## :movie_camera: Demos

### Before

https://github.com/user-attachments/assets/c225cda3-d5d7-44b1-97fe-098b894f3874

### After

https://github.com/user-attachments/assets/1453d313-9579-4a23-a345-0f8b87218a6e

## Testing
- Built the Fennec scheme successfully with Xcode 27.0.
- Tested on an iPhone 17 simulator running iOS 27.0.
- Verified the first-tab boundary swipe in light and dark mode.
- Verified that swiping between adjacent tabs remains functional.
- Ran SwiftLint 0.65.0 on the modified file with 0 violations.

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow the PR naming guidelines
- [ ] I ensured unit tests pass and wrote tests for new code
- [x] Accessibility was considered; this change does not add or modify text, controls, or accessibility semantics
- [x] No telemetry was added or modified
- [x] No strings or localization were added or modified
- [x] No documentation update is required
