### PR TITLE
Bugfix FX-14729 Close Old Tabs skipping automatically selected tab

### DIFF
--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -530,13 +530,20 @@ final class TabManagerImplementation: NSObject,
                 }
                 return
             }
-
             if let mostRecentViableTab = mostRecentTab(inTabs: viableTabs), mostRecentViableTab == removedTab.parent {
                 // 1. Try to select the most recently used viable tab, if it's the removed tab's parent.
                 selectTab(mostRecentViableTab, previous: removedTab)
-            } else if let rightOrLeftTab = findRightOrLeftTab(forRemovedTab: removedTab, withDeletedIndex: deletedIndex) {
+            } else if let rightOrLeftTab = findRightOrLeftTab(
+                forRemovedTab: removedTab,
+                withDeletedIndex: deletedIndex
+            ) {
                 // 2. Try to select an array neighbour of the same tab type
-                selectTab(rightOrLeftTab, previous: removedTab)
+                selectTabInternal(
+                    rightOrLeftTab,
+                    previous: removedTab,
+                    immediatePreservation: false,
+                    updateLastExecutedTime: false
+                )
             } else {
                 // 3. If there are no suitable tabs to select, create a new normal tab.
                 selectTab(addTab(), previous: removedTab)
@@ -941,11 +948,24 @@ final class TabManagerImplementation: NSObject,
     /// Note: it is safe to call this with `tab` and `previous` as the same tab, for use in the case
     /// where the index of the tab has changed (such as after deletion).
     func selectTab(_ tab: Tab?, previous: Tab? = nil, immediatePreservation: Bool = false) {
+        selectTabInternal(
+            tab,
+            previous: previous,
+            immediatePreservation: immediatePreservation,
+            updateLastExecutedTime: true
+        )
+    }
+
+    private func selectTabInternal(
+        _ tab: Tab?,
+        previous: Tab?,
+        immediatePreservation: Bool,
+        updateLastExecutedTime: Bool
+    ) {
         assert(Thread.isMainThread)
         // Fallback everywhere to selectedTab if no previous tab
         let previous = previous ?? selectedTab
         previous?.pauseDocumentDownload()
-
         guard let tab = tab,
               let tabUUID = UUID(uuidString: tab.tabUUID)
         else {
@@ -960,7 +980,6 @@ final class TabManagerImplementation: NSObject,
         logger.log("Select tab",
                    level: .info,
                    category: .tabs)
-
         // Before moving to a new tab save the current tab session data in order to preserve things like scroll position
         saveSessionData(forTab: selectedTab)
 
@@ -972,11 +991,14 @@ final class TabManagerImplementation: NSObject,
         }
 
         selectedIndex = tabs.firstIndex(of: tab) ?? -1
-
         preserveTabs(immediate: immediatePreservation)
 
         let sessionData = tabSessionStore.fetchTabSession(tabID: tabUUID)
-        selectTabWithSession(tab: tab, sessionData: sessionData)
+        selectTabWithSession(
+            tab: tab,
+            sessionData: sessionData,
+            updateLastExecutedTime: updateLastExecutedTime
+        )
 
         let action = PrivateModeAction(isPrivate: tab.isPrivate,
                                        windowUUID: windowUUID,
@@ -984,7 +1006,6 @@ final class TabManagerImplementation: NSObject,
         store.dispatch(action)
 
         tab.resumeDocumentDownload()
-
         didSelectTab(url)
         updateMenuItemsForSelectedTab()
         if isDeeplinkOptimizationRefactorEnabled {
@@ -992,7 +1013,6 @@ final class TabManagerImplementation: NSObject,
         } else {
             dispatchDidSetScreenshotAction(for: tab)
         }
-
         // Broadcast updates for any listeners
         delegates.forEach {
             $0.get()?.tabManager(
@@ -1009,7 +1029,6 @@ final class TabManagerImplementation: NSObject,
         if let tab = selectedTab {
             TabEvent.post(.didGainFocus, for: tab)
         }
-
         // Note: we setup last session private case as the session is tied to user's selected
         // tab but there are times when tab manager isn't available and we need to know
         // users's last state (Private vs Regular)
@@ -1059,11 +1078,18 @@ final class TabManagerImplementation: NSObject,
         store.dispatch(action)
     }
 
-    private func selectTabWithSession(tab: Tab, sessionData: Data?) {
+    private func selectTabWithSession(
+        tab: Tab,
+        sessionData: Data?,
+        updateLastExecutedTime: Bool
+    ) {
         MainActor.assertIsolated("Expected to be called only on main actor.")
         let configuration = tabConfigurationProvider.configuration(isPrivate: tab.isPrivate).webViewConfiguration
         selectedTab?.createWebview(with: sessionData, configuration: configuration)
-        selectedTab?.lastExecutedTime = Date.now()
+
+        if updateLastExecutedTime {
+            selectedTab?.lastExecutedTime = Date.now()
+        }
     }
 
     // MARK: - TabEventHandler

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerOlderTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/TabManagement/TabManagerOlderTabsTests.swift
@@ -33,6 +33,23 @@ final class TabManagerOlderTabsTests: TabManagerTestsBase {
     }
 
     @MainActor
+    func testRemoveNormalTabsOlderThan_whenFreshTabClosed_thenAllOldTabsRemoved() {
+        let oldTabs = generateTabs(ofType: .normalOlder2Weeks, count: 5)
+        let tabManager = createSubject(tabs: oldTabs)
+
+        let freshTab = tabManager.addTab()
+        tabManager.selectTab(freshTab)
+
+        tabManager.removeTab(freshTab.tabUUID)
+
+        tabManager.removeNormalTabsOlderThan(period: .oneWeek, currentDate: testDate)
+
+        XCTAssertEqual(tabManager.normalTabs.count, 1)
+        XCTAssertTrue(tabManager.selectedTab?.isURLStartingPage == true)
+        XCTAssertFalse(oldTabs.contains { $0 === tabManager.selectedTab })
+    }
+
+    @MainActor
     func testRemoveNormalTabsOlderThan_whenPrivateTabs_thenNoTabsRemoved() {
         let numberPrivateTabs = 3
         let tabs = generateTabs(ofType: .privateAny, count: numberPrivateTabs)


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14729)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31809)

## :bulb: Description
- When a newly created tab is closed, Firefox automatically selects the neighboring tab and updates its `lastExecutedTime`
- If that neighboring tab is an older tab, it is then treated as recently used and skipped when using `Close Old Tabs`
- This change prevents `lastExecutedTime` from being updated when a neighboring tab is automatically selected after tab removal.

## Testing
- Update `TabManagerOlderTabsTests` with a regression test for the scenario 
- Manually verified the QA reproduction steps

## :pencil: Checklist
- [X] I filled in the ticket numbers and a description of my work
- [X] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [X] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

