### PR TITLE
Add FXIOS-14570 [JS] Add npm start alias for watcher task

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Firefox for iOS",
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "dev": "webpack --config webpack.config.js --mode development --watch"
+    "dev": "webpack --config webpack.config.js --mode development --watch",
+    "start": "npm run dev"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## :scroll: Tickets
No ticket, linking against #31525 as I originally added it for that.

## :bulb: Description

Trivial QoL for those used to "npm start".

"start" task being implicit doesn't need "run", so this is a shorthand for:

```sh
npm run dev
```
that can now be launched just by the customary:

```sh
npm start
```

 _(without having to remember what actual run command is that for the watcher;D)_

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [ ] I ensured unit tests pass and wrote tests for new code
- [ ] If needed, I updated documentation and added comments to complex code