### PR TITLE
[MTE-6183] - login and search fixes on iPad

### DIFF
--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/LoginsTests.swift
@@ -678,10 +678,12 @@ class LoginTest: BaseTestCase {
             mozWaitForElementToNotExist(app.keyboards.buttons["Continue"])
             mozWaitForElementToExist(app.keyboards.keys.firstMatch)
         }
-        mozWaitElementHittable(element: app.keyboards.keys.firstMatch, timeout: TIMEOUT)
+        // The first key match on iPad is a zero sized padding key that never becomes hittable,
+        // so the key about to be tapped is the one awaited
         for letter in typedText {
-            print("\(letter)")
-            app.keyboards.keys["\(letter)"].waitAndTap()
+            let key = app.keyboards.keys["\(letter)"]
+            mozWaitElementHittable(element: key, timeout: TIMEOUT)
+            key.tap()
         }
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/SearchTest.swift
@@ -864,6 +864,7 @@ class SearchTests: FeatureFlaggedTestBase {
         }
 
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "trending-searches-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "recent-searches-feature")
 
         app.launch()
         navigator.goto(SearchSettings)
@@ -891,6 +892,7 @@ class SearchTests: FeatureFlaggedTestBase {
         }
 
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "trending-searches-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "recent-searches-feature")
         app.launch()
 
         navigator.goto(SearchSettings)
@@ -991,6 +993,7 @@ class SearchTests: FeatureFlaggedTestBase {
         }
 
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "recent-searches-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "trending-searches-feature")
 
         app.launch()
 
@@ -1020,6 +1023,7 @@ class SearchTests: FeatureFlaggedTestBase {
         }
 
         addLaunchArgument(jsonFileName: "defaultEnabledOn", featureName: "recent-searches-feature")
+        addLaunchArgument(jsonFileName: "defaultEnabledOff", featureName: "trending-searches-feature")
         app.launch()
 
         enterTextOnSearchBar(text: "example")


### PR DESCRIPTION
## :scroll: Tickets
https://mozilla-hub.atlassian.net/browse/MTE-6183

## :bulb: Description
Search tests — trending and recent searches (4 failures)
Each test turned on one of the two features and expected the other one's toggle to be missing from Settings → Search. That assumption broke when both features were switched on by default for development builds last week, so the "other" toggle is always there now and the tests waited forever for it to disappear. Each test now explicitly turns the other feature off, so it controls both instead of relying on defaults.

Login tests (5 failures)
Before typing into a login field, the helper waited for the keyboard's first key to become tappable. On iPad that first key is an invisible spacer at the edge of the keyboard, which never becomes tappable, so every one of these tests timed out in the same place. It now waits for the actual letter it's about to type. One helper change covers all five tests.
