### PR TITLE
[MTE-6182] - multiple auto updates

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
@@ -193,7 +193,7 @@
         "HomePageSettingsUITests\/testRecentlySaved()",
         "HomePageSettingsUITests\/testSetFirefoxHomeAsHome()",
         "HomePageSettingsUITests\/testShortcutsRows()",
-        "HomePageSettingsUITests\/testTyping()",
+        "HomePageSettingsUITests\/testValidateCustomURLAsCurrentHomepage()",
         "IntegrationTests",
         "IntegrationTests\/testFxADisconnectConnect()",
         "IntegrationTests\/testFxASyncBookmark()",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -297,7 +297,7 @@
         "HomePageSettingsUITests\/testSetFirefoxHomeAsHome()",
         "HomePageSettingsUITests\/testShortcutsRows()",
         "HomePageSettingsUITests\/testTopSitesCustomNumberOfRows()",
-        "HomePageSettingsUITests\/testTyping()",
+        "HomePageSettingsUITests\/testValidateCustomURLAsCurrentHomepage()",
         "IntegrationTests",
         "IpadOnlyTestCase",
         "IphoneOnlyTestCase",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/HomePageSettingsUITest.swift
@@ -15,6 +15,8 @@ let urlMozillaLabel = "Internet for people, not profit — Mozilla (US)"
 
 class HomePageSettingsUITests: FeatureFlaggedTestBase {
     private var homepageSettingsScreen: HomepageSettingsScreen!
+    private var settingsHomepageScreen: SettingsHomepageScreen!
+    private var homePageScreen: HomePageScreen!
     private var settingScreen: SettingScreen!
     private var toolbarScreen: ToolbarScreen!
     private var browserScreen: BrowserScreen!
@@ -41,6 +43,8 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
         launchArguments.append(LaunchArguments.SkipAppleIntelligence)
         try await super.setUp()
         homepageSettingsScreen = HomepageSettingsScreen(app: app)
+        settingsHomepageScreen = SettingsHomepageScreen(app: app)
+        homePageScreen = HomePageScreen(app: app)
         settingScreen = SettingScreen(app: app)
         toolbarScreen = ToolbarScreen(app: app)
         browserScreen = BrowserScreen(app: app)
@@ -52,31 +56,28 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
 
-        waitForElementsToExist(
-            [
-                app.navigationBars["Homepage"],
-                app.tables.otherElements["OPENING SCREEN"],
-                app.tables.otherElements["INCLUDE ON HOMEPAGE"],
-                app.tables.otherElements["CURRENT HOMEPAGE"]
-            ]
-        )
+        settingsHomepageScreen.assertSectionsAreDisplayed()
 
         // Opening Screen
-        XCTAssertFalse(app.tables.cells["StartAtHomeAlways"].isSelected)
-        XCTAssertFalse(app.tables.cells["StartAtHomeAfterFourHours"].isSelected)
-        XCTAssertTrue(app.tables.cells["StartAtHomeDisabled"].isSelected)
+        settingsHomepageScreen.assertLastTabIsSelectedAsOpeningScreen()
 
         // Include on Homepage
-        mozWaitForElementToExist(app.tables.cells["TopSitesSettings"].staticTexts["On"])
+        homepageSettingsScreen.assertJumpBackInToggleIsDisabled()
+        homepageSettingsScreen.assertShortcutsSettingIsOn()
+        // The Stories row is not rendered on iOS 16, where the locale identifier is
+        // reported as "en-US_US" and fails the Merino supported locale check
+        if #available(iOS 17, *) {
+            settingsHomepageScreen.assertStoriesSwitch(isOn: true)
+        }
+        homepageSettingsScreen.assertBookmarkToggleIsDisabled()
 
         // Current Homepage
-        XCTAssertTrue(app.tables.cells["Firefox Home"].isSelected)
-        mozWaitForElementToExist(app.tables.cells["HomeAsCustomURL"])
+        settingsHomepageScreen.assertFirefoxHomeIsSelectedAsCurrentHomepage()
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339257
     // Regression
-    func testTyping() throws {
+    func testValidateCustomURLAsCurrentHomepage() throws {
         guard !iPad() else {
             throw XCTSkip("The navigation toolbar middle button cannot be configured on iPad")
         }
@@ -129,28 +130,36 @@ class HomePageSettingsUITests: FeatureFlaggedTestBase {
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339260
-    func testSetFirefoxHomeAsHome() {
+    func testSetFirefoxHomeAsHome() throws {
+        guard !iPad() else {
+            throw XCTSkip("The navigation toolbar middle button cannot be configured on iPad")
+        }
         app.launch()
         // Go to homepage settings
         waitForTabsButton()
         navigator.nowAt(NewTabScreen)
         navigator.goto(HomeSettings)
-        // Firefox home and custom URL options are displayed
-        // Firefox Home is selected by default
-        mozWaitForElementToExist(app.tables.cells["HomeAsFirefoxHome"])
-        mozWaitForElementToExist(app.tables.cells["HomeAsCustomURL"])
-        XCTAssertTrue(app.tables.cells["HomeAsFirefoxHome"].isSelected, "Firefox Home is not selected by default")
+        // Firefox home and custom URL options are displayed, Firefox Home is selected by default
+        settingsHomepageScreen.assertFirefoxHomeIsSelectedAsCurrentHomepage()
+
+        // The homepage is loaded by the Home button, which replaces the new tab button in the
+        // middle of the navigation toolbar
         navigator.goto(SettingsScreen)
-        navigator.goto(NewTabScreen)
+        settingScreen.navigateToToolbarSettings()
+        settingScreen.selectNavigationToolbarMiddleButton(.home)
+        settingScreen.tapBackToSettings()
+        settingScreen.closeSettingsWithDoneButton()
+
+        // Go to a webpage and tap the home button
+        navigator.nowAt(NewTabScreen)
         navigator.openURL(path(forTestPage: TestPages.mozillaOrg))
         waitUntilPageLoad()
-        navigator.nowAt(BrowserTab)
-        // Add a new tab
-        navigator.performAction(Action.GoToHomePage)
-        // A new tab with Firefox homepage is added
-        waitForTabsButton()
-        navigator.nowAt(NewTabScreen)
-        mozWaitForElementToExist(app.textFields[AccessibilityIdentifiers.Browser.AddressToolbar.searchTextField])
+        toolbarScreen.tapHomeButton()
+
+        // The Firefox homepage opens on the same tab
+        homePageScreen.assertHomepageIsDisplayed()
+        toolbarScreen.assertTabsButtonValue(expectedCount: "1",
+                                            message: "The homepage did not open on the same tab")
     }
 
     // https://mozilla.testrail.io/index.php?/cases/view/2339489

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomepageSettingsScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/HomepageSettingsScreen.swift
@@ -14,8 +14,6 @@ final class HomepageSettingsScreen {
         self.sel = selectors
     }
 
-    private var bookmarkToggle: XCUIElement { sel.BOOKMARK_TOGGLE.element(in: app) }
-
     // helper to centralize the duplicated lookup
     private var bookmarkSwitch: XCUIElement {
         let settingTable = sel.HOMEPAGE_SETTINGS_TABLE.element(in: app)
@@ -30,6 +28,8 @@ final class HomepageSettingsScreen {
     }
 
     private var customURLTextField: XCUIElement { sel.CUSTOM_URL_TEXT_FIELD.element(in: app) }
+
+    private var shortcutsSettingsCell: XCUIElement { sel.SHORTCUTS_SETTINGS_CELL.element(in: app) }
 
     func typeCustomHomepageURL(_ url: String) {
         customURLTextField.tapAndTypeText(url)
@@ -91,5 +91,11 @@ final class HomepageSettingsScreen {
     func assertJumpBackInToggleIsDisabled() {
         let switchElement = jumpBackInSwitch
         XCTAssertEqual(switchElement.value as? String, "0", "Jump Back In toggle is not disabled")
+    }
+
+    func assertShortcutsSettingIsOn() {
+        BaseTestCase().mozWaitForElementToExist(
+            shortcutsSettingsCell.staticTexts[sel.SHORTCUTS_STATUS_ON.value]
+        )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingsHomepageScreen.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/PageScreens/SettingsHomepageScreen.swift
@@ -14,6 +14,32 @@ final class SettingsHomepageScreen {
         self.sel = selectors
     }
 
+    func assertSectionsAreDisplayed() {
+        BaseTestCase().waitForElementsToExist([
+            sel.NAVBAR.element(in: app),
+            sel.OPENING_SCREEN_SECTION.element(in: app),
+            sel.INCLUDE_ON_HOMEPAGE_SECTION.element(in: app),
+            sel.CURRENT_HOMEPAGE_SECTION.element(in: app)
+        ])
+    }
+
+    /// Asserts "Last tab" is the option selected in the Opening screen section, i.e. Start at Home disabled.
+    func assertLastTabIsSelectedAsOpeningScreen() {
+        assertDefaultOptionsVisible()
+        XCTAssertFalse(sel.START_AT_HOME_ALWAYS.element(in: app).isSelected,
+                       "Homepage is selected as the opening screen")
+        XCTAssertFalse(sel.START_AT_HOME_AFTER_4H.element(in: app).isSelected,
+                       "Homepage after four hours of inactivity is selected as the opening screen")
+        XCTAssertTrue(sel.START_AT_HOME_DISABLED.element(in: app).isSelected,
+                      "Last tab is not selected as the opening screen")
+    }
+
+    func assertFirefoxHomeIsSelectedAsCurrentHomepage() {
+        let firefoxHomeOption = sel.HOME_AS_FIREFOX_HOME.element(in: app)
+        BaseTestCase().waitForElementsToExist([firefoxHomeOption, sel.HOME_AS_CUSTOM_URL.element(in: app)])
+        XCTAssertTrue(firefoxHomeOption.isSelected, "Firefox Home is not selected as the current homepage")
+    }
+
     func assertDefaultOptionsVisible() {
         BaseTestCase().waitForElementsToExist([
             sel.NAVBAR.element(in: app),

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/HomepageSettingsSelector.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/HomepageSettingsSelector.swift
@@ -9,14 +9,26 @@ protocol HomepageSettingsSelectorSet {
     var JUMP_BACK_IN_TOGGLE: Selector { get }
     var HOMEPAGE_SETTINGS_TABLE: Selector { get }
     var CUSTOM_URL_TEXT_FIELD: Selector { get }
+    var SHORTCUTS_SETTINGS_CELL: Selector { get }
+    var SHORTCUTS_STATUS_ON: Selector { get }
     var all: [Selector] { get }
 }
 
 struct HomepageSettingsSelectors: HomepageSettingsSelectorSet {
     private enum IDs {
-        static let bookmarkToogle = "Bookmarks"
-        static let jumpBackInToggle = "Jump Back In"
+        // Mirrors PrefsKeys.HomepageSettings.BookmarksSection, used as the switch identifier
+        static let bookmarkToogle = "BookmarksSectionUserPrefsKey"
+        // Mirrors PrefsKeys.HomepageSettings.JumpBackInSection, used as the switch identifier
+        static let jumpBackInToggle = "JumpBackInSectionUserPrefsKey"
         static let customURLTextField = "HomeAsCustomURLTextField"
+        static let shortcutsSettingsCell = AccessibilityIdentifiers
+            .Settings
+            .Homepage
+            .CustomizeFirefox
+            .Shortcuts
+            .settingsPage
+        // The row status has no accessibility identifier, it is matched on its label
+        static let shortcutsStatusOn = "On"
     }
 
     let HOMEPAGE_SETTINGS_TABLE = Selector.firstTable(
@@ -24,13 +36,13 @@ struct HomepageSettingsSelectors: HomepageSettingsSelectorSet {
         groups: ["homepage_settings"]
     )
 
-    let BOOKMARK_TOGGLE = Selector.staticTextByLabel(
+    let BOOKMARK_TOGGLE = Selector.switchByIdOrLabel(
         IDs.bookmarkToogle,
         description: "Bookmark toggle in homepage settings",
         groups: ["homepage_settings"]
     )
 
-    let JUMP_BACK_IN_TOGGLE = Selector.staticTextByLabel(
+    let JUMP_BACK_IN_TOGGLE = Selector.switchByIdOrLabel(
         IDs.jumpBackInToggle,
         description: "Jump back in toggle in homepage settings",
         groups: ["homepage_settings"]
@@ -42,5 +54,26 @@ struct HomepageSettingsSelectors: HomepageSettingsSelectorSet {
         groups: ["homepage_settings"]
     )
 
-    var all: [Selector] { [BOOKMARK_TOGGLE, HOMEPAGE_SETTINGS_TABLE, JUMP_BACK_IN_TOGGLE, CUSTOM_URL_TEXT_FIELD] }
+    let SHORTCUTS_SETTINGS_CELL = Selector.tableCellById(
+        IDs.shortcutsSettingsCell,
+        description: "Shortcuts row of the include on homepage section",
+        groups: ["homepage_settings"]
+    )
+
+    let SHORTCUTS_STATUS_ON = Selector.staticTextByLabel(
+        IDs.shortcutsStatusOn,
+        description: "On status of the shortcuts row in homepage settings",
+        groups: ["homepage_settings"]
+    )
+
+    var all: [Selector] {
+        [
+            BOOKMARK_TOGGLE,
+            HOMEPAGE_SETTINGS_TABLE,
+            JUMP_BACK_IN_TOGGLE,
+            CUSTOM_URL_TEXT_FIELD,
+            SHORTCUTS_SETTINGS_CELL,
+            SHORTCUTS_STATUS_ON
+        ]
+    }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SettingsHomePageSelectors.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/Selectors/SettingsHomePageSelectors.swift
@@ -5,10 +5,15 @@ import XCTest
 
 protocol SettingsHomepageSelectorsSet {
     var NAVBAR: Selector { get }
+    var OPENING_SCREEN_SECTION: Selector { get }
+    var INCLUDE_ON_HOMEPAGE_SECTION: Selector { get }
+    var CURRENT_HOMEPAGE_SECTION: Selector { get }
     var START_AT_HOME_ALWAYS: Selector { get }
     var START_AT_HOME_DISABLED: Selector { get }
     var START_AT_HOME_AFTER_4H: Selector { get }
     var STORIES_SWITCH: Selector { get }
+    var HOME_AS_FIREFOX_HOME: Selector { get }
+    var HOME_AS_CUSTOM_URL: Selector { get }
     var all: [Selector] { get }
 }
 
@@ -18,12 +23,37 @@ struct SettingsHomepageSelectors: SettingsHomepageSelectorsSet {
         static let always          = AccessibilityIdentifiers.Settings.Homepage.StartAtHome.always
         static let disabled        = AccessibilityIdentifiers.Settings.Homepage.StartAtHome.disabled
         static let afterFourHours  = AccessibilityIdentifiers.Settings.Homepage.StartAtHome.afterFourHours
-        static let storiesSwitch   = "Stories"
+        // Mirrors PrefsKeys.UserFeatureFlagPrefs.ASPocketStories, used as the switch identifier
+        static let storiesSwitch   = "ASPocketStoriesUserPrefsKey"
+        static let firefoxHome     = "HomeAsFirefoxHome"
+        static let customURL       = "HomeAsCustomURL"
+        // Section headers have no accessibility identifier, they are matched on their uppercased title
+        static let openingScreenSection     = "OPENING SCREEN"
+        static let includeOnHomepageSection = "INCLUDE ON HOMEPAGE"
+        static let currentHomepageSection   = "CURRENT HOMEPAGE"
     }
 
     let NAVBAR = Selector.navigationBarId(
         IDs.navBar,
         description: "Homepage settings navigation bar",
+        groups: ["settings", "homepage"]
+    )
+
+    let OPENING_SCREEN_SECTION = Selector.tableOtherById(
+        IDs.openingScreenSection,
+        description: "Opening screen section header",
+        groups: ["settings", "homepage"]
+    )
+
+    let INCLUDE_ON_HOMEPAGE_SECTION = Selector.tableOtherById(
+        IDs.includeOnHomepageSection,
+        description: "Include on homepage section header",
+        groups: ["settings", "homepage"]
+    )
+
+    let CURRENT_HOMEPAGE_SECTION = Selector.tableOtherById(
+        IDs.currentHomepageSection,
+        description: "Current homepage section header",
         groups: ["settings", "homepage"]
     )
 
@@ -51,7 +81,30 @@ struct SettingsHomepageSelectors: SettingsHomepageSelectorsSet {
         groups: ["settings", "homepage"]
     )
 
+    let HOME_AS_FIREFOX_HOME = Selector.tableCellById(
+        IDs.firefoxHome,
+        description: "Firefox Home option of the current homepage section",
+        groups: ["settings", "homepage"]
+    )
+
+    let HOME_AS_CUSTOM_URL = Selector.tableCellById(
+        IDs.customURL,
+        description: "Custom URL option of the current homepage section",
+        groups: ["settings", "homepage"]
+    )
+
     var all: [Selector] {
-        [NAVBAR, START_AT_HOME_ALWAYS, START_AT_HOME_DISABLED, START_AT_HOME_AFTER_4H, STORIES_SWITCH]
+        [
+            NAVBAR,
+            OPENING_SCREEN_SECTION,
+            INCLUDE_ON_HOMEPAGE_SECTION,
+            CURRENT_HOMEPAGE_SECTION,
+            START_AT_HOME_ALWAYS,
+            START_AT_HOME_DISABLED,
+            START_AT_HOME_AFTER_4H,
+            STORIES_SWITCH,
+            HOME_AS_FIREFOX_HOME,
+            HOME_AS_CUSTOM_URL
+        ]
     }
 }


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-6182

## :bulb: Description
Updated three Homepage settings tests to match the latest TestRail cases.

Check Home Settings By Default (C2339256) — the case now spells out the default state of every toggle in the "Include on Homepage" section. The test only checked Shortcuts, so it now also verifies that Jump Back In and Bookmarks are off and Stories is on. The Stories check is skipped on iOS 16, where that row doesn't appear due to https://github.com/mozilla-mobile/firefox-ios/issues/35618

Firefox Home as default option (C2339260) — the case expects the homepage to open in the same tab after tapping the Home button. The test was tapping the New Tab button instead, so it was opening a brand-new tab and couldn't catch the real behaviour. It now sets the toolbar's middle button to Home first (as the case's precondition asks), taps Home, and confirms the homepage appears without a new tab being created. Like its sibling test, it's skipped on iPad, where that button can't be configured.

Validate Custom URL as Current Homepage (C2339257) — no behaviour change needed; the test already covered every step. Only renamed from testTyping to match the case title, with the two test plans that reference it updated so nothing goes stale.
