### PR TITLE
Add FXIOS-14720 [Quick Answers] Expose strings to localization

### DIFF
--- a/BrowserKit/Sources/QuickAnswersKit/UI/ErrorHandler.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/ErrorHandler.swift
@@ -18,7 +18,6 @@ final class ErrorHandler {
     }
 
     // MARK: - Speech Errors
-    // TODO: - FXIOS-14720 Add Strings and accessibility ids
     func handleSpeechError(_ error: SpeechError) {
         switch error {
         // if it is the first time the permission was viewed it means the OS alert was shown
@@ -26,14 +25,14 @@ final class ErrorHandler {
         case .microphonePermissionDenied(let isFirstTime):
             handlePermissionDenied(
                 isFirstTime: isFirstTime,
-                title: "Change Settings to Use Quick Answers",
-                message: "Allow Firefox to access the Microphone."
+                title: .QuickAnswers.Errors.PermissionAlertTitle,
+                message: .QuickAnswers.Errors.MicrophonePermissionMessage
             )
         case .speechRecognitionPermissionDenied(let isFirstTime):
             handlePermissionDenied(
                 isFirstTime: isFirstTime,
-                title: "Change Settings to Use Quick Answers",
-                message: "Allow Firefox to access Speech Recognition."
+                title: .QuickAnswers.Errors.PermissionAlertTitle,
+                message: .QuickAnswers.Errors.SpeechRecognitionPermissionMessage
             )
         default:
             showCatchAllErrorAlert()
@@ -56,8 +55,8 @@ final class ErrorHandler {
         switch error {
         case .rateLimited:
             showCatchAllErrorAlert(
-                title: "Daily Limit Reached",
-                message: "Try Quick Answers again tomorrow."
+                title: .QuickAnswers.Errors.DailyLimitTitle,
+                message: .QuickAnswers.Errors.DailyLimitMessage
             )
         default:
             showCatchAllErrorAlert()
@@ -66,7 +65,6 @@ final class ErrorHandler {
 
     // MARK: - Private
 
-    // TODO: - FXIOS-14720 Add Strings and accessibility ids
     private func showPermissionAlert(title: String, message: String) {
         let alertController = UIAlertController(
             title: title,
@@ -74,7 +72,7 @@ final class ErrorHandler {
             preferredStyle: .alert
         )
         alertController.addAction(
-            UIAlertAction(title: "Open Settings", style: .default) { [weak self] _ in
+            UIAlertAction(title: .QuickAnswers.Errors.OpenSettings, style: .default) { [weak self] _ in
                 self?.onDismiss?()
                 if let url = URL(string: UIApplication.openSettingsURLString) {
                     UIApplication.shared.open(url)
@@ -82,17 +80,16 @@ final class ErrorHandler {
             }
         )
         alertController.addAction(
-            UIAlertAction(title: "Cancel", style: .cancel) { [weak self] _ in
+            UIAlertAction(title: .QuickAnswers.Errors.Cancel, style: .cancel) { [weak self] _ in
                 self?.onDismiss?()
             }
         )
         presenter?.present(alertController, animated: true)
     }
 
-    // TODO: - FXIOS-14720 Add Strings and accessibility ids
     private func showCatchAllErrorAlert(
-        title: String = "Couldn't get an answer",
-        message: String = "Try asking again later."
+        title: String = .QuickAnswers.Errors.GenericErrorTitle,
+        message: String = .QuickAnswers.Errors.GenericErrorMessage
     ) {
         let alertController = UIAlertController(
             title: title,
@@ -100,7 +97,7 @@ final class ErrorHandler {
             preferredStyle: .alert
         )
         alertController.addAction(
-            UIAlertAction(title: "Ok", style: .default) { [weak self] _ in
+            UIAlertAction(title: .QuickAnswers.Errors.OK, style: .default) { [weak self] _ in
                 self?.onDismiss?()
             }
         )

--- a/BrowserKit/Sources/QuickAnswersKit/UI/ErrorHandler.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/ErrorHandler.swift
@@ -3,18 +3,20 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
-import Shared
 
 @MainActor
 final class ErrorHandler {
     private weak var presenter: UIViewController?
+    private let strings: QuickAnswersViewConfiguration.ErrorStrings
     private var onDismiss: (() -> Void)?
 
     init(
         presenter: UIViewController,
+        strings: QuickAnswersViewConfiguration.ErrorStrings,
         onDismiss: (() -> Void)?
     ) {
         self.presenter = presenter
+        self.strings = strings
         self.onDismiss = onDismiss
     }
 
@@ -26,14 +28,14 @@ final class ErrorHandler {
         case .microphonePermissionDenied(let isFirstTime):
             handlePermissionDenied(
                 isFirstTime: isFirstTime,
-                title: .QuickAnswers.Errors.PermissionAlertTitle,
-                message: String(format: .QuickAnswers.Errors.MicrophonePermissionMessage, AppName.shortName.rawValue)
+                title: strings.permissionAlertTitle,
+                message: strings.microphonePermissionMessage
             )
         case .speechRecognitionPermissionDenied(let isFirstTime):
             handlePermissionDenied(
                 isFirstTime: isFirstTime,
-                title: .QuickAnswers.Errors.PermissionAlertTitle,
-                message: String(format: .QuickAnswers.Errors.SpeechRecognitionPermissionMessage, AppName.shortName.rawValue)
+                title: strings.permissionAlertTitle,
+                message: strings.speechRecognitionPermissionMessage
             )
         default:
             showCatchAllErrorAlert()
@@ -56,8 +58,8 @@ final class ErrorHandler {
         switch error {
         case .rateLimited:
             showCatchAllErrorAlert(
-                title: .QuickAnswers.Errors.DailyLimitTitle,
-                message: .QuickAnswers.Errors.DailyLimitMessage
+                title: strings.dailyLimitTitle,
+                message: strings.dailyLimitMessage
             )
         default:
             showCatchAllErrorAlert()
@@ -73,7 +75,7 @@ final class ErrorHandler {
             preferredStyle: .alert
         )
         alertController.addAction(
-            UIAlertAction(title: .QuickAnswers.Errors.OpenSettings, style: .default) { [weak self] _ in
+            UIAlertAction(title: strings.openSettings, style: .default) { [weak self] _ in
                 self?.onDismiss?()
                 if let url = URL(string: UIApplication.openSettingsURLString) {
                     UIApplication.shared.open(url)
@@ -81,24 +83,21 @@ final class ErrorHandler {
             }
         )
         alertController.addAction(
-            UIAlertAction(title: .QuickAnswers.Errors.Cancel, style: .cancel) { [weak self] _ in
+            UIAlertAction(title: strings.cancel, style: .cancel) { [weak self] _ in
                 self?.onDismiss?()
             }
         )
         presenter?.present(alertController, animated: true)
     }
 
-    private func showCatchAllErrorAlert(
-        title: String = .QuickAnswers.Errors.GenericErrorTitle,
-        message: String = .QuickAnswers.Errors.GenericErrorMessage
-    ) {
+    private func showCatchAllErrorAlert(title: String? = nil, message: String? = nil) {
         let alertController = UIAlertController(
-            title: title,
-            message: message,
+            title: title ?? strings.genericErrorTitle,
+            message: message ?? strings.genericErrorMessage,
             preferredStyle: .alert
         )
         alertController.addAction(
-            UIAlertAction(title: .QuickAnswers.Errors.OK, style: .default) { [weak self] _ in
+            UIAlertAction(title: strings.ok, style: .default) { [weak self] _ in
                 self?.onDismiss?()
             }
         )

--- a/BrowserKit/Sources/QuickAnswersKit/UI/ErrorHandler.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/ErrorHandler.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import UIKit
+import Shared
 
 @MainActor
 final class ErrorHandler {
@@ -26,13 +27,13 @@ final class ErrorHandler {
             handlePermissionDenied(
                 isFirstTime: isFirstTime,
                 title: .QuickAnswers.Errors.PermissionAlertTitle,
-                message: .QuickAnswers.Errors.MicrophonePermissionMessage
+                message: String(format: .QuickAnswers.Errors.MicrophonePermissionMessage, AppName.shortName.rawValue)
             )
         case .speechRecognitionPermissionDenied(let isFirstTime):
             handlePermissionDenied(
                 isFirstTime: isFirstTime,
                 title: .QuickAnswers.Errors.PermissionAlertTitle,
-                message: .QuickAnswers.Errors.SpeechRecognitionPermissionMessage
+                message: String(format: .QuickAnswers.Errors.SpeechRecognitionPermissionMessage, AppName.shortName.rawValue)
             )
         default:
             showCatchAllErrorAlert()

--- a/BrowserKit/Sources/QuickAnswersKit/UI/OptInView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/OptInView.swift
@@ -5,7 +5,6 @@
 import UIKit
 import Common
 
-// TODO: - FXIOS-14720 Add Strings and accessibility ids
 final class OptInView: UIView, UITextViewDelegate, ThemeApplicable {
     private struct UX {
         static let contentSpacing: CGFloat = 16.0
@@ -15,11 +14,8 @@ final class OptInView: UIView, UITextViewDelegate, ThemeApplicable {
             bottom: 13.5,
             trailing: 16.0
         )
-        static let descriptionText = """
-        Ask a question out loud, and get a short answer. \
-        We don't store your voice or questions.
-        """
-        static let learnMoreText = "Learn more"
+        static let descriptionText = String.QuickAnswers.OptIn.Description
+        static let learnMoreText = String.QuickAnswers.OptIn.LearnMore
     }
 
     private var onContinue: (() -> Void)?
@@ -28,7 +24,7 @@ final class OptInView: UIView, UITextViewDelegate, ThemeApplicable {
     // MARK: - Subviews
     private let titleLabel: UILabel = .build {
         $0.font = FXFontStyles.Bold.headline.scaledFont()
-        $0.text = "Ask With Your Voice"
+        $0.text = .QuickAnswers.OptIn.Title
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.adjustsFontForContentSizeCategory = true
@@ -48,7 +44,7 @@ final class OptInView: UIView, UITextViewDelegate, ThemeApplicable {
         }
         $0.configuration?.cornerStyle = .capsule
         $0.configuration?.contentInsets = UX.buttonContentInset
-        $0.configuration?.title = "Continue"
+        $0.configuration?.title = .QuickAnswers.OptIn.ContinueButton
         $0.addAction(UIAction { [weak self] _ in self?.onContinue?() }, for: .touchUpInside)
     }
 

--- a/BrowserKit/Sources/QuickAnswersKit/UI/OptInView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/OptInView.swift
@@ -14,8 +14,6 @@ final class OptInView: UIView, UITextViewDelegate, ThemeApplicable {
             bottom: 13.5,
             trailing: 16.0
         )
-        static let descriptionText = String.QuickAnswers.OptIn.Description
-        static let learnMoreText = String.QuickAnswers.OptIn.LearnMore
     }
 
     private var onContinue: (() -> Void)?
@@ -24,7 +22,6 @@ final class OptInView: UIView, UITextViewDelegate, ThemeApplicable {
     // MARK: - Subviews
     private let titleLabel: UILabel = .build {
         $0.font = FXFontStyles.Bold.headline.scaledFont()
-        $0.text = .QuickAnswers.OptIn.Title
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.adjustsFontForContentSizeCategory = true
@@ -44,7 +41,6 @@ final class OptInView: UIView, UITextViewDelegate, ThemeApplicable {
         }
         $0.configuration?.cornerStyle = .capsule
         $0.configuration?.contentInsets = UX.buttonContentInset
-        $0.configuration?.title = .QuickAnswers.OptIn.ContinueButton
         $0.addAction(UIAction { [weak self] _ in self?.onContinue?() }, for: .touchUpInside)
     }
 
@@ -80,6 +76,7 @@ final class OptInView: UIView, UITextViewDelegate, ThemeApplicable {
     }
 
     func configure(
+        strings: QuickAnswersViewConfiguration.OptInStrings,
         learnMoreURL: URL?,
         theme: Theme,
         onContinue: @escaping () -> Void,
@@ -87,20 +84,26 @@ final class OptInView: UIView, UITextViewDelegate, ThemeApplicable {
     ) {
         self.onLearnMore = onLearnMore
         self.onContinue = onContinue
-        descriptionTextView.attributedText = makeDescriptionText(url: learnMoreURL)
+        titleLabel.text = strings.title
+        continueButton.configuration?.title = strings.continueButton
+        descriptionTextView.attributedText = makeDescriptionText(
+            description: strings.description,
+            learnMore: strings.learnMore,
+            url: learnMoreURL
+        )
         applyTheme(theme: theme)
     }
 
-    private func makeDescriptionText(url: URL?) -> NSAttributedString {
+    private func makeDescriptionText(description: String, learnMore: String, url: URL?) -> NSAttributedString {
         let font = FXFontStyles.Regular.subheadline.scaledFont()
         let text = NSMutableAttributedString(
-            string: UX.descriptionText + " ",
+            string: description + " ",
             attributes: [.font: font]
         )
         if let url {
             var linkAttributes: [NSAttributedString.Key: Any] = [.font: font]
             linkAttributes[.link] = url
-            text.append(NSAttributedString(string: UX.learnMoreText, attributes: linkAttributes))
+            text.append(NSAttributedString(string: learnMore, attributes: linkAttributes))
         }
         return text
     }

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersContentView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersContentView.swift
@@ -5,7 +5,6 @@
 import UIKit
 import Common
 
-// TODO: - FXIOS-14720 Add Strings and accessibility ids
 final class QuickAnswersContentView: UIView, ThemeApplicable {
     private struct UX {
         static let contentSpacing: CGFloat = 32.0
@@ -23,7 +22,7 @@ final class QuickAnswersContentView: UIView, ThemeApplicable {
     private let audioWaveform: AudioWaveformView = .build()
     private let placeholderLabel: UILabel = .build {
         $0.font = FXFontStyles.Regular.title2.scaledFont()
-        $0.text = "Ask anything…"
+        $0.text = .QuickAnswers.ContentView.Placeholder
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.adjustsFontForContentSizeCategory = true
@@ -35,7 +34,7 @@ final class QuickAnswersContentView: UIView, ThemeApplicable {
     }
     private let searchingLabel: UILabel = .build {
         $0.font = FXFontStyles.Bold.callout.scaledFont()
-        $0.text = "Answering…"
+        $0.text = .QuickAnswers.ContentView.Answering
         $0.alpha = 0.0
         $0.adjustsFontForContentSizeCategory = true
     }
@@ -197,7 +196,7 @@ final class QuickAnswersContentView: UIView, ThemeApplicable {
     func configureAnswer(_ text: String, modelName: String) {
         searchingLabel.stopShimmering()
         searchingLabel.alpha = 0.0
-        footerLabel.text = "Powered by \(modelName) · Answers can contain mistakes."
+        footerLabel.text = String.localizedStringWithFormat(.QuickAnswers.ContentView.FooterFormat, modelName)
         UIView.animate(withDuration: UX.animationDuration) { [self] in
             answerLabel.text = text
             answerLabel.alpha = 1.0

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersContentView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersContentView.swift
@@ -22,7 +22,6 @@ final class QuickAnswersContentView: UIView, ThemeApplicable {
     private let audioWaveform: AudioWaveformView = .build()
     private let placeholderLabel: UILabel = .build {
         $0.font = FXFontStyles.Regular.title2.scaledFont()
-        $0.text = .QuickAnswers.ContentView.Placeholder
         $0.numberOfLines = 0
         $0.textAlignment = .center
         $0.adjustsFontForContentSizeCategory = true
@@ -34,7 +33,6 @@ final class QuickAnswersContentView: UIView, ThemeApplicable {
     }
     private let searchingLabel: UILabel = .build {
         $0.font = FXFontStyles.Bold.callout.scaledFont()
-        $0.text = .QuickAnswers.ContentView.Answering
         $0.alpha = 0.0
         $0.adjustsFontForContentSizeCategory = true
     }
@@ -55,6 +53,7 @@ final class QuickAnswersContentView: UIView, ThemeApplicable {
     }
     private let optInView: OptInView = .build()
     private var theme: Theme?
+    private var strings: QuickAnswersViewConfiguration.ContentViewStrings?
 
     // MARK: - Init
     override init(frame: CGRect) {
@@ -121,6 +120,13 @@ final class QuickAnswersContentView: UIView, ThemeApplicable {
     }
 
     // MARK: - Configuration
+    func configureStrings(_ strings: QuickAnswersViewConfiguration.ContentViewStrings) {
+        self.strings = strings
+        placeholderLabel.text = strings.placeholder
+        searchingLabel.text = strings.answering
+        sourceView.configureStrings(sourcesHeader: strings.sources)
+    }
+
     func startAudioWaveformAnimation() {
         audioWaveform.startAnimating()
     }
@@ -130,12 +136,14 @@ final class QuickAnswersContentView: UIView, ThemeApplicable {
     }
 
     func configureOptIn(
+        strings: QuickAnswersViewConfiguration.OptInStrings,
         learnMoreURL: URL?,
         theme: Theme,
         onContinue: @escaping () -> Void,
         onLearnMore: @escaping (URL) -> Void
     ) {
         optInView.configure(
+            strings: strings,
             learnMoreURL: learnMoreURL,
             theme: theme,
             onContinue: onContinue,
@@ -196,7 +204,7 @@ final class QuickAnswersContentView: UIView, ThemeApplicable {
     func configureAnswer(_ text: String, modelName: String) {
         searchingLabel.stopShimmering()
         searchingLabel.alpha = 0.0
-        footerLabel.text = String.localizedStringWithFormat(.QuickAnswers.ContentView.FooterFormat, modelName)
+        footerLabel.text = String(format: strings?.footerFormat ?? "", modelName)
         UIView.animate(withDuration: UX.animationDuration) { [self] in
             answerLabel.text = text
             answerLabel.alpha = 1.0

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
@@ -132,7 +132,7 @@ final class QuickAnswersSourceView: UIView,
 
     private let headerLabel: UILabel = .build {
         $0.font = FXFontStyles.Bold.caption1.scaledFont()
-        $0.text = .QuickAnswers.ContentView.Sources
+        $0.text = ""
         $0.adjustsFontForContentSizeCategory = true
     }
     private lazy var collectionView: UICollectionView = {
@@ -201,6 +201,10 @@ final class QuickAnswersSourceView: UIView,
     }
 
     // MARK: - Configuration
+    func configureStrings(sourcesHeader: String) {
+        headerLabel.text = sourcesHeader
+    }
+
     func configure(with items: [SearchResult.Source], onSourceTapped: ((URL) -> Void)? = nil) {
         self.items = items
         self.onSourceTapped = onSourceTapped

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersSourceView.swift
@@ -119,7 +119,6 @@ final class QuickAnswersSourceCell: UICollectionViewCell, ReusableCell, ThemeApp
     }
 }
 
-// TODO: - FXIOS-14720 Add Strings and accessibility ids
 final class QuickAnswersSourceView: UIView,
                                     UICollectionViewDataSource,
                                     UICollectionViewDelegateFlowLayout,
@@ -133,7 +132,7 @@ final class QuickAnswersSourceView: UIView,
 
     private let headerLabel: UILabel = .build {
         $0.font = FXFontStyles.Bold.caption1.scaledFont()
-        $0.text = "Sources"
+        $0.text = .QuickAnswers.ContentView.Sources
         $0.adjustsFontForContentSizeCategory = true
     }
     private lazy var collectionView: UICollectionView = {

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewConfiguration.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewConfiguration.swift
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public struct QuickAnswersViewConfiguration: Sendable {
+    public let optIn: OptInStrings
+    public let contentView: ContentViewStrings
+    public let errors: ErrorStrings
+    public let closeAccessibilityLabel: String
+    public let appName: String
+
+    public struct OptInStrings: Sendable {
+        public let title: String
+        public let description: String
+        public let learnMore: String
+        public let continueButton: String
+
+        public init(title: String, description: String, learnMore: String, continueButton: String) {
+            self.title = title
+            self.description = description
+            self.learnMore = learnMore
+            self.continueButton = continueButton
+        }
+    }
+
+    public struct ContentViewStrings: Sendable {
+        public let placeholder: String
+        public let answering: String
+        public let footerFormat: String
+        public let sources: String
+
+        public init(placeholder: String, answering: String, footerFormat: String, sources: String) {
+            self.placeholder = placeholder
+            self.answering = answering
+            self.footerFormat = footerFormat
+            self.sources = sources
+        }
+    }
+
+    public struct ErrorStrings: Sendable {
+        public let permissionAlertTitle: String
+        public let microphonePermissionMessage: String
+        public let speechRecognitionPermissionMessage: String
+        public let openSettings: String
+        public let cancel: String
+        public let dailyLimitTitle: String
+        public let dailyLimitMessage: String
+        public let genericErrorTitle: String
+        public let genericErrorMessage: String
+        public let ok: String
+
+        public init(
+            permissionAlertTitle: String,
+            microphonePermissionMessage: String,
+            speechRecognitionPermissionMessage: String,
+            openSettings: String,
+            cancel: String,
+            dailyLimitTitle: String,
+            dailyLimitMessage: String,
+            genericErrorTitle: String,
+            genericErrorMessage: String,
+            ok: String
+        ) {
+            self.permissionAlertTitle = permissionAlertTitle
+            self.microphonePermissionMessage = microphonePermissionMessage
+            self.speechRecognitionPermissionMessage = speechRecognitionPermissionMessage
+            self.openSettings = openSettings
+            self.cancel = cancel
+            self.dailyLimitTitle = dailyLimitTitle
+            self.dailyLimitMessage = dailyLimitMessage
+            self.genericErrorTitle = genericErrorTitle
+            self.genericErrorMessage = genericErrorMessage
+            self.ok = ok
+        }
+    }
+
+    public init(
+        optIn: OptInStrings,
+        contentView: ContentViewStrings,
+        errors: ErrorStrings,
+        closeAccessibilityLabel: String,
+        appName: String
+    ) {
+        self.optIn = optIn
+        self.contentView = contentView
+        self.errors = errors
+        self.closeAccessibilityLabel = closeAccessibilityLabel
+        self.appName = appName
+    }
+}

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
@@ -47,8 +47,7 @@ public final class QuickAnswersViewController: UIViewController,
             }),
             for: .touchUpInside
         )
-        // TODO: - FXIOS-14720 add Strings
-        $0.accessibilityLabel = "Close"
+        $0.accessibilityLabel = .QuickAnswers.AccessibilityLabels.Close
     }
     private let contentView: QuickAnswersContentView = .build()
     private let transitionAnimator: CrossDissolveTransitionAnimator?

--- a/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
+++ b/BrowserKit/Sources/QuickAnswersKit/UI/QuickAnswersViewController.swift
@@ -47,7 +47,6 @@ public final class QuickAnswersViewController: UIViewController,
             }),
             for: .touchUpInside
         )
-        $0.accessibilityLabel = .QuickAnswers.AccessibilityLabels.Close
     }
     private let contentView: QuickAnswersContentView = .build()
     private let transitionAnimator: CrossDissolveTransitionAnimator?
@@ -59,8 +58,10 @@ public final class QuickAnswersViewController: UIViewController,
     private weak var navigationHandler: QuickAnswersNavigationHandler?
     private let viewModel: QuickAnswersViewModel
     private let learnMoreURL: URL?
+    private let stringsConfiguration: QuickAnswersViewConfiguration
     private lazy var errorHandler = ErrorHandler(
         presenter: self,
+        strings: stringsConfiguration.errors,
         onDismiss: { [weak self] in
             self?.dismiss(with: nil)
         }
@@ -76,6 +77,7 @@ public final class QuickAnswersViewController: UIViewController,
         telemetry: QuickAnswersTelemetry,
         configFetcher: QuickAnswersConfigFetcher,
         learnMoreURL: URL?,
+        stringsConfiguration: QuickAnswersViewConfiguration,
         notificationCenter: NotificationProtocol = NotificationCenter.default,
     ) {
         self.init(
@@ -85,6 +87,7 @@ public final class QuickAnswersViewController: UIViewController,
             windowUUID: windowUUID,
             themeManager: themeManager,
             learnMoreURL: learnMoreURL,
+            stringsConfiguration: stringsConfiguration,
             notificationCenter: notificationCenter
         )
     }
@@ -96,12 +99,14 @@ public final class QuickAnswersViewController: UIViewController,
         windowUUID: WindowUUID,
         themeManager: any ThemeManager,
         learnMoreURL: URL?,
+        stringsConfiguration: QuickAnswersViewConfiguration,
         notificationCenter: NotificationProtocol
     ) {
         self.navigationHandler = navigationHandler
         self.currentWindowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
+        self.stringsConfiguration = stringsConfiguration
         // The custom transition animator is only used for the cross dissolve transition; the form sheet
         // relies on the system presentation.
         if case let .crossDissolve(sourceRect) = transitionType {
@@ -144,6 +149,8 @@ public final class QuickAnswersViewController: UIViewController,
     }
 
     private func setupSubviews() {
+        closeButton.accessibilityLabel = stringsConfiguration.closeAccessibilityLabel
+        contentView.configureStrings(stringsConfiguration.contentView)
         view.addSubviews(
             backgroundRecordEffect,
             backgroundBlur,
@@ -208,6 +215,7 @@ public final class QuickAnswersViewController: UIViewController,
             }
         }
         contentView.configureOptIn(
+            strings: stringsConfiguration.optIn,
             learnMoreURL: learnMoreURL,
             theme: themeManager.getCurrentTheme(for: currentWindowUUID),
             onContinue: { [weak self] in

--- a/BrowserKit/Tests/QuickAnswersKitTests/ErrorHandlerTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/ErrorHandlerTests.swift
@@ -85,8 +85,27 @@ struct ErrorHandlerTests {
 
     // MARK: - Helper
     private func createSubject() -> ErrorHandler {
-        let subject = ErrorHandler(presenter: presenter, onDismiss: { [dismissSpy] in dismissSpy.callCount += 1 })
+        let subject = ErrorHandler(
+            presenter: presenter,
+            strings: .mock,
+            onDismiss: { [dismissSpy] in dismissSpy.callCount += 1 }
+        )
         testHelper.trackForMemoryLeaks(subject)
         return subject
     }
+}
+
+extension QuickAnswersViewConfiguration.ErrorStrings {
+    static let mock = QuickAnswersViewConfiguration.ErrorStrings(
+        permissionAlertTitle: "Permission Title",
+        microphonePermissionMessage: "Mic Message",
+        speechRecognitionPermissionMessage: "Speech Message",
+        openSettings: "Open Settings",
+        cancel: "Cancel",
+        dailyLimitTitle: "Daily Limit",
+        dailyLimitMessage: "Daily Limit Message",
+        genericErrorTitle: "Error",
+        genericErrorMessage: "Error Message",
+        ok: "Ok"
+    )
 }

--- a/BrowserKit/Tests/QuickAnswersKitTests/QuickAnswersViewConfigurationTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/QuickAnswersViewConfigurationTests.swift
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Testing
+
+@testable import QuickAnswersKit
+
+@Suite
+struct QuickAnswersViewConfigurationTests {
+    @Test
+    func testOptInStrings_storesValues() {
+        let subject = QuickAnswersViewConfiguration.OptInStrings(
+            title: "title",
+            description: "desc",
+            learnMore: "learn",
+            continueButton: "go"
+        )
+
+        #expect(subject.title == "title")
+        #expect(subject.description == "desc")
+        #expect(subject.learnMore == "learn")
+        #expect(subject.continueButton == "go")
+    }
+
+    @Test
+    func testContentViewStrings_storesValues() {
+        let subject = QuickAnswersViewConfiguration.ContentViewStrings(
+            placeholder: "ask",
+            answering: "loading",
+            footerFormat: "Powered by %@",
+            sources: "Sources"
+        )
+
+        #expect(subject.placeholder == "ask")
+        #expect(subject.answering == "loading")
+        #expect(subject.footerFormat == "Powered by %@")
+        #expect(subject.sources == "Sources")
+    }
+
+    @Test
+    func testErrorStrings_storesValues() {
+        let subject = QuickAnswersViewConfiguration.ErrorStrings(
+            permissionAlertTitle: "perm",
+            microphonePermissionMessage: "mic",
+            speechRecognitionPermissionMessage: "speech",
+            openSettings: "settings",
+            cancel: "cancel",
+            dailyLimitTitle: "limit",
+            dailyLimitMessage: "limitMsg",
+            genericErrorTitle: "error",
+            genericErrorMessage: "errorMsg",
+            ok: "ok"
+        )
+
+        #expect(subject.permissionAlertTitle == "perm")
+        #expect(subject.microphonePermissionMessage == "mic")
+        #expect(subject.speechRecognitionPermissionMessage == "speech")
+        #expect(subject.openSettings == "settings")
+        #expect(subject.cancel == "cancel")
+        #expect(subject.dailyLimitTitle == "limit")
+        #expect(subject.dailyLimitMessage == "limitMsg")
+        #expect(subject.genericErrorTitle == "error")
+        #expect(subject.genericErrorMessage == "errorMsg")
+        #expect(subject.ok == "ok")
+    }
+
+    @Test
+    func testConfiguration_storesAllSections() {
+        let subject = QuickAnswersViewConfiguration(
+            optIn: .init(title: "t", description: "d", learnMore: "l", continueButton: "c"),
+            contentView: .init(placeholder: "p", answering: "a", footerFormat: "f", sources: "s"),
+            errors: .init(
+                permissionAlertTitle: "", microphonePermissionMessage: "",
+                speechRecognitionPermissionMessage: "", openSettings: "",
+                cancel: "", dailyLimitTitle: "", dailyLimitMessage: "",
+                genericErrorTitle: "", genericErrorMessage: "", ok: ""
+            ),
+            closeAccessibilityLabel: "close",
+            appName: "Firefox"
+        )
+
+        #expect(subject.optIn.title == "t")
+        #expect(subject.contentView.placeholder == "p")
+        #expect(subject.closeAccessibilityLabel == "close")
+        #expect(subject.appName == "Firefox")
+    }
+}

--- a/BrowserKit/Tests/QuickAnswersKitTests/QuickAnswersViewConfigurationTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/QuickAnswersViewConfigurationTests.swift
@@ -71,10 +71,16 @@ struct QuickAnswersViewConfigurationTests {
             optIn: .init(title: "t", description: "d", learnMore: "l", continueButton: "c"),
             contentView: .init(placeholder: "p", answering: "a", footerFormat: "f", sources: "s"),
             errors: .init(
-                permissionAlertTitle: "", microphonePermissionMessage: "",
-                speechRecognitionPermissionMessage: "", openSettings: "",
-                cancel: "", dailyLimitTitle: "", dailyLimitMessage: "",
-                genericErrorTitle: "", genericErrorMessage: "", ok: ""
+                permissionAlertTitle: "",
+                microphonePermissionMessage: "",
+                speechRecognitionPermissionMessage: "",
+                openSettings: "",
+                cancel: "",
+                dailyLimitTitle: "",
+                dailyLimitMessage: "",
+                genericErrorTitle: "",
+                genericErrorMessage: "",
+                ok: ""
             ),
             closeAccessibilityLabel: "close",
             appName: "Firefox"

--- a/BrowserKit/Tests/QuickAnswersKitTests/QuickAnswersViewControllerTests.swift
+++ b/BrowserKit/Tests/QuickAnswersKitTests/QuickAnswersViewControllerTests.swift
@@ -44,9 +44,30 @@ final class QuickAnswersViewControllerTests: XCTestCase {
             windowUUID: .XCTestDefaultUUID,
             themeManager: DefaultThemeManager(sharedContainerIdentifier: ""),
             learnMoreURL: nil,
+            stringsConfiguration: .mock,
             notificationCenter: NotificationCenter.default
         )
         trackForMemoryLeaks(subject, file: file, line: line)
         return subject
     }
+}
+
+extension QuickAnswersViewConfiguration {
+    static let mock = QuickAnswersViewConfiguration(
+        optIn: .init(
+            title: "Title",
+            description: "Description",
+            learnMore: "Learn more",
+            continueButton: "Continue"
+        ),
+        contentView: .init(
+            placeholder: "Ask anything",
+            answering: "Answering",
+            footerFormat: "Powered by %@",
+            sources: "Sources"
+        ),
+        errors: .mock,
+        closeAccessibilityLabel: "Close",
+        appName: "Firefox"
+    )
 }

--- a/firefox-ios/Client/Coordinators/QuickAnswersCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/QuickAnswersCoordinator.swift
@@ -49,8 +49,44 @@ final class QuickAnswersCoordinator: BaseCoordinator, QuickAnswersNavigationHand
             telemetry: DefaultQuickAnswersTelemetry(),
             configFetcher: RemoteQuickAnswersConfigFetcher(model: resolvedModel()),
             learnMoreURL: Self.learnMoreURL,
+            stringsConfiguration: makeStringsConfiguration()
         )
         router.present(controller, animated: shouldAnimateTransition)
+    }
+
+    private func makeStringsConfiguration() -> QuickAnswersViewConfiguration {
+        let appName = AppName.shortName.rawValue
+        return QuickAnswersViewConfiguration(
+            optIn: .init(
+                title: .QuickAnswers.OptIn.Title,
+                description: .QuickAnswers.OptIn.Description,
+                learnMore: .QuickAnswers.OptIn.LearnMore,
+                continueButton: .QuickAnswers.OptIn.ContinueButton
+            ),
+            contentView: .init(
+                placeholder: .QuickAnswers.ContentView.Placeholder,
+                answering: .QuickAnswers.ContentView.Answering,
+                footerFormat: .QuickAnswers.ContentView.FooterFormat,
+                sources: .QuickAnswers.ContentView.Sources
+            ),
+            errors: .init(
+                permissionAlertTitle: .QuickAnswers.Errors.PermissionAlertTitle,
+                microphonePermissionMessage: String(format: .QuickAnswers.Errors.MicrophonePermissionMessage, appName),
+                speechRecognitionPermissionMessage: String(
+                    format: .QuickAnswers.Errors.SpeechRecognitionPermissionMessage,
+                    appName
+                ),
+                openSettings: .QuickAnswers.Errors.OpenSettings,
+                cancel: .QuickAnswers.Errors.Cancel,
+                dailyLimitTitle: .QuickAnswers.Errors.DailyLimitTitle,
+                dailyLimitMessage: .QuickAnswers.Errors.DailyLimitMessage,
+                genericErrorTitle: .QuickAnswers.Errors.GenericErrorTitle,
+                genericErrorMessage: .QuickAnswers.Errors.GenericErrorMessage,
+                ok: .QuickAnswers.Errors.OK
+            ),
+            closeAccessibilityLabel: .QuickAnswers.AccessibilityLabels.Close,
+            appName: appName
+        )
     }
 
     /// The model backing Quick Answers: the debug override set from the hidden settings when

--- a/firefox-ios/Client/Frontend/Home/Homepage/Header/HomepageHeaderCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/Header/HomepageHeaderCell.swift
@@ -59,8 +59,7 @@ class HomepageHeaderCell: UICollectionViewCell, ReusableCell, ThemeApplicable, F
         button.configuration?.image = UIImage(named: StandardImageIdentifiers.Large.audioWave)?
             .withRenderingMode(.alwaysTemplate)
         button.configuration?.cornerStyle = .capsule
-        // TODO: - FXIOS-14720 Add Strings for accessibility label
-        button.accessibilityLabel = "Open Quick Answers"
+        button.accessibilityLabel = .QuickAnswers.AccessibilityLabels.OpenQuickAnswers
         button.accessibilityIdentifier = a11y.quickAnswersButton
         button.adjustsImageSizeForAccessibilityContentSizeCategory = false
         button.addAction(UIAction(handler: { [weak self] _ in

--- a/firefox-ios/Client/Frontend/QuickAnswers/QuickAnswersTip.swift
+++ b/firefox-ios/Client/Frontend/QuickAnswers/QuickAnswersTip.swift
@@ -8,13 +8,12 @@ import TipKit
 
 @available(iOS 17.0, *)
 struct QuickAnswersTip: Tip {
-    // TODO: FXIOS-14720 add Translations
     var title: Text {
-        Text(verbatim: "Ask Out Loud for Quick Answers")
+        Text(verbatim: .QuickAnswers.Tip.Title)
     }
 
     var message: Text? {
-        Text(verbatim: "Tap here to get started.")
+        Text(verbatim: .QuickAnswers.Tip.Message)
     }
 
     var options: [any TipOption] {

--- a/firefox-ios/Client/Frontend/Settings/Main/General/QuickAnswersSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/General/QuickAnswersSetting.swift
@@ -24,8 +24,7 @@ final class QuickAnswersSetting: Setting, UserFeaturePreferenceProvider {
 
     override var status: NSAttributedString? {
         let isSwitchOn = userPreferences.getPreferenceFor(.quickAnswers)
-        // TODO: - FXIOS-14720 Add Strings
-        let statusString: String = isSwitchOn ? "On" : "Off"
+        let statusString: String = isSwitchOn ? .QuickAnswers.Settings.StatusOn : .QuickAnswers.Settings.StatusOff
         return NSAttributedString(string: statusString)
     }
 
@@ -38,10 +37,9 @@ final class QuickAnswersSetting: Setting, UserFeaturePreferenceProvider {
         self.settingsDelegate = settingsDelegate
         self.userPreferences = userPreferences
         let theme = settings.themeManager.getCurrentTheme(for: settings.windowUUID)
-        // TODO: - FXIOS-14720 Add Strings
         super.init(
             title: NSAttributedString(
-                string: "Quick Answers",
+                string: .QuickAnswers.Settings.Title,
                 attributes: [
                     NSAttributedString.Key.foregroundColor: theme.colors.textPrimary
                 ]

--- a/firefox-ios/Client/Frontend/Settings/QuickAnswers/QuickAnswersSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/QuickAnswers/QuickAnswersSettingsViewController.swift
@@ -16,8 +16,7 @@ final class QuickAnswersSettingsViewController: SettingsTableViewController, Use
     init(prefs: Prefs, windowUUID: WindowUUID) {
         self.prefs = prefs
         super.init(style: .grouped, windowUUID: windowUUID)
-        // TODO: - FXIOS-14720 Add Strings
-        self.title = "Quick Answers"
+        self.title = .QuickAnswers.Settings.Title
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -38,8 +37,7 @@ final class QuickAnswersSettingsViewController: SettingsTableViewController, Use
             theme: theme,
             prefKey: PrefsKeys.Settings.quickAnswersFeature,
             defaultValue: userPreferences.getPreferenceFor(.quickAnswers),
-            // TODO: - FXIOS-14720 Add Strings
-            titleText: "Quick Answers"
+            titleText: .QuickAnswers.Settings.Title
         ) { [weak self] _ in
             guard let self else { return }
             // Instead of passing the updated value here, we are using determining
@@ -52,8 +50,7 @@ final class QuickAnswersSettingsViewController: SettingsTableViewController, Use
                 )
             )
         }
-        // TODO: - FXIOS-14720 Add Strings
-        let footer = "Ask out loud and get short answers. We don’t store your voice, questions, or answers."
+        let footer: String = .QuickAnswers.Settings.Footer
         return SettingSection(
             footerTitle: NSAttributedString(string: footer),
             children: [enableFeatureSwitch]
@@ -67,8 +64,7 @@ final class QuickAnswersSettingsViewController: SettingsTableViewController, Use
         ) as? ThemedTableSectionHeaderFooterView else { return nil }
 
         let linkButtonViewModel = LinkButtonViewModel(
-            // TODO: - FXIOS-14720 Add Strings
-            title: "Learn more",
+            title: .QuickAnswers.Settings.LearnMore,
             a11yIdentifier: AccessibilityIdentifiers.Settings.QuickAnswers.learnMoreButton,
             font: FXFontStyles.Regular.caption1.scaledFont(),
             contentInsets: UX.buttonContentInsets

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2760,6 +2760,212 @@ extension String {
     }
 }
 
+// MARK: - Quick Answers
+extension String {
+    public struct QuickAnswers {
+        public struct OptIn {
+            public static let Title = MZLocalizedString(
+                key: "QuickAnswers.OptIn.Title.v157",
+                tableName: "QuickAnswers",
+                value: "Ask With Your Voice",
+                comment: "Title displayed on the Quick Answers opt-in screen that introduces the voice feature."
+            )
+
+            public static let Description = MZLocalizedString(
+                key: "QuickAnswers.OptIn.Description.v157",
+                tableName: "QuickAnswers",
+                value: "Ask a question out loud, and get a short answer. We don’t store your voice or questions.",
+                comment: "Description displayed on the Quick Answers opt-in screen explaining how the feature works and its privacy policy."
+            )
+
+            public static let LearnMore = MZLocalizedString(
+                key: "QuickAnswers.OptIn.LearnMore.v157",
+                tableName: "QuickAnswers",
+                value: "Learn more",
+                comment: "Link text on the Quick Answers opt-in screen that opens more information about the feature."
+            )
+
+            public static let ContinueButton = MZLocalizedString(
+                key: "QuickAnswers.OptIn.ContinueButton.v157",
+                tableName: "QuickAnswers",
+                value: "Continue",
+                comment: "Button on the Quick Answers opt-in screen that the user taps to accept and start using the feature."
+            )
+        }
+
+        public struct ContentView {
+            public static let Placeholder = MZLocalizedString(
+                key: "QuickAnswers.ContentView.Placeholder.v157",
+                tableName: "QuickAnswers",
+                value: "Ask anything…",
+                comment: "Placeholder text shown in the Quick Answers view before the user starts speaking."
+            )
+
+            public static let Answering = MZLocalizedString(
+                key: "QuickAnswers.ContentView.Answering.v157",
+                tableName: "QuickAnswers",
+                value: "Answering…",
+                comment: "Loading label shown in the Quick Answers view while an answer is being fetched."
+            )
+
+            public static let FooterFormat = MZLocalizedString(
+                key: "QuickAnswers.ContentView.Footer.v157",
+                tableName: "QuickAnswers",
+                value: "Powered by %@ · Answers can contain mistakes.",
+                comment: "Footer text displayed below the Quick Answers result. The placeholder is the name of the AI model providing the answer. The name could be providers like Liner, Exa..."
+            )
+
+            public static let Sources = MZLocalizedString(
+                key: "QuickAnswers.ContentView.Sources.v157",
+                tableName: "QuickAnswers",
+                value: "Sources",
+                comment: "Header label for the sources section shown below a Quick Answers result."
+            )
+        }
+
+        public struct AccessibilityLabels {
+            public static let Close = MZLocalizedString(
+                key: "QuickAnswers.AccessibilityLabels.Close.v157",
+                tableName: "QuickAnswers",
+                value: "Close",
+                comment: "Accessibility label for the close button on the Quick Answers screen."
+            )
+
+            public static let OpenQuickAnswers = MZLocalizedString(
+                key: "QuickAnswers.AccessibilityLabels.OpenQuickAnswers.v157",
+                tableName: "QuickAnswers",
+                value: "Open Quick Answers",
+                comment: "Accessibility label for the button on the homepage that opens the Quick Answers feature."
+            )
+        }
+
+        public struct Errors {
+            public static let PermissionAlertTitle = MZLocalizedString(
+                key: "QuickAnswers.Errors.PermissionAlertTitle.v157",
+                tableName: "QuickAnswers",
+                value: "Change Settings to Use Quick Answers",
+                comment: "Title of the alert shown when the user has denied microphone or speech recognition permissions needed for Quick Answers."
+            )
+
+            public static let MicrophonePermissionMessage = MZLocalizedString(
+                key: "QuickAnswers.Errors.MicrophonePermissionMessage.v157",
+                tableName: "QuickAnswers",
+                value: "Allow Firefox to access the Microphone.",
+                comment: "Message shown in the permission alert when microphone access has been denied for the Quick Answers feature."
+            )
+
+            public static let SpeechRecognitionPermissionMessage = MZLocalizedString(
+                key: "QuickAnswers.Errors.SpeechRecognitionPermissionMessage.v157",
+                tableName: "QuickAnswers",
+                value: "Allow Firefox to access Speech Recognition.",
+                comment: "Message shown in the permission alert when speech recognition access has been denied for the Quick Answers feature."
+            )
+
+            public static let OpenSettings = MZLocalizedString(
+                key: "QuickAnswers.Errors.OpenSettings.v157",
+                tableName: "QuickAnswers",
+                value: "Open Settings",
+                comment: "Button label on the permission alert that opens the iOS Settings app so the user can grant permissions."
+            )
+
+            public static let Cancel = MZLocalizedString(
+                key: "QuickAnswers.Errors.Cancel.v157",
+                tableName: "QuickAnswers",
+                value: "Cancel",
+                comment: "Button label on the Quick Answers permission alert to dismiss the alert without taking action."
+            )
+
+            public static let DailyLimitTitle = MZLocalizedString(
+                key: "QuickAnswers.Errors.DailyLimitTitle.v157",
+                tableName: "QuickAnswers",
+                value: "Daily Limit Reached",
+                comment: "Title of the alert shown when the user has exceeded the daily usage limit for Quick Answers."
+            )
+
+            public static let DailyLimitMessage = MZLocalizedString(
+                key: "QuickAnswers.Errors.DailyLimitMessage.v157",
+                tableName: "QuickAnswers",
+                value: "Try Quick Answers again tomorrow.",
+                comment: "Message shown in the alert when the user has exceeded the daily usage limit for Quick Answers."
+            )
+
+            public static let GenericErrorTitle = MZLocalizedString(
+                key: "QuickAnswers.Errors.GenericErrorTitle.v157",
+                tableName: "QuickAnswers",
+                value: "Couldn't get an answer",
+                comment: "Title of the alert shown when Quick Answers encounters an unexpected error."
+            )
+
+            public static let GenericErrorMessage = MZLocalizedString(
+                key: "QuickAnswers.Errors.GenericErrorMessage.v157",
+                tableName: "QuickAnswers",
+                value: "Try asking again later.",
+                comment: "Message shown in the alert when Quick Answers encounters an unexpected error."
+            )
+
+            public static let OK = MZLocalizedString(
+                key: "QuickAnswers.Errors.OK.v157",
+                tableName: "QuickAnswers",
+                value: "Ok",
+                comment: "Button label to dismiss the Quick Answers error alert."
+            )
+        }
+
+        public struct Tip {
+            public static let Title = MZLocalizedString(
+                key: "QuickAnswers.Tip.Title.v157",
+                tableName: "QuickAnswers",
+                value: "Ask Out Loud for Quick Answers",
+                comment: "Title of the tooltip that introduces the Quick Answers feature on the homepage."
+            )
+
+            public static let Message = MZLocalizedString(
+                key: "QuickAnswers.Tip.Message.v157",
+                tableName: "QuickAnswers",
+                value: "Tap here to get started.",
+                comment: "Message of the tooltip that introduces the Quick Answers feature on the homepage."
+            )
+        }
+
+        public struct Settings {
+            public static let Title = MZLocalizedString(
+                key: "QuickAnswers.Settings.Title.v157",
+                tableName: "Settings",
+                value: "Quick Answers",
+                comment: "Title shown in the navigation bar and as the toggle label on the Quick Answers settings screen."
+            )
+
+            public static let Footer = MZLocalizedString(
+                key: "QuickAnswers.Settings.Footer.v157",
+                tableName: "Settings",
+                value: "Ask out loud and get short answers. We don’t store your voice, questions, or answers.",
+                comment: "Footer text on the Quick Answers settings screen explaining the feature and its privacy policy."
+            )
+
+            public static let LearnMore = MZLocalizedString(
+                key: "QuickAnswers.Settings.LearnMore.v157",
+                tableName: "Settings",
+                value: "Learn more",
+                comment: "Link button on the Quick Answers settings screen that opens more information about the feature."
+            )
+
+            public static let StatusOn = MZLocalizedString(
+                key: "QuickAnswers.Settings.StatusOn.v157",
+                tableName: "Settings",
+                value: "On",
+                comment: "Status text shown next to the Quick Answers row in the general settings when the feature is enabled."
+            )
+
+            public static let StatusOff = MZLocalizedString(
+                key: "QuickAnswers.Settings.StatusOff.v157",
+                tableName: "Settings",
+                value: "Off",
+                comment: "Status text shown next to the Quick Answers row in the general settings when the feature is disabled."
+            )
+        }
+    }
+}
+
 // MARK: - Settings screen
 extension String {
     public struct Settings {

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2812,7 +2812,7 @@ extension String {
                 key: "QuickAnswers.ContentView.Footer.v158",
                 tableName: "QuickAnswers",
                 value: "Powered by %@ · Answers can contain mistakes.",
-                comment: "Footer text displayed below the Quick Answers result. The placeholder is the name of the AI model providing the answer. The name could be providers like Liner, Exa..."
+                comment: "Footer text displayed below the Quick Answers result. %@ is the name of the AI model providing the answer, for example Liner or Exa."
             )
 
             public static let Sources = MZLocalizedString(
@@ -2892,7 +2892,7 @@ extension String {
             public static let GenericErrorTitle = MZLocalizedString(
                 key: "QuickAnswers.Errors.GenericErrorTitle.v158",
                 tableName: "QuickAnswers",
-                value: "Couldn't get an answer",
+                value: "Couldn’t get an answer",
                 comment: "Title of the alert shown when Quick Answers encounters an unexpected error."
             )
 

--- a/firefox-ios/Shared/Strings.swift
+++ b/firefox-ios/Shared/Strings.swift
@@ -2765,28 +2765,28 @@ extension String {
     public struct QuickAnswers {
         public struct OptIn {
             public static let Title = MZLocalizedString(
-                key: "QuickAnswers.OptIn.Title.v157",
+                key: "QuickAnswers.OptIn.Title.v158",
                 tableName: "QuickAnswers",
                 value: "Ask With Your Voice",
                 comment: "Title displayed on the Quick Answers opt-in screen that introduces the voice feature."
             )
 
             public static let Description = MZLocalizedString(
-                key: "QuickAnswers.OptIn.Description.v157",
+                key: "QuickAnswers.OptIn.Description.v158",
                 tableName: "QuickAnswers",
                 value: "Ask a question out loud, and get a short answer. We don’t store your voice or questions.",
                 comment: "Description displayed on the Quick Answers opt-in screen explaining how the feature works and its privacy policy."
             )
 
             public static let LearnMore = MZLocalizedString(
-                key: "QuickAnswers.OptIn.LearnMore.v157",
+                key: "QuickAnswers.OptIn.LearnMore.v158",
                 tableName: "QuickAnswers",
                 value: "Learn more",
                 comment: "Link text on the Quick Answers opt-in screen that opens more information about the feature."
             )
 
             public static let ContinueButton = MZLocalizedString(
-                key: "QuickAnswers.OptIn.ContinueButton.v157",
+                key: "QuickAnswers.OptIn.ContinueButton.v158",
                 tableName: "QuickAnswers",
                 value: "Continue",
                 comment: "Button on the Quick Answers opt-in screen that the user taps to accept and start using the feature."
@@ -2795,28 +2795,28 @@ extension String {
 
         public struct ContentView {
             public static let Placeholder = MZLocalizedString(
-                key: "QuickAnswers.ContentView.Placeholder.v157",
+                key: "QuickAnswers.ContentView.Placeholder.v158",
                 tableName: "QuickAnswers",
                 value: "Ask anything…",
                 comment: "Placeholder text shown in the Quick Answers view before the user starts speaking."
             )
 
             public static let Answering = MZLocalizedString(
-                key: "QuickAnswers.ContentView.Answering.v157",
+                key: "QuickAnswers.ContentView.Answering.v158",
                 tableName: "QuickAnswers",
                 value: "Answering…",
                 comment: "Loading label shown in the Quick Answers view while an answer is being fetched."
             )
 
             public static let FooterFormat = MZLocalizedString(
-                key: "QuickAnswers.ContentView.Footer.v157",
+                key: "QuickAnswers.ContentView.Footer.v158",
                 tableName: "QuickAnswers",
                 value: "Powered by %@ · Answers can contain mistakes.",
                 comment: "Footer text displayed below the Quick Answers result. The placeholder is the name of the AI model providing the answer. The name could be providers like Liner, Exa..."
             )
 
             public static let Sources = MZLocalizedString(
-                key: "QuickAnswers.ContentView.Sources.v157",
+                key: "QuickAnswers.ContentView.Sources.v158",
                 tableName: "QuickAnswers",
                 value: "Sources",
                 comment: "Header label for the sources section shown below a Quick Answers result."
@@ -2825,14 +2825,14 @@ extension String {
 
         public struct AccessibilityLabels {
             public static let Close = MZLocalizedString(
-                key: "QuickAnswers.AccessibilityLabels.Close.v157",
+                key: "QuickAnswers.AccessibilityLabels.Close.v158",
                 tableName: "QuickAnswers",
                 value: "Close",
                 comment: "Accessibility label for the close button on the Quick Answers screen."
             )
 
             public static let OpenQuickAnswers = MZLocalizedString(
-                key: "QuickAnswers.AccessibilityLabels.OpenQuickAnswers.v157",
+                key: "QuickAnswers.AccessibilityLabels.OpenQuickAnswers.v158",
                 tableName: "QuickAnswers",
                 value: "Open Quick Answers",
                 comment: "Accessibility label for the button on the homepage that opens the Quick Answers feature."
@@ -2841,70 +2841,70 @@ extension String {
 
         public struct Errors {
             public static let PermissionAlertTitle = MZLocalizedString(
-                key: "QuickAnswers.Errors.PermissionAlertTitle.v157",
+                key: "QuickAnswers.Errors.PermissionAlertTitle.v158",
                 tableName: "QuickAnswers",
                 value: "Change Settings to Use Quick Answers",
                 comment: "Title of the alert shown when the user has denied microphone or speech recognition permissions needed for Quick Answers."
             )
 
             public static let MicrophonePermissionMessage = MZLocalizedString(
-                key: "QuickAnswers.Errors.MicrophonePermissionMessage.v157",
+                key: "QuickAnswers.Errors.MicrophonePermissionMessage.v158",
                 tableName: "QuickAnswers",
-                value: "Allow Firefox to access the Microphone.",
-                comment: "Message shown in the permission alert when microphone access has been denied for the Quick Answers feature."
+                value: "Allow %@ to access the Microphone.",
+                comment: "Message shown in the permission alert when microphone access has been denied for the Quick Answers feature. %@ is the name of the app (e.g. Firefox)."
             )
 
             public static let SpeechRecognitionPermissionMessage = MZLocalizedString(
-                key: "QuickAnswers.Errors.SpeechRecognitionPermissionMessage.v157",
+                key: "QuickAnswers.Errors.SpeechRecognitionPermissionMessage.v158",
                 tableName: "QuickAnswers",
-                value: "Allow Firefox to access Speech Recognition.",
-                comment: "Message shown in the permission alert when speech recognition access has been denied for the Quick Answers feature."
+                value: "Allow %@ to access Speech Recognition.",
+                comment: "Message shown in the permission alert when speech recognition access has been denied for the Quick Answers feature. %@ is the name of the app (e.g. Firefox)."
             )
 
             public static let OpenSettings = MZLocalizedString(
-                key: "QuickAnswers.Errors.OpenSettings.v157",
+                key: "QuickAnswers.Errors.OpenSettings.v158",
                 tableName: "QuickAnswers",
                 value: "Open Settings",
                 comment: "Button label on the permission alert that opens the iOS Settings app so the user can grant permissions."
             )
 
             public static let Cancel = MZLocalizedString(
-                key: "QuickAnswers.Errors.Cancel.v157",
+                key: "QuickAnswers.Errors.Cancel.v158",
                 tableName: "QuickAnswers",
                 value: "Cancel",
                 comment: "Button label on the Quick Answers permission alert to dismiss the alert without taking action."
             )
 
             public static let DailyLimitTitle = MZLocalizedString(
-                key: "QuickAnswers.Errors.DailyLimitTitle.v157",
+                key: "QuickAnswers.Errors.DailyLimitTitle.v158",
                 tableName: "QuickAnswers",
                 value: "Daily Limit Reached",
                 comment: "Title of the alert shown when the user has exceeded the daily usage limit for Quick Answers."
             )
 
             public static let DailyLimitMessage = MZLocalizedString(
-                key: "QuickAnswers.Errors.DailyLimitMessage.v157",
+                key: "QuickAnswers.Errors.DailyLimitMessage.v158",
                 tableName: "QuickAnswers",
                 value: "Try Quick Answers again tomorrow.",
                 comment: "Message shown in the alert when the user has exceeded the daily usage limit for Quick Answers."
             )
 
             public static let GenericErrorTitle = MZLocalizedString(
-                key: "QuickAnswers.Errors.GenericErrorTitle.v157",
+                key: "QuickAnswers.Errors.GenericErrorTitle.v158",
                 tableName: "QuickAnswers",
                 value: "Couldn't get an answer",
                 comment: "Title of the alert shown when Quick Answers encounters an unexpected error."
             )
 
             public static let GenericErrorMessage = MZLocalizedString(
-                key: "QuickAnswers.Errors.GenericErrorMessage.v157",
+                key: "QuickAnswers.Errors.GenericErrorMessage.v158",
                 tableName: "QuickAnswers",
                 value: "Try asking again later.",
                 comment: "Message shown in the alert when Quick Answers encounters an unexpected error."
             )
 
             public static let OK = MZLocalizedString(
-                key: "QuickAnswers.Errors.OK.v157",
+                key: "QuickAnswers.Errors.OK.v158",
                 tableName: "QuickAnswers",
                 value: "Ok",
                 comment: "Button label to dismiss the Quick Answers error alert."
@@ -2913,14 +2913,14 @@ extension String {
 
         public struct Tip {
             public static let Title = MZLocalizedString(
-                key: "QuickAnswers.Tip.Title.v157",
+                key: "QuickAnswers.Tip.Title.v158",
                 tableName: "QuickAnswers",
                 value: "Ask Out Loud for Quick Answers",
                 comment: "Title of the tooltip that introduces the Quick Answers feature on the homepage."
             )
 
             public static let Message = MZLocalizedString(
-                key: "QuickAnswers.Tip.Message.v157",
+                key: "QuickAnswers.Tip.Message.v158",
                 tableName: "QuickAnswers",
                 value: "Tap here to get started.",
                 comment: "Message of the tooltip that introduces the Quick Answers feature on the homepage."
@@ -2929,35 +2929,35 @@ extension String {
 
         public struct Settings {
             public static let Title = MZLocalizedString(
-                key: "QuickAnswers.Settings.Title.v157",
+                key: "QuickAnswers.Settings.Title.v158",
                 tableName: "Settings",
                 value: "Quick Answers",
                 comment: "Title shown in the navigation bar and as the toggle label on the Quick Answers settings screen."
             )
 
             public static let Footer = MZLocalizedString(
-                key: "QuickAnswers.Settings.Footer.v157",
+                key: "QuickAnswers.Settings.Footer.v158",
                 tableName: "Settings",
                 value: "Ask out loud and get short answers. We don’t store your voice, questions, or answers.",
                 comment: "Footer text on the Quick Answers settings screen explaining the feature and its privacy policy."
             )
 
             public static let LearnMore = MZLocalizedString(
-                key: "QuickAnswers.Settings.LearnMore.v157",
+                key: "QuickAnswers.Settings.LearnMore.v158",
                 tableName: "Settings",
                 value: "Learn more",
                 comment: "Link button on the Quick Answers settings screen that opens more information about the feature."
             )
 
             public static let StatusOn = MZLocalizedString(
-                key: "QuickAnswers.Settings.StatusOn.v157",
+                key: "QuickAnswers.Settings.StatusOn.v158",
                 tableName: "Settings",
                 value: "On",
                 comment: "Status text shown next to the Quick Answers row in the general settings when the feature is enabled."
             )
 
             public static let StatusOff = MZLocalizedString(
-                key: "QuickAnswers.Settings.StatusOff.v157",
+                key: "QuickAnswers.Settings.StatusOff.v158",
                 tableName: "Settings",
                 value: "Off",
                 comment: "Status text shown next to the Quick Answers row in the general settings when the feature is disabled."


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14720)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/31799)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
This PR:
- Moves strings for quick answers to strings file

## :movie_camera: Demos
<!-- Please upload screenshots or video demos of your work, if applicable -->
<!-- You can either use a table (best for before/after screenshots) or the <details> disclosure -->

| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

