### PR TITLE
Add [AdBlocker] Enable the ad blocker by default for all users

### DIFF
--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -452,7 +452,8 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
     }
 
     private func checkAdBlockerBadgeFeature() -> Bool {
-        return nimbus.features.adBlockerFeature.value().badgeEnabled
+        // Hardcoded on so the ad blocker is enabled for everyone, without risking changes to the code directly.
+        return true
     }
 
     func checkStartAtHomeConfiguration() -> StartAtHome {

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -443,7 +443,8 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
     }
 
     private func checkAdBlockerFeature() -> Bool {
-        return nimbus.features.adBlockerFeature.value().enabled
+        // Hardcoded on so the ad blocker is enabled for everyone, without risking changes to the code directly.
+        return true
     }
 
     private func checkBackgroundAudioFeature() -> Bool {


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16799)

Enable ad block by default bypassing Nimbus. I intentionally didn't touch the code branches to remove the flag altogether because I didn't want to risk breaking anything. Clean up can be a follow up task.

## :pencil: Checklist
- [ ] I filled in the ticket numbers and a description of my work
- [ ] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

