### PR TITLE
Add FXIOS-16826 [Onboarding] Create feature flag for new onboarding

### DIFF
--- a/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
+++ b/firefox-ios/Client/FeatureFlags/FeatureFlagID.swift
@@ -41,6 +41,7 @@ enum FeatureFlagID: String, CaseIterable {
     case improvedAppStoreReviewTriggerFeature
     case microsurvey
     case modernOnboardingUI
+    case multiDayOnboarding
     case nativeErrorPage
     case newBookmarkFolderTree
     case novaDesign
@@ -122,6 +123,7 @@ enum FeatureFlagID: String, CaseIterable {
                 .httpsUpgrade,
                 .improvedAppStoreReviewTriggerFeature,
                 .microsurvey,
+                .multiDayOnboarding,
                 .nativeErrorPage,
                 .newBookmarkFolderTree,
                 .novaDesign,

--- a/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Debug/FeatureFlags/FeatureFlagsDebugViewController.swift
@@ -200,6 +200,13 @@ final class FeatureFlagsDebugViewController: SettingsTableViewController, Featur
                 self?.reloadView()
             },
             FeatureFlagsBoolSetting(
+                with: .multiDayOnboarding,
+                titleText: format(string: "Multi-day Onboarding"),
+                statusText: format(string: "Toggle to enable multi-day onboarding")
+            ) { [weak self] _ in
+                self?.reloadView()
+            },
+            FeatureFlagsBoolSetting(
                 with: .nativeErrorPage,
                 titleText: format(string: "Native Error Page"),
                 statusText: format(string: "Toggle to display natively created error pages")

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -128,6 +128,8 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
         case .modernOnboardingUI:
             return checkMondernOnboardingUIFeature()
 
+        case .multiDayOnboarding:
+            return checkMultiDayOnboardingFeature()
         case .nativeErrorPage:
             return checkNativeErrorPageFeature()
 
@@ -504,5 +506,9 @@ final class NimbusFeatureFlagLayer: NimbusFeatureFlagLayerProviding, Sendable {
 
     private func checkCellularDataRestrictedErrorPageFeature() -> Bool {
         return nimbus.features.cellularDataRestrictedErrorPageFeature.value().enabled
+    }
+
+    private func checkMultiDayOnboardingFeature() -> Bool {
+        return nimbus.features.multiDayOnboardingFeature.value().useMultiDayOnboarding
     }
 }

--- a/firefox-ios/nimbus-features/multiDayOnboardingFeature.yaml
+++ b/firefox-ios/nimbus-features/multiDayOnboardingFeature.yaml
@@ -1,0 +1,18 @@
+# The configuration for the multiDayOnboardingFeature feature
+features:
+  multi-day-onboarding-feature:
+    description: >
+      Multi-day progressive onboarding
+    variables:
+      useMultiDayOnboarding:
+        description: >
+          Whether or not multi-day onboarding is enabled
+        type: Boolean
+        default: false
+    defaults:
+      - channel: beta
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: true

--- a/firefox-ios/nimbus.fml.yaml
+++ b/firefox-ios/nimbus.fml.yaml
@@ -13,11 +13,12 @@ channels:
   - beta
   - release
 include:
+
   - nimbus-features/adBlockerFeature.yaml
-  - nimbus-features/backgroundAudioFeature.yaml
   - nimbus-features/addressAutofillFeature.yaml
   - nimbus-features/addressBarGestureToOpenTabTrayFeature.yaml
   - nimbus-features/aiKillSwitchFeature.yaml
+  - nimbus-features/backgroundAudioFeature.yaml
   - nimbus-features/bookmarksSearchFeature.yaml
   - nimbus-features/cellularDataRestrictedErrorPageFeature.yaml
   - nimbus-features/customReaderModeSchemeFeature.yaml
@@ -33,6 +34,7 @@ include:
   - nimbus-features/improvedAppStoreReviewTriggerFeature.yaml
   - nimbus-features/messagingFeature.yaml
   - nimbus-features/microsurveyFeature.yaml
+  - nimbus-features/multiDayOnboardingFeature.yaml
   - nimbus-features/nativeErrorPageFeature.yaml
   - nimbus-features/newBookmarkFolderTreeFeature.yaml
   - nimbus-features/novaDesignFeature.yaml


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-16826)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/35661)

## :bulb: Description
<!--- Describe your changes so the reviewer can understand the context and decisions made for your work -->
Adds feature flag stuff for continuous onboarding

<!-- 
| Before | After |
| - | - |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |
| <!--insert "before" image here--> | <!--insert "after" image here--> |

<!-- If you're only using the Before/After table above, or the Demo disclosure below, you can delete the other, unused markup -->
<details>
<summary>Demo</summary>
<!-- Shorthand image template: <img height=400 src="<URL>" /> -->
</details>

-->
## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [ ] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [ ] If adding telemetry, I read the [data stewardship requirements](https://mozilla-hub.atlassian.net/wiki/x/A4Aykg) and will request a data review
- [ ] If adding or modifying strings, I read the [guidelines](https://mozilla-hub.atlassian.net/wiki/x/IQDFog) and will request a string review from l10n
- [ ] If needed, I updated documentation and added comments to complex code

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>